### PR TITLE
Fix link to wallet interface in altcoins.md

### DIFF
--- a/docs/altcoins.md
+++ b/docs/altcoins.md
@@ -16,7 +16,7 @@ running instances.
 
 ### How to integrate your altcoin
 
-The first thing you need to do is create a wallet implementation that conforms to the wallet interface found [here](https://github.com/OpenBazaar/openbazaar-go/blob/master/bitcoin/wallet.go).
+The first thing you need to do is create a wallet implementation that conforms to the wallet interface found [here](https://github.com/OpenBazaar/wallet-interface).
 The interface *should* be agnostic enough to support most bitcoin derived altcoins, though if you find it isn't just talk to us and we'll see if
 we can make the necessary changes. 
 


### PR DESCRIPTION
The link was pointing to bitcoin/wallet.go which has probably
been moved.

Changed the link to point to OpenBazaar/wallet-interface
repository instead.