### PR TITLE
Add profile caching

### DIFF
--- a/core/profile.go
+++ b/core/profile.go
@@ -11,22 +11,22 @@ import (
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/imdario/mergo"
+	ipnspb "github.com/ipfs/go-ipfs/namesys/pb"
 	ipnspath "github.com/ipfs/go-ipfs/path"
 	ds "gx/ipfs/QmRWDav6mzWseLWeYfVd5fvUKiVe9xNH29YfMF438fG364/go-datastore"
+	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
 	u "gx/ipfs/QmZuY8aV7zbNXVy6DyN9SmnuH3o9nG852F4aTiSBpts8d1/go-ipfs-util"
 	mh "gx/ipfs/QmbZ6Cee2uHjG7hf19qLHppgKDRtaG4CVtMzdmK9VCVqLu/go-multihash"
-	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
-	ipnspb "github.com/ipfs/go-ipfs/namesys/pb"
 	"io/ioutil"
 	"os"
 	"path"
-	"time"
 	"strings"
+	"time"
 )
 
 const (
-	cachePrefix = "IPNSPERSISENTCACHE_"
-	CachedProfileTime   = time.Hour * 24 * 7
+	cachePrefix       = "IPNSPERSISENTCACHE_"
+	CachedProfileTime = time.Hour * 24 * 7
 )
 
 var ErrorProfileNotFound error = errors.New("Profile not found")
@@ -132,7 +132,7 @@ func (n *OpenBazaarNode) FetchProfile(peerId string, useCache bool) (pb.Profile,
 		if err != nil {
 			return
 		}
-		n.IpfsNode.Repo.Datastore().Put(ds.NewKey(cachePrefix + peerId), v)
+		n.IpfsNode.Repo.Datastore().Put(ds.NewKey(cachePrefix+peerId), v)
 	}()
 	return pro, nil
 }

--- a/core/profile.go
+++ b/core/profile.go
@@ -12,11 +12,21 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/imdario/mergo"
 	ipnspath "github.com/ipfs/go-ipfs/path"
+	ds "gx/ipfs/QmRWDav6mzWseLWeYfVd5fvUKiVe9xNH29YfMF438fG364/go-datastore"
+	u "gx/ipfs/QmZuY8aV7zbNXVy6DyN9SmnuH3o9nG852F4aTiSBpts8d1/go-ipfs-util"
 	mh "gx/ipfs/QmbZ6Cee2uHjG7hf19qLHppgKDRtaG4CVtMzdmK9VCVqLu/go-multihash"
+	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
+	ipnspb "github.com/ipfs/go-ipfs/namesys/pb"
 	"io/ioutil"
 	"os"
 	"path"
 	"time"
+	"strings"
+)
+
+const (
+	cachePrefix = "IPNSPERSISENTCACHE_"
+	CachedProfileTime   = time.Hour * 24 * 7
 )
 
 var ErrorProfileNotFound error = errors.New("Profile not found")
@@ -35,22 +45,107 @@ func (n *OpenBazaarNode) GetProfile() (pb.Profile, error) {
 	return profile, nil
 }
 
-func (n *OpenBazaarNode) FetchProfile(peerId string) (pb.Profile, error) {
-	profile, err := ipfs.ResolveThenCat(n.Context, ipnspath.FromString(path.Join(peerId, "profile")))
-	if err != nil || len(profile) == 0 {
-		return pb.Profile{}, err
+func (n *OpenBazaarNode) FetchProfile(peerId string, useCache bool) (pb.Profile, error) {
+	fetch := func(rootHash string) (pb.Profile, error) {
+		var pro pb.Profile
+		var profile []byte
+		var err error
+		if rootHash == "" {
+			profile, err = ipfs.ResolveThenCat(n.Context, ipnspath.FromString(path.Join(peerId, "profile")))
+			if err != nil || len(profile) == 0 {
+				return pro, err
+			}
+		} else {
+			profile, err = ipfs.Cat(n.Context, path.Join(rootHash, "profile"))
+			if err != nil || len(profile) == 0 {
+				return pro, err
+			}
+		}
+		err = jsonpb.UnmarshalString(string(profile), &pro)
+		if err != nil {
+			return pro, err
+		}
+		return pro, nil
 	}
+
 	var pro pb.Profile
-	err = jsonpb.UnmarshalString(string(profile), &pro)
-	if err != nil {
-		return pb.Profile{}, err
+	var err error
+	var recordAvailable bool
+	var val interface{}
+	if useCache {
+		val, err = n.IpfsNode.Repo.Datastore().Get(ds.NewKey(cachePrefix + peerId))
+		if err != nil { // No record in datastore
+			pro, err = fetch("")
+			if err != nil {
+				return pb.Profile{}, err
+			}
+		} else { // Record available, let's see how old it is
+			entry := new(ipnspb.IpnsEntry)
+			err = proto.Unmarshal(val.([]byte), entry)
+			if err != nil {
+				return pb.Profile{}, err
+			}
+			p, err := ipnspath.ParsePath(string(entry.GetValue()))
+			if err != nil {
+				return pb.Profile{}, err
+			}
+			eol, ok := checkEOL(entry)
+			if ok && eol.Before(time.Now()) { // Too old, fetch new profile
+				pro, err = fetch("")
+			} else { // Relatively new, we can do a standard IPFS query (which should be cached)
+				pro, err = fetch(strings.TrimPrefix(p.String(), "/ipfs/"))
+				// Let's now try to get the latest record in a new goroutine so it's available next time
+				go fetch("")
+			}
+			if err != nil {
+				return pb.Profile{}, err
+			}
+			recordAvailable = true
+		}
+	} else {
+		pro, err = fetch("")
+		if err != nil {
+			return pb.Profile{}, err
+		}
+		recordAvailable = false
 	}
 	/*TODO: re-enable when client adds support for this
 	if err := ValidateProfile(&pro); err != nil {
 		return pb.Profile{}, err
 	}
 	*/
+	// Update the record with a new EOL
+	go func() {
+		if !recordAvailable {
+			val, err = n.IpfsNode.Repo.Datastore().Get(ds.NewKey(cachePrefix + peerId))
+			if err != nil {
+				return
+			}
+		}
+		entry := new(ipnspb.IpnsEntry)
+		err = proto.Unmarshal(val.([]byte), entry)
+		if err != nil {
+			return
+		}
+		entry.Validity = []byte(u.FormatRFC3339(time.Now().Add(CachedProfileTime)))
+		v, err := proto.Marshal(entry)
+		if err != nil {
+			return
+		}
+		n.IpfsNode.Repo.Datastore().Put(ds.NewKey(cachePrefix + peerId), v)
+	}()
 	return pro, nil
+}
+
+func checkEOL(e *ipnspb.IpnsEntry) (time.Time, bool) {
+	if e.GetValidityType() == ipnspb.IpnsEntry_EOL {
+		eol, err := u.ParseRFC3339(string(e.GetValidity()))
+		if err != nil {
+			return time.Time{}, false
+		}
+		return eol, true
+	}
+	return time.Time{}, false
 }
 
 func (n *OpenBazaarNode) UpdateProfile(profile *pb.Profile) error {


### PR DESCRIPTION
Given the slow speed of ipns calls there are some places where we can probably
get away with loading a profile from cache.

This commit adds a `usecache` argument to the `FetchProfile()` function which will
load the last IPNS record from the datastore and use that in an IPFS cat call
(which should pull from the disk cache). At the same time a goroutine fires
fetching the most recent profile and updating the cache so that the next time
`FetchProfile()` is queried the cache will have the update. In this sense the `usecache`
argument returns a profile that is always one update behind (though given that
profiles don't update with high frequency most of the time it will be the latest).