### PR TITLE
Spvwallet - Improve blockchain handling

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -13,7 +13,7 @@
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/spvwallet",
-			"Rev": "02b5c342ff890c72b92f4de6799947e1a0eaf49d"
+			"Rev": "4a16c7942b76a49911d58e65ea37020dbd0d2fa2"
 		},
 		{
 			"ImportPath": "github.com/boltdb/bolt",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -13,7 +13,7 @@
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/spvwallet",
-			"Rev": "d4fb2fbddd3b88f295b0b2c3acdc001b11b87c09"
+			"Rev": "02b5c342ff890c72b92f4de6799947e1a0eaf49d"
 		},
 		{
 			"ImportPath": "github.com/boltdb/bolt",
@@ -1666,6 +1666,10 @@
 		{
 			"ImportPath": "gx/ipfs/QmfJHywXQu98UeZtGJBQrPAR6AtmDjjbe3qjTo9piXHPnx/murmur3",
 			"Rev": "be2d1a2331f5caa2315e99fc187b77286d6d9a0b"
+		},
+		{
+			"ImportPath": "github.com/cevaris/ordered_map",
+			"Rev": "531fd444821a2eda0e8d1ed033ae207641e03b54"
 		}
 	]
 }

--- a/core/core.go
+++ b/core/core.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	VERSION   = "0.7.1"
+	VERSION   = "0.7.2"
 	USERAGENT = "/openbazaar-go:" + VERSION + "/"
 )
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openbazaar-go",
   "author": "chris",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
   "language": "english",
   "license": "",

--- a/vendor/github.com/OpenBazaar/spvwallet/README.md
+++ b/vendor/github.com/OpenBazaar/spvwallet/README.md
@@ -31,6 +31,7 @@ Easy peasy
 
 The wallet implements the following interface:
 ```go
+
 type BitcoinWallet interface {
 
 	// Start the wallet
@@ -41,6 +42,9 @@ type BitcoinWallet interface {
 
 	// Returns the type of crytocurrency this wallet implements
 	CurrencyCode() string
+
+	// Check if this amount is considered dust
+	IsDust(amount int64) bool
 
 	// Get the master private key
 	MasterPrivateKey() *hd.ExtendedKey
@@ -99,8 +103,8 @@ type BitcoinWallet interface {
 	// Combine signatures and optionally broadcast
 	Multisign(ins []spvwallet.TransactionInput, outs []spvwallet.TransactionOutput, sigs1 []spvwallet.Signature, sigs2 []spvwallet.Signature, redeemScript []byte, feePerByte uint64, broadcast bool) ([]byte, error)
 
-	// Generate a multisig script from public keys
-	GenerateMultisigScript(keys []hd.ExtendedKey, threshold int) (addr btc.Address, redeemScript []byte, err error)
+	// Generate a multisig script from public keys. If a timeout is included the returned script should be a timelocked escrow which releases using the timeoutKey.
+	GenerateMultisigScript(keys []hd.ExtendedKey, threshold int, timeout time.Duration, timeoutKey *hd.ExtendedKey) (addr btc.Address, redeemScript []byte, err error)
 
 	// Add a script to the wallet and get notifications back when coins are received or spent from it
 	AddWatchedScript(script []byte) error
@@ -139,6 +143,7 @@ Available commands:
   chaintip                 return the height of the chain
   createmultisigsignature  create a p2sh multisig signature
   currentaddress           get the current bitcoin address
+  dumpheaders              print the header database
   estimatefee              estimate the fee for a tx
   getconfirmations         get the number of confirmations for a tx
   getfeeperbyte            get the current bitcoin fee
@@ -156,6 +161,7 @@ Available commands:
   sweepaddress             sweep all coins from an address
   transactions             get a list of transactions
   version                  print the version number
+
 ```
 
 Finally a gRPC API is available on port 8234. The same interface is exposed via the API plus a streaming wallet notifier which fires when a new transaction (either incoming or outgoing) is recorded then again when it gains its first confirmation.

--- a/vendor/github.com/OpenBazaar/spvwallet/blockchain.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/blockchain.go
@@ -41,10 +41,14 @@ type Blockchain struct {
 }
 
 func NewBlockchain(filePath string, walletCreationDate time.Time, params *chaincfg.Params) (*Blockchain, error) {
+	hdb, err := NewHeaderDB(filePath)
+	if err != nil {
+		return nil, err
+	}
 	b := &Blockchain{
 		lock:   new(sync.Mutex),
 		params: params,
-		db:     NewHeaderDB(filePath),
+		db:     hdb,
 	}
 
 	h, err := b.db.Height()
@@ -220,7 +224,6 @@ func (b *Blockchain) CalcMedianTimePast(header *wire.BlockHeader) (time.Time, er
 	sort.Sort(timeSorter(timestamps))
 	medianTimestamp := timestamps[numNodes/2]
 	return time.Unix(medianTimestamp, 0), nil
-	return time.Now(), nil
 }
 
 func (b *Blockchain) GetEpoch() (*wire.BlockHeader, error) {

--- a/vendor/github.com/OpenBazaar/spvwallet/eight333.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/eight333.go
@@ -80,10 +80,12 @@ func (w *SPVWallet) onMerkleBlock(p *peer.Peer, m *wire.MsgMerkleBlock) {
 		if err != nil {
 			log.Error(err)
 		}
-		w.blockchain.SetChainState(SYNCING)
-		w.blockchain.db.Put(*reorg, true)
-		go w.startChainDownload(p)
-		return
+		if w.blockchain.state != SYNCING {
+			w.blockchain.SetChainState(SYNCING)
+			w.blockchain.db.Put(*reorg, true)
+			go w.startChainDownload(p)
+			return
+		}
 	}
 
 	for _, txid := range txids {

--- a/vendor/github.com/OpenBazaar/spvwallet/headers.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/headers.go
@@ -12,10 +12,16 @@ import (
 	"sync"
 
 	"github.com/boltdb/bolt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/cevaris/ordered_map"
+	"strings"
 )
 
-const MAX_HEADERS = 2000
+const (
+	MAX_HEADERS = 2000
+	CACHE_SIZE  = 100
+)
 
 // Database interface for storing block headers
 type Headers interface {
@@ -29,6 +35,9 @@ type Headers interface {
 
 	// Returns all information about the previous header
 	GetPreviousHeader(header wire.BlockHeader) (StoredHeader, error)
+
+	// Grab a header given hash
+	GetHeader(hash chainhash.Hash) (StoredHeader, error)
 
 	// Retrieve the best header from the database
 	GetBestHeader() (StoredHeader, error)
@@ -51,9 +60,11 @@ type StoredHeader struct {
 
 // HeaderDB implements Headers using bolt DB
 type HeaderDB struct {
-	lock     *sync.Mutex
-	db       *bolt.DB
-	filePath string
+	lock      *sync.Mutex
+	db        *bolt.DB
+	filePath  string
+	bestCache *StoredHeader
+	cache     *HeaderCache
 }
 
 var (
@@ -63,11 +74,15 @@ var (
 )
 
 func NewHeaderDB(filePath string) *HeaderDB {
+	if !strings.Contains(filePath, ".bin") {
+		filePath = path.Join(filePath, "headers.bin")
+	}
 	h := new(HeaderDB)
-	db, _ := bolt.Open(path.Join(filePath, "headers.bin"), 0644, &bolt.Options{InitialMmapSize: 5000000})
+	db, _ := bolt.Open(filePath, 0644, &bolt.Options{InitialMmapSize: 5000000})
 	h.db = db
 	h.lock = new(sync.Mutex)
 	h.filePath = filePath
+	h.cache = &HeaderCache{ordered_map.NewOrderedMap(), sync.Mutex{}, CACHE_SIZE}
 
 	db.Update(func(btx *bolt.Tx) error {
 		_, err := btx.CreateBucketIfNotExists(BKTHeaders)
@@ -80,12 +95,18 @@ func NewHeaderDB(filePath string) *HeaderDB {
 		}
 		return nil
 	})
+
+	h.initializeCache()
 	return h
 }
 
 func (h *HeaderDB) Put(sh StoredHeader, newBestHeader bool) error {
 	h.lock.Lock()
 	defer h.lock.Unlock()
+	h.cache.Set(sh)
+	if newBestHeader {
+		h.bestCache = &sh
+	}
 	return h.db.Update(func(btx *bolt.Tx) error {
 		hdrs := btx.Bucket(BKTHeaders)
 		ser, err := serializeHeader(sh)
@@ -153,11 +174,19 @@ func (h *HeaderDB) Prune() error {
 }
 
 func (h *HeaderDB) GetPreviousHeader(header wire.BlockHeader) (sh StoredHeader, err error) {
+	hash := header.PrevBlock
+	return h.GetHeader(hash)
+}
+
+func (h *HeaderDB) GetHeader(hash chainhash.Hash) (sh StoredHeader, err error) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
+	cachedHeader, cerr := h.cache.Get(hash)
+	if cerr == nil {
+		return cachedHeader, nil
+	}
 	err = h.db.View(func(btx *bolt.Tx) error {
 		hdrs := btx.Bucket(BKTHeaders)
-		hash := header.PrevBlock
 		b := hdrs.Get(hash.CloneBytes())
 		if b == nil {
 			return errors.New("Header does not exist in database")
@@ -177,6 +206,10 @@ func (h *HeaderDB) GetPreviousHeader(header wire.BlockHeader) (sh StoredHeader, 
 func (h *HeaderDB) GetBestHeader() (sh StoredHeader, err error) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
+	if h.bestCache != nil {
+		best := h.bestCache
+		return *best, nil
+	}
 	err = h.db.View(func(btx *bolt.Tx) error {
 		tip := btx.Bucket(BKTChainTip)
 		b := tip.Get(KEYChainTip)
@@ -198,6 +231,9 @@ func (h *HeaderDB) GetBestHeader() (sh StoredHeader, err error) {
 func (h *HeaderDB) Height() (uint32, error) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
+	if h.bestCache != nil {
+		return h.bestCache.height, nil
+	}
 	var height uint32
 	err := h.db.View(func(btx *bolt.Tx) error {
 		tip := btx.Bucket(BKTChainTip)
@@ -247,6 +283,25 @@ func (h *HeaderDB) Print(w io.Writer) {
 	sort.Float64s(keys)
 	for _, k := range keys {
 		fmt.Fprintf(w, "Height: %.1f, Hash: %s, Parent: %s\n", k, m[k][0], m[k][1])
+	}
+}
+
+func (h *HeaderDB) initializeCache() {
+	best, err := h.GetBestHeader()
+	if err != nil {
+		return
+	}
+	h.bestCache = &best
+	headers := []StoredHeader{best}
+	for i := 0; i < 99; i++ {
+		sh, err := h.GetPreviousHeader(best.header)
+		if err != nil {
+			break
+		}
+		headers = append(headers, sh)
+	}
+	for i := len(headers) - 1; i >= 0; i-- {
+		h.cache.Set(headers[i])
 	}
 }
 
@@ -302,4 +357,36 @@ func deserializeHeader(b []byte) (sh StoredHeader, err error) {
 		totalWork: bi,
 	}
 	return sh, nil
+}
+
+type HeaderCache struct {
+	headers *ordered_map.OrderedMap
+	sync.Mutex
+	cacheSize int
+}
+
+func (h *HeaderCache) pop() {
+	iter := h.headers.IterFunc()
+	k, ok := iter()
+	if ok {
+		h.headers.Delete(k.Key)
+	}
+}
+
+func (h *HeaderCache) Set(sh StoredHeader) {
+	h.Lock()
+	defer h.Unlock()
+	if h.headers.Len() > h.cacheSize {
+		h.pop()
+	}
+	hash := sh.header.BlockHash()
+	h.headers.Set(hash.String(), sh)
+}
+
+func (h *HeaderCache) Get(hash chainhash.Hash) (StoredHeader, error) {
+	sh, ok := h.headers.Get(hash.String())
+	if !ok {
+		return StoredHeader{}, errors.New("Not found")
+	}
+	return sh.(StoredHeader), nil
 }

--- a/vendor/github.com/OpenBazaar/spvwallet/makefile
+++ b/vendor/github.com/OpenBazaar/spvwallet/makefile
@@ -4,4 +4,5 @@ install:
 protos:
 		cd api/pb && protoc --go_out=plugins=grpc:. api.proto
 
-
+resources:
+		cd gui && go-bindata -o resources.go -pkg gui resources/...

--- a/vendor/github.com/OpenBazaar/spvwallet/peers.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/peers.go
@@ -86,6 +86,8 @@ type PeerManager struct {
 	getFilter          func() (*bloom.Filter, error)
 	startChainDownload func(*peer.Peer)
 
+	targetOutbound uint32
+
 	proxy proxy.Dialer
 }
 
@@ -116,6 +118,7 @@ func NewPeerManager(config *PeerManagerConfig) (*PeerManager, error) {
 	if config.TrustedPeer != nil {
 		targetOutbound = 1
 	}
+	pm.targetOutbound = targetOutbound
 
 	retryDuration := config.RetryDuration
 	if config.RetryDuration <= 0 {
@@ -267,11 +270,15 @@ func (pm *PeerManager) onDisconnection(req *connmgr.ConnReq) {
 	// If this was our download peer we lost, replace him
 	if pm.downloadPeer != nil && peer != nil {
 		if pm.downloadPeer.ID() == peer.ID() {
-			for id := range pm.connectedPeers {
-				pm.setDownloadPeer(pm.connectedPeers[id])
-				break
-			}
+			go pm.selectNewDownlaodPeer()
 		}
+	}
+}
+
+func (pm *PeerManager) selectNewDownlaodPeer() {
+	for _, peer := range pm.connectedPeers {
+		pm.setDownloadPeer(peer)
+		break
 	}
 }
 
@@ -312,18 +319,19 @@ func (pm *PeerManager) DequeueTx(peer *peer.Peer, txid chainhash.Hash) (int32, e
 // Iterates over our peers and sees if any are reporting a height
 // greater than our height. If so switch them to the download peer
 // and start the chain download again.
-func (pm *PeerManager) CheckForMoreBlocks(height uint32) (moar bool) {
+func (pm *PeerManager) CheckForMoreBlocks(height uint32) bool {
 	pm.peerMutex.RLock()
 	defer pm.peerMutex.RUnlock()
 
+	moar := false
 	for _, peer := range pm.connectedPeers {
 		if uint32(peer.LastBlock()) > height {
 			pm.downloadPeer = peer
 			go pm.startChainDownload(peer)
-			return true
+			moar = true
 		}
 	}
-	return false
+	return moar
 }
 
 // Called by connManager when it adds a new connection

--- a/vendor/github.com/OpenBazaar/spvwallet/sortsignsend.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/sortsignsend.go
@@ -384,6 +384,12 @@ func (w *SPVWallet) Multisign(ins []TransactionInput, outs []TransactionOutput, 
 
 		if timeLocked {
 			builder.AddOp(txscript.OP_1)
+			tx.Version = 2
+			locktime, err := LockTimeFromRedeemScript(redeemScript)
+			if err != nil {
+				return nil, err
+			}
+			input.Sequence = locktime
 		}
 
 		builder.AddData(redeemScript)

--- a/vendor/github.com/OpenBazaar/spvwallet/timesorter.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/timesorter.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2013-2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package spvwallet
+
+// timeSorter implements sort.Interface to allow a slice of timestamps to
+// be sorted.
+type timeSorter []int64
+
+// Len returns the number of timestamps in the slice.  It is part of the
+// sort.Interface implementation.
+func (s timeSorter) Len() int {
+	return len(s)
+}
+
+// Swap swaps the timestamps at the passed indices.  It is part of the
+// sort.Interface implementation.
+func (s timeSorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less returns whether the timstamp with index i should sort before the
+// timestamp with index j.  It is part of the sort.Interface implementation.
+func (s timeSorter) Less(i, j int) bool {
+	return s[i] < s[j]
+}

--- a/vendor/github.com/OpenBazaar/spvwallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/wallet.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/op/go-logging"
 	b39 "github.com/tyler-smith/go-bip39"
+	"io"
 	"os"
 	"path"
 	"sync"
@@ -310,6 +311,10 @@ func (w *SPVWallet) AddWatchedScript(script []byte) error {
 		w.updateFilterAndSend(peer)
 	}
 	return err
+}
+
+func (w *SPVWallet) DumpHeaders(writer io.Writer) {
+	w.blockchain.db.Print(writer)
 }
 
 func (w *SPVWallet) Close() {

--- a/vendor/github.com/OpenBazaar/spvwallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/wallet.go
@@ -24,6 +24,8 @@ type SPVWallet struct {
 	masterPrivateKey *hd.ExtendedKey
 	masterPublicKey  *hd.ExtendedKey
 
+	mnemonic string
+
 	feeProvider *FeeProvider
 
 	repoPath string
@@ -64,6 +66,7 @@ func NewSPVWallet(config *Config) (*SPVWallet, error) {
 			return nil, err
 		}
 		config.Mnemonic = mnemonic
+		config.CreationDate = time.Now()
 	}
 	seed := b39.NewSeed(config.Mnemonic, "")
 
@@ -79,6 +82,7 @@ func NewSPVWallet(config *Config) (*SPVWallet, error) {
 		repoPath:         config.RepoPath,
 		masterPrivateKey: mPrivKey,
 		masterPublicKey:  mPubKey,
+		mnemonic:         config.Mnemonic,
 		params:           config.Params,
 		creationDate:     config.CreationDate,
 		feeProvider: NewFeeProvider(
@@ -182,6 +186,10 @@ func (w *SPVWallet) MasterPrivateKey() *hd.ExtendedKey {
 
 func (w *SPVWallet) MasterPublicKey() *hd.ExtendedKey {
 	return w.masterPublicKey
+}
+
+func (w *SPVWallet) Mnemonic() string {
+	return w.mnemonic
 }
 
 func (w *SPVWallet) ConnectedPeers() []*peer.Peer {
@@ -335,6 +343,7 @@ func (w *SPVWallet) ReSyncBlockchain(fromHeight int32) {
 		return
 	}
 	w.blockchain = blockchain
+	w.txstore.PopulateAdrs()
 	w.peerManager, err = NewPeerManager(w.config)
 	if err != nil {
 		return

--- a/vendor/github.com/cevaris/ordered_map/.gitignore
+++ b/vendor/github.com/cevaris/ordered_map/.gitignore
@@ -1,0 +1,5 @@
+*.test
+*~
+
+.idea
+*.iml

--- a/vendor/github.com/cevaris/ordered_map/.travis.yml
+++ b/vendor/github.com/cevaris/ordered_map/.travis.yml
@@ -1,0 +1,14 @@
+---
+language: go
+
+go:
+  - tip
+  - 1.7
+  - 1.6
+  - 1.5
+  - 1.4
+  - 1.3
+
+install:
+  - make
+  - make test

--- a/vendor/github.com/cevaris/ordered_map/LICENSE.md
+++ b/vendor/github.com/cevaris/ordered_map/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2016 Adam Cardenas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/cevaris/ordered_map/Makefile
+++ b/vendor/github.com/cevaris/ordered_map/Makefile
@@ -1,0 +1,10 @@
+all: build install 
+
+build:
+	go build
+
+install:
+	go install
+
+test:
+	go test -v *.go

--- a/vendor/github.com/cevaris/ordered_map/README.md
+++ b/vendor/github.com/cevaris/ordered_map/README.md
@@ -1,0 +1,113 @@
+# Ordered Map for golang
+
+[![Build Status](https://travis-ci.org/cevaris/ordered_map.svg?branch=master)](https://travis-ci.org/cevaris/ordered_map)
+
+**OrderedMap** is a Python port of OrderedDict implemented in golang. Golang's builtin `map` purposefully randomizes the iteration of stored key/values. **OrderedMap**` struct preserves inserted key/value pairs; such that on iteration, key/value pairs are received in inserted (first in, first out) order.
+
+
+## Features
+- Full support Key/Value for all data types
+- Exposes an Iterator that iterates in order of insertion
+- Full Get/Set/Delete map interface
+- Supports Golang v1.3 through v1.7
+
+## Download and Install 
+  
+`go get https://github.com/cevaris/ordered_map.git`
+
+
+## Examples
+
+### Create, Get, Set, Delete
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/cevaris/ordered_map"
+)
+
+func main() {
+
+    // Init new OrderedMap
+    om := ordered_map.NewOrderedMap()
+
+    // Set key
+    om.Set("a", 1)
+    om.Set("b", 2)
+    om.Set("c", 3)
+    om.Set("d", 4)
+
+    // Same interface as builtin map
+    if val, ok := om.Get("b"); ok == true {
+        // Found key "b"
+        fmt.Println(val)
+    }
+
+    // Delete a key
+    om.Delete("c")
+
+    // Failed Get lookup becase we deleted "c"
+    if _, ok := om.Get("c"); ok == false {
+        // Did not find key "c"
+        fmt.Println("c not found")
+    }
+    
+    fmt.Println(om)
+}
+```
+
+
+### Iterator
+
+```go
+n := 100
+om := ordered_map.NewOrderedMap()
+
+for i := 0; i < n; i++ {
+    // Insert data into OrderedMap
+    om.Set(i, fmt.Sprintf("%d", i * i))
+}
+
+// Iterate though values
+// - Values iteration are in insert order
+// - Returned in a key/value pair struct
+iter := om.IterFunc()
+for kv, ok := iter(); ok; kv, ok = iter() {
+    fmt.Println(kv, kv.Key, kv.Value)
+}
+```
+
+### Custom Structs
+
+```go
+om := ordered_map.NewOrderedMap()
+om.Set("one", &MyStruct{1, 1.1})
+om.Set("two", &MyStruct{2, 2.2})
+om.Set("three", &MyStruct{3, 3.3})
+
+fmt.Println(om)
+// Ouput: OrderedMap[one:&{1 1.1},  two:&{2 2.2},  three:&{3 3.3}, ]
+```
+  
+## For Development
+
+Git clone project 
+
+`git clone https://github.com/cevaris/ordered_map.git`  
+  
+Build and install project
+
+`make`
+
+Run tests 
+
+`make test`
+
+
+
+
+
+
+

--- a/vendor/github.com/cevaris/ordered_map/key_pair.go
+++ b/vendor/github.com/cevaris/ordered_map/key_pair.go
@@ -1,0 +1,16 @@
+package ordered_map
+
+import "fmt"
+
+type KVPair struct {
+	Key   interface{}
+	Value interface{}
+}
+
+func (k *KVPair) String() string {
+	return fmt.Sprintf("%v:%v", k.Key, k.Value)
+}
+
+func (kv1 *KVPair) Compare(kv2 *KVPair) bool {
+	return kv1.Key == kv2.Key && kv1.Value == kv2.Value
+}

--- a/vendor/github.com/cevaris/ordered_map/node.go
+++ b/vendor/github.com/cevaris/ordered_map/node.go
@@ -1,0 +1,62 @@
+package ordered_map
+
+import (
+	"fmt"
+	"bytes"
+)
+
+type node struct {
+	Prev  *node
+	Next  *node
+	Value interface{}
+}
+
+func newRootNode() *node {
+	root := &node{}
+	root.Prev = root
+	root.Next = root
+	return root
+}
+
+func newNode(prev *node, next *node, key interface{}) *node {
+	return &node{Prev: prev, Next: next, Value: key}
+}
+
+func (n *node) Add(value string) {
+	root := n
+	last := root.Prev
+	last.Next = newNode(last, n, value)
+	root.Prev = last.Next
+}
+
+func (n *node) String() string {
+	var buffer bytes.Buffer
+	if n.Value == "" {
+		// Need to sentinel
+		var curr *node
+		root := n
+		curr = root.Next
+		for curr != root {
+			buffer.WriteString(fmt.Sprintf("%s, ", curr.Value))
+			curr = curr.Next
+		}
+	} else {
+		// Else, print pointer value
+		buffer.WriteString(fmt.Sprintf("%p, ", &n))
+	}
+	return fmt.Sprintf("LinkList[%v]", buffer.String())
+}
+
+func (n *node) IterFunc() func() (string, bool) {
+	var curr *node
+	root := n
+	curr = root.Next
+	return func() (string, bool) {
+		for curr != root {
+			tmp := curr.Value.(string)
+			curr = curr.Next
+			return tmp, true
+		}
+		return "", false
+	}
+}

--- a/vendor/github.com/cevaris/ordered_map/ordered_map.go
+++ b/vendor/github.com/cevaris/ordered_map/ordered_map.go
@@ -1,0 +1,120 @@
+package ordered_map
+
+import (
+	"fmt"
+)
+
+type OrderedMap struct {
+	store  map[interface{}]interface{}
+	mapper map[interface{}]*node
+	root   *node
+}
+
+func NewOrderedMap() *OrderedMap {
+	om := &OrderedMap{
+		store:  make(map[interface{}]interface{}),
+		mapper: make(map[interface{}]*node),
+		root:   newRootNode(),
+	}
+	return om
+}
+
+func NewOrderedMapWithArgs(args []*KVPair) *OrderedMap {
+	om := NewOrderedMap()
+	om.update(args)
+	return om
+}
+
+func (om *OrderedMap) update(args []*KVPair) {
+	for _, pair := range args {
+		om.Set(pair.Key, pair.Value)
+	}
+}
+
+func (om *OrderedMap) Set(key interface{}, value interface{}) {
+	if _, ok := om.store[key]; ok == false {
+		root := om.root
+		last := root.Prev
+		last.Next = newNode(last, root, key)
+		root.Prev = last.Next
+		om.mapper[key] = last.Next
+	}
+	om.store[key] = value
+}
+
+func (om *OrderedMap) Get(key interface{}) (interface{}, bool) {
+	val, ok := om.store[key]
+	return val, ok
+}
+
+func (om *OrderedMap) Delete(key interface{}) {
+	_, ok := om.store[key]
+	if ok {
+		delete(om.store, key)
+	}
+	root, rootFound := om.mapper[key]
+	if rootFound {
+		prev := root.Prev
+		next := root.Next
+		prev.Next = next
+		next.Prev = prev
+	}
+}
+
+func (om *OrderedMap) String() string {
+	builder := make([]string, len(om.store))
+
+	var index int = 0
+	iter := om.IterFunc()
+	for kv, ok := iter(); ok; kv, ok = iter() {
+		val, _ := om.Get(kv.Key)
+		builder[index] = fmt.Sprintf("%v:%v, ", kv.Key, val)
+		index++
+	}
+	return fmt.Sprintf("OrderedMap%v", builder)
+}
+
+func (om *OrderedMap) Iter() <-chan *KVPair {
+	println("Iter() method is deprecated!. Use IterFunc() instead.")
+	return om.UnsafeIter()
+}
+
+/*
+Beware, Iterator leaks goroutines if we do not fully traverse the map.
+For most cases, `IterFunc()` should work as an iterator.
+ */
+func (om *OrderedMap) UnsafeIter() <-chan *KVPair {
+	keys := make(chan *KVPair)
+	go func() {
+		defer close(keys)
+		var curr *node
+		root := om.root
+		curr = root.Next
+		for curr != root {
+			v, _ := om.store[curr.Value]
+			keys <- &KVPair{curr.Value, v}
+			curr = curr.Next
+		}
+	}()
+	return keys
+}
+
+func (om *OrderedMap) IterFunc() func() (*KVPair, bool) {
+	var curr *node
+	root := om.root
+	curr = root.Next
+	return func() (*KVPair, bool) {
+		for curr != root {
+			tmp := curr
+			curr = curr.Next
+			v, _ := om.store[tmp.Value]
+			return &KVPair{tmp.Value, v}, true
+		}
+		return nil, false
+	}
+}
+
+func (om *OrderedMap) Len() int {
+	return len(om.store)
+}
+


### PR DESCRIPTION
Adds an in-memory cache of 100 blocks to improve validation speeds and make it easier to calculate MTP in the future. 

It also fixes a bug calculating the common ancestor in certain types of reorgs. 