### PR TITLE
Add a max of 70 characters to the coupon code.

### DIFF
--- a/core/listings.go
+++ b/core/listings.go
@@ -890,8 +890,8 @@ func validateListing(listing *pb.Listing) (err error) {
 			return fmt.Errorf("Coupon title length must be less than the max of %d", SentenceMaxCharacters)
 		}
 		if len(coupon.GetDiscountCode()) > SentenceMaxCharacters {
-            return fmt.Errorf("Coupon code length must be less than the max of %d", SentenceMaxCharacters)
-        }
+			return fmt.Errorf("Coupon code length must be less than the max of %d", SentenceMaxCharacters)
+		}
 		if coupon.GetPercentDiscount() > 100 {
 			return errors.New("Percent discount cannot be over 100 percent")
 		}

--- a/core/listings.go
+++ b/core/listings.go
@@ -889,6 +889,9 @@ func validateListing(listing *pb.Listing) (err error) {
 		if len(coupon.Title) > SentenceMaxCharacters {
 			return fmt.Errorf("Coupon title length must be less than the max of %d", SentenceMaxCharacters)
 		}
+		if len(coupon.GetDiscountCode()) > SentenceMaxCharacters {
+            return fmt.Errorf("Coupon code length must be less than the max of %d", SentenceMaxCharacters)
+        }
 		if coupon.GetPercentDiscount() > 100 {
 			return errors.New("Percent discount cannot be over 100 percent")
 		}

--- a/core/listings.go
+++ b/core/listings.go
@@ -32,6 +32,7 @@ const (
 	MaxCategories            = 10
 	MaxListItems             = 30
 	FilenameMaxCharacters    = 255
+	CodeMaxCharacters        = 20
 	WordMaxCharacters        = 40
 	SentenceMaxCharacters    = 70
 	PolicyMaxCharacters      = 10000
@@ -889,8 +890,8 @@ func validateListing(listing *pb.Listing) (err error) {
 		if len(coupon.Title) > SentenceMaxCharacters {
 			return fmt.Errorf("Coupon title length must be less than the max of %d", SentenceMaxCharacters)
 		}
-		if len(coupon.GetDiscountCode()) > SentenceMaxCharacters {
-			return fmt.Errorf("Coupon code length must be less than the max of %d", SentenceMaxCharacters)
+		if len(coupon.GetDiscountCode()) > CodeMaxCharacters {
+			return fmt.Errorf("Coupon code length must be less than the max of %d", CodeMaxCharacters)
 		}
 		if coupon.GetPercentDiscount() > 100 {
 			return errors.New("Percent discount cannot be over 100 percent")


### PR DESCRIPTION
The coupon code should have a maximum, otherwise users can add very long strings (I tested with two paragraphs of lorem ipsum). 

This sets the max to 20.

If this PR is accepted, we will need to do the same validation on the client.