### PR TITLE
Use deterministic magic ids

### DIFF
--- a/core/moderation.go
+++ b/core/moderation.go
@@ -3,10 +3,6 @@ package core
 import (
 	"crypto/sha256"
 	"errors"
-	"github.com/OpenBazaar/jsonpb"
-	"github.com/OpenBazaar/openbazaar-go/ipfs"
-	"github.com/OpenBazaar/openbazaar-go/pb"
-	"golang.org/x/net/context"
 	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
 	multihash "gx/ipfs/QmbZ6Cee2uHjG7hf19qLHppgKDRtaG4CVtMzdmK9VCVqLu/go-multihash"
 	"io/ioutil"
@@ -14,6 +10,11 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/OpenBazaar/jsonpb"
+	"github.com/OpenBazaar/openbazaar-go/ipfs"
+	"github.com/OpenBazaar/openbazaar-go/pb"
+	"golang.org/x/net/context"
 )
 
 var ModeratorPointerID multihash.Multihash
@@ -79,7 +80,7 @@ func (n *OpenBazaarNode) SetSelfAsModerator(moderator *pb.Moderator) error {
 		if err != nil {
 			return err
 		}
-		pointer, err := ipfs.PublishPointer(n.IpfsNode, ctx, ModeratorPointerID, 64, addr)
+		pointer, err := ipfs.PublishPointer(n.IpfsNode, ctx, ModeratorPointerID, 64, addr, []byte(n.IpfsNode.Identity.Pretty()))
 		if err != nil {
 			return err
 		}

--- a/core/net.go
+++ b/core/net.go
@@ -71,7 +71,7 @@ func (n *OpenBazaarNode) SendOfflineMessage(p peer.ID, k *libp2p.PubKey, m *pb.M
 	}
 	/* TODO: We are just using a default prefix length for now. Eventually we will want to customize this,
 	   but we will need some way to get the recipient's desired prefix length. Likely will be in profile. */
-	pointer, err := ipfs.PublishPointer(n.IpfsNode, ctx, mh, DefaultPointerPrefixLength, addr)
+	pointer, err := ipfs.PublishPointer(n.IpfsNode, ctx, mh, DefaultPointerPrefixLength, addr, ciphertext)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
See #484, this has magic ids derived from the message ciphertext hash for offline messages, and the peerID for moderator pointers.