### PR TITLE
Change IPFS gateway PUT handling

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"time"
 )
 
 var log = logging.MustGetLogger("core")
@@ -85,7 +86,10 @@ func (n *OpenBazaarNode) SeedNode() error {
 			if err != nil {
 				return
 			}
-			http.DefaultClient.Do(req)
+			var client = &http.Client{
+				Timeout: time.Second * 10,
+			}
+			client.Do(req)
 		}()
 	}
 	go n.publish(rootHash)

--- a/ipfs/add.go
+++ b/ipfs/add.go
@@ -2,16 +2,15 @@ package ipfs
 
 import (
 	"errors"
-	"path"
-
 	"github.com/ipfs/go-ipfs/commands"
 	"github.com/ipfs/go-ipfs/core/coreunix"
+	"path"
 )
 
 var addErr = errors.New(`Add directory failed`)
 
 // Resursively add a directory to IPFS and return the root hash
-func AddDirectory(ctx commands.Context, fpath string) (string, error) {
+func AddDirectory(ctx commands.Context, fpath string) (rootHash string, err error) {
 	_, root := path.Split(fpath)
 	args := []string{"add", "-r", fpath}
 	req, cmd, err := NewRequest(ctx, args)
@@ -21,7 +20,6 @@ func AddDirectory(ctx commands.Context, fpath string) (string, error) {
 	res := commands.NewResponse(req)
 	cmd.PreRun(req)
 	cmd.Run(req, res)
-	var rootHash string
 	for r := range res.Output().(<-chan interface{}) {
 		if r.(*coreunix.AddedObject).Name == root {
 			rootHash = r.(*coreunix.AddedObject).Hash

--- a/ipfs/add_test.go
+++ b/ipfs/add_test.go
@@ -43,11 +43,11 @@ func TestAddDirectory(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	hash, err := AddDirectory(ctx, path.Join("./", "root"))
+	root, err := AddDirectory(ctx, path.Join("./", "root"))
 	if err != nil {
 		t.Error(err)
 	}
-	if hash != "QmbuHqv8yQDwSsLvK4wGEBBXAYiqzXn23yqU9rh1tYwJSb" {
+	if root != "QmbuHqv8yQDwSsLvK4wGEBBXAYiqzXn23yqU9rh1tYwJSb" {
 		t.Error("Ipfs add directory failed")
 	}
 }

--- a/ipfs/blocks.go
+++ b/ipfs/blocks.go
@@ -1,0 +1,15 @@
+package ipfs
+
+import (
+	key "github.com/ipfs/go-ipfs/blocks/key"
+	"github.com/ipfs/go-ipfs/commands"
+)
+
+func BlockstoreHas(ctx commands.Context, hash string) (bool, error) {
+	node, err := ctx.GetNode()
+	if err != nil {
+		return false, err
+	}
+	k := key.B58KeyDecode(hash)
+	return node.Blockstore.Has(k)
+}

--- a/vendor/github.com/ipfs/go-ipfs/core/corehttp/gateway_handler.go
+++ b/vendor/github.com/ipfs/go-ipfs/core/corehttp/gateway_handler.go
@@ -1,7 +1,6 @@
 package corehttp
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,12 +12,12 @@ import (
 	humanize "gx/ipfs/QmPSBJL4momYnE7DcUyk2DVhD6rH488ZmHBGLbxNdhU44K/go-humanize"
 	"gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
 
+	"errors"
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	core "github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/importer"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	dag "github.com/ipfs/go-ipfs/merkledag"
-	dagutils "github.com/ipfs/go-ipfs/merkledag/utils"
 	"github.com/ipfs/go-ipfs/namesys"
 	pb "github.com/ipfs/go-ipfs/namesys/pb"
 	path "github.com/ipfs/go-ipfs/path"
@@ -384,91 +383,30 @@ func (i *gatewayHandler) postHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
-	// TODO(cryptix): move me to ServeHTTP and pass into all handlers
-	ctx, cancel := context.WithCancel(i.node.Context())
-	defer cancel()
+	ctx, cancel := context.WithTimeout(i.node.Context(), time.Second*300)
 
-	rootPath, err := path.ParsePath(r.URL.Path)
-	if err != nil {
-		webError(w, "putHandler: ipfs path not valid", err, http.StatusBadRequest)
+	var paths []string = strings.Split(r.URL.Path, "/")
+	fmt.Println(paths)
+	if paths[1] != "ipfs" {
+		webError(w, "Cannot put to IPNS", errors.New("Cannot put to IPNS"), http.StatusInternalServerError)
+		cancel()
 		return
 	}
-
-	rsegs := rootPath.Segments()
-	if rsegs[0] == ipnsPathPrefix {
-		webError(w, "putHandler: updating named entries not supported", errors.New("WritableGateway: ipns put not supported"), http.StatusBadRequest)
+	if len(paths) != 3 {
+		webError(w, "Path must contain only one hash", errors.New("Path must contain only one hash"), http.StatusInternalServerError)
+		cancel()
 		return
 	}
-
-	var newnode *dag.Node
-	if rsegs[len(rsegs)-1] == "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn" {
-		newnode = uio.NewEmptyDirectory()
-	} else {
-		putNode, err := i.newDagFromReader(r.Body)
+	go func() {
+		node, err := i.node.DAG.Get(ctx, key.B58KeyDecode(paths[2]))
 		if err != nil {
-			webError(w, "putHandler: Could not create DAG from request", err, http.StatusInternalServerError)
 			return
 		}
-		newnode = putNode
-	}
+		dag.FetchGraph(ctx, node, i.node.DAG)
+	}()
 
-	var newPath string
-	if len(rsegs) > 1 {
-		newPath = path.Join(rsegs[2:])
-	}
-
-	var newkey key.Key
-	rnode, err := core.Resolve(ctx, i.node, rootPath)
-	switch ev := err.(type) {
-	case path.ErrNoLink:
-		// ev.Node < node where resolve failed
-		// ev.Name < new link
-		// but we need to patch from the root
-		rnode, err := i.node.DAG.Get(ctx, key.B58KeyDecode(rsegs[1]))
-		if err != nil {
-			webError(w, "putHandler: Could not create DAG from request", err, http.StatusInternalServerError)
-			return
-		}
-
-		e := dagutils.NewDagEditor(rnode, i.node.DAG)
-		err = e.InsertNodeAtPath(ctx, newPath, newnode, uio.NewEmptyDirectory)
-		if err != nil {
-			webError(w, "putHandler: InsertNodeAtPath failed", err, http.StatusInternalServerError)
-			return
-		}
-
-		nnode, err := e.Finalize(i.node.DAG)
-		if err != nil {
-			webError(w, "putHandler: could not get node", err, http.StatusInternalServerError)
-			return
-		}
-
-		newkey, err = nnode.Key()
-		if err != nil {
-			webError(w, "putHandler: could not get key of edited node", err, http.StatusInternalServerError)
-			return
-		}
-
-	case nil:
-		// object set-data case
-		rnode.SetData(newnode.Data())
-
-		newkey, err = i.node.DAG.Add(rnode)
-		if err != nil {
-			nnk, _ := newnode.Key()
-			rk, _ := rnode.Key()
-			webError(w, fmt.Sprintf("putHandler: Could not add newnode(%q) to root(%q)", nnk.B58String(), rk.B58String()), err, http.StatusInternalServerError)
-			return
-		}
-	default:
-		log.Warningf("putHandler: unhandled resolve error %T", ev)
-		webError(w, "could not resolve root DAG", ev, http.StatusInternalServerError)
-		return
-	}
-
-	i.addUserHeaders(w) // ok, _now_ write user's headers.
-	w.Header().Set("IPFS-Hash", newkey.String())
-	http.Redirect(w, r, gopath.Join(ipfsPathPrefix, newkey.String(), newPath), http.StatusCreated)
+	i.addUserHeaders(w)
+	return
 }
 
 func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {

--- a/vendor/github.com/ipfs/go-ipfs/core/corehttp/gateway_handler.go
+++ b/vendor/github.com/ipfs/go-ipfs/core/corehttp/gateway_handler.go
@@ -386,7 +386,6 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(i.node.Context(), time.Second*300)
 
 	var paths []string = strings.Split(r.URL.Path, "/")
-	fmt.Println(paths)
 	if paths[1] != "ipfs" {
 		webError(w, "Cannot put to IPNS", errors.New("Cannot put to IPNS"), http.StatusInternalServerError)
 		cancel()


### PR DESCRIPTION
Currently PUT is kind of hard to work with and requires many back and forth
messages to upload a directory. Additionally, we don't really want nodes who
are pushing to the gateway to have to upload their entire directory each time as
this wastes bandwidth.

This commit changes the put handler to accept a directory hash. The gateway then traverses the graph, downloading only those nodes it doesn't have. 

The downside to this approach is if client has firewall issues, the gateway might not be able to get files from the network. Possibly we might want to force an outgoing connection to the gateway node if one doesn't exist. 