### PR TITLE
Add a custom JSON field inside metadata

### DIFF
--- a/pb/protos/contracts.proto
+++ b/pb/protos/contracts.proto
@@ -36,7 +36,7 @@ message Listing {
         ContractType contractType = 2;
         ListingType listingType   = 3;
         uint32 expiry             = 4; // unix timestamp
-        string customJSON         = 5; // JSON for extensions and plugins
+        string nonBindingMetadata = 5; // JSON for extensions and plugins
 
         enum ContractType {
             UNKNOWN       = 0;

--- a/pb/protos/contracts.proto
+++ b/pb/protos/contracts.proto
@@ -36,6 +36,7 @@ message Listing {
         ContractType contractType = 2;
         ListingType listingType   = 3;
         uint32 expiry             = 4; // unix timestamp
+        string customJSON         = 5; // JSON for extensions and plugins
 
         enum ContractType {
             UNKNOWN       = 0;


### PR DESCRIPTION
After some conversation with @drwasho (http://imgur.com/a/s6Unw) and @SamPatt (http://imgur.com/a/TT1Pm) a while back, I'd like to submit a pull request to add a text field for JSON which allows nodes to add any amount of structured information to their listings. Extensive third party uses of this field might inform future updates to the protocol that weren't on the radar before or up the priority of those that were.

A good example use case is for a listing posted by a handy man in Cambridge that can only service people in this area. He may want to specify some JSON which allows others to know his location like:

```
{
    "location" : {
        "latitude" : "52.2053° N",
        "longitude" : "0.1218° E"
    }
}
```