### PR TITLE
Reduce default prefix length to 14 bits

### DIFF
--- a/core/net.go
+++ b/core/net.go
@@ -16,6 +16,7 @@ import (
 const (
 	CHAT_MESSAGE_MAX_CHARACTERS = 20000
 	CHAT_SUBJECT_MAX_CHARACTERS = 500
+	DefaultPointerPrefixLength  = 14
 )
 
 func (n *OpenBazaarNode) sendMessage(peerId string, k *libp2p.PubKey, message pb.Message) error {
@@ -70,7 +71,7 @@ func (n *OpenBazaarNode) SendOfflineMessage(p peer.ID, k *libp2p.PubKey, m *pb.M
 	}
 	/* TODO: We are just using a default prefix length for now. Eventually we will want to customize this,
 	   but we will need some way to get the recipient's desired prefix length. Likely will be in profile. */
-	pointer, err := ipfs.PublishPointer(n.IpfsNode, ctx, mh, 16, addr)
+	pointer, err := ipfs.PublishPointer(n.IpfsNode, ctx, mh, DefaultPointerPrefixLength, addr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Reasons for reducing the prefix length to 14 bits:

* Increase deniability (Realistically the network will grow to less than 100,000 active nodes within the first year. Using 16 bits gives a very poor deniability ratio of 100,000/2^16 < 1!)
* Maintain room for growth (I am assuming nodes can bear an 8-to-1 deniability ratio. With 14 bits, that means the network can grow to 8*2^14 = 131,072 active users before the default prefix length will need changing. This is at least one year after launch.)
* It reduces the number of prefixes which makes DHT crawling for prefixes significantly easier for partners such as Duo.