### PR TITLE
updating the client cert name

### DIFF
--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -13,7 +13,7 @@ cd .openbazaar2.0
 Next enter the following commands to generate a self-signed server certificate. If running a remote server, on the fourth line, be sure to replace \<server-ip\> with the ip of your remote server.
 ```
 openssl genrsa -out rootCA.key 4096
-openssl req -x509 -new -nodes -key rootCA.key -days 1024 -out OpenBazaar.crt -subj "/C=DE/ST=Germany/L=Walldorf/O=SAP SE/OU=Tools/CN=rootCA"
+openssl req -x509 -new -nodes -key rootCA.key -days 1024 -out OpenBazaar.crt -subj "/C=DE/ST=Germany/L=Walldorf/O=SAP SE/OU=Tools/CN=OpenBazaar.crt"
 openssl genrsa -out server.key 4096
 openssl req -new -key server.key -out server.csr -subj "/C=DE/ST=Germany/L=Walldorf/O=SAP SE/OU=Tools/CN=<server-ip>"
 openssl x509 -req -in server.csr -CA OpenBazaar.crt -CAkey rootCA.key -CAcreateserial -out server.crt


### PR DESCRIPTION
Updating the client certificate name to match the file it's output to. This is needed for it to work properly (at least on osx - high sierra).