### PR TITLE
Fix defer and error check ordering

### DIFF
--- a/core/completion.go
+++ b/core/completion.go
@@ -322,10 +322,10 @@ func (n *OpenBazaarNode) ValidateAndSaveRating(contract *pb.RicardianContract) e
 
 		ratingPath := path.Join(n.RepoPath, "root", "ratings", "rating_"+mh.B58String()[:12])
 		f, err := os.Create(ratingPath)
-		defer f.Close()
 		if err != nil {
 			return err
 		}
+		defer f.Close()
 
 		_, werr := f.Write([]byte(ratingJson))
 		if werr != nil {

--- a/core/follow.go
+++ b/core/follow.go
@@ -20,10 +20,10 @@ func (n *OpenBazaarNode) UpdateFollow() error {
 		return err
 	}
 	f1, err := os.Create(followPath)
-	defer f1.Close()
 	if err != nil {
 		return err
 	}
+	defer f1.Close()
 
 	j, jerr := json.MarshalIndent(followers, "", "    ")
 	if jerr != nil {

--- a/core/listings.go
+++ b/core/listings.go
@@ -298,10 +298,10 @@ func (n *OpenBazaarNode) UpdateListingIndex(contract *pb.RicardianContract) erro
 
 	// Write it back to file
 	f, err := os.Create(indexPath)
-	defer f.Close()
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	j, jerr := json.MarshalIndent(index, "", "    ")
 	if jerr != nil {

--- a/core/profile.go
+++ b/core/profile.go
@@ -17,10 +17,10 @@ import (
 func (n *OpenBazaarNode) GetProfile() (pb.Profile, error) {
 	var profile pb.Profile
 	f, err := os.Open(path.Join(n.RepoPath, "root", "profile"))
-	defer f.Close()
 	if err != nil {
 		return profile, err
 	}
+	defer f.Close()
 	err = jsonpb.Unmarshal(f, &profile)
 	if err != nil {
 		return profile, err

--- a/openbazaard.go
+++ b/openbazaard.go
@@ -336,11 +336,11 @@ func (x *Start) Execute(args []string) error {
 		rand.Read(authBytes)
 		authCookie.Value = base58.Encode(authBytes)
 		f, err := os.Create(cookiePath)
-		defer f.Close()
 		if err != nil {
 			log.Error(err)
 			return err
 		}
+		defer f.Close()
 		cookie := cookiePrefix + authCookie.Value
 		_, werr := f.Write([]byte(cookie))
 		if werr != nil {

--- a/repo/db/cases.go
+++ b/repo/db/cases.go
@@ -175,10 +175,10 @@ func (c *CasesDB) GetAll() ([]string, error) {
 	defer c.lock.RUnlock()
 	stm := "select caseID from cases"
 	rows, err := c.db.Query(stm)
-	defer rows.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	var ret []string
 	for rows.Next() {
 		var orderID string

--- a/repo/db/inventory.go
+++ b/repo/db/inventory.go
@@ -44,10 +44,10 @@ func (i *InventoryDB) Get(slug string) (map[string]int, error) {
 	ret := make(map[string]int)
 	stm := `select * from inventory where slug like "` + slug + `%";`
 	rows, err := i.db.Query(stm)
-	defer rows.Close()
 	if err != nil {
 		return ret, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var slug string
 		var count int

--- a/repo/db/pointers.go
+++ b/repo/db/pointers.go
@@ -62,10 +62,10 @@ func (p *PointersDB) GetAll() ([]ipfs.Pointer, error) {
 	defer p.lock.RUnlock()
 	stm := "select * from pointers"
 	rows, err := p.db.Query(stm)
-	defer rows.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	var ret []ipfs.Pointer
 	for rows.Next() {
 		var pointerID string

--- a/repo/db/purchases.go
+++ b/repo/db/purchases.go
@@ -122,10 +122,10 @@ func (p *PurchasesDB) GetAll() ([]string, error) {
 	defer p.lock.RUnlock()
 	stm := "select orderID from purchases"
 	rows, err := p.db.Query(stm)
-	defer rows.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	var ret []string
 	for rows.Next() {
 		var orderID string

--- a/repo/db/sales.go
+++ b/repo/db/sales.go
@@ -123,10 +123,10 @@ func (s *SalesDB) GetAll() ([]string, error) {
 	defer s.lock.RUnlock()
 	stm := "select orderID from sales"
 	rows, err := s.db.Query(stm)
-	defer rows.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	var ret []string
 	for rows.Next() {
 		var orderID string

--- a/repo/db/stxo.go
+++ b/repo/db/stxo.go
@@ -21,11 +21,11 @@ func (s *StxoDB) Put(stxo spvwallet.Stxo) error {
 	defer s.lock.Unlock()
 	tx, _ := s.db.Begin()
 	stmt, err := tx.Prepare("insert or replace into stxos(outpoint, value, height, scriptPubKey, spendHeight, spendTxid) values(?,?,?,?,?,?)")
-	defer stmt.Close()
 	if err != nil {
 		tx.Rollback()
 		return err
 	}
+	defer stmt.Close()
 	outpoint := stxo.Utxo.Op.Hash.String() + ":" + strconv.Itoa(int(stxo.Utxo.Op.Index))
 	_, err = stmt.Exec(outpoint, int(stxo.Utxo.Value), int(stxo.Utxo.AtHeight), hex.EncodeToString(stxo.Utxo.ScriptPubkey), int(stxo.SpendHeight), stxo.SpendTxid.String())
 	if err != nil {

--- a/repo/db/txns.go
+++ b/repo/db/txns.go
@@ -22,11 +22,11 @@ func (t *TxnsDB) Put(txn *wire.MsgTx, value, height int) error {
 		return err
 	}
 	stmt, err := tx.Prepare("insert or replace into txns(txid, value, height, tx) values(?,?,?,?)")
-	defer stmt.Close()
 	if err != nil {
 		tx.Rollback()
 		return err
 	}
+	defer stmt.Close()
 	var buf bytes.Buffer
 	txn.Serialize(&buf)
 	_, err = stmt.Exec(txn.TxHash().String(), value, height, buf.Bytes())

--- a/repo/db/utxos.go
+++ b/repo/db/utxos.go
@@ -21,11 +21,11 @@ func (u *UtxoDB) Put(utxo spvwallet.Utxo) error {
 	defer u.lock.Unlock()
 	tx, _ := u.db.Begin()
 	stmt, err := tx.Prepare("insert or replace into utxos(outpoint, value, height, scriptPubKey, freeze) values(?,?,?,?,?)")
-	defer stmt.Close()
 	if err != nil {
 		tx.Rollback()
 		return err
 	}
+	defer stmt.Close()
 	freezeInt := 0
 	if utxo.Freeze {
 		freezeInt = 1

--- a/repo/db/watched_scripts.go
+++ b/repo/db/watched_scripts.go
@@ -16,11 +16,11 @@ func (w *WatchedScriptsDB) Put(scriptPubKey []byte) error {
 	defer w.lock.Unlock()
 	tx, _ := w.db.Begin()
 	stmt, err := tx.Prepare("insert or replace into watchedscripts(scriptPubKey) values(?)")
-	defer stmt.Close()
 	if err != nil {
 		tx.Rollback()
 		return err
 	}
+	defer stmt.Close()
 	_, err = stmt.Exec(hex.EncodeToString(scriptPubKey))
 	if err != nil {
 		tx.Rollback()

--- a/storage/selfhosted/selfhostedstorage.go
+++ b/storage/selfhosted/selfhostedstorage.go
@@ -34,10 +34,10 @@ func (s *SelfHostedStorage) Store(peerID peer.ID, ciphertext []byte) (ma.Multiad
 	hash := hex.EncodeToString(b[:])
 	filePath := path.Join(s.repoPath, "outbox", hash)
 	f, err := os.Create(filePath)
-	defer f.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 	_, ferr := f.Write(ciphertext)
 	if ferr != nil {
 		return nil, ferr


### PR DESCRIPTION
Felt like some regex today, so fixed #211 with this one:

```bash
find -name '*.go' -not -path 'vendors/*' -exec perl -i -p0e \
    's/(defer [a-zA-Z0-9]+.Close\(\)\n)(\s+)(if err != nil \{.*?\}\n)/\3\2\1/s' \
    {} \;
```
😃 