### PR TITLE
Return from stream handler on stream close

### DIFF
--- a/net/service/service.go
+++ b/net/service/service.go
@@ -75,10 +75,11 @@ func (service *OpenBazaarService) handleNewMessage(s inet.Stream) {
 		// Receive msg
 		pmes := new(pb.Message)
 		if err := r.ReadMsg(pmes); err != nil {
-			if err != io.EOF {
+			if err == io.EOF {
 				// EOF error means the sender closed the stream
-				log.Errorf("Error unmarshaling data: %s", err)
+				return
 			}
+			log.Errorf("Error unmarshaling data: %s", err)
 			continue
 		}
 


### PR DESCRIPTION
This prevents an infinite error loop if the counterparty closes the stream.