### PR TITLE
Listen on websocket transport

### DIFF
--- a/openbazaard.go
+++ b/openbazaard.go
@@ -481,9 +481,6 @@ func (x *Start) Execute(args []string) error {
 		return err
 	}
 	onionAddrString := "/onion/" + onionAddr + ":4003"
-	// add websocket support for browser peers
-	cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip4/0.0.0.0/tcp/9005/ws")
-	cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip6/::/tcp/9005/ws")
 	if x.Tor {
 		cfg.Addresses.Swarm = []string{}
 		cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, onionAddrString)

--- a/openbazaard.go
+++ b/openbazaard.go
@@ -481,6 +481,9 @@ func (x *Start) Execute(args []string) error {
 		return err
 	}
 	onionAddrString := "/onion/" + onionAddr + ":4003"
+	// add websocket support for browser peers
+	cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip4/0.0.0.0/tcp/9005/ws")
+	cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip6/::/tcp/9005/ws")
 	if x.Tor {
 		cfg.Addresses.Swarm = []string{}
 		cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, onionAddrString)
@@ -489,9 +492,9 @@ func (x *Start) Execute(args []string) error {
 		cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, onionAddrString)
 		cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip4/0.0.0.0/tcp/4001")
 		cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip6/::/tcp/4001")
+		cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip6/::/tcp/9005/ws")
+		cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip4/0.0.0.0/tcp/9005/ws")
 	}
-	cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip4/0.0.0.0/tcp/9005/ws")
-	cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip6/::/tcp/9005/ws")
 	// Iterate over our address and process them as needed
 	var onionTransport *torOnion.OnionTransport
 	var torDialer proxy.Dialer

--- a/openbazaard.go
+++ b/openbazaard.go
@@ -490,7 +490,8 @@ func (x *Start) Execute(args []string) error {
 		cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip4/0.0.0.0/tcp/4001")
 		cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip6/::/tcp/4001")
 	}
-
+	cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip4/0.0.0.0/tcp/9005/ws")
+	cfg.Addresses.Swarm = append(cfg.Addresses.Swarm, "/ip6/::/tcp/9005/ws")
 	// Iterate over our address and process them as needed
 	var onionTransport *torOnion.OnionTransport
 	var torDialer proxy.Dialer

--- a/repo/config.go
+++ b/repo/config.go
@@ -207,7 +207,9 @@ func InitConfig(repoRoot string) (*config.Config, error) {
 		Addresses: config.Addresses{
 			Swarm: []string{
 				"/ip4/0.0.0.0/tcp/4001",
+				"/ip4/0.0.0.0/tcp/9005/ws",
 				"/ip6/::/tcp/4001",
+				"/ip6/::/tcp/9005/ws",
 			},
 			API:     "",
 			Gateway: "/ip4/127.0.0.1/tcp/4002",


### PR DESCRIPTION
The ipfs websocket transport allows the browser to connect directly to ipfs nodes for online communication. The ipfs basichost has this transport enabled by default, but we need to add the relevant address to the swarm. This means that Duo browser clients, or anyone else for that matter, can engage in online comms. I am in the process of testing this and have already had a lot of success sending messages from js to an OB node with this websocket address enabled. This will greatly improve the usability of browser clients.

Fortunately, we can enable this transport in two lines!