### PR TITLE
Rename Signatures to Signature

### DIFF
--- a/core/completion.go
+++ b/core/completion.go
@@ -210,7 +210,7 @@ func (n *OpenBazaarNode) CompleteOrder(orderRatings *OrderRatings, contract *pb.
 
 	contract.BuyerOrderCompletion = oc
 	for _, sig := range rc.Signatures {
-		if sig.Section == pb.Signatures_ORDER_COMPLETION {
+		if sig.Section == pb.Signature_ORDER_COMPLETION {
 			contract.Signatures = append(contract.Signatures, sig)
 		}
 	}
@@ -227,8 +227,8 @@ func (n *OpenBazaarNode) SignOrderCompletion(contract *pb.RicardianContract) (*p
 	if err != nil {
 		return contract, err
 	}
-	s := new(pb.Signatures)
-	s.Section = pb.Signatures_ORDER_COMPLETION
+	s := new(pb.Signature)
+	s.Section = pb.Signature_ORDER_COMPLETION
 	if err != nil {
 		return contract, err
 	}
@@ -449,10 +449,10 @@ func verifySignaturesOnOrderCompletion(contract *pb.RicardianContract) error {
 	}
 	var guidSig []byte
 	var bitcoinSig *btcec.Signature
-	var sig *pb.Signatures
+	var sig *pb.Signature
 	sigExists := false
 	for _, s := range contract.Signatures {
-		if s.Section == pb.Signatures_ORDER_COMPLETION {
+		if s.Section == pb.Signature_ORDER_COMPLETION {
 			sig = s
 			sigExists = true
 			break

--- a/core/confirmation.go
+++ b/core/confirmation.go
@@ -297,8 +297,8 @@ func (n *OpenBazaarNode) SignOrderConfirmation(contract *pb.RicardianContract) (
 	if err != nil {
 		return contract, err
 	}
-	s := new(pb.Signatures)
-	s.Section = pb.Signatures_ORDER_CONFIRMATION
+	s := new(pb.Signature)
+	s.Section = pb.Signature_ORDER_CONFIRMATION
 	if err != nil {
 		return contract, err
 	}
@@ -340,10 +340,10 @@ func verifySignaturesOnOrderConfirmation(contract *pb.RicardianContract) error {
 	}
 	var guidSig []byte
 	var bitcoinSig *btcec.Signature
-	var sig *pb.Signatures
+	var sig *pb.Signature
 	sigExists := false
 	for _, s := range contract.Signatures {
-		if s.Section == pb.Signatures_ORDER_CONFIRMATION {
+		if s.Section == pb.Signature_ORDER_CONFIRMATION {
 			sig = s
 			sigExists = true
 			break

--- a/core/fulfillment.go
+++ b/core/fulfillment.go
@@ -127,7 +127,7 @@ func (n *OpenBazaarNode) FulfillOrder(fulfillment *pb.OrderFulfillment, contract
 	}
 	contract.VendorOrderFulfillment = append(contract.VendorOrderFulfillment, fulfillment)
 	for _, sig := range rc.Signatures {
-		if sig.Section == pb.Signatures_ORDER_FULFILLMENT {
+		if sig.Section == pb.Signature_ORDER_FULFILLMENT {
 			contract.Signatures = append(contract.Signatures, sig)
 		}
 	}
@@ -140,8 +140,8 @@ func (n *OpenBazaarNode) SignOrderFulfillment(contract *pb.RicardianContract) (*
 	if err != nil {
 		return contract, err
 	}
-	s := new(pb.Signatures)
-	s.Section = pb.Signatures_ORDER_FULFILLMENT
+	s := new(pb.Signature)
+	s.Section = pb.Signature_ORDER_FULFILLMENT
 	if err != nil {
 		return contract, err
 	}
@@ -267,11 +267,11 @@ func verifySignaturesOnOrderFulfilment(contract *pb.RicardianContract) error {
 		}
 		var guidSig []byte
 		var bitcoinSig *btcec.Signature
-		var sig *pb.Signatures
+		var sig *pb.Signature
 		sigExists := false
 		a := 0
 		for _, s := range contract.Signatures {
-			if s.Section == pb.Signatures_ORDER_FULFILLMENT {
+			if s.Section == pb.Signature_ORDER_FULFILLMENT {
 				if a == i {
 					sig = s
 					sigExists = true

--- a/core/listings.go
+++ b/core/listings.go
@@ -120,8 +120,8 @@ func (n *OpenBazaarNode) SignListing(listing *pb.Listing) (*pb.RicardianContract
 	listing.Metadata.AcceptedCurrency = n.Wallet.CurrencyCode()
 
 	// Sign listing
-	s := new(pb.Signatures)
-	s.Section = pb.Signatures_LISTING
+	s := new(pb.Signature)
+	s.Section = pb.Signature_LISTING
 	serializedListing, err := proto.Marshal(listing)
 	if err != nil {
 		return c, err
@@ -847,7 +847,7 @@ func verifySignaturesOnListing(contract *pb.RicardianContract) error {
 		var guidSig []byte
 		var bitcoinSig *btcec.Signature
 		sig := contract.Signatures[n]
-		if sig.Section != pb.Signatures_LISTING {
+		if sig.Section != pb.Signature_LISTING {
 			return errors.New("Contract does not contain listing signature")
 		}
 		guidSig = sig.Guid

--- a/core/order.go
+++ b/core/order.go
@@ -376,7 +376,7 @@ func (n *OpenBazaarNode) Purchase(data *PurchaseData) (orderId string, paymentAd
 			}
 			contract.VendorOrderConfirmation = rc.VendorOrderConfirmation
 			for _, sig := range rc.Signatures {
-				if sig.Section == pb.Signatures_ORDER_CONFIRMATION {
+				if sig.Section == pb.Signature_ORDER_CONFIRMATION {
 					contract.Signatures = append(contract.Signatures, sig)
 				}
 			}
@@ -505,7 +505,7 @@ func (n *OpenBazaarNode) Purchase(data *PurchaseData) (orderId string, paymentAd
 			}
 			contract.VendorOrderConfirmation = rc.VendorOrderConfirmation
 			for _, sig := range rc.Signatures {
-				if sig.Section == pb.Signatures_ORDER_CONFIRMATION {
+				if sig.Section == pb.Signature_ORDER_CONFIRMATION {
 					contract.Signatures = append(contract.Signatures, sig)
 				}
 			}
@@ -905,10 +905,10 @@ func verifySignaturesOnOrder(contract *pb.RicardianContract) error {
 	}
 	var guidSig []byte
 	var bitcoinSig *btcec.Signature
-	var sig *pb.Signatures
+	var sig *pb.Signature
 	sigExists := false
 	for _, s := range contract.Signatures {
-		if s.Section == pb.Signatures_ORDER {
+		if s.Section == pb.Signature_ORDER {
 			sig = s
 			sigExists = true
 		}
@@ -1278,8 +1278,8 @@ func (n *OpenBazaarNode) SignOrder(contract *pb.RicardianContract) (*pb.Ricardia
 	if err != nil {
 		return contract, err
 	}
-	s := new(pb.Signatures)
-	s.Section = pb.Signatures_ORDER
+	s := new(pb.Signature)
+	s.Section = pb.Signature_ORDER
 	if err != nil {
 		return contract, err
 	}

--- a/core/refunds.go
+++ b/core/refunds.go
@@ -121,8 +121,8 @@ func (n *OpenBazaarNode) SignRefund(contract *pb.RicardianContract) (*pb.Ricardi
 	if err != nil {
 		return contract, err
 	}
-	s := new(pb.Signatures)
-	s.Section = pb.Signatures_REFUND
+	s := new(pb.Signature)
+	s.Section = pb.Signature_REFUND
 	if err != nil {
 		return contract, err
 	}
@@ -164,10 +164,10 @@ func (n *OpenBazaarNode) VerifySignaturesOnRefund(contract *pb.RicardianContract
 	}
 	var guidSig []byte
 	var bitcoinSig *btcec.Signature
-	var sig *pb.Signatures
+	var sig *pb.Signature
 	sigExists := false
 	for _, s := range contract.Signatures {
-		if s.Section == pb.Signatures_REFUND {
+		if s.Section == pb.Signature_REFUND {
 			sig = s
 			sigExists = true
 			break

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -235,7 +235,7 @@ func (service *OpenBazaarService) handleOrderConfirmation(p peer.ID, pmes *pb.Me
 	// Append the order confirmation
 	contract.VendorOrderConfirmation = vendorContract.VendorOrderConfirmation
 	for _, sig := range vendorContract.Signatures {
-		if sig.Section == pb.Signatures_ORDER_CONFIRMATION {
+		if sig.Section == pb.Signature_ORDER_CONFIRMATION {
 			contract.Signatures = append(contract.Signatures, sig)
 		}
 	}
@@ -506,7 +506,7 @@ func (service *OpenBazaarService) handleRefund(p peer.ID, pmes *pb.Message, opti
 	}
 	contract.Refund = rc.Refund
 	for _, sig := range contract.Signatures {
-		if sig.Section == pb.Signatures_REFUND {
+		if sig.Section == pb.Signature_REFUND {
 			contract.Signatures = append(contract.Signatures, sig)
 		}
 	}
@@ -538,7 +538,7 @@ func (service *OpenBazaarService) handleOrderFulfillment(p peer.ID, pmes *pb.Mes
 
 	contract.VendorOrderFulfillment = append(contract.VendorOrderFulfillment, rc.VendorOrderFulfillment[0])
 	for _, sig := range rc.Signatures {
-		if sig.Section == pb.Signatures_ORDER_FULFILLMENT {
+		if sig.Section == pb.Signature_ORDER_FULFILLMENT {
 			contract.Signatures = append(contract.Signatures, sig)
 		}
 	}
@@ -576,7 +576,7 @@ func (service *OpenBazaarService) handleOrderCompletion(p peer.ID, pmes *pb.Mess
 
 	contract.BuyerOrderCompletion = rc.BuyerOrderCompletion
 	for _, sig := range rc.Signatures {
-		if sig.Section == pb.Signatures_ORDER_COMPLETION {
+		if sig.Section == pb.Signature_ORDER_COMPLETION {
 			contract.Signatures = append(contract.Signatures, sig)
 		}
 	}

--- a/pb/protos/contracts.proto
+++ b/pb/protos/contracts.proto
@@ -12,7 +12,7 @@ message RicardianContract {
     Dispute dispute                                    = 6;
     DisputeResolution disputeResolution                = 7;
     Refund refund                                      = 8;
-    repeated Signatures signatures                     = 9;
+    repeated Signature signatures                      = 9;
 }
 
 message Listing {
@@ -310,7 +310,7 @@ message ID {
     }
 }
 
-message Signatures {
+message Signature {
     Section section = 1;
     bytes guid      = 2;
     bytes bitcoin   = 3;


### PR DESCRIPTION
I haven't recompiled the protobufs. Apparently I'm meant to run `protoc go_out=./ contracts.proto` and expect errors, but I can't even install `protoc`. Is there documentation for MacOS X?