### PR TITLE
Allow optional user-supplied refund address on purchase, make internal vs external address use consistent, always use refund address from contract

### DIFF
--- a/bitcoin/bitcoind/wallet.go
+++ b/bitcoin/bitcoind/wallet.go
@@ -302,8 +302,13 @@ func (w *BitcoindWallet) Multisign(ins []spvwallet.TransactionInput, outs []spvw
 	return nil
 }
 
-func (w *BitcoindWallet) SweepMultisig(utxos []spvwallet.Utxo, key *hd.ExtendedKey, redeemScript []byte, feeLevel spvwallet.FeeLevel) error {
-	internalAddr := w.CurrentAddress(spvwallet.INTERNAL)
+func (w *BitcoindWallet) SweepMultisig(utxos []spvwallet.Utxo, address *btc.Address, key *hd.ExtendedKey, redeemScript []byte, feeLevel spvwallet.FeeLevel) error {
+	var internalAddr btc.Address
+	if address != nil {
+		internalAddr = *address
+	} else {
+		internalAddr = w.CurrentAddress(spvwallet.INTERNAL)
+	}
 	script, err := txscript.PayToAddrScript(internalAddr)
 	if err != nil {
 		return err

--- a/bitcoin/wallet.go
+++ b/bitcoin/wallet.go
@@ -45,8 +45,8 @@ type BitcoinWallet interface {
 	// Calculates the estimated size of the transaction and returns the total fee for the given feePerByte
 	EstimateFee(ins []spvwallet.TransactionInput, outs []spvwallet.TransactionOutput, feePerByte uint64) uint64
 
-	// Build and broadcast a transaction that sweeps all coins from a 1 of 2 multisig to an internal address
-	SweepMultisig(utxos []spvwallet.Utxo, key *hd.ExtendedKey, reddemScript []byte, feeLevel spvwallet.FeeLevel) error
+	// Build and broadcast a transaction that sweeps all coins from a 1 of 2 multisig to an internal address (optionally provided)
+	SweepMultisig(utxos []spvwallet.Utxo, address *btc.Address, key *hd.ExtendedKey, reddemScript []byte, feeLevel spvwallet.FeeLevel) error
 
 	// Create a signature for a multisig transaction
 	CreateMultisigSignature(ins []spvwallet.TransactionInput, outs []spvwallet.TransactionOutput, key *hd.ExtendedKey, redeemScript []byte, feePerByte uint64) ([]spvwallet.Signature, error)

--- a/core/confirmation.go
+++ b/core/confirmation.go
@@ -127,7 +127,7 @@ func (n *OpenBazaarNode) ConfirmOfflineOrder(contract *pb.RicardianContract, rec
 			return err
 		}
 		redeemScript, err := hex.DecodeString(contract.BuyerOrder.Payment.RedeemScript)
-		err = n.Wallet.SweepMultisig(utxos, vendorKey, redeemScript, spvwallet.NORMAL)
+		err = n.Wallet.SweepMultisig(utxos, nil, vendorKey, redeemScript, spvwallet.NORMAL)
 		if err != nil {
 			return err
 		}

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -399,7 +399,11 @@ func (service *OpenBazaarService) handleReject(p peer.ID, pmes *pb.Message, opti
 			return nil, err
 		}
 		redeemScript, err := hex.DecodeString(contract.BuyerOrder.Payment.RedeemScript)
-		err = service.node.Wallet.SweepMultisig(utxos, buyerKey, redeemScript, spvwallet.NORMAL)
+		refundAddress, err := btcutil.DecodeAddress(contract.BuyerOrder.RefundAddress, service.node.Wallet.Params())
+		if err != nil {
+			return nil, err
+		}
+		err = service.node.Wallet.SweepMultisig(utxos, &refundAddress, buyerKey, redeemScript, spvwallet.NORMAL)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/OpenBazaar/spvwallet/sortsignsend.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/sortsignsend.go
@@ -217,8 +217,13 @@ func (w *SPVWallet) Multisign(ins []TransactionInput, outs []TransactionOutput, 
 	return nil
 }
 
-func (w *SPVWallet) SweepMultisig(utxos []Utxo, key *hd.ExtendedKey, redeemScript []byte, feeLevel FeeLevel) error {
-	internalAddr := w.CurrentAddress(INTERNAL)
+func (w *SPVWallet) SweepMultisig(utxos []Utxo, address *btc.Address, key *hd.ExtendedKey, redeemScript []byte, feeLevel FeeLevel) error {
+	var internalAddr btc.Address
+	if address != nil {
+		internalAddr = *address
+	} else {
+		internalAddr = w.CurrentAddress(INTERNAL)
+	}
 	script, err := txscript.PayToAddrScript(internalAddr)
 	if err != nil {
 		return err
@@ -264,10 +269,10 @@ func (w *SPVWallet) SweepMultisig(utxos []Utxo, key *hd.ExtendedKey, redeemScrip
 	}
 
 	pk := privKey.PubKey().SerializeCompressed()
-	address, err := btc.NewAddressPubKey(pk, w.params)
+	addressPub, err := btc.NewAddressPubKey(pk, w.params)
 
 	getKey := txscript.KeyClosure(func(addr btc.Address) (*btcec.PrivateKey, bool, error) {
-		if address.EncodeAddress() == addr.EncodeAddress() {
+		if addressPub.EncodeAddress() == addr.EncodeAddress() {
 			wif, err := btc.NewWIF(privKey, w.params, true)
 			if err != nil {
 				return nil, false, err


### PR DESCRIPTION
SweepMultisig functions in bitcoind and spvwallet can now optionally take specific address, defaulting to their internal address as before. Purchase() can now also optionally take a refund address in its json input, defaulting to the internal address - previously the external address was used, which likely would lead to bugs. All buyer calls of SweepMultisig now use the address stored in the purchase contract, instead of letting the Sweep function supply the internal address. I have not added an equivalent ability for sellers to provide a custom address on confirmation of offline orders, but this isn't a bad idea.

This resolves issues #282 and #283 