### PR TITLE
Reuse streams for all messaging

### DIFF
--- a/net/service/messagesender.go
+++ b/net/service/messagesender.go
@@ -1,0 +1,165 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	inet "gx/ipfs/QmQx1dHDDYENugYgqA22BaBrRfuv1coSsuPiM7rYh1wwGH/go-libp2p-net"
+	protocol "gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
+	peer "gx/ipfs/QmfMmLGoKzCHDN7cGgk64PJr4iipzidDRME8HABSJqvmhC/go-libp2p-peer"
+	"sync"
+	"time"
+
+	"github.com/OpenBazaar/openbazaar-go/pb"
+	ggio "github.com/gogo/protobuf/io"
+	proto "github.com/gogo/protobuf/proto"
+)
+
+type messageSender struct {
+	s         inet.Stream
+	r         ggio.ReadCloser
+	w         ggio.WriteCloser
+	lk        sync.Mutex
+	p         peer.ID
+	service   *OpenBazaarService
+	protoc    protocol.ID
+	singleMes int
+}
+
+var ReadMessageTimeout = time.Minute
+var ErrReadTimeout = fmt.Errorf("timed out reading response")
+
+func (service *OpenBazaarService) messageSenderForPeer(p peer.ID, s *inet.Stream) *messageSender {
+	service.senderlk.Lock()
+	defer service.senderlk.Unlock()
+
+	ms, ok := service.sender[p]
+	if !ok {
+		ms = service.newMessageSender(p)
+		service.sender[p] = ms
+	}
+	if s != nil {
+		// replace old stream
+		if ms.s != nil {
+			ms.s.Close()
+		}
+		ms.s = *s
+		ms.r = ggio.NewDelimitedReader(ms.s, inet.MessageSizeMax)
+		ms.w = ggio.NewDelimitedWriter(ms.s)
+	}
+	return ms
+}
+
+func (service *OpenBazaarService) newMessageSender(p peer.ID) *messageSender {
+	return &messageSender{p: p, service: service, protoc: ProtocolOpenBazaar}
+}
+
+func (ms *messageSender) prep() error {
+	if ms.s != nil {
+		return nil
+	}
+
+	nstr, err := ms.service.host.NewStream(ms.service.ctx, ms.p, ms.protoc)
+	if err != nil {
+		return err
+	}
+
+	ms.r = ggio.NewDelimitedReader(nstr, inet.MessageSizeMax)
+	ms.w = ggio.NewDelimitedWriter(nstr)
+	ms.s = nstr
+
+	return nil
+}
+
+// streamReuseTries is the number of times we will try to reuse a stream to a
+// given peer before giving up and reverting to the old one-message-per-stream
+// behaviour.
+const streamReuseTries = 3
+
+func (ms *messageSender) SendMessage(ctx context.Context, pmes proto.Message) error {
+	ms.lk.Lock()
+	defer ms.lk.Unlock()
+	if err := ms.prep(); err != nil {
+		return err
+	}
+
+	if err := ms.writeMessage(pmes); err != nil {
+		return err
+	}
+
+	if ms.singleMes > streamReuseTries {
+		ms.s.Close()
+		ms.s = nil
+	}
+
+	return nil
+}
+
+func (ms *messageSender) writeMessage(pmes proto.Message) error {
+	err := ms.w.WriteMsg(pmes)
+	if err != nil {
+		// If the other side isnt expecting us to be reusing streams, we're gonna
+		// end up erroring here. To make sure things work seamlessly, lets retry once
+		// before continuing
+
+		log.Infof("error writing message: ", err)
+		ms.s.Close()
+		ms.s = nil
+		if err := ms.prep(); err != nil {
+			return err
+		}
+
+		if err := ms.w.WriteMsg(pmes); err != nil {
+			return err
+		}
+
+		// keep track of this happening. If it happens a few times, its
+		// likely we can assume the otherside will never support stream reuse
+		ms.singleMes++
+	}
+	return nil
+}
+
+func (ms *messageSender) SendRequest(ctx context.Context, pmes *pb.Message) (*pb.Message, error) {
+	ms.lk.Lock()
+	defer ms.lk.Unlock()
+	if err := ms.prep(); err != nil {
+		return nil, err
+	}
+
+	if err := ms.writeMessage(pmes); err != nil {
+		return nil, err
+	}
+
+	mes := new(pb.Message)
+	if err := ms.ctxReadMsg(ctx, mes); err != nil {
+		ms.s.Close()
+		ms.s = nil
+		return nil, err
+	}
+
+	if ms.singleMes > streamReuseTries {
+		ms.s.Close()
+		ms.s = nil
+	}
+
+	return mes, nil
+}
+
+func (ms *messageSender) ctxReadMsg(ctx context.Context, mes *pb.Message) error {
+	errc := make(chan error, 1)
+	go func(r ggio.ReadCloser) {
+		errc <- r.ReadMsg(mes)
+	}(ms.r)
+
+	t := time.NewTimer(ReadMessageTimeout)
+	defer t.Stop()
+
+	select {
+	case err := <-errc:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return ErrReadTimeout
+	}
+}

