### PR TITLE
Segwit prep: refactor keys db

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -13,7 +13,7 @@
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/spvwallet",
-			"Rev": "934645fbb1f1e66ecce4fb116d66d1f207001067"
+			"Rev": "d469e31117648b985fc901c5d10a00706bc44924"
 		},
 		{
 			"ImportPath": "github.com/boltdb/bolt",

--- a/api/notifier.go
+++ b/api/notifier.go
@@ -48,7 +48,7 @@ type notifier interface {
 func (m *notificationManager) sendNotification(n interface{}) {
 	for _, notifier := range m.getNotifiers() {
 		if err := notifier.notify(n); err != nil {
-			log.Errorf("Notification failed")
+			log.Errorf("Notification failed: %s", err.Error())
 		}
 	}
 }

--- a/repo/db/db.go
+++ b/repo/db/db.go
@@ -278,7 +278,7 @@ func initDatabaseTables(db *sql.DB, password string) error {
 	create table following (peerID text primary key not null);
 	create table offlinemessages (url text primary key not null, timestamp integer, message blob);
 	create table pointers (pointerID text primary key not null, key text, address text, cancelID text, purpose integer, timestamp integer);
-	create table keys (scriptPubKey text primary key not null, purpose integer, keyIndex integer, used integer, key text);
+	create table keys (scriptAddress text primary key not null, purpose integer, keyIndex integer, used integer, key text);
 	create table utxos (outpoint text primary key not null, value integer, height integer, scriptPubKey text, watchOnly integer);
 	create table stxos (outpoint text primary key not null, value integer, height integer, scriptPubKey text, watchOnly integer, spendHeight integer, spendTxid text);
 	create table txns (txid text primary key not null, value integer, height integer, timestamp integer, watchOnly integer, tx blob);

--- a/repo/db/keys.go
+++ b/repo/db/keys.go
@@ -15,16 +15,16 @@ type KeysDB struct {
 	lock sync.RWMutex
 }
 
-func (k *KeysDB) Put(scriptPubKey []byte, keyPath spvwallet.KeyPath) error {
+func (k *KeysDB) Put(scriptAddress []byte, keyPath spvwallet.KeyPath) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	tx, err := k.db.Begin()
 	if err != nil {
 		return err
 	}
-	stmt, _ := tx.Prepare("insert into keys(scriptPubKey, purpose, keyIndex, used) values(?,?,?,?)")
+	stmt, _ := tx.Prepare("insert into keys(scriptAddress, purpose, keyIndex, used) values(?,?,?,?)")
 	defer stmt.Close()
-	_, err = stmt.Exec(hex.EncodeToString(scriptPubKey), int(keyPath.Purpose), keyPath.Index, 0)
+	_, err = stmt.Exec(hex.EncodeToString(scriptAddress), int(keyPath.Purpose), keyPath.Index, 0)
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -33,16 +33,16 @@ func (k *KeysDB) Put(scriptPubKey []byte, keyPath spvwallet.KeyPath) error {
 	return nil
 }
 
-func (k *KeysDB) ImportKey(scriptPubKey []byte, key *btcec.PrivateKey) error {
+func (k *KeysDB) ImportKey(scriptAddress []byte, key *btcec.PrivateKey) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	tx, err := k.db.Begin()
 	if err != nil {
 		return err
 	}
-	stmt, _ := tx.Prepare("insert into keys(scriptPubKey, purpose, used, key) values(?,?,?,?)")
+	stmt, _ := tx.Prepare("insert into keys(scriptAddress, purpose, used, key) values(?,?,?,?)")
 	defer stmt.Close()
-	_, err = stmt.Exec(hex.EncodeToString(scriptPubKey), -1, 0, hex.EncodeToString(key.Serialize()))
+	_, err = stmt.Exec(hex.EncodeToString(scriptAddress), -1, 0, hex.EncodeToString(key.Serialize()))
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -51,17 +51,17 @@ func (k *KeysDB) ImportKey(scriptPubKey []byte, key *btcec.PrivateKey) error {
 	return nil
 }
 
-func (k *KeysDB) MarkKeyAsUsed(scriptPubKey []byte) error {
+func (k *KeysDB) MarkKeyAsUsed(scriptAddress []byte) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	tx, err := k.db.Begin()
 	if err != nil {
 		return err
 	}
-	stmt, _ := tx.Prepare("update keys set used=1 where scriptPubKey=?")
+	stmt, _ := tx.Prepare("update keys set used=1 where scriptAddress=?")
 
 	defer stmt.Close()
-	_, err = stmt.Exec(hex.EncodeToString(scriptPubKey))
+	_, err = stmt.Exec(hex.EncodeToString(scriptAddress))
 	if err != nil {
 		tx.Rollback()
 		return err
@@ -92,18 +92,18 @@ func (k *KeysDB) GetLastKeyIndex(purpose spvwallet.KeyPurpose) (int, bool, error
 	return index, used, nil
 }
 
-func (k *KeysDB) GetPathForScript(scriptPubKey []byte) (spvwallet.KeyPath, error) {
+func (k *KeysDB) GetPathForKey(scriptAddress []byte) (spvwallet.KeyPath, error) {
 	k.lock.RLock()
 	defer k.lock.RUnlock()
 
-	stmt, err := k.db.Prepare("select purpose, keyIndex from keys where scriptPubKey=?")
+	stmt, err := k.db.Prepare("select purpose, keyIndex from keys where scriptAddress=?")
 	if err != nil {
 		return spvwallet.KeyPath{}, err
 	}
 	defer stmt.Close()
 	var purpose int
 	var index int
-	err = stmt.QueryRow(hex.EncodeToString(scriptPubKey)).Scan(&purpose, &index)
+	err = stmt.QueryRow(hex.EncodeToString(scriptAddress)).Scan(&purpose, &index)
 	if err != nil {
 		return spvwallet.KeyPath{}, errors.New("Key not found")
 	}
@@ -114,17 +114,17 @@ func (k *KeysDB) GetPathForScript(scriptPubKey []byte) (spvwallet.KeyPath, error
 	return p, nil
 }
 
-func (k *KeysDB) GetKeyForScript(scriptPubKey []byte) (*btcec.PrivateKey, error) {
+func (k *KeysDB) GetKey(scriptAddress []byte) (*btcec.PrivateKey, error) {
 	k.lock.Lock()
 	defer k.lock.Unlock()
 
-	stmt, err := k.db.Prepare("select key from keys where scriptPubKey=? and purpose=-1")
+	stmt, err := k.db.Prepare("select key from keys where scriptAddress=? and purpose=-1")
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
 	var keyHex string
-	err = stmt.QueryRow(hex.EncodeToString(scriptPubKey)).Scan(&keyHex)
+	err = stmt.QueryRow(hex.EncodeToString(scriptAddress)).Scan(&keyHex)
 	if err != nil {
 		return nil, errors.New("Key not found")
 	}

--- a/repo/db/keys.go
+++ b/repo/db/keys.go
@@ -22,7 +22,10 @@ func (k *KeysDB) Put(scriptAddress []byte, keyPath spvwallet.KeyPath) error {
 	if err != nil {
 		return err
 	}
-	stmt, _ := tx.Prepare("insert into keys(scriptAddress, purpose, keyIndex, used) values(?,?,?,?)")
+	stmt, err := tx.Prepare("insert into keys(scriptAddress, purpose, keyIndex, used) values(?,?,?,?)")
+	if err != nil {
+		return err
+	}
 	defer stmt.Close()
 	_, err = stmt.Exec(hex.EncodeToString(scriptAddress), int(keyPath.Purpose), keyPath.Index, 0)
 	if err != nil {
@@ -40,7 +43,10 @@ func (k *KeysDB) ImportKey(scriptAddress []byte, key *btcec.PrivateKey) error {
 	if err != nil {
 		return err
 	}
-	stmt, _ := tx.Prepare("insert into keys(scriptAddress, purpose, used, key) values(?,?,?,?)")
+	stmt, err := tx.Prepare("insert into keys(scriptAddress, purpose, used, key) values(?,?,?,?)")
+	if err != nil {
+		return err
+	}
 	defer stmt.Close()
 	_, err = stmt.Exec(hex.EncodeToString(scriptAddress), -1, 0, hex.EncodeToString(key.Serialize()))
 	if err != nil {
@@ -58,7 +64,10 @@ func (k *KeysDB) MarkKeyAsUsed(scriptAddress []byte) error {
 	if err != nil {
 		return err
 	}
-	stmt, _ := tx.Prepare("update keys set used=1 where scriptAddress=?")
+	stmt, err := tx.Prepare("update keys set used=1 where scriptAddress=?")
+	if err != nil {
+		return err
+	}
 
 	defer stmt.Close()
 	_, err = stmt.Exec(hex.EncodeToString(scriptAddress))

--- a/repo/db/keys_test.go
+++ b/repo/db/keys_test.go
@@ -41,19 +41,19 @@ func TestPutKey(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	stmt, _ := kdb.db.Prepare("select scriptPubKey, purpose, keyIndex, used from keys where scriptPubKey=?")
+	stmt, _ := kdb.db.Prepare("select scriptAddress, purpose, keyIndex, used from keys where scriptAddress=?")
 	defer stmt.Close()
 
-	var scriptPubKey string
+	var scriptAddress string
 	var purpose int
 	var index int
 	var used int
-	err = stmt.QueryRow(hex.EncodeToString(b)).Scan(&scriptPubKey, &purpose, &index, &used)
+	err = stmt.QueryRow(hex.EncodeToString(b)).Scan(&scriptAddress, &purpose, &index, &used)
 	if err != nil {
 		t.Error(err)
 	}
-	if scriptPubKey != hex.EncodeToString(b) {
-		t.Errorf(`Expected %s got %s`, hex.EncodeToString(b), scriptPubKey)
+	if scriptAddress != hex.EncodeToString(b) {
+		t.Errorf(`Expected %s got %s`, hex.EncodeToString(b), scriptAddress)
 	}
 	if purpose != 0 {
 		t.Errorf(`Expected 0 got %d`, purpose)
@@ -79,19 +79,19 @@ func TestImportKey(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	stmt, _ := kdb.db.Prepare("select scriptPubKey, purpose, used, key from keys where scriptPubKey=?")
+	stmt, _ := kdb.db.Prepare("select scriptAddress, purpose, used, key from keys where scriptAddress=?")
 	defer stmt.Close()
 
-	var scriptPubKey string
+	var scriptAddress string
 	var purpose int
 	var used int
 	var keyHex string
-	err = stmt.QueryRow(hex.EncodeToString(b)).Scan(&scriptPubKey, &purpose, &used, &keyHex)
+	err = stmt.QueryRow(hex.EncodeToString(b)).Scan(&scriptAddress, &purpose, &used, &keyHex)
 	if err != nil {
 		t.Error(err)
 	}
-	if scriptPubKey != hex.EncodeToString(b) {
-		t.Errorf(`Expected %s got %s`, hex.EncodeToString(b), scriptPubKey)
+	if scriptAddress != hex.EncodeToString(b) {
+		t.Errorf(`Expected %s got %s`, hex.EncodeToString(b), scriptAddress)
 	}
 	if purpose != -1 {
 		t.Errorf(`Expected -1 got %d`, purpose)
@@ -127,14 +127,14 @@ func TestMarkKeyAsUsed(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	stmt, _ := kdb.db.Prepare("select scriptPubKey, purpose, keyIndex, used from keys where scriptPubKey=?")
+	stmt, _ := kdb.db.Prepare("select scriptAddress, purpose, keyIndex, used from keys where scriptAddress=?")
 	defer stmt.Close()
 
-	var scriptPubKey string
+	var scriptAddress string
 	var purpose int
 	var index int
 	var used int
-	err = stmt.QueryRow(hex.EncodeToString(b)).Scan(&scriptPubKey, &purpose, &index, &used)
+	err = stmt.QueryRow(hex.EncodeToString(b)).Scan(&scriptAddress, &purpose, &index, &used)
 	if err != nil {
 		t.Error(err)
 	}
@@ -165,14 +165,14 @@ func TestGetLastKeyIndex(t *testing.T) {
 	}
 }
 
-func TestGetPathForScript(t *testing.T) {
+func TestGetPathForKey(t *testing.T) {
 	b := make([]byte, 32)
 	rand.Read(b)
 	err := kdb.Put(b, spvwallet.KeyPath{spvwallet.EXTERNAL, 15})
 	if err != nil {
 		t.Error(err)
 	}
-	path, err := kdb.GetPathForScript(b)
+	path, err := kdb.GetPathForKey(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -181,7 +181,7 @@ func TestGetPathForScript(t *testing.T) {
 	}
 }
 
-func TestKeyForScript(t *testing.T) {
+func TestGetKey(t *testing.T) {
 	key, err := btcec.NewPrivateKey(btcec.S256())
 	if err != nil {
 		t.Error(err)
@@ -194,7 +194,7 @@ func TestKeyForScript(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	k, err := kdb.GetKeyForScript(b)
+	k, err := kdb.GetKey(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -206,7 +206,7 @@ func TestKeyForScript(t *testing.T) {
 func TestKeyNotFound(t *testing.T) {
 	b := make([]byte, 32)
 	rand.Read(b)
-	_, err := kdb.GetPathForScript(b)
+	_, err := kdb.GetPathForKey(b)
 	if err == nil {
 		t.Error("Return key when it shouldn't have")
 	}

--- a/vendor/github.com/OpenBazaar/spvwallet/blockchain.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/blockchain.go
@@ -173,20 +173,16 @@ func (b *Blockchain) calcRequiredWork(header wire.BlockHeader, height int32, pre
 			} else { // Otherwise return the difficulty of the last block not using special difficulty rules
 				for {
 					var err error = nil
-					fmt.Println(err, prevHeader.height, prevHeader.header.Bits)
 					for err == nil && int32(prevHeader.height)%epochLength != 0 && prevHeader.header.Bits == b.params.PowLimitBits {
 						var sh StoredHeader
 						sh, err = b.db.GetPreviousHeader(prevHeader.header)
 						// Error should only be non-nil if prevHeader is the checkpoint.
 						// In that case we should just return checkpoint bits
-						fmt.Println("**", sh.height, err)
 						if err == nil {
 							prevHeader = sh
-							fmt.Println("here")
 						}
 
 					}
-					fmt.Println(prevHeader.height)
 					return prevHeader.header.Bits, nil
 				}
 			}

--- a/vendor/github.com/OpenBazaar/spvwallet/checkpoints.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/checkpoints.go
@@ -17,33 +17,43 @@ var testnet3Checkpoints []Checkpoint
 var regtestCheckpoint Checkpoint
 
 func init() {
-	mainnetPrev, _ := chainhash.NewHashFromStr("000000000000000000b3ff31d54e9e83515ee18360c7dc59e30697d083c745ff")
-	mainnetMerk, _ := chainhash.NewHashFromStr("33d4a902daa28d09f9f6a319f538153e4b747938e20e113a2935c8dc0b971584")
+	// Mainnet
+	mainnetPrev, _ := chainhash.NewHashFromStr("000000000000000001389446206ebcd378c32cd00b4920a8a1ba7b540ca7d699")
+	mainnetMerk, _ := chainhash.NewHashFromStr("ddc4fede55aeebe6e3bfd3292145b011a4f16ead187ed90d7df0fd4c020b6ab6")
 	mainnetCheckpoints = append(mainnetCheckpoints, Checkpoint{
-		Height: 443520,
+		Height: 473760,
 		Header: wire.BlockHeader{
-			Version:    536870912,
+			Version:    536870914,
 			PrevBlock:  *mainnetPrev,
 			MerkleRoot: *mainnetMerk,
-			Timestamp:  time.Unix(1481765313, 0),
-			Bits:       402885509,
-			Nonce:      251583942,
+			Timestamp:  time.Unix(1498956437, 0),
+			Bits:       402754864,
+			Nonce:      134883004,
 		},
 	})
+	if mainnetCheckpoints[0].Header.BlockHash().String() != "000000000000000000802ba879f1b7a638dcea6ff0ceb614d91afc8683ac0502" {
+		panic("Invalid checkpoint")
+	}
 
-	testnet3Prev, _ := chainhash.NewHashFromStr("00000000000016abe4e7c10ddb658bb089b2ef3b1de3f3329097cf679eedf2b5")
-	testnet3Merk, _ := chainhash.NewHashFromStr("ba732d7a0e4b0b46351b1b476e1628ff03f399ce07f888a257982240b36e2ed2")
+	// Testnet3
+	testnet3Prev, _ := chainhash.NewHashFromStr("0000000000001e8cdb2d98471a5c60bdbddbe644b9ad08e17a97b3a7dce1e332")
+	testnet3Merk, _ := chainhash.NewHashFromStr("f675c565b293be2ad808b01b0a763557c8874e4aefe7f2eea0dab91b1f60ec45")
 	testnet3Checkpoints = append(testnet3Checkpoints, Checkpoint{
-		Height: 1114848,
+		Height: 1151136,
 		Header: wire.BlockHeader{
 			Version:    536870912,
 			PrevBlock:  *testnet3Prev,
 			MerkleRoot: *testnet3Merk,
-			Timestamp:  time.Unix(1491041521, 0),
-			Bits:       438809536,
-			Nonce:      2732625067,
+			Timestamp:  time.Unix(1498950206, 0),
+			Bits:       436724869,
+			Nonce:      2247874206,
 		},
 	})
+	if testnet3Checkpoints[0].Header.BlockHash().String() != "00000000000002c04de174cf25c993b4dd221eb087c0601a599ff1977e230c99" {
+		panic("Invalid checkpoint")
+	}
+
+	// Regtest
 	regtestCheckpoint = Checkpoint{0, chaincfg.RegressionNetParams.GenesisBlock.Header}
 }
 

--- a/vendor/github.com/OpenBazaar/spvwallet/datastore.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/datastore.go
@@ -65,20 +65,20 @@ type Keys interface {
 	Put(hash160 []byte, keyPath KeyPath) error
 
 	// Import a loose private key not part of the keychain
-	ImportKey(scriptPubKey []byte, key *btcec.PrivateKey) error
+	ImportKey(scriptAddress []byte, key *btcec.PrivateKey) error
 
 	// Mark the script as used
-	MarkKeyAsUsed(scriptPubKey []byte) error
+	MarkKeyAsUsed(scriptAddress []byte) error
 
 	// Fetch the last index for the given key purpose
 	// The bool should state whether the key has been used or not
 	GetLastKeyIndex(purpose KeyPurpose) (int, bool, error)
 
 	// Returns the first unused path for the given purpose
-	GetPathForScript(scriptPubKey []byte) (KeyPath, error)
+	GetPathForKey(scriptAddress []byte) (KeyPath, error)
 
-	// Returns an imported private key given a script
-	GetKeyForScript(scriptPubKey []byte) (*btcec.PrivateKey, error)
+	// Returns an imported private key given a script address
+	GetKey(scriptAddress []byte) (*btcec.PrivateKey, error)
 
 	// Get a list of unused key indexes for the given purpose
 	GetUnused(purpose KeyPurpose) ([]int, error)

--- a/vendor/github.com/OpenBazaar/spvwallet/txstore.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/txstore.go
@@ -61,7 +61,7 @@ func (ts *TxStore) GimmeFilter() (*bloom.Filter, error) {
 	}
 	ts.addrMutex.Lock()
 	elem := uint32(len(ts.adrs)+len(allUtxos)+len(allStxos)) + uint32(len(ts.watchedScripts))
-	f := bloom.NewFilter(elem, 0, 0.0001, wire.BloomUpdateAll)
+	f := bloom.NewFilter(elem, 0, 0.00003, wire.BloomUpdateAll)
 
 	// note there could be false positives since we're just looking
 	// for the 20 byte PKH without the opcodes.
@@ -223,6 +223,7 @@ func (ts *TxStore) Ingest(tx *wire.MsgTx, height int32) (uint32, error) {
 	PKscripts := make([][]byte, len(ts.adrs))
 	for i := range ts.adrs {
 		// Iterate through all our addresses
+		// TODO: This will need to test both segwit and legacy once segwit activates
 		PKscripts[i], err = txscript.PayToAddrScript(ts.adrs[i])
 		if err != nil {
 			return hits, err

--- a/vendor/github.com/OpenBazaar/spvwallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/wallet.go
@@ -223,11 +223,7 @@ func (w *SPVWallet) AddressToScript(addr btc.Address) ([]byte, error) {
 }
 
 func (w *SPVWallet) HasKey(addr btc.Address) bool {
-	script, err := txscript.PayToAddrScript(addr)
-	if err != nil {
-		return false
-	}
-	_, err = w.keyManager.GetKeyForScript(script)
+	_, err := w.keyManager.GetKeyForScript(addr.ScriptAddress())
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Most of the change is to the spvwallet lib, but it does push up a refactor of the keys db implementation. 

Keys used to be fetched from the db by giving the corresponding scriptPubKey. Since segwit introduces a new kind of scriptPubKey, and if a user resyncs the chain from seed we wont know which scriptPubKey to use. 

So this changes it to save the hash160 instead of the scriptPubKey since segwit addresses use the same hash160. 

Keys can now be fetched by giving the hash160, which makes the keys db agnostic to segwit. 

This will likely require resetting the data directory. 