### PR TITLE
Add NewAddress wallet function

### DIFF
--- a/bitcoin/bitcoind/wallet.go
+++ b/bitcoin/bitcoind/wallet.go
@@ -164,6 +164,11 @@ func (w *BitcoindWallet) CurrentAddress(purpose spvwallet.KeyPurpose) btc.Addres
 	return addr
 }
 
+func (w *BitcoindWallet) NewAddress(purpose spvwallet.KeyPurpose) btc.Address {
+	addr, _ := w.rpcClient.GetNewAddress(Account)
+	return addr
+}
+
 func (w *BitcoindWallet) HasKey(addr btc.Address) bool {
 	_, err := w.rpcClient.DumpPrivKey(addr)
 	if err != nil {

--- a/bitcoin/wallet.go
+++ b/bitcoin/wallet.go
@@ -28,6 +28,9 @@ type BitcoinWallet interface {
 	// Get the current address for the given purpose
 	CurrentAddress(purpose spvwallet.KeyPurpose) btc.Address
 
+	// Returns a fresh address that has never been returned by this function
+	NewAddress(purpose spvwallet.KeyPurpose) btc.Address
+
 	// Returns if the wallet has the key for the given address
 	HasKey(addr btc.Address) bool
 

--- a/core/confirmation.go
+++ b/core/confirmation.go
@@ -27,7 +27,7 @@ func (n *OpenBazaarNode) NewOrderConfirmation(contract *pb.RicardianContract, ad
 	}
 	oc.OrderID = orderID
 	if addressRequest {
-		addr := n.Wallet.CurrentAddress(spvwallet.EXTERNAL)
+		addr := n.Wallet.NewAddress(spvwallet.EXTERNAL)
 		oc.PaymentAddress = addr.EncodeAddress()
 	}
 

--- a/repo/db/keys_test.go
+++ b/repo/db/keys_test.go
@@ -216,13 +216,16 @@ func TestGetUnsed(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		b := make([]byte, 32)
 		rand.Read(b)
-		err := kdb.Put(b, spvwallet.KeyPath{spvwallet.EXTERNAL, i})
+		err := kdb.Put(b, spvwallet.KeyPath{spvwallet.INTERNAL, i})
 		if err != nil {
 			t.Error(err)
 		}
 	}
-	idx, err := kdb.GetUnused(spvwallet.EXTERNAL)
-	if err != nil || idx != 0 {
+	idx, err := kdb.GetUnused(spvwallet.INTERNAL)
+	if err != nil {
+		t.Error("Failed to fetch correct unused")
+	}
+	if len(idx) != 100 {
 		t.Error("Failed to fetch correct unused")
 	}
 }

--- a/vendor/github.com/OpenBazaar/spvwallet/datastore.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/datastore.go
@@ -79,8 +79,8 @@ type Keys interface {
 	// Returns an imported private key given a script
 	GetKeyForScript(scriptPubKey []byte) (*btcec.PrivateKey, error)
 
-	// Get the first unused index for the given purpose
-	GetUnused(purpose KeyPurpose) (int, error)
+	// Get a list of unused key indexes for the given purpose
+	GetUnused(purpose KeyPurpose) ([]int, error)
 
 	// Fetch all key paths
 	GetAll() ([]KeyPath, error)

--- a/vendor/github.com/OpenBazaar/spvwallet/keys.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/keys.go
@@ -18,7 +18,10 @@ func (ts *TxStore) GetCurrentKey(purpose KeyPurpose) (*hd.ExtendedKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ts.generateChildKey(purpose, uint32(i))
+	if len(i) == 0 {
+		return nil, errors.New("No unused keys in database")
+	}
+	return ts.generateChildKey(purpose, uint32(i[0]))
 }
 
 func (ts *TxStore) GetFreshKey(purpose KeyPurpose) *hd.ExtendedKey {

--- a/vendor/github.com/OpenBazaar/spvwallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/wallet.go
@@ -175,6 +175,16 @@ func (w *SPVWallet) CurrentAddress(purpose KeyPurpose) btc.Address {
 	return btc.Address(addr)
 }
 
+func (w *SPVWallet) NewAddress(purpose KeyPurpose) btc.Address {
+	i, _ := w.txstore.Keys().GetUnused(EXTERNAL)
+	key, _ := w.txstore.generateChildKey(EXTERNAL, uint32(i[1]))
+	addr, _ := key.Address(w.params)
+	script, _ := txscript.PayToAddrScript(btc.Address(addr))
+	w.txstore.Keys().MarkKeyAsUsed(script)
+	w.txstore.PopulateAdrs()
+	return btc.Address(addr)
+}
+
 func (w *SPVWallet) HasKey(addr btc.Address) bool {
 	script, err := txscript.PayToAddrScript(addr)
 	if err != nil {


### PR DESCRIPTION
Orders need to go to a unique address in order for the listener to determine
what order they are for. This would normally be OK except scenarios where someone
has placed a direct order but hasn't paid (or two direct orders come in at the same time).

So we need a wallet function that returns a new address each time. Sadly this
can make it such that malicous buyers can place unfunded orders and run up
the size of the lookahead window in the keychain making it unlikely if not impossible
for all transactions will be detected when restoring from seed.

This can be fixed by either adding the lookahead window size to the config (TODO)
and implementing better DoS protection for unfunded orders.