### PR TITLE
Use contract public key for entire contract state machine

### DIFF
--- a/core/completion.go
+++ b/core/completion.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	libp2p "gx/ipfs/QmUWER4r4qMvaCnX5zREcfyiWN7cXN9g3a7fkRqNz8qWPP/go-libp2p-crypto"
 	"gx/ipfs/QmYf7ng2hG5XBtJA3tN34DQ2GUN5HNksEw1rLDkmr6vGku/go-multihash"
 	"io/ioutil"
 	"os"
@@ -201,8 +202,11 @@ func (n *OpenBazaarNode) CompleteOrder(orderRatings *OrderRatings, contract *pb.
 	if err != nil {
 		return err
 	}
-
-	err = n.SendOrderCompletion(contract.VendorListings[0].VendorID.Guid, rc)
+	vendorkey, err := libp2p.UnmarshalPublicKey(contract.VendorListings[0].VendorID.Pubkeys.Guid)
+	if err != nil {
+		return err
+	}
+	err = n.SendOrderCompletion(contract.VendorListings[0].VendorID.Guid, &vendorkey, rc)
 	if err != nil {
 		return err
 	}

--- a/core/disputes.go
+++ b/core/disputes.go
@@ -367,7 +367,9 @@ func (n *OpenBazaarNode) CloseDispute(orderId string, buyerPercentage, vendorPer
 	var chaincode string
 	var feePerByte uint64
 	var vendorId string
+	var vendorKey libp2p.PubKey
 	var buyerId string
+	var buyerKey libp2p.PubKey
 	if buyerPercentage > 0 && vendorPercentage == 0 {
 		buyerPayout = true
 		outpoints = buyerOutpoints
@@ -375,7 +377,15 @@ func (n *OpenBazaarNode) CloseDispute(orderId string, buyerPercentage, vendorPer
 		chaincode = buyerContract.BuyerOrder.Payment.Chaincode
 		feePerByte = buyerContract.BuyerOrder.RefundFee
 		buyerId = buyerContract.BuyerOrder.BuyerID.Guid
+		buyerKey, err = libp2p.UnmarshalPublicKey(buyerContract.BuyerOrder.BuyerID.Pubkeys.Guid)
+		if err != nil {
+			return err
+		}
 		vendorId = buyerContract.VendorListings[0].VendorID.Guid
+		vendorKey, err = libp2p.UnmarshalPublicKey(buyerContract.VendorListings[0].VendorID.Pubkeys.Guid)
+		if err != nil {
+			return err
+		}
 	} else if vendorPercentage > 0 && buyerPercentage == 0 {
 		vendorPayout = true
 		outpoints = vendorOutpoints
@@ -387,7 +397,15 @@ func (n *OpenBazaarNode) CloseDispute(orderId string, buyerPercentage, vendorPer
 			feePerByte = n.Wallet.GetFeePerByte(spvwallet.NORMAL)
 		}
 		buyerId = vendorContract.BuyerOrder.BuyerID.Guid
+		buyerKey, err = libp2p.UnmarshalPublicKey(vendorContract.BuyerOrder.BuyerID.Pubkeys.Guid)
+		if err != nil {
+			return err
+		}
 		vendorId = vendorContract.VendorListings[0].VendorID.Guid
+		vendorKey, err = libp2p.UnmarshalPublicKey(vendorContract.VendorListings[0].VendorID.Pubkeys.Guid)
+		if err != nil {
+			return err
+		}
 	} else if vendorPercentage > buyerPercentage {
 		buyerPayout = true
 		vendorPayout = true
@@ -400,7 +418,15 @@ func (n *OpenBazaarNode) CloseDispute(orderId string, buyerPercentage, vendorPer
 			feePerByte = n.Wallet.GetFeePerByte(spvwallet.NORMAL)
 		}
 		buyerId = vendorContract.BuyerOrder.BuyerID.Guid
+		buyerKey, err = libp2p.UnmarshalPublicKey(vendorContract.BuyerOrder.BuyerID.Pubkeys.Guid)
+		if err != nil {
+			return err
+		}
 		vendorId = vendorContract.VendorListings[0].VendorID.Guid
+		vendorKey, err = libp2p.UnmarshalPublicKey(vendorContract.VendorListings[0].VendorID.Pubkeys.Guid)
+		if err != nil {
+			return err
+		}
 	} else if buyerPercentage >= vendorPercentage {
 		buyerPayout = true
 		vendorPayout = true
@@ -409,7 +435,15 @@ func (n *OpenBazaarNode) CloseDispute(orderId string, buyerPercentage, vendorPer
 		chaincode = buyerContract.BuyerOrder.Payment.Chaincode
 		feePerByte = buyerContract.BuyerOrder.RefundFee
 		buyerId = buyerContract.BuyerOrder.BuyerID.Guid
+		buyerKey, err = libp2p.UnmarshalPublicKey(buyerContract.BuyerOrder.BuyerID.Pubkeys.Guid)
+		if err != nil {
+			return err
+		}
 		vendorId = buyerContract.VendorListings[0].VendorID.Guid
+		vendorKey, err = libp2p.UnmarshalPublicKey(buyerContract.VendorListings[0].VendorID.Pubkeys.Guid)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Calculate total out value
@@ -585,12 +619,11 @@ func (n *OpenBazaarNode) CloseDispute(orderId string, buyerPercentage, vendorPer
 		return err
 	}
 
-	err = n.SendDisputeClose(buyerId, rc)
+	err = n.SendDisputeClose(buyerId, &buyerKey, rc)
 	if err != nil {
 		return err
 	}
-
-	err = n.SendDisputeClose(vendorId, rc)
+	err = n.SendDisputeClose(vendorId, &vendorKey, rc)
 	if err != nil {
 		return err
 	}

--- a/core/fulfillment.go
+++ b/core/fulfillment.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	crypto "gx/ipfs/QmUWER4r4qMvaCnX5zREcfyiWN7cXN9g3a7fkRqNz8qWPP/go-libp2p-crypto"
+	libp2p "gx/ipfs/QmUWER4r4qMvaCnX5zREcfyiWN7cXN9g3a7fkRqNz8qWPP/go-libp2p-crypto"
 
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/spvwallet"
@@ -119,7 +120,11 @@ func (n *OpenBazaarNode) FulfillOrder(fulfillment *pb.OrderFulfillment, contract
 	if err != nil {
 		return err
 	}
-	err = n.SendOrderFulfillment(contract.BuyerOrder.BuyerID.Guid, rc)
+	buyerkey, err := libp2p.UnmarshalPublicKey(contract.BuyerOrder.BuyerID.Pubkeys.Guid)
+	if err != nil {
+		return err
+	}
+	err = n.SendOrderFulfillment(contract.BuyerOrder.BuyerID.Guid, &buyerkey, rc)
 	if err != nil {
 		return err
 	}

--- a/core/net.go
+++ b/core/net.go
@@ -255,7 +255,7 @@ func (n *OpenBazaarNode) SendOrderFulfillment(peerId string, fulfillmentMessage 
 	return n.sendMessage(peerId, nil, m)
 }
 
-func (n *OpenBazaarNode) SendOrderCompletion(peerId string, completionMessage *pb.RicardianContract) error {
+func (n *OpenBazaarNode) SendOrderCompletion(peerId string, k *libp2p.PubKey, completionMessage *pb.RicardianContract) error {
 	a, err := ptypes.MarshalAny(completionMessage)
 	if err != nil {
 		return err
@@ -267,7 +267,7 @@ func (n *OpenBazaarNode) SendOrderCompletion(peerId string, completionMessage *p
 	if err != nil {
 		return err
 	}
-	return n.sendMessage(peerId, nil, m)
+	return n.sendMessage(peerId, k, m)
 }
 
 func (n *OpenBazaarNode) SendDisputeOpen(peerId string, disputeMessage *pb.RicardianContract) error {

--- a/core/net.go
+++ b/core/net.go
@@ -243,7 +243,7 @@ func (n *OpenBazaarNode) SendRefund(peerId string, refundMessage *pb.RicardianCo
 	return n.sendMessage(peerId, &k, m)
 }
 
-func (n *OpenBazaarNode) SendOrderFulfillment(peerId string, fulfillmentMessage *pb.RicardianContract) error {
+func (n *OpenBazaarNode) SendOrderFulfillment(peerId string, k *libp2p.PubKey, fulfillmentMessage *pb.RicardianContract) error {
 	a, err := ptypes.MarshalAny(fulfillmentMessage)
 	if err != nil {
 		return err
@@ -252,7 +252,7 @@ func (n *OpenBazaarNode) SendOrderFulfillment(peerId string, fulfillmentMessage 
 		MessageType: pb.Message_ORDER_FULFILLMENT,
 		Payload:     a,
 	}
-	return n.sendMessage(peerId, nil, m)
+	return n.sendMessage(peerId, k, m)
 }
 
 func (n *OpenBazaarNode) SendOrderCompletion(peerId string, k *libp2p.PubKey, completionMessage *pb.RicardianContract) error {

--- a/core/net.go
+++ b/core/net.go
@@ -270,7 +270,7 @@ func (n *OpenBazaarNode) SendOrderCompletion(peerId string, k *libp2p.PubKey, co
 	return n.sendMessage(peerId, k, m)
 }
 
-func (n *OpenBazaarNode) SendDisputeOpen(peerId string, disputeMessage *pb.RicardianContract) error {
+func (n *OpenBazaarNode) SendDisputeOpen(peerId string, k *libp2p.PubKey, disputeMessage *pb.RicardianContract) error {
 	a, err := ptypes.MarshalAny(disputeMessage)
 	if err != nil {
 		return err
@@ -279,7 +279,7 @@ func (n *OpenBazaarNode) SendDisputeOpen(peerId string, disputeMessage *pb.Ricar
 		MessageType: pb.Message_DISPUTE_OPEN,
 		Payload:     a,
 	}
-	return n.sendMessage(peerId, nil, m)
+	return n.sendMessage(peerId, k, m)
 }
 
 func (n *OpenBazaarNode) SendDisputeUpdate(peerId string, updateMessage *pb.DisputeUpdate) error {

--- a/core/net.go
+++ b/core/net.go
@@ -294,7 +294,7 @@ func (n *OpenBazaarNode) SendDisputeUpdate(peerId string, updateMessage *pb.Disp
 	return n.sendMessage(peerId, nil, m)
 }
 
-func (n *OpenBazaarNode) SendDisputeClose(peerId string, resolutionMessage *pb.RicardianContract) error {
+func (n *OpenBazaarNode) SendDisputeClose(peerId string, k *libp2p.PubKey, resolutionMessage *pb.RicardianContract) error {
 	a, err := ptypes.MarshalAny(resolutionMessage)
 	if err != nil {
 		return err
@@ -303,7 +303,7 @@ func (n *OpenBazaarNode) SendDisputeClose(peerId string, resolutionMessage *pb.R
 		MessageType: pb.Message_DISPUTE_CLOSE,
 		Payload:     a,
 	}
-	return n.sendMessage(peerId, nil, m)
+	return n.sendMessage(peerId, k, m)
 	return nil
 }
 


### PR DESCRIPTION
This PR completes earlier work I did to change net functions to use public keys when they are known. Public keys for `SendOrderFulfillment`, `SendOrderCompletion`, `SendDisputeOpen`, `SendDisputeClose` can now be passed in; in all cases, the places where where they are called have access to contract holding the relevant public key (the only exception is `SendDisputeOpen` when sending to a moderator). 

The most obvious benefit of this is that a vendor can interact with a buyer who is not publishing their public key to ipfs; all interactions with the buyer now use the public key as provided in the initial BuyerOrder.

The only functions still forced to do an ipfs lookup are:
`SendChat`, `SendOfflineAck`, `Follow`, `Unfollow`, all of which are not connected to a contract holding a public key.
And `SendDisputeUpdate`, which only ever goes to the moderator; moderator public keys are not stored in contracts.