### PR TITLE
Allow CORS access to the API by fixing Prelight Header Handling.

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -105,7 +105,7 @@ func (i *jsonAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if i.config.Cors != nil {
 		w.Header().Set("Access-Control-Allow-Origin", *i.config.Cors)
-		w.Header().Set("Access-Control-Allow-Methods", "PUT,POST,DELETE")
+		w.Header().Set("Access-Control-Allow-Methods", "PUT,POST,DELETE,GET,OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 	}
 
@@ -127,6 +127,13 @@ func (i *jsonAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
+      
+      if r.Method == "OPTIONS" {
+        w.WriteHeader(http.StatusOK)
+        fmt.Fprint(w, "200 - OK")
+        return
+      }
+      
 			username, password, ok := r.BasicAuth()
 			h := sha256.Sum256([]byte(password))
 			password = hex.EncodeToString(h[:])

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -127,13 +127,13 @@ func (i *jsonAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-      
-      if r.Method == "OPTIONS" {
-        w.WriteHeader(http.StatusOK)
-        fmt.Fprint(w, "200 - OK")
-        return
-      }
-      
+
+			if r.Method == "OPTIONS" {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "200 - OK")
+				return
+			}
+
 			username, password, ok := r.BasicAuth()
 			h := sha256.Sum256([]byte(password))
 			password = hex.EncodeToString(h[:])


### PR DESCRIPTION
The current implementation of the JSON API does not handle true Cross Origin Resource Sharing (CORS) support. 

When making an AJAX call using Basic Authentiation, a preflight OPTIONS header is sent before the actual GET request. An OPTIONS header does not/can not contain the Authorization Token. Only the GET request can contain the token. The current implementation does not respond to CORS OPTIONS or GET calls.

There are two changes in the PR:

* Change the `Access-Control-Allow-Methods` to allow GET and OPTIONS HTTP methods.

* Respond to OPTIONS headers with an HTTP status of `200 - OK`. This permits the client to *then* send the actual GET request with the authorization token.

The changes in this PR solve Issue #761 