### PR TITLE
Fix net.Encrypt() to use correct MAC key size

### DIFF
--- a/net/encryption.go
+++ b/net/encryption.go
@@ -68,7 +68,7 @@ func Encrypt(pubKey libp2p.PubKey, plaintext []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	macKey := make([]byte, AESKeyBytes)
+	macKey := make([]byte, MacKeyBytes)
 	_, err = io.ReadFull(hkdf, macKey)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
See #270.