### PR TITLE
embrace timestamp conversion functions

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -36,7 +36,6 @@ import (
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/ipfs/go-ipfs/core/coreunix"
 	ipnspath "github.com/ipfs/go-ipfs/path"
 	lockfile "github.com/ipfs/go-ipfs/repo/fsrepo/lock"
@@ -1883,9 +1882,11 @@ func (i *jsonAPIHandler) GETCase(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := new(pb.CaseRespApi)
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = int64(date.Unix())
-	ts.Nanos = 0
+	ts, err := ptypes.TimestampProto(date)
+	if err != nil {
+		ErrorResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	resp.BuyerContract = buyerContract
 	resp.VendorContract = vendorContract
 	resp.BuyerOpened = buyerOpened
@@ -1895,6 +1896,7 @@ func (i *jsonAPIHandler) GETCase(w http.ResponseWriter, r *http.Request) {
 	resp.State = state
 	resp.Claim = claim
 	resp.Resolution = resolution
+	resp.Timestamp = ts
 
 	m := jsonpb.Marshaler{
 		EnumsAsInts:  false,

--- a/core/completion.go
+++ b/core/completion.go
@@ -21,7 +21,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	hd "github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/golang/protobuf/ptypes"
 )
 
 const (
@@ -57,9 +57,10 @@ func (n *OpenBazaarNode) CompleteOrder(orderRatings *OrderRatings, contract *pb.
 	oc.OrderId = orderId
 	oc.Ratings = []*pb.OrderCompletion_Rating{}
 
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
-	ts.Nanos = 0
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return err
+	}
 	oc.Timestamp = ts
 
 	for _, r := range orderRatings.Ratings {
@@ -90,9 +91,10 @@ func (n *OpenBazaarNode) CompleteOrder(orderRatings *OrderRatings, contract *pb.
 		rd.DeliverySpeed = uint32(r.DeliverySpeed)
 		rd.Review = r.Review
 
-		ts := new(timestamp.Timestamp)
-		ts.Seconds = time.Now().Unix()
-		ts.Nanos = 0
+		ts, err := ptypes.TimestampProto(time.Now())
+		if err != nil {
+			return err
+		}
 		rd.Timestamp = ts
 		rating.RatingData = rd
 

--- a/core/confirmation.go
+++ b/core/confirmation.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	crypto "gx/ipfs/QmPGxZ1DP2w45WcogpW1h43BvseXbfke9N91qotpoQcUeS/go-libp2p-crypto"
 
+	"time"
+
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/spvwallet"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -14,8 +16,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	hd "github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/timestamp"
-	"time"
+	"github.com/golang/protobuf/ptypes"
 )
 
 func (n *OpenBazaarNode) NewOrderConfirmation(contract *pb.RicardianContract, addressRequest bool) (*pb.RicardianContract, error) {
@@ -31,9 +32,10 @@ func (n *OpenBazaarNode) NewOrderConfirmation(contract *pb.RicardianContract, ad
 		oc.PaymentAddress = addr.EncodeAddress()
 	}
 
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
-	ts.Nanos = 0
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return nil, err
+	}
 	oc.Timestamp = ts
 
 	oc.RatingSignatures = []*pb.RatingSignature{}
@@ -154,9 +156,10 @@ func (n *OpenBazaarNode) RejectOfflineOrder(contract *pb.RicardianContract, reco
 	}
 	rejectMsg := new(pb.OrderReject)
 	rejectMsg.OrderID = orderId
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
-	ts.Nanos = 0
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return err
+	}
 	rejectMsg.Timestamp = ts
 	if contract.BuyerOrder.Payment.Method == pb.Order_Payment_MODERATED {
 		var ins []spvwallet.TransactionInput

--- a/core/disputes.go
+++ b/core/disputes.go
@@ -19,7 +19,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	hd "github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/ipfs/go-ipfs/routing/dht"
 	"golang.org/x/net/context"
 )
@@ -37,9 +37,10 @@ func (n *OpenBazaarNode) OpenDispute(orderID string, contract *pb.RicardianContr
 	dispute := new(pb.Dispute)
 
 	// Create timestamp
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
-	ts.Nanos = 0
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return err
+	}
 	dispute.Timestamp = ts
 
 	// Add claim
@@ -346,9 +347,10 @@ func (n *OpenBazaarNode) CloseDispute(orderId string, buyerPercentage, vendorPer
 	d := new(pb.DisputeResolution)
 
 	// Add timestamp
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
-	ts.Nanos = 0
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return err
+	}
 	d.Timestamp = ts
 
 	// Add orderId

--- a/core/fulfillment.go
+++ b/core/fulfillment.go
@@ -6,14 +6,15 @@ import (
 	"errors"
 	crypto "gx/ipfs/QmPGxZ1DP2w45WcogpW1h43BvseXbfke9N91qotpoQcUeS/go-libp2p-crypto"
 
+	"time"
+
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/spvwallet"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcutil"
 	hd "github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/timestamp"
-	"time"
+	"github.com/golang/protobuf/ptypes"
 )
 
 func (n *OpenBazaarNode) FulfillOrder(fulfillment *pb.OrderFulfillment, contract *pb.RicardianContract, records []*spvwallet.TransactionRecord) error {
@@ -97,9 +98,10 @@ func (n *OpenBazaarNode) FulfillOrder(fulfillment *pb.OrderFulfillment, contract
 		}
 	}
 
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
-	ts.Nanos = 0
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return err
+	}
 	fulfillment.Timestamp = ts
 
 	rs := new(pb.RatingSignature)

--- a/core/order.go
+++ b/core/order.go
@@ -5,6 +5,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	crypto "gx/ipfs/QmPGxZ1DP2w45WcogpW1h43BvseXbfke9N91qotpoQcUeS/go-libp2p-crypto"
+	peer "gx/ipfs/QmWUswjn261LSyVxWAEpMVtPdy8zmKBJJfBpG3Qdpa8ZsE/go-libp2p-peer"
+	mh "gx/ipfs/QmbZ6Cee2uHjG7hf19qLHppgKDRtaG4CVtMzdmK9VCVqLu/go-multihash"
+	"strings"
+	"time"
+
 	"github.com/OpenBazaar/jsonpb"
 	"github.com/OpenBazaar/openbazaar-go/ipfs"
 	"github.com/OpenBazaar/openbazaar-go/pb"
@@ -16,13 +22,7 @@ import (
 	hd "github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	ipfspath "github.com/ipfs/go-ipfs/path"
-	crypto "gx/ipfs/QmPGxZ1DP2w45WcogpW1h43BvseXbfke9N91qotpoQcUeS/go-libp2p-crypto"
-	peer "gx/ipfs/QmWUswjn261LSyVxWAEpMVtPdy8zmKBJJfBpG3Qdpa8ZsE/go-libp2p-peer"
-	mh "gx/ipfs/QmbZ6Cee2uHjG7hf19qLHppgKDRtaG4CVtMzdmK9VCVqLu/go-multihash"
-	"strings"
-	"time"
 )
 
 type option struct {
@@ -104,9 +104,10 @@ func (n *OpenBazaarNode) Purchase(data *PurchaseData) (orderId string, paymentAd
 	id.BitcoinSig = sig.Serialize()
 	order.BuyerID = id
 
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
-	ts.Nanos = 0
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return "", "", 0, false, err
+	}
 	order.Timestamp = ts
 	order.AlternateContactInfo = data.AlternateContactInfo
 

--- a/core/profile.go
+++ b/core/profile.go
@@ -12,7 +12,7 @@ import (
 	"github.com/OpenBazaar/jsonpb"
 	"github.com/OpenBazaar/openbazaar-go/ipfs"
 	"github.com/OpenBazaar/openbazaar-go/pb"
-	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/imdario/mergo"
 	ipnspath "github.com/ipfs/go-ipfs/path"
 )
@@ -148,9 +148,10 @@ func (n *OpenBazaarNode) appendCountsToProfile(profile *pb.Profile) (*pb.Profile
 	profile.FollowerCount = uint32(n.Datastore.Followers().Count())
 	profile.FollowingCount = uint32(n.Datastore.Following().Count())
 
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
-	ts.Nanos = 0
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return nil, err
+	}
 	profile.LastModified = ts
 	return profile, nil
 }

--- a/core/refunds.go
+++ b/core/refunds.go
@@ -4,14 +4,15 @@ import (
 	"encoding/hex"
 	"errors"
 
+	"time"
+
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/spvwallet"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcutil"
 	hd "github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/timestamp"
-	"time"
+	"github.com/golang/protobuf/ptypes"
 )
 
 func (n *OpenBazaarNode) RefundOrder(contract *pb.RicardianContract, records []*spvwallet.TransactionRecord) error {
@@ -21,9 +22,10 @@ func (n *OpenBazaarNode) RefundOrder(contract *pb.RicardianContract, records []*
 		return err
 	}
 	refundMsg.OrderID = orderId
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
-	ts.Nanos = 0
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return err
+	}
 	refundMsg.Timestamp = ts
 	if contract.BuyerOrder.Payment.Method == pb.Order_Payment_MODERATED {
 		var ins []spvwallet.TransactionInput

--- a/repo/db/cases_test.go
+++ b/repo/db/cases_test.go
@@ -3,12 +3,13 @@ package db
 import (
 	"bytes"
 	"database/sql"
-	"github.com/OpenBazaar/openbazaar-go/pb"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"gx/ipfs/QmT6n4mspWYEya864BhCUJEgyxiRfmiSY9ruQwTUNpRKaM/protobuf/proto"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/OpenBazaar/openbazaar-go/pb"
+	"github.com/golang/protobuf/ptypes"
 )
 
 var casesdb CasesDB
@@ -44,8 +45,10 @@ func init() {
 	shipping.Address = "1234 test ave."
 	shipping.ShipTo = "buyer name"
 	order.Shipping = shipping
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return
+	}
 	order.Timestamp = ts
 	payment := new(pb.Order_Payment)
 	payment.Amount = 10

--- a/repo/db/purchases_test.go
+++ b/repo/db/purchases_test.go
@@ -2,14 +2,15 @@ package db
 
 import (
 	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/spvwallet"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil"
-	"github.com/golang/protobuf/ptypes/timestamp"
-	"strings"
-	"testing"
-	"time"
+	"github.com/golang/protobuf/ptypes"
 )
 
 var purdb PurchasesDB
@@ -43,8 +44,10 @@ func init() {
 	shipping.Address = "1234 test ave."
 	shipping.ShipTo = "buyer name"
 	order.Shipping = shipping
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return
+	}
 	order.Timestamp = ts
 	payment := new(pb.Order_Payment)
 	payment.Amount = 10

--- a/repo/db/sales_test.go
+++ b/repo/db/sales_test.go
@@ -2,14 +2,15 @@ package db
 
 import (
 	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/spvwallet"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil"
-	"github.com/golang/protobuf/ptypes/timestamp"
-	"strings"
-	"testing"
-	"time"
+	"github.com/golang/protobuf/ptypes"
 )
 
 var saldb SalesDB
@@ -42,8 +43,10 @@ func init() {
 	shipping.Address = "1234 test ave."
 	shipping.ShipTo = "buyer name"
 	order.Shipping = shipping
-	ts := new(timestamp.Timestamp)
-	ts.Seconds = time.Now().Unix()
+	ts, err := ptypes.TimestampProto(time.Now())
+	if err != nil {
+		return
+	}
 	order.Timestamp = ts
 	payment := new(pb.Order_Payment)
 	payment.Amount = 10


### PR DESCRIPTION
this allows nanosecond granularity in message ids, which fixes the very regular message id collision errors