### PR TITLE
Add mispayment buffer

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -699,6 +699,10 @@ func (i *jsonAPIHandler) POSTSettings(w http.ResponseWriter, r *http.Request) {
 		ErrorResponse(w, http.StatusConflict, "Settings is already set. Use PUT.")
 		return
 	}
+	if settings.MisPaymentBuffer == nil {
+		i := float32(1)
+		settings.MisPaymentBuffer = &i
+	}
 	err = i.node.Datastore.Settings().Put(settings)
 	if err != nil {
 		ErrorResponse(w, http.StatusInternalServerError, err.Error())

--- a/core/order.go
+++ b/core/order.go
@@ -1325,3 +1325,19 @@ func validateVersionNumber(rc *pb.RicardianContract) error {
 	}
 	return nil
 }
+
+func (n *OpenBazaarNode) ValidatePaymentAmount(requestedAmount, paymentAmount uint64) bool {
+	settings, err := n.Datastore.Settings().Get()
+	if err != nil {
+		return false
+	}
+	bufferPercent := float32(0)
+	if settings.MisPaymentBuffer != nil {
+		bufferPercent = *settings.MisPaymentBuffer
+	}
+	buffer := float32(requestedAmount) * (bufferPercent / 100)
+	if float32(paymentAmount)+buffer < float32(requestedAmount) {
+		return false
+	}
+	return true
+}

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -184,7 +184,7 @@ func (service *OpenBazaarService) handleOrder(peer peer.ID, pmes *pb.Message, op
 		if err != nil {
 			return errorResponse("Error calculating payment amount"), err
 		}
-		if total != contract.BuyerOrder.Payment.Amount {
+		if !service.node.ValidatePaymentAmount(total, contract.BuyerOrder.Payment.Amount) {
 			return errorResponse("Calculated a different payment amount"), err
 		}
 		contract, err = service.node.NewOrderConfirmation(contract, true)
@@ -226,7 +226,7 @@ func (service *OpenBazaarService) handleOrder(peer peer.ID, pmes *pb.Message, op
 		if err != nil {
 			return errorResponse("Error calculating payment amount"), err
 		}
-		if total != contract.BuyerOrder.Payment.Amount {
+		if !service.node.ValidatePaymentAmount(total, contract.BuyerOrder.Payment.Amount) {
 			return errorResponse("Calculated a different payment amount"), err
 		}
 		err = service.node.ValidateModeratedPaymentAddress(contract.BuyerOrder)

--- a/repo/db/settings.go
+++ b/repo/db/settings.go
@@ -99,6 +99,9 @@ func (s *SettingsDB) Update(settings repo.SettingsData) error {
 	if settings.StoreModerators == nil {
 		settings.StoreModerators = current.StoreModerators
 	}
+	if settings.MisPaymentBuffer == nil {
+		settings.MisPaymentBuffer = current.MisPaymentBuffer
+	}
 	if settings.SMTPSettings == nil {
 		settings.SMTPSettings = current.SMTPSettings
 	}

--- a/repo/settings.go
+++ b/repo/settings.go
@@ -12,6 +12,7 @@ type SettingsData struct {
 	RefundPolicy       *string            `json:"refundPolicy"`
 	BlockedNodes       *[]string          `json:"blockedNodes"`
 	StoreModerators    *[]string          `json:"storeModerators"`
+	MisPaymentBuffer   *float32           `json:"mispaymentBuffer"`
 	SMTPSettings       *SMTPSettings      `json:"smtpSettings"`
 	Version            *string            `json:"version"`
 }


### PR DESCRIPTION
Allows an order to be processed if the order amount is less than the requested
amount. This should prevent some bugs due to differing exchange rates.

Defaults to 1% and can be set in settings.