### PR TITLE
Run IPFS bootstrap in its own goroutine

### DIFF
--- a/mobile/node.go
+++ b/mobile/node.go
@@ -307,6 +307,7 @@ func (n *Node) Start() error {
 	go gateway.Serve()
 
 	go func() {
+		<-ipfscore.DefaultBootstrapConfig.DoneChan
 		n.node.Service = service.New(n.node, n.node.Context, n.node.Datastore)
 		MR := ret.NewMessageRetriever(n.node.Datastore, n.node.Context, n.node.IpfsNode, n.node.BanManager, n.node.Service, 14, nil, n.node.CrosspostGateways, n.node.SendOfflineAck)
 		go MR.Run()

--- a/openbazaard.go
+++ b/openbazaard.go
@@ -921,6 +921,7 @@ func (x *Start) Execute(args []string) error {
 	}
 
 	go func() {
+		<-ipfscore.DefaultBootstrapConfig.DoneChan
 		core.Node.Service = service.New(core.Node, ctx, sqliteDB)
 		MR := ret.NewMessageRetriever(sqliteDB, ctx, nd, bm, core.Node.Service, 14, torDialer, core.Node.CrosspostGateways, core.Node.SendOfflineAck)
 		go MR.Run()


### PR DESCRIPTION
Bootstrapping an IPFS node currencly blocks the OpenBazaar node from starting
for about 10 seconds. This commit runs the bootstrapper in a new goroutine
so that the rest of the OpenBazaar app can move on with its life.