### PR TITLE
Move signature verification to dedicated function

### DIFF
--- a/core/listings.go
+++ b/core/listings.go
@@ -5,14 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/OpenBazaar/jsonpb"
-	"github.com/OpenBazaar/openbazaar-go/ipfs"
-	"github.com/OpenBazaar/openbazaar-go/pb"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/golang/protobuf/proto"
-	"github.com/kennygrant/sanitize"
-	peer "gx/ipfs/QmRBqJF7hb8ZSpRcMwUt8hNhydWcxGEhtk81HKq6oUwKvs/go-libp2p-peer"
-	crypto "gx/ipfs/QmUWER4r4qMvaCnX5zREcfyiWN7cXN9g3a7fkRqNz8qWPP/go-libp2p-crypto"
 	mh "gx/ipfs/QmYf7ng2hG5XBtJA3tN34DQ2GUN5HNksEw1rLDkmr6vGku/go-multihash"
 	"io/ioutil"
 	"net/url"
@@ -21,6 +13,12 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/OpenBazaar/jsonpb"
+	"github.com/OpenBazaar/openbazaar-go/ipfs"
+	"github.com/OpenBazaar/openbazaar-go/pb"
+	"github.com/golang/protobuf/proto"
+	"github.com/kennygrant/sanitize"
 )
 
 const (
@@ -825,44 +823,39 @@ func validateListing(listing *pb.Listing) (err error) {
 }
 
 func verifySignaturesOnListing(contract *pb.RicardianContract) error {
-	for n, listing := range contract.VendorListings {
+	for _, listing := range contract.VendorListings {
 		// Verify identity signature on listing
-		guidPubkeyBytes := listing.VendorID.Pubkeys.Guid
-		guidPubkey, err := crypto.UnmarshalPublicKey(guidPubkeyBytes)
-		if err != nil {
-			return err
+		if err := verifyMessageSignature(
+			listing,
+			listing.VendorID.Pubkeys.Guid,
+			contract.Signatures,
+			pb.Signature_LISTING,
+			listing.VendorID.Guid,
+		); err != nil {
+			switch err.(type) {
+			case noSigError:
+				return errors.New("Contract does not contain listing signature")
+			case invalidSigError:
+				return errors.New("Buyer's guid signature on contact failed to verify")
+			case matchKeyError:
+				return errors.New("Public key in order does not match reported buyer ID")
+			default:
+				return err
+			}
 		}
-		ser, err := proto.Marshal(listing)
-		if err != nil {
-			return err
-		}
-		sig := contract.Signatures[n]
-		if sig.Section != pb.Signature_LISTING {
-			return errors.New("Contract does not contain listing signature")
-		}
-		valid, err := guidPubkey.Verify(ser, sig.SignatureBytes)
-		if err != nil || !valid {
-			return errors.New("Vendor's guid signature on contact failed to verify")
-		}
-		pid, err := peer.IDB58Decode(listing.VendorID.Guid)
-		if err != nil {
-			return err
-		}
-		if !pid.MatchesPublicKey(guidPubkey) {
-			return errors.New("Public key in listing does not match reported vendor ID")
-		}
+
 		// Verify the bitcoin signature in the ID
-		bitcoinPubkey, err := btcec.ParsePubKey(listing.VendorID.Pubkeys.Bitcoin, btcec.S256())
-		if err != nil {
-			return err
-		}
-		bitcoinSig, err := btcec.ParseSignature(listing.VendorID.BitcoinSig, btcec.S256())
-		if err != nil {
-			return err
-		}
-		valid = bitcoinSig.Verify([]byte(listing.VendorID.Guid), bitcoinPubkey)
-		if !valid {
-			return errors.New("Vendor's bitcoin signature on GUID failed to verify")
+		if err := verifyBitcoinSignature(
+			listing.VendorID.Pubkeys.Bitcoin,
+			listing.VendorID.BitcoinSig,
+			listing.VendorID.Guid,
+		); err != nil {
+			switch err.(type) {
+			case invalidSigError:
+				return errors.New("Vendor's bitcoin signature on GUID failed to verify")
+			default:
+				return err
+			}
 		}
 	}
 	return nil

--- a/core/signatures.go
+++ b/core/signatures.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	peer "gx/ipfs/QmRBqJF7hb8ZSpRcMwUt8hNhydWcxGEhtk81HKq6oUwKvs/go-libp2p-peer"
+	crypto "gx/ipfs/QmUWER4r4qMvaCnX5zREcfyiWN7cXN9g3a7fkRqNz8qWPP/go-libp2p-crypto"
+
+	"github.com/OpenBazaar/openbazaar-go/pb"
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/golang/protobuf/proto"
+)
+
+type noSigError struct{}
+type invalidSigError struct{}
+type matchKeyError struct{}
+
+func (noSigError) Error() string {
+	return "Contract does not contain a signature for the given section"
+}
+
+func (invalidSigError) Error() string {
+	return "Invalid signature"
+}
+
+func (matchKeyError) Error() string {
+	return "Signature does not match public key"
+}
+
+// verifyMessageSignature accepts message, public key butes, list of signatures,
+// signature section to be looked up in this list, and GUID string. Returns an
+// error, with special cases:
+//     - noSigError (signature not present in the list);
+//     - invalidSigError (signature is invalid);
+//     - matchKeyError (GUID does not match public key).
+// Example usage can be seen in verifySignaturesOnOrder() in 'core/order.go'.
+func verifyMessageSignature(msg proto.Message, pk []byte, sigs []*pb.Signature, sigType pb.Signature_Section, guid string) error {
+	ser, err := proto.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	guidPubkey, err := crypto.UnmarshalPublicKey(pk)
+	if err != nil {
+		return err
+	}
+	sig, err := selectSignature(sigs, sigType)
+	if err != nil {
+		return err
+	}
+	valid, err := guidPubkey.Verify(ser, sig.SignatureBytes)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return invalidSigError{}
+	}
+	pid, err := peer.IDB58Decode(guid)
+	if err != nil {
+		return err
+	}
+	if !pid.MatchesPublicKey(guidPubkey) {
+		return matchKeyError{}
+	}
+	return nil
+}
+
+func verifyBitcoinSignature(pubkeyBytes, sigBytes []byte, guid string) error {
+	bitcoinPubkey, err := btcec.ParsePubKey(pubkeyBytes, btcec.S256())
+	if err != nil {
+		return err
+	}
+	bitcoinSig, err := btcec.ParseSignature(sigBytes, btcec.S256())
+	if err != nil {
+		return err
+	}
+	if !bitcoinSig.Verify([]byte(guid), bitcoinPubkey) {
+		return invalidSigError{}
+	}
+	return nil
+}
+
+func selectSignature(signatures []*pb.Signature, sigType pb.Signature_Section) (*pb.Signature, error) {
+	var sig *pb.Signature
+	var err error = noSigError{}
+	for _, s := range signatures {
+		if s.Section == sigType {
+			sig, err = s, nil
+		}
+	}
+	return sig, err
+}


### PR DESCRIPTION
Added new file `core/signatures.go` that contains two functions for verifying message and bitcoin signatures respectively. Verification is delegated to `verifyMessageSignature()` via closure argument that
captures logic for extracting signatures from contract context. Also, some imports rearrangement due to `goimports` tool.

Seems to be 150+ lines of code diff, so code review would be very much appreciated.