### PR TITLE
Only send read message if read status changes

### DIFF
--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -906,7 +906,7 @@ func (service *OpenBazaarService) handleChat(p peer.ID, pmes *pb.Message, option
 			MessageId: chat.MessageId,
 		}
 		service.broadcast <- n
-		_, err = service.datastore.Chat().MarkAsRead(p.Pretty(), chat.Subject, true, chat.MessageId)
+		_, _, err = service.datastore.Chat().MarkAsRead(p.Pretty(), chat.Subject, true, chat.MessageId)
 		if err != nil {
 			return nil, err
 		}

--- a/repo/config.go
+++ b/repo/config.go
@@ -207,8 +207,8 @@ func InitConfig(repoRoot string) (*config.Config, error) {
 		Addresses: config.Addresses{
 			Swarm: []string{
 				"/ip4/0.0.0.0/tcp/4001",
-				"/ip4/0.0.0.0/tcp/9005/ws",
 				"/ip6/::/tcp/4001",
+				"/ip4/0.0.0.0/tcp/9005/ws",
 				"/ip6/::/tcp/9005/ws",
 			},
 			API:     "",

--- a/repo/datastore.go
+++ b/repo/datastore.go
@@ -225,9 +225,10 @@ type Chat interface {
 	// A list of messages given a peer ID and a subject
 	GetMessages(peerID string, subject string, offsetID string, limit int) []ChatMessage
 
-	// Mark all chat messages for a peer as read. Returns the Id of the last seen message.
+	// Mark all chat messages for a peer as read. Returns the Id of the last seen message and
+	// whether any messages were updated.
 	// If message Id is specified it will only mark that message and earlier as read.
-	MarkAsRead(peerID string, subject string, outgoing bool, messageId string) (string, error)
+	MarkAsRead(peerID string, subject string, outgoing bool, messageId string) (string, bool, error)
 
 	// Delete a message
 	DeleteMessage(msgID string) error

--- a/repo/db/chat.go
+++ b/repo/db/chat.go
@@ -150,44 +150,63 @@ func (c *ChatDB) GetMessages(peerID string, subject string, offsetId string, lim
 	return ret
 }
 
-func (c *ChatDB) MarkAsRead(peerID string, subject string, outgoing bool, messageId string) (string, error) {
+func (c *ChatDB) MarkAsRead(peerID string, subject string, outgoing bool, messageId string) (string, bool, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	updated := false
 	outgoingInt := 0
 	if outgoing {
 		outgoingInt = 1
 	}
 	tx, err := c.db.Begin()
 	if err != nil {
-		return "", err
+		return "", updated, err
 	}
 	var stmt *sql.Stmt
 	if messageId != "" {
 		stmt, _ = tx.Prepare("update chat set read=1 where peerID=? and subject=? and outgoing=? and timestamp<=(select timestamp from chat where messageID=?)")
+		stm := "select messageID from chat where peerID=? and subject=? and outgoing=? and read=0 and timestamp<=(select timestamp from chat where messageID=?)"
+		rows, err := c.db.Query(stm, peerID, subject, outgoingInt, messageId)
+		if err != nil {
+			return "", updated, err
+		}
+		for rows.Next() {
+			updated = true
+			break
+		}
 		_, err = stmt.Exec(peerID, subject, outgoingInt, messageId)
 	} else {
+		stm := "select messageID from chat where peerID=? and subject=? and outgoing=? and read=0"
+		rows, err := c.db.Query(stm, peerID, subject, outgoingInt)
+		if err != nil {
+			return "", updated, err
+		}
+		for rows.Next() {
+			updated = true
+			break
+		}
 		stmt, _ = tx.Prepare("update chat set read=1 where peerID=? and subject=? and outgoing=?")
 		_, err = stmt.Exec(peerID, subject, outgoingInt)
 	}
 	defer stmt.Close()
 	if err != nil {
 		tx.Rollback()
-		return "", err
+		return "", updated, err
 	}
 	tx.Commit()
 
 	stmt2, err := c.db.Prepare("select max(timestamp), messageID from chat where peerID=? and subject=? and outgoing=?")
 	if err != nil {
-		return "", err
+		return "", updated, err
 	}
 	defer stmt2.Close()
 	var ts int
 	var msgId string
 	err = stmt2.QueryRow(peerID, subject, outgoingInt).Scan(&ts, &msgId)
 	if err != nil {
-		return "", err
+		return "", updated, err
 	}
-	return msgId, nil
+	return msgId, updated, nil
 }
 
 func (c *ChatDB) DeleteMessage(msgID string) error {

--- a/repo/db/chat.go
+++ b/repo/db/chat.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"database/sql"
-	"fmt"
 	"github.com/OpenBazaar/openbazaar-go/repo"
 	"strconv"
 	"sync"
@@ -163,15 +162,13 @@ func (c *ChatDB) MarkAsRead(peerID string, subject string, outgoing bool, messag
 	var tx *sql.Tx
 	var err error
 	if messageId != "" {
-		stm := "select messageID from chat where peerID=? and subject=? and outgoing=? and read=0 and timestamp<=(select timestamp from chat where messageID=?)"
+		stm := "select messageID from chat where peerID=? and subject=? and outgoing=? and read=0 and timestamp<=(select timestamp from chat where messageID=?) limit 1"
 		rows, err := c.db.Query(stm, peerID, subject, outgoingInt, messageId)
 		if err != nil {
-			fmt.Println("***", err)
 			return "", updated, err
 		}
-		for rows.Next() {
+		if rows.Next() {
 			updated = true
-			break
 		}
 		rows.Close()
 		tx, err = c.db.Begin()
@@ -181,15 +178,13 @@ func (c *ChatDB) MarkAsRead(peerID string, subject string, outgoing bool, messag
 		stmt, _ = tx.Prepare("update chat set read=1 where peerID=? and subject=? and outgoing=? and timestamp<=(select timestamp from chat where messageID=?)")
 		_, err = stmt.Exec(peerID, subject, outgoingInt, messageId)
 	} else {
-		stm := "select messageID from chat where peerID=? and subject=? and outgoing=? and read=0"
+		stm := "select messageID from chat where peerID=? and subject=? and outgoing=? and read=0 limit 1"
 		rows, err := c.db.Query(stm, peerID, subject, outgoingInt)
 		if err != nil {
-			fmt.Println("***", err)
 			return "", updated, err
 		}
-		for rows.Next() {
+		if rows.Next() {
 			updated = true
-			break
 		}
 		rows.Close()
 		tx, err = c.db.Begin()

--- a/repo/db/chat_test.go
+++ b/repo/db/chat_test.go
@@ -199,9 +199,12 @@ func TestChatDB_MarkAsRead(t *testing.T) {
 		t.Error("Returned incorrect number of messages")
 		return
 	}
-	last, err := chdb.MarkAsRead("abc", "", true, "")
+	last, updated, err := chdb.MarkAsRead("abc", "", true, "")
 	if err != nil {
 		t.Error(err)
+	}
+	if !updated {
+		t.Error("Updated bool returned incorrectly")
 	}
 	stmt, err := chdb.db.Prepare("select read from chat where messageID=?")
 	defer stmt.Close()
@@ -225,9 +228,12 @@ func TestChatDB_MarkAsRead(t *testing.T) {
 	if read != 0 {
 		t.Error("Failed to mark message as read")
 	}
-	last, err = chdb.MarkAsRead("abc", "", false, "")
+	last, updated, err = chdb.MarkAsRead("abc", "", false, "")
 	if err != nil {
 		t.Error(err)
+	}
+	if !updated {
+		t.Error("Updated bool returned incorrectly")
 	}
 	stmt3, err := chdb.db.Prepare("select read from chat where messageID=?")
 	defer stmt3.Close()
@@ -241,9 +247,12 @@ func TestChatDB_MarkAsRead(t *testing.T) {
 	if last != "22222" {
 		t.Error("Returned incorrect last message Id")
 	}
-	_, err = chdb.MarkAsRead("xyz", "", true, "44444")
+	_, updated, err = chdb.MarkAsRead("xyz", "", true, "44444")
 	if err != nil {
 		t.Error(err)
+	}
+	if !updated {
+		t.Error("Updated bool returned incorrectly")
 	}
 	stm := `select read, messageID from chat where peerID="xyz"`
 	rows, _ := chdb.db.Query(stm)


### PR DESCRIPTION
To prevent the server from sending read messages to the other chat party if the
UI calls MarkChatAsRead more than once, let's check to make sure the status
changed before sending the message.