### PR TITLE
Lock publishes on startup

### DIFF
--- a/mobile/node.go
+++ b/mobile/node.go
@@ -94,11 +94,12 @@ func NewNode(config NodeConfig) (*Node, error) {
 		return nil, err
 	}
 
-	walletCfg, err := repo.GetWalletConfig(configFile)
+	dataSharing, err := repo.GetDataSharing(configFile)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	gatewayUrlStrings, err := repo.GetCrosspostGateway(configFile)
+
+	walletCfg, err := repo.GetWalletConfig(configFile)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +145,7 @@ func NewNode(config NodeConfig) (*Node, error) {
 		bitswap.ProtocolBitswap = "/openbazaar/bitswap/testnet/1.1.0"
 		service.ProtocolOpenBazaar = "/openbazaar/app/testnet/1.0.0"
 
-		gatewayUrlStrings = []string{}
+		dataSharing.PushTo = []string{}
 	}
 
 	ncfg := &ipfscore.BuildCfg{
@@ -201,21 +202,10 @@ func NewNode(config NodeConfig) (*Node, error) {
 		TrustedPeer:  tp,
 		Logger:       logger,
 	}
+	core.PublishLock.Lock()
 	wallet, err = spvwallet.NewSPVWallet(spvwalletConfig)
 	if err != nil {
 		return nil, err
-	}
-
-	// Crosspost gateway
-	var gatewayUrls []*url.URL
-	for _, gw := range gatewayUrlStrings {
-		if gw != "" {
-			u, err := url.Parse(gw)
-			if err != nil {
-				return nil, err
-			}
-			gatewayUrls = append(gatewayUrls, u)
-		}
 	}
 
 	exchangeRates := exchange.NewBitcoinPriceFetcher(nil)
@@ -247,16 +237,26 @@ func NewNode(config NodeConfig) (*Node, error) {
 		return nil, err
 	}
 
+	// Push nodes
+	var pushNodes []peer.ID
+	for _, pnd := range dataSharing.PushTo {
+		p, err := peer.IDB58Decode(pnd)
+		if err != nil {
+			return err
+		}
+		pushNodes = append(pushNodes, p)
+	}
+
 	// OpenBazaar node setup
 	core.Node = &core.OpenBazaarNode{
-		RepoPath:          config.RepoPath,
-		Datastore:         sqliteDB,
-		Wallet:            wallet,
-		NameSystem:        ns,
-		ExchangeRates:     exchangeRates,
-		CrosspostGateways: gatewayUrls,
-		UserAgent:         core.USERAGENT,
-		BanManager:        bm,
+		RepoPath:      config.RepoPath,
+		Datastore:     sqliteDB,
+		Wallet:        wallet,
+		NameSystem:    ns,
+		ExchangeRates: exchangeRates,
+		UserAgent:     core.USERAGENT,
+		PushNodes:     pushNodes,
+		BanManager:    bm,
 	}
 
 	if len(cfg.Addresses.Gateway) <= 0 {
@@ -310,7 +310,7 @@ func (n *Node) Start() error {
 	n.node.RootHash = ipath.Path(e.Value).String()
 
 	// Offline messaging storage
-	n.node.MessageStorage = selfhosted.NewSelfHostedStorage(n.node.RepoPath, ctx, n.node.CrosspostGateways, nil)
+	n.node.MessageStorage = selfhosted.NewSelfHostedStorage(n.node.RepoPath, ctx, n.node.PushNodes, n.node.SendStore)
 
 	// Start gateway
 	// Create authentication cookie
@@ -328,12 +328,12 @@ func (n *Node) Start() error {
 	go gateway.Serve()
 
 	go func() {
-		<-ipfscore.DefaultBootstrapConfig.DoneChan
+		<-dht.DefaultBootstrapConfig.DoneChan
 		n.node.Service = service.New(n.node, n.node.Context, n.node.Datastore)
-		MR := ret.NewMessageRetriever(n.node.Datastore, n.node.Context, n.node.IpfsNode, n.node.BanManager, n.node.Service, 14, nil, n.node.CrosspostGateways, n.node.SendOfflineAck)
+		MR := ret.NewMessageRetriever(n.node.Datastore, n.node.Context, n.node.IpfsNode, n.node.BanManager, n.node.Service, 14, n.node.PushNodes, nil, n.node.SendOfflineAck)
 		go MR.Run()
 		n.node.MessageRetriever = MR
-		PR := rep.NewPointerRepublisher(n.node.IpfsNode, n.node.Datastore, n.node.IsModerator)
+		PR := rep.NewPointerRepublisher(n.node.IpfsNode, n.node.Datastore, n.node.PushNodes, n.node.IsModerator)
 		go PR.Run()
 		n.node.PointerRepublisher = PR
 		MR.Wait()
@@ -345,8 +345,11 @@ func (n *Node) Start() error {
 		go su.Start()
 		go n.node.Wallet.Start()
 
-		n.node.UpdateFollow()
-		n.node.SeedNode()
+		core.PublishLock.Unlock()
+		core.Node.UpdateFollow()
+		if !core.InitalPublishComplete {
+			core.Node.SeedNode()
+		}
 	}()
 
 	return nil

--- a/openbazaard.go
+++ b/openbazaard.go
@@ -163,6 +163,7 @@ func main() {
 			log.Info("OpenBazaar Server shutting down...")
 			if core.Node != nil {
 				core.OfflineMessageWaitGroup.Wait()
+				core.PublishLock.Lock()
 				core.Node.Datastore.Close()
 				repoLockFile := filepath.Join(core.Node.RepoPath, lockfile.LockFile)
 				os.Remove(repoLockFile)
@@ -946,6 +947,7 @@ func (x *Start) Execute(args []string) error {
 		UserAgent:           core.USERAGENT,
 		BanManager:          bm,
 	}
+	core.PublishLock.Lock()
 
 	// Offline messaging storage
 	var storage sto.OfflineMessagingStorage
@@ -1007,6 +1009,7 @@ func (x *Start) Execute(args []string) error {
 			go su.Start()
 			go cryptoWallet.Start()
 		}
+		core.PublishLock.Unlock()
 		core.Node.UpdateFollow()
 		core.Node.SeedNode()
 	}()

--- a/openbazaard.go
+++ b/openbazaard.go
@@ -1011,7 +1011,9 @@ func (x *Start) Execute(args []string) error {
 		}
 		core.PublishLock.Unlock()
 		core.Node.UpdateFollow()
-		core.Node.SeedNode()
+		if !core.InitalPublishComplete {
+			core.Node.SeedNode()
+		}
 	}()
 
 	// Start gateway


### PR DESCRIPTION
Prevent user publishes from blocking the message retreiver from crawling the DHT
on startup. User publishes can be processed after startup is complete.