--- a/net/service/messagesender.go
+++ b/net/service/messagesender.go
@@ -9,9 +9,10 @@ import (
 	"sync"
 	"time"
 
+	ggio "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/io"
+	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
+
 	"github.com/OpenBazaar/openbazaar-go/pb"
-	ggio "github.com/gogo/protobuf/io"
-	proto "github.com/gogo/protobuf/proto"
 )
 
 type messageSender struct {

--- a/net/service/service.go
+++ b/net/service/service.go
@@ -70,10 +70,7 @@ func (service *OpenBazaarService) handleNewMessage(s inet.Stream) {
 	// ensure the message sender for this peer is updated with this stream, so we reply over it
 	ms := service.messageSenderForPeer(mPeer, &s)
 	defer s.Close()
-	i := 0 // REMOVE
 	for {
-		log.Info("inbound stream reuse count:", i)
-		i++
 		// Receive msg
 		pmes := new(pb.Message)
 		if err := r.ReadMsg(pmes); err != nil {

--- a/net/service/service.go
+++ b/net/service/service.go
@@ -46,6 +46,7 @@ func New(node *core.OpenBazaarNode, ctx commands.Context, datastore repo.Datasto
 		broadcast: node.Broadcast,
 		datastore: datastore,
 		node:      node,
+		sender:    make(map[peer.ID]*messageSender),
 	}
 	node.IpfsNode.PeerHost.SetStreamHandler(ProtocolOpenBazaar, service.HandleNewStream)
 	log.Infof("OpenBazaar service running at %s", ProtocolOpenBazaar)

--- a/net/service/service.go
+++ b/net/service/service.go
@@ -9,6 +9,7 @@ import (
 	protocol "gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
 	ps "gx/ipfs/QmeXj9VAjmYQZxpmVz7VzccbJrpmr8qkCDSjfVNsPTWTYU/go-libp2p-peerstore"
 	peer "gx/ipfs/QmfMmLGoKzCHDN7cGgk64PJr4iipzidDRME8HABSJqvmhC/go-libp2p-peer"
+	"sync"
 
 	"github.com/OpenBazaar/openbazaar-go/core"
 	"github.com/OpenBazaar/openbazaar-go/pb"
@@ -31,6 +32,8 @@ type OpenBazaarService struct {
 	broadcast chan interface{}
 	datastore repo.Datastore
 	node      *core.OpenBazaarNode
+	sender    map[peer.ID]*messageSender
+	senderlk  sync.Mutex
 }
 
 func New(node *core.OpenBazaarNode, ctx commands.Context, datastore repo.Datastore) *OpenBazaarService {
@@ -59,71 +62,67 @@ func (service *OpenBazaarService) handleNewMessage(s inet.Stream) {
 	r := ggio.NewDelimitedReader(cr, inet.MessageSizeMax)
 	w := ggio.NewDelimitedWriter(cw)
 	mPeer := s.Conn().RemotePeer()
-
 	// Check if banned
 	if service.node.BanManager.IsBanned(mPeer) {
 		return
 	}
 
-	// Receive msg
+	// ensure the message sender for this peer is updated with this stream, so we reply over it
+	service.messageSenderForPeer(mPeer, &s)
 	defer s.Close()
-	pmes := new(pb.Message)
-	if err := r.ReadMsg(pmes); err != nil {
-		log.Errorf("Error unmarshaling data: %s", err)
-	}
+	i := 0 // REMOVE
+	for {
+		log.Info("inbound stream reuse count:", i)
+		i++
+		// Receive msg
+		pmes := new(pb.Message)
+		if err := r.ReadMsg(pmes); err != nil {
+			log.Errorf("Error unmarshaling data: %s", err)
+			return
+		}
 
-	// Get handler for this msg type
-	handler := service.HandlerForMsgType(pmes.MessageType)
-	if handler == nil {
-		log.Debug("Got back nil handler from handlerForMsgType")
-		return
-	}
+		// Get handler for this msg type
+		handler := service.HandlerForMsgType(pmes.MessageType)
+		if handler == nil {
+			log.Debug("Got back nil handler from handlerForMsgType")
+			return
+		}
 
-	// Dispatch handler
-	rpmes, err := handler(mPeer, pmes, nil)
-	if err != nil {
-		log.Debugf("handle message error: %s", err)
-		return
-	}
+		// Dispatch handler
+		rpmes, err := handler(mPeer, pmes, nil)
+		if err != nil {
+			log.Debugf("handle message error: %s", err)
+			return
+		}
 
-	// If nil response, return it before serializing
-	if rpmes == nil {
-		return
-	}
+		// If nil response, return it before serializing
+		if rpmes == nil {
+			continue
+		}
 
-	// Send out response msg
-	if err := w.WriteMsg(rpmes); err != nil {
-		log.Debugf("send response error: %s", err)
-		return
+		// Send out response msg
+		if err := w.WriteMsg(rpmes); err != nil {
+			log.Debugf("send response error: %s", err)
+			return
+		}
 	}
 }
 
 func (service *OpenBazaarService) SendRequest(ctx context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
 	log.Debugf("Sending %s request to %s", pmes.MessageType.String(), p.Pretty())
-	s, err := service.host.NewStream(ctx, p, ProtocolOpenBazaar)
+	ms := service.messageSenderForPeer(p, nil)
+
+	rpmes, err := ms.SendRequest(ctx, pmes)
 	if err != nil {
-		return nil, err
-	}
-	defer s.Close()
-
-	cr := ctxio.NewReader(ctx, s) // Ok to use. We defer close stream in this func.
-	cw := ctxio.NewWriter(ctx, s) // Ok to use. We defer close stream in this func.
-	r := ggio.NewDelimitedReader(cr, inet.MessageSizeMax)
-	w := ggio.NewDelimitedWriter(cw)
-
-	if err := w.WriteMsg(pmes); err != nil {
-		return nil, err
-	}
-
-	rpmes := new(pb.Message)
-	if err := r.ReadMsg(rpmes); err != nil {
 		log.Debugf("No response from %s", p.Pretty())
 		return nil, err
 	}
+
 	if rpmes == nil {
 		log.Debugf("No response from %s", p.Pretty())
 		return nil, errors.New("no response from peer")
 	}
+
 	log.Debugf("Received response from %s", p.Pretty())
 
 	return rpmes, nil
@@ -131,16 +130,9 @@ func (service *OpenBazaarService) SendRequest(ctx context.Context, p peer.ID, pm
 
 func (service *OpenBazaarService) SendMessage(ctx context.Context, p peer.ID, pmes *pb.Message) error {
 	log.Debugf("Sending %s message to %s", pmes.MessageType.String(), p.Pretty())
-	s, err := service.host.NewStream(ctx, p, ProtocolOpenBazaar)
-	if err != nil {
-		return err
-	}
-	defer s.Close()
+	ms := service.messageSenderForPeer(p, nil)
 
-	cw := ctxio.NewWriter(ctx, s) // Ok to use. We defer close stream in this func.
-	w := ggio.NewDelimitedWriter(cw)
-
-	if err := w.WriteMsg(pmes); err != nil {
+	if err := ms.SendMessage(ctx, pmes); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
As discussed with @cpacia, add a new mechanism for stream reuse; when a peer sends an online message to you, this stream is never closed (barring errors), and all future communication can go back and forth over this stream.

This means that the following groups can now receive online messages where previously they could not:
1. Users behind heavy nats
2. Users connecting from a browser implementation of libp2p 😉 

All they need to do is initiate a connection first, eg with a chat message. Given that it is mostly buyers with networking challenges, and mostly buyers initiating communications, this is a great solution.

The code is modelled (read: shamelessly taken) from the implementation of stream reuse used by the libp2p kademlia-dht implementation; all peers are assigned 'messageSender' objects which act as caretakers for the stream. The only difference is that in this implementation incoming streams will also be reused for outgoing messages to the same peer, while in dht the same outgoing stream is used repeatedly. You can see the libp2p implementation [here](https://github.com/libp2p/go-libp2p-kad-dht/blob/master/dht_net.go)

We could implement a timeout for streams, to save memory; however I am not sure I think this is worthwhile on desktop implementations, especially considering how worthwhile it is to be able to have duplex online communication many minutes after the inital connection, even behind a NAT. Furthermore, the DHT implementation connects to many more peers than OpenBazaar needs to, and has no timeout.