### PR TITLE
Fix coupon handling in CalculateOrderTotal()

### DIFF
--- a/core/order.go
+++ b/core/order.go
@@ -691,10 +691,10 @@ func (n *OpenBazaarNode) CalculateOrderTotal(contract *pb.RicardianContract) (ui
 					return 0, err
 				}
 				if multihash.B58String() == vendorCoupon.Hash {
-					if vendorCoupon.GetPriceDiscount() > 0 {
-						itemTotal -= itemTotal
-					} else {
-						itemTotal -= uint64((float32(itemTotal) * (vendorCoupon.GetPercentDiscount() / 100)))
+					if discount := vendorCoupon.GetPriceDiscount(); discount > 0 {
+						itemTotal -= discount
+					} else if discount := vendorCoupon.GetPercentDiscount(); discount > 0 {
+						itemTotal -= uint64((float32(itemTotal) * (discount / 100)))
 					}
 				}
 			}


### PR DESCRIPTION
Fix for #191 and my first PR

As I understand, original intention was to subtract `GetPriceDiscount()` or `GetPercentDiscount()` as percentage from `itemTotal`, if any of those returns non-zero.
