### PR TITLE
Validate peer ID before deleting pointer

### DIFF
--- a/core/moderation.go
+++ b/core/moderation.go
@@ -64,7 +64,7 @@ func (n *OpenBazaarNode) SetSelfAsModerator(moderator *pb.Moderator) error {
 	}
 
 	// Publish pointer
-	pointers, err := n.Datastore.Pointers().Get(ipfs.MODERATOR)
+	pointers, err := n.Datastore.Pointers().GetByPurpose(ipfs.MODERATOR)
 	ctx := context.Background()
 	if err != nil || len(pointers) == 0 {
 		b, err := multihash.Encode([]byte(n.IpfsNode.Identity.Pretty()), multihash.SHA1)

--- a/core/net.go
+++ b/core/net.go
@@ -77,6 +77,7 @@ func (n *OpenBazaarNode) SendOfflineMessage(p peer.ID, k *libp2p.PubKey, m *pb.M
 	}
 	if m.MessageType != pb.Message_OFFLINE_ACK {
 		pointer.Purpose = ipfs.MESSAGE
+		pointer.CancelID = &p
 		err = n.Datastore.Pointers().Put(pointer)
 		if err != nil {
 			return err

--- a/ipfs/pointers.go
+++ b/ipfs/pointers.go
@@ -45,6 +45,7 @@ type Pointer struct {
 	Value     ps.PeerInfo
 	Purpose   Purpose
 	Timestamp time.Time
+	CancelID  *peer.ID
 }
 
 func PublishPointer(node *core.IpfsNode, ctx context.Context, mhKey multihash.Multihash, prefixLen int, addr ma.Multiaddr) (Pointer, error) {

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -103,9 +103,12 @@ func (service *OpenBazaarService) handleOfflineAck(p peer.ID, pmes *pb.Message, 
 	if err != nil {
 		return nil, err
 	}
-	_, err = service.datastore.Pointers().Get(pid)
+	pointer, err := service.datastore.Pointers().Get(pid)
 	if err != nil {
 		return nil, err
+	}
+	if pointer.CancelID == nil || pointer.CancelID.Pretty() != p.Pretty() {
+		return nil, errors.New("Peer is not authorized to delete pointer")
 	}
 	err = service.datastore.Pointers().Delete(pid)
 	if err != nil {

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -103,6 +103,10 @@ func (service *OpenBazaarService) handleOfflineAck(p peer.ID, pmes *pb.Message, 
 	if err != nil {
 		return nil, err
 	}
+	_, err = service.datastore.Pointers().Get(pid)
+	if err != nil {
+		return nil, err
+	}
 	err = service.datastore.Pointers().Delete(pid)
 	if err != nil {
 		return nil, err

--- a/repo/datastore.go
+++ b/repo/datastore.go
@@ -99,8 +99,11 @@ type Pointers interface {
 	// Delete all pointers of a given purpose
 	DeleteAll(purpose ipfs.Purpose) error
 
+	// Fetch a specific pointer
+	Get(id peer.ID) (ipfs.Pointer, error)
+
 	// Fetch all pointers of the given type
-	Get(purpose ipfs.Purpose) ([]ipfs.Pointer, error)
+	GetByPurpose(purpose ipfs.Purpose) ([]ipfs.Pointer, error)
 
 	// Fetch the entire list of pointers
 	GetAll() ([]ipfs.Pointer, error)

--- a/repo/db/db.go
+++ b/repo/db/db.go
@@ -276,7 +276,7 @@ func initDatabaseTables(db *sql.DB, password string) error {
 	create table followers (peerID text primary key not null);
 	create table following (peerID text primary key not null);
 	create table offlinemessages (url text primary key not null, timestamp integer);
-	create table pointers (pointerID text primary key not null, key text, address text, purpose integer, timestamp integer);
+	create table pointers (pointerID text primary key not null, key text, address text, cancelID text, purpose integer, timestamp integer);
 	create table keys (scriptPubKey text primary key not null, purpose integer, keyIndex integer, used integer, key text);
 	create table utxos (outpoint text primary key not null, value integer, height integer, scriptPubKey text, freeze int);
 	create table stxos (outpoint text primary key not null, value integer, height integer, scriptPubKey text, spendHeight integer, spendTxid text);


### PR DESCRIPTION
To prevent a malious peer from sending us an ACK to a message not intended for
him, thus causing us to prematurely stop re-publishing pointers, let's save
the recipient's ID in the db with the pointer and check it against the peer ID
when receiving and ACK.

closes #355