### PR TITLE
Update QA tests to check for confirmed payouts

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	VERSION   = "0.7.2"
+	VERSION   = "0.7.3"
 	USERAGENT = "/openbazaar-go:" + VERSION + "/"
 )
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openbazaar-go",
   "author": "chris",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
   "language": "english",
   "license": "",

--- a/qa/cancel_direct_offline.py
+++ b/qa/cancel_direct_offline.py
@@ -139,6 +139,7 @@ class CancelDirectOfflineTest(OpenBazaarTestFramework):
 
         # startup alice again
         self.start_node(alice)
+        self.send_bitcoin_cmd("generate", 1)
         time.sleep(45)
 
         # check alice detected order
@@ -156,8 +157,8 @@ class CancelDirectOfflineTest(OpenBazaarTestFramework):
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= 50 - payment_amount:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 50 - payment_amount:
                 raise TestFailure("CancelDirectOfflineTest - FAIL: Bob failed to receive the multisig payout")
         else:
             raise TestFailure("CancelDirectOfflineTest - FAIL: Failed to query Bob's balance")

--- a/qa/complete_disputed.py
+++ b/qa/complete_disputed.py
@@ -254,14 +254,17 @@ class CompleteDisputedTest(OpenBazaarTestFramework):
             raise TestFailure("CompleteDisputedTest - FAIL: ReleaseFunds POST failed. Reason: %s", resp["reason"])
         time.sleep(20)
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check bob received payout
         api_url = bob["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= (generated_coins*100000000) - payment_amount:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= (generated_coins*100000000) - payment_amount:
                 raise TestFailure("CompleteDisputedTest - FAIL: Bob failed to detect dispute payout")
         elif r.status_code == 404:
             raise TestFailure("CompleteDisputedTest - FAIL: Receive coins endpoint not found")

--- a/qa/complete_moderated_online.py
+++ b/qa/complete_moderated_online.py
@@ -219,14 +219,17 @@ class CompleteModeratedOnlineTest(OpenBazaarTestFramework):
         if resp["state"] != "COMPLETED":
             raise TestFailure("CompleteModeratedOnlineTest - FAIL: Bob failed to order completion")
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check the funds moved into alice's wallet
         api_url = alice["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= 0:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 0:
                 raise TestFailure("RefundDirectTest - FAIL: Alice failed to receive the multisig payout")
         else:
             raise TestFailure("RefundDirectTest - FAIL: Failed to query Alice's balance")

--- a/qa/complete_moderated_with_timeout.py
+++ b/qa/complete_moderated_with_timeout.py
@@ -220,14 +220,17 @@ class CompleteModeratedWithTimeout(OpenBazaarTestFramework):
         if resp["state"] != "COMPLETED":
             raise TestFailure("CompleteModeratedWithTimeout - FAIL: Bob failed to order completion")
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check the funds moved into alice's wallet
         api_url = alice["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= 0:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 0:
                 raise TestFailure("RefundDirectTest - FAIL: Alice failed to receive the multisig payout")
         else:
             raise TestFailure("RefundDirectTest - FAIL: Failed to query Alice's balance")

--- a/qa/dispute_close_buyer.py
+++ b/qa/dispute_close_buyer.py
@@ -252,14 +252,17 @@ class DisputeCloseBuyerTest(OpenBazaarTestFramework):
             raise TestFailure("DisputeCloseBuyerTest - FAIL: ReleaseFunds POST failed. Reason: %s", resp["reason"])
         time.sleep(20)
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check bob received payout
         api_url = bob["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= (generated_coins*100000000) - payment_amount:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= (generated_coins*100000000) - payment_amount:
                 raise TestFailure("DisputeCloseBuyerTest - FAIL: Bob failed to detect dispute payout")
         elif r.status_code == 404:
             raise TestFailure("DisputeCloseBuyerTest - FAIL: Receive coins endpoint not found")

--- a/qa/dispute_close_split.py
+++ b/qa/dispute_close_split.py
@@ -266,14 +266,17 @@ class DisputeCloseSplitTest(OpenBazaarTestFramework):
         else:
             raise TestFailure("DisputeCloseSplitTest - FAIL: Unknown response")
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check alice received payout
         api_url = alice["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= 0:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 0:
                 raise TestFailure("DisputeCloseSplitTest - FAIL: Alice failed to detect dispute payout")
         elif r.status_code == 404:
             raise TestFailure("DisputeCloseSplitTest - FAIL: Receive coins endpoint not found")

--- a/qa/dispute_close_vendor.py
+++ b/qa/dispute_close_vendor.py
@@ -285,14 +285,17 @@ class DisputeCloseVendorTest(OpenBazaarTestFramework):
             raise TestFailure("DisputeCloseVendorTest - FAIL: ReleaseFunds POST failed. Reason: %s", resp["reason"])
         time.sleep(20)
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check alice received payout
         api_url = alice["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= 0:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 0:
                 raise TestFailure("DisputeCloseVendorTest - FAIL: Alice failed to detect dispute payout")
         elif r.status_code == 404:
             raise TestFailure("DisputeCloseVendorTest - FAIL: Receive coins endpoint not found")

--- a/qa/escrow_release_after_timeout.py
+++ b/qa/escrow_release_after_timeout.py
@@ -217,14 +217,17 @@ class EscrowTimeoutRelease(OpenBazaarTestFramework):
 
         time.sleep(20)
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check the funds moved into alice's wallet
         api_url = alice["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= 0:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 0:
                 raise TestFailure("RefundDirectTest - FAIL: Alice failed to receive the multisig payout")
         else:
             raise TestFailure("RefundDirectTest - FAIL: Failed to query Alice's balance")

--- a/qa/purchase_direct_offline.py
+++ b/qa/purchase_direct_offline.py
@@ -160,14 +160,17 @@ class PurchaseDirectOfflineTest(OpenBazaarTestFramework):
             raise TestFailure("PurchaseDirectOfflineTest - FAIL: Purchase POST failed. Reason: %s", resp["reason"])
         time.sleep(10)
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check the funds moved into alice's wallet
         api_url = alice["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= 0:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 0:
                 raise TestFailure("PurchaseDirectOfflineTest - FAIL: Alice failed to receive the multisig payout")
         else:
             raise TestFailure("PurchaseDirectOfflineTest - FAIL: Failed to query Alice's balance")

--- a/qa/refund_direct.py
+++ b/qa/refund_direct.py
@@ -172,14 +172,17 @@ class RefundDirectTest(OpenBazaarTestFramework):
         if "refundAddressTransaction" not in resp:
             raise TestFailure("RefundDirectTest - FAIL: Bob failed to record refund payment")
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check the funds moved into bob's wallet
         api_url = bob["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= 50 - payment_amount:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 50 - payment_amount:
                 raise TestFailure("RefundDirectTest - FAIL: Bob failed to receive the multisig payout")
         else:
             raise TestFailure("RefundDirectTest - FAIL: Failed to query Bob's balance")

--- a/qa/refund_moderated.py
+++ b/qa/refund_moderated.py
@@ -191,14 +191,17 @@ class RefundModeratedTest(OpenBazaarTestFramework):
         if "refundAddressTransaction" not in resp or resp["refundAddressTransaction"] == {}:
             raise TestFailure("RefundModeratedTest - FAIL: Alice failed to detect refund payment")
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check the funds moved into bob's wallet
         api_url = bob["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= 50 - payment_amount:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 50 - payment_amount:
                 raise TestFailure("RefundModeratedTest - FAIL: Bob failed to receive the multisig payout")
         else:
             raise TestFailure("RefundModeratedTest - FAIL: Failed to query Bob's balance")

--- a/qa/reject_direct_offline.py
+++ b/qa/reject_direct_offline.py
@@ -158,14 +158,17 @@ class RejectDirectOfflineTest(OpenBazaarTestFramework):
         if len(resp["paymentAddressTransactions"]) != 2:
             raise TestFailure("RejectDirectOfflineTest - FAIL: Bob failed to detect outgoing payment")
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check the funds moved into bob's wallet
         api_url = bob["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= 50 - payment_amount:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 50 - payment_amount:
                 raise TestFailure("RejectDirectOfflineTest - FAIL: Bob failed to receive the multisig payout")
         else:
             raise TestFailure("RejectDirectOfflineTest - FAIL: Failed to query Bob's balance")

--- a/qa/reject_moderated_offine.py
+++ b/qa/reject_moderated_offine.py
@@ -185,14 +185,17 @@ class RejectModeratedOffline(OpenBazaarTestFramework):
         if len(resp["paymentAddressTransactions"]) != 2:
             raise TestFailure("RejectModeratedOffline - FAIL: Bob failed to detect outgoing payment")
 
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
         # Check the funds moved into bob's wallet
         api_url = bob["gateway_url"] + "wallet/balance"
         r = requests.get(api_url)
         if r.status_code == 200:
             resp = json.loads(r.text)
             confirmed = int(resp["confirmed"])
-            unconfirmed = int(resp["unconfirmed"])
-            if confirmed + unconfirmed <= 50 - payment_amount:
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 50 - payment_amount:
                 raise TestFailure("RejectModeratedOffline - FAIL: Bob failed to receive the multisig payout")
         else:
             raise TestFailure("RejectModeratedOffline - FAIL: Failed to query Bob's balance")


### PR DESCRIPTION
The QA package was mostly only checking that the wallet recorded an unconfirmed
payment and was missing the case where the payment was rejected by the bitcoin
network and failed to confirmed.

This commit updates the package to check the confirmed balance whenever checking
to make sure the funds were received correctly.