### PR TITLE
Adapt core.EncryptMessage to optionally take a public key

### DIFF
--- a/core/net.go
+++ b/core/net.go
@@ -448,7 +448,7 @@ func (n *OpenBazaarNode) SendChat(peerId string, chatMessage *pb.Chat) error {
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, &m); err != nil {
+		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
 			return err
 		}
 	}

--- a/core/net.go
+++ b/core/net.go
@@ -424,31 +424,9 @@ func (n *OpenBazaarNode) SendDisputeClose(peerId string, resolutionMessage *pb.R
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (n *OpenBazaarNode) SendChat(peerId string, chatMessage *pb.Chat) error {
-	p, err := peer.IDB58Decode(peerId)
-	if err != nil {
-		return err
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	a, err := ptypes.MarshalAny(chatMessage)
-	if err != nil {
-		return err
-	}
-	m := pb.Message{
-		MessageType: pb.Message_CHAT,
-		Payload:     a,
-	}
-	err = n.Service.SendMessage(ctx, p, &m)
-	if err != nil {
+==== BASE ====
 		if err := n.SendOfflineMessage(p, &m); err != nil {
+==== BASE ====
 			return err
 		}
 	}

--- a/core/net.go
+++ b/core/net.go
@@ -196,9 +196,10 @@ func (n *OpenBazaarNode) SendOrderConfirmation(peerId string, contract *pb.Ricar
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
 		if k, err := libp2p.UnmarshalPublicKey(contract.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid); err != nil {
-			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
-				return err
-			}
+			return err
+		}
+		if err := n.SendOfflineMessage(p, &k, &m); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -226,10 +227,9 @@ func (n *OpenBazaarNode) SendCancel(peerId, orderId string) error {
 		} else {
 			k, err := libp2p.UnmarshalPublicKey(order.GetVendorListings()[0].GetVendorID().GetPubkeys().Guid)
 			if err != nil {
-				kp = &k
-			} else {
-				kp = nil
+				return err
 			}
+			kp = &k
 		}
 		if err := n.SendOfflineMessage(p, kp, &m); err != nil {
 			return err
@@ -261,12 +261,11 @@ func (n *OpenBazaarNode) SendReject(peerId string, rejectMessage *pb.OrderReject
 		if err != nil { //probably implies we can't find the order in the Datastore
 			kp = nil //instead SendOfflineMessage can try to get the key from the peerId
 		} else {
-			k, err := libp2p.UnmarshalPublicKey(order.GetVendorListings()[0].GetVendorID().GetPubkeys().Guid)
+			k, err := libp2p.UnmarshalPublicKey(order.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid)
 			if err != nil {
-				kp = &k
-			} else {
-				kp = nil
+				return err
 			}
+			kp = &k
 		}
 		if err := n.SendOfflineMessage(p, kp, &m); err != nil {
 			return err
@@ -293,9 +292,10 @@ func (n *OpenBazaarNode) SendRefund(peerId string, refundMessage *pb.RicardianCo
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
 		if k, err := libp2p.UnmarshalPublicKey(refundMessage.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid); err != nil {
-			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
-				return err
-			}
+			return err
+		}
+		if err := n.SendOfflineMessage(p, &k, &m); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -319,9 +319,10 @@ func (n *OpenBazaarNode) SendOrderFulfillment(peerId string, fulfillmentMessage 
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
 		if k, err := libp2p.UnmarshalPublicKey(fulfillmentMessage.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid); err != nil {
-			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
-				return err
-			}
+			return err
+		}
+		if err := n.SendOfflineMessage(p, &k, &m); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -345,9 +346,10 @@ func (n *OpenBazaarNode) SendOrderCompletion(peerId string, completionMessage *p
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
 		if k, err := libp2p.UnmarshalPublicKey(completionMessage.GetVendorListings()[0].GetVendorID().GetPubkeys().Guid); err != nil {
-			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
-				return err
-			}
+			return err
+		}
+		if err := n.SendOfflineMessage(p, &k, &m); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/core/net.go
+++ b/core/net.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	peer "gx/ipfs/QmRBqJF7hb8ZSpRcMwUt8hNhydWcxGEhtk81HKq6oUwKvs/go-libp2p-peer"
+	libp2p "gx/ipfs/QmUWER4r4qMvaCnX5zREcfyiWN7cXN9g3a7fkRqNz8qWPP/go-libp2p-crypto"
 	multihash "gx/ipfs/QmYf7ng2hG5XBtJA3tN34DQ2GUN5HNksEw1rLDkmr6vGku/go-multihash"
 
 	"github.com/OpenBazaar/openbazaar-go/ipfs"
@@ -17,7 +18,8 @@ const (
 	CHAT_SUBJECT_MAX_CHARACTERS = 500
 )
 
-func (n *OpenBazaarNode) SendOfflineMessage(p peer.ID, m *pb.Message) error {
+//supply of a public key is optional, if nil is instead provided n.EncryptMessage does a lookup
+func (n *OpenBazaarNode) SendOfflineMessage(p peer.ID, k *libp2p.PubKey, m *pb.Message) error {
 	log.Debugf("Sending offline message to %s", p.Pretty())
 	pubKeyBytes, err := n.IpfsNode.PrivateKey.GetPublic().Bytes()
 	if err != nil {
@@ -36,7 +38,7 @@ func (n *OpenBazaarNode) SendOfflineMessage(p peer.ID, m *pb.Message) error {
 	if merr != nil {
 		return merr
 	}
-	ciphertext, cerr := n.EncryptMessage(p, messageBytes)
+	ciphertext, cerr := n.EncryptMessage(p, k, messageBytes)
 	if cerr != nil {
 		return cerr
 	}
@@ -80,7 +82,7 @@ func (n *OpenBazaarNode) SendOfflineAck(peerId string, pointerID peer.ID) error 
 		Payload:     a}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil { // Could not connect directly to peer. Likely offline.
-		if err := n.SendOfflineMessage(p, &m); err != nil {
+		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
 			return err
 		}
 	}
@@ -112,7 +114,7 @@ func (n *OpenBazaarNode) Follow(peerId string) error {
 	m := pb.Message{MessageType: pb.Message_FOLLOW}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil { // Could not connect directly to peer. Likely offline.
-		if err := n.SendOfflineMessage(p, &m); err != nil {
+		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
 			return err
 		}
 	}
@@ -137,7 +139,7 @@ func (n *OpenBazaarNode) Unfollow(peerId string) error {
 	m := pb.Message{MessageType: pb.Message_UNFOLLOW}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, &m); err != nil {
+		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
 			return err
 		}
 	}
@@ -193,8 +195,10 @@ func (n *OpenBazaarNode) SendOrderConfirmation(peerId string, contract *pb.Ricar
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, &m); err != nil {
-			return err
+		if k, err := libp2p.UnmarshalPublicKey(contract.VendorListings[0].VendorID.Pubkeys.Guid); err != nil {
+			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -214,7 +218,7 @@ func (n *OpenBazaarNode) SendCancel(peerId, orderId string) error {
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, &m); err != nil {
+		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
 			return err
 		}
 	}
@@ -238,7 +242,7 @@ func (n *OpenBazaarNode) SendReject(peerId string, rejectMessage *pb.OrderReject
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, &m); err != nil {
+		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
 			return err
 		}
 	}
@@ -262,8 +266,10 @@ func (n *OpenBazaarNode) SendRefund(peerId string, refundMessage *pb.RicardianCo
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, &m); err != nil {
-			return err
+		if k, err := libp2p.UnmarshalPublicKey(refundMessage.VendorListings[0].VendorID.Pubkeys.Guid); err != nil {
+			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -286,8 +292,10 @@ func (n *OpenBazaarNode) SendOrderFulfillment(peerId string, fulfillmentMessage 
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, &m); err != nil {
-			return err
+		if k, err := libp2p.UnmarshalPublicKey(fulfillmentMessage.VendorListings[0].VendorID.Pubkeys.Guid); err != nil {
+			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -310,8 +318,10 @@ func (n *OpenBazaarNode) SendOrderCompletion(peerId string, completionMessage *p
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, &m); err != nil {
-			return err
+		if k, err := libp2p.UnmarshalPublicKey(completionMessage.VendorListings[0].VendorID.Pubkeys.Guid); err != nil {
+			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/core/net.go
+++ b/core/net.go
@@ -195,7 +195,8 @@ func (n *OpenBazaarNode) SendOrderConfirmation(peerId string, contract *pb.Ricar
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if k, err := libp2p.UnmarshalPublicKey(contract.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid); err != nil {
+		k, err := libp2p.UnmarshalPublicKey(contract.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid)
+		if err != nil {
 			return err
 		}
 		if err := n.SendOfflineMessage(p, &k, &m); err != nil {
@@ -291,7 +292,8 @@ func (n *OpenBazaarNode) SendRefund(peerId string, refundMessage *pb.RicardianCo
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if k, err := libp2p.UnmarshalPublicKey(refundMessage.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid); err != nil {
+		k, err := libp2p.UnmarshalPublicKey(refundMessage.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid)
+		if err != nil {
 			return err
 		}
 		if err := n.SendOfflineMessage(p, &k, &m); err != nil {
@@ -318,7 +320,8 @@ func (n *OpenBazaarNode) SendOrderFulfillment(peerId string, fulfillmentMessage 
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if k, err := libp2p.UnmarshalPublicKey(fulfillmentMessage.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid); err != nil {
+		k, err := libp2p.UnmarshalPublicKey(fulfillmentMessage.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid)
+		if err != nil {
 			return err
 		}
 		if err := n.SendOfflineMessage(p, &k, &m); err != nil {
@@ -345,7 +348,8 @@ func (n *OpenBazaarNode) SendOrderCompletion(peerId string, completionMessage *p
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if k, err := libp2p.UnmarshalPublicKey(completionMessage.GetVendorListings()[0].GetVendorID().GetPubkeys().Guid); err != nil {
+		k, err := libp2p.UnmarshalPublicKey(completionMessage.GetVendorListings()[0].GetVendorID().GetPubkeys().Guid)
+		if err != nil {
 			return err
 		}
 		if err := n.SendOfflineMessage(p, &k, &m); err != nil {

--- a/core/net.go
+++ b/core/net.go
@@ -430,3 +430,27 @@ func (n *OpenBazaarNode) SendDisputeClose(peerId string, resolutionMessage *pb.R
 	}
 	return nil
 }
+
+func (n *OpenBazaarNode) SendChat(peerId string, chatMessage *pb.Chat) error {
+	p, err := peer.IDB58Decode(peerId)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	a, err := ptypes.MarshalAny(chatMessage)
+	if err != nil {
+		return err
+	}
+	m := pb.Message{
+		MessageType: pb.Message_CHAT,
+		Payload:     a,
+	}
+	err = n.Service.SendMessage(ctx, p, &m)
+	if err != nil {
+		if err := n.SendOfflineMessage(p, &m); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/core/net.go
+++ b/core/net.go
@@ -195,7 +195,7 @@ func (n *OpenBazaarNode) SendOrderConfirmation(peerId string, contract *pb.Ricar
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if k, err := libp2p.UnmarshalPublicKey(contract.VendorListings[0].VendorID.Pubkeys.Guid); err != nil {
+		if k, err := libp2p.UnmarshalPublicKey(contract.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid); err != nil {
 			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
 				return err
 			}
@@ -218,7 +218,20 @@ func (n *OpenBazaarNode) SendCancel(peerId, orderId string) error {
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
+		//try to get public key from order
+		order, _, _, _, _, err := n.Datastore.Purchases().GetByOrderId(orderId)
+		var kp *libp2p.PubKey
+		if err != nil { //probably implies we can't find the order in the Datastore
+			kp = nil //instead SendOfflineMessage can try to get the key from the peerId
+		} else {
+			k, err := libp2p.UnmarshalPublicKey(order.GetVendorListings()[0].GetVendorID().GetPubkeys().Guid)
+			if err != nil {
+				kp = &k
+			} else {
+				kp = nil
+			}
+		}
+		if err := n.SendOfflineMessage(p, kp, &m); err != nil {
 			return err
 		}
 	}
@@ -242,7 +255,20 @@ func (n *OpenBazaarNode) SendReject(peerId string, rejectMessage *pb.OrderReject
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
+		var kp *libp2p.PubKey
+		//try to get public key from order
+		order, _, _, _, _, err := n.Datastore.Sales().GetByOrderId(rejectMessage.OrderID)
+		if err != nil { //probably implies we can't find the order in the Datastore
+			kp = nil //instead SendOfflineMessage can try to get the key from the peerId
+		} else {
+			k, err := libp2p.UnmarshalPublicKey(order.GetVendorListings()[0].GetVendorID().GetPubkeys().Guid)
+			if err != nil {
+				kp = &k
+			} else {
+				kp = nil
+			}
+		}
+		if err := n.SendOfflineMessage(p, kp, &m); err != nil {
 			return err
 		}
 	}
@@ -266,7 +292,7 @@ func (n *OpenBazaarNode) SendRefund(peerId string, refundMessage *pb.RicardianCo
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if k, err := libp2p.UnmarshalPublicKey(refundMessage.VendorListings[0].VendorID.Pubkeys.Guid); err != nil {
+		if k, err := libp2p.UnmarshalPublicKey(refundMessage.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid); err != nil {
 			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
 				return err
 			}
@@ -292,7 +318,7 @@ func (n *OpenBazaarNode) SendOrderFulfillment(peerId string, fulfillmentMessage 
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if k, err := libp2p.UnmarshalPublicKey(fulfillmentMessage.VendorListings[0].VendorID.Pubkeys.Guid); err != nil {
+		if k, err := libp2p.UnmarshalPublicKey(fulfillmentMessage.GetBuyerOrder().GetBuyerID().GetPubkeys().Guid); err != nil {
 			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
 				return err
 			}
@@ -318,7 +344,7 @@ func (n *OpenBazaarNode) SendOrderCompletion(peerId string, completionMessage *p
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if k, err := libp2p.UnmarshalPublicKey(completionMessage.VendorListings[0].VendorID.Pubkeys.Guid); err != nil {
+		if k, err := libp2p.UnmarshalPublicKey(completionMessage.GetVendorListings()[0].GetVendorID().GetPubkeys().Guid); err != nil {
 			if err := n.SendOfflineMessage(p, &k, &m); err != nil {
 				return err
 			}

--- a/core/net.go
+++ b/core/net.go
@@ -376,7 +376,7 @@ func (n *OpenBazaarNode) SendDisputeOpen(peerId string, disputeMessage *pb.Ricar
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, &m); err != nil {
+		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
 			return err
 		}
 	}
@@ -400,7 +400,7 @@ func (n *OpenBazaarNode) SendDisputeUpdate(peerId string, updateMessage *pb.Disp
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, &m); err != nil {
+		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
 			return err
 		}
 	}
@@ -424,7 +424,7 @@ func (n *OpenBazaarNode) SendDisputeClose(peerId string, resolutionMessage *pb.R
 	}
 	err = n.Service.SendMessage(ctx, p, &m)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, &m); err != nil {
+		if err := n.SendOfflineMessage(p, nil, &m); err != nil {
 			return err
 		}
 	}

--- a/core/order.go
+++ b/core/order.go
@@ -358,7 +358,11 @@ func (n *OpenBazaarNode) Purchase(data *PurchaseData) (orderId string, paymentAd
 				MessageType: pb.Message_ORDER,
 				Payload:     any,
 			}
-			err = n.SendOfflineMessage(peerId, &m)
+			k, err := crypto.UnmarshalPublicKey(contract.VendorListings[0].VendorID.Pubkeys.Guid)
+			if err != nil {
+				return "", "", 0, false, err
+			}
+			err = n.SendOfflineMessage(peerId, &k, &m)
 			if err != nil {
 				return "", "", 0, false, err
 			}
@@ -487,7 +491,11 @@ func (n *OpenBazaarNode) Purchase(data *PurchaseData) (orderId string, paymentAd
 				MessageType: pb.Message_ORDER,
 				Payload:     any,
 			}
-			err = n.SendOfflineMessage(peerId, &m)
+			k, err := crypto.UnmarshalPublicKey(contract.VendorListings[0].VendorID.Pubkeys.Guid)
+			if err != nil {
+				return "", "", 0, false, err
+			}
+			err = n.SendOfflineMessage(peerId, &k, &m)
 			if err != nil {
 				return "", "", 0, false, err
 			}


### PR DESCRIPTION
See #272. core.EncryptMessage now takes a pointer to a public key as its second argument. If left nil, an IPFS lookup is done for the public key. Most functions in core/net.go now take advantage of this feature, mostly by looking in the contract; SendOrderConfirmation, SendCancel + SendReject (both via datastore lookup for public key), SendRefund, SendOrderFulfillment, SendOrderCompletion.

I have chosen to use libp2p.PubKey throughout, arguably instead we could use []byte, and finally unmarshal in core.EncryptMessage, and this would mean we don't need to import libp2p in net.go. I am not sure what the best option is.