### PR TITLE
Ignore deprecation warnings in sqlite3

### DIFF
--- a/vendor/github.com/mutecomm/go-sqlcipher/sqlite3.go
+++ b/vendor/github.com/mutecomm/go-sqlcipher/sqlite3.go
@@ -9,6 +9,7 @@ package sqlite3
 #cgo CFLAGS: -std=gnu99
 #cgo CFLAGS: -DSQLITE_ENABLE_RTREE -DSQLITE_THREADSAFE
 #cgo CFLAGS: -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4_UNICODE61
+#cgo CFLAGS: -Wno-deprecated-declarations -Wno-c99-extensions
 #include <sqlite3.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This should remove #224 even though it was already closed. 

An even better solution would be to update the vendored module for sqlite3 but this suppresses the warnings for now to remove confusion.