### PR TITLE
Don't close outbound streams

### DIFF
--- a/net/service/messagesender.go
+++ b/net/service/messagesender.go
@@ -69,7 +69,7 @@ func (ms *messageSender) prep() error {
 	if err != nil {
 		return err
 	}
-	ms.service.HandleNewStream(nstr)
+	go ms.service.handleNewMessage(nstr, false)
 
 	ms.w = ggio.NewDelimitedWriter(nstr)
 	ms.s = nstr


### PR DESCRIPTION
Apologies for yet another stream reuse fix. This prevents the closing of outbound streams after a message is sent.