### PR TITLE
enable multiplex stream muxer

### DIFF
--- a/openbazaard.go
+++ b/openbazaard.go
@@ -603,6 +603,9 @@ func (x *Start) Execute(args []string) error {
 	ncfg := &ipfscore.BuildCfg{
 		Repo:   r,
 		Online: true,
+		ExtraOpts: map[string]bool{
+			"mplex": true,
+		},
 	}
 
 	if onionTransport != nil {


### PR DESCRIPTION
This allows js ipfs nodes to connect to go-ipfs nodes, which paves the way for browser openbazaar implementations 😛 (spdy stream muxer doesn't work in js ipfs at the moment) . multiplex is already enabled by default in ipfs 0.4.7 in the daemon (ie when run from command line), but is not enabled in default repo config when using ipfs as a go import yet.