### PR TITLE
Add RepublishInterval config option

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -176,6 +176,18 @@ func (n *OpenBazaarNode) publish(hash string) {
 	}
 }
 
+func (n *OpenBazaarNode) SetUpRepublisher(interval time.Duration) {
+	if interval == 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	go func() {
+		for range ticker.C {
+			n.SeedNode()
+		}
+	}()
+}
+
 /* This is a placeholder until the libsignal is operational.
    For now we will just encrypt outgoing offline messages with the long lived identity key.
    Optionally you may provide a public key, to avoid doing an IPFS lookup */

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -309,6 +309,15 @@ func (n *Node) Start() error {
 	proto.Unmarshal(dhtrec.GetValue(), e)
 	n.node.RootHash = ipath.Path(e.Value).String()
 
+	configFile, err := ioutil.ReadFile(path.Join(n.node.RepoPath, "config"))
+	if err != nil {
+		return nil, err
+	}
+	republishInterval, err := repo.GetRepublishInterval(configFile)
+	if err != nil {
+		return nil, err
+	}
+
 	// Offline messaging storage
 	n.node.MessageStorage = selfhosted.NewSelfHostedStorage(n.node.RepoPath, ctx, n.node.PushNodes, n.node.SendStore)
 
@@ -350,6 +359,7 @@ func (n *Node) Start() error {
 		if !core.InitalPublishComplete {
 			core.Node.SeedNode()
 		}
+		core.Node.SetUpRepublisher(republishInterval)
 	}()
 
 	return nil

--- a/openbazaard.go
+++ b/openbazaard.go
@@ -532,6 +532,11 @@ func (x *Start) Execute(args []string) error {
 		log.Error(err)
 		return err
 	}
+	republishInterval, err := repo.GetRepublishInterval(configFile)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
 
 	// IPFS node setup
 	r, err := fsrepo.Open(repoPath)
@@ -1018,6 +1023,7 @@ func (x *Start) Execute(args []string) error {
 		if !core.InitalPublishComplete {
 			core.Node.SeedNode()
 		}
+		core.Node.SetUpRepublisher(republishInterval)
 	}()
 
 	// Start gateway

--- a/repo/config.go
+++ b/repo/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/ipfs/go-ipfs/repo"
 	"github.com/ipfs/go-ipfs/repo/config"
+	"time"
 )
 
 var DefaultBootstrapAddresses = []string{
@@ -367,6 +368,33 @@ func GetDropboxApiToken(cfgBytes []byte) (string, error) {
 	}
 
 	return tokenStr, nil
+}
+
+func GetRepublishInterval(cfgBytes []byte) (time.Duration, error) {
+	var cfgIface interface{}
+	json.Unmarshal(cfgBytes, &cfgIface)
+
+	cfg, ok := cfgIface.(map[string]interface{})
+	if !ok {
+		return time.Duration(0), MalformedConfigError
+	}
+
+	interval, ok := cfg["RepublishInterval"]
+	if !ok {
+		return time.Duration(0), MalformedConfigError
+	}
+	intervalStr, ok := interval.(string)
+	if !ok {
+		return time.Duration(0), MalformedConfigError
+	}
+	if intervalStr == "" {
+		return time.Duration(0), nil
+	}
+	d, err := time.ParseDuration(intervalStr)
+	if err != nil {
+		return d, err
+	}
+	return d, nil
 }
 
 func GetDataSharing(cfgBytes []byte) (*DataSharing, error) {

--- a/repo/config_test.go
+++ b/repo/config_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 const testConfigFolder = "testdata"
@@ -125,6 +126,28 @@ func TestGetDropboxApiToken(t *testing.T) {
 	}
 	if err == nil {
 		t.Error("GetDropboxApiToken didn't throw an error")
+	}
+}
+
+func TestRepublishInterval(t *testing.T) {
+	configFile, err := ioutil.ReadFile(testConfigPath)
+	if err != nil {
+		t.Error(err)
+	}
+	interval, err := GetRepublishInterval(configFile)
+	if interval != time.Hour*24 {
+		t.Error("RepublishInterval does not equal expected value")
+	}
+	if err != nil {
+		t.Error("RepublishInterval threw an unexpected error")
+	}
+
+	interval, err = GetRepublishInterval([]byte{})
+	if interval != time.Second*0 {
+		t.Error("Expected zero duration, got ", interval)
+	}
+	if err == nil {
+		t.Error("GetRepublishInterval didn't throw an error")
 	}
 }
 

--- a/repo/init.go
+++ b/repo/init.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-const RepoVersion = "3"
+const RepoVersion = "4"
 
 var log = logging.MustGetLogger("repo")
 var ErrRepoExists = errors.New("IPFS configuration file exists. Reinitializing would overwrite your keys. Use -f to force overwrite.")
@@ -239,6 +239,9 @@ func addConfigExtensions(repoRoot string, testnet bool) error {
 		return err
 	}
 	if err := extendConfigFile(r, "Dropbox-api-token", ""); err != nil {
+		return err
+	}
+	if err := extendConfigFile(r, "RepublishInterval", "24h"); err != nil {
 		return err
 	}
 	if err := extendConfigFile(r, "JSON-API", a); err != nil {

--- a/repo/migration.go
+++ b/repo/migration.go
@@ -17,6 +17,7 @@ var Migrations = []Migration{
 	migrations.Migration000,
 	migrations.Migration001,
 	migrations.Migration002,
+	migrations.Migration003,
 }
 
 // MigrateUp looks at the currently active migration version

--- a/repo/migrations/Migrations003.go
+++ b/repo/migrations/Migrations003.go
@@ -1,0 +1,93 @@
+package migrations
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+var Migration003 migration003
+
+type migration003 struct{}
+
+func (migration003) Up(repoPath string) error {
+	configFile, err := ioutil.ReadFile(path.Join(repoPath, "config"))
+	if err != nil {
+		return err
+	}
+	var cfgIface interface{}
+	json.Unmarshal(configFile, &cfgIface)
+	cfg, ok := cfgIface.(map[string]interface{})
+	if !ok {
+		return errors.New("Invalid config file")
+	}
+
+	cfg["RepublishInterval"] = "24h"
+
+	out, err := json.MarshalIndent(cfg, "", "   ")
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(path.Join(repoPath, "config"))
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(out)
+	if err != nil {
+		return err
+	}
+	f.Close()
+
+	f1, err := os.Create(path.Join(repoPath, "repover"))
+	if err != nil {
+		return err
+	}
+	_, err = f1.Write([]byte("4"))
+	if err != nil {
+		return err
+	}
+	f1.Close()
+	return nil
+}
+
+func (migration003) Down(repoPath string) error {
+	configFile, err := ioutil.ReadFile(path.Join(repoPath, "config"))
+	if err != nil {
+		return err
+	}
+	var cfgIface interface{}
+	json.Unmarshal(configFile, &cfgIface)
+	cfg, ok := cfgIface.(map[string]interface{})
+	if !ok {
+		return errors.New("Invalid config file")
+	}
+
+	delete(cfg, "RepublishInterval")
+
+	out, err := json.MarshalIndent(cfg, "", "   ")
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(path.Join(repoPath, "config"))
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(out)
+	if err != nil {
+		return err
+	}
+	f.Close()
+
+	f1, err := os.Create(path.Join(repoPath, "repover"))
+	if err != nil {
+		return err
+	}
+	_, err = f1.Write([]byte("3"))
+	if err != nil {
+		return err
+	}
+	f1.Close()
+	return nil
+}

--- a/repo/migrations/Migrations003_test.go
+++ b/repo/migrations/Migrations003_test.go
@@ -1,0 +1,65 @@
+package migrations
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+var testConfig3 string = `{
+    "RepublishInterval": "24h"
+}`
+
+func TestMigration003(t *testing.T) {
+	f, err := os.Create("./config")
+	if err != nil {
+		t.Error(err)
+	}
+	f.Write([]byte(testConfig3))
+	f.Close()
+	var m migration003
+
+	// Up
+	err = m.Up("./")
+	if err != nil {
+		t.Error(err)
+	}
+	newConfig, err := ioutil.ReadFile("./config")
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(string(newConfig), `"RepublishInterval": "24h"`) {
+		t.Error("Failed to write new RepublishInterval object")
+	}
+	repoVer, err := ioutil.ReadFile("./repover")
+	if err != nil {
+		t.Error(err)
+	}
+	if string(repoVer) != "4" {
+		t.Error("Failed to write new repo version")
+	}
+
+	// Down
+	err = m.Down("./")
+	if err != nil {
+		t.Error(err)
+	}
+	newConfig, err = ioutil.ReadFile("./config")
+	if err != nil {
+		t.Error(err)
+	}
+	if strings.Contains(string(newConfig), `RepublishInterval`) {
+		t.Error("Failed to delete RepublishInterval")
+	}
+	repoVer, err = ioutil.ReadFile("./repover")
+	if err != nil {
+		t.Error(err)
+	}
+	if string(repoVer) != "3" {
+		t.Error("Failed to write new repo version")
+	}
+
+	os.Remove("./config")
+	os.Remove("./repover")
+}

--- a/repo/testdata/config
+++ b/repo/testdata/config
@@ -111,6 +111,7 @@
     "Interval": "",
     "Strategy": ""
   },
+  "RepublishInterval": "24h",
   "Resolvers": {
     ".id": "https://resolver.onename.com/"
   },

--- a/vendor/github.com/ipfs/go-ipfs/core/builder.go
+++ b/vendor/github.com/ipfs/go-ipfs/core/builder.go
@@ -20,7 +20,6 @@ import (
 	cfg "github.com/ipfs/go-ipfs/repo/config"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
-
 	"github.com/ipfs/go-ipfs/namesys"
 
 	retry "gx/ipfs/QmPP91WFAb8LCs8EMzGvDPPvg1kacbqRkoxgTTnUsZckGe/retry-datastore"

--- a/vendor/github.com/ipfs/go-ipfs/core/commands/dht.go
+++ b/vendor/github.com/ipfs/go-ipfs/core/commands/dht.go
@@ -17,8 +17,8 @@ import (
 	notif "gx/ipfs/QmPR2JzfKd9poHx9XBhzoFeBBC31ZM3W5iUPKJZWyaoZZm/go-libp2p-routing/notifications"
 	pstore "gx/ipfs/QmPgDWmTmuzvP7QE5zwo1TmjbJme9pmZHNujB2453jkCTr/go-libp2p-peerstore"
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
-	ipdht "gx/ipfs/QmUCS9EnqNq1kCnJds2eLDypBiS21aSiCf1MVzSUVB9TGA/go-libp2p-kad-dht"
 	b58 "gx/ipfs/QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf/go-base58"
+	ipdht "gx/ipfs/QmUCS9EnqNq1kCnJds2eLDypBiS21aSiCf1MVzSUVB9TGA/go-libp2p-kad-dht"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
 )
 

--- a/vendor/github.com/ipfs/go-ipfs/core/core.go
+++ b/vendor/github.com/ipfs/go-ipfs/core/core.go
@@ -75,7 +75,6 @@ import (
 	p2phost "gx/ipfs/QmaSxYRuMq4pkpBBG2CYaRrPx2z7NmMVEs34b9g61biQA6/go-libp2p-host"
 	circuit "gx/ipfs/QmbMNjK69isbpzVGKKrsnM7Sqyh3TVKAphRn5WuUhwTFbW/go-libp2p-circuit"
 	floodsub "gx/ipfs/Qmdnza7rLi7CMNNwNhNkcs9piX5sf6rxE8FrCsPzYtUEUi/floodsub"
-
 )
 
 const IpnsValidatorTag = "ipns"

--- a/vendor/github.com/ipfs/go-ipfs/namesys/routing.go
+++ b/vendor/github.com/ipfs/go-ipfs/namesys/routing.go
@@ -28,9 +28,9 @@ var UsePersistentCache bool
 
 // routingResolver implements NSResolver for the main IPFS SFS-like naming
 type routingResolver struct {
-	routing            routing.ValueStore
-	datastore          ds.Datastore
-	cache              *lru.Cache
+	routing   routing.ValueStore
+	datastore ds.Datastore
+	cache     *lru.Cache
 }
 
 func (r *routingResolver) cacheGet(name string) (path.Path, bool) {
@@ -104,9 +104,9 @@ func NewRoutingResolver(route routing.ValueStore, cachesize int, ds ds.Datastore
 	}
 
 	return &routingResolver{
-		routing:            route,
-		cache:              cache,
-		datastore:          ds,
+		routing:   route,
+		cache:     cache,
+		datastore: ds,
 	}
 }
 


### PR DESCRIPTION
Adds a new config file option to specify how frequently the user/store data
is republished to IPNS. There is a tradeoff between the desire to have your
data cached on as many nodes as possible and having the latest content (such as
ratings) visible. The config options allows users make this tradeoff according
to their preferences.