### PR TITLE
Simpler and more consistent labels in contracts.proto

### DIFF
--- a/pb/protos/contracts.proto
+++ b/pb/protos/contracts.proto
@@ -2,11 +2,11 @@ syntax = "proto3";
 
 import "countrycodes.proto";
 
-message RicardianContract {
-    repeated Listing vendorListings           = 1;
-    Order buyerOrder                          = 2;
-    OrderConfirmation vendorOrderConfirmation = 3;
-    Rating buyerRating                        = 4;
+message Contract {
+    repeated Listing listings                 = 1;
+    Order order                               = 2;
+    OrderConfirmation orderConfirmation       = 3;
+    Rating rating                             = 4;
     Dispute dispute                           = 5;
     DisputeResolution disputeResolution       = 6;
     Refund refund                             = 7;


### PR DESCRIPTION
Remove redundant information (e.g. `buyerOrder` -> `order`). Simplify label (e.g. `RicardianContract` -> `Contract`).