### PR TITLE
Revert back to using a regular mutex in the database

### DIFF
--- a/repo/db/cases.go
+++ b/repo/db/cases.go
@@ -13,7 +13,7 @@ import (
 
 type CasesDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (c *CasesDB) Put(caseID string, state pb.OrderState, buyerOpened bool, claim string) error {
@@ -184,8 +184,8 @@ func (c *CasesDB) Delete(orderID string) error {
 }
 
 func (c *CasesDB) GetAll(stateFilter []pb.OrderState, searchTerm string, sortByAscending bool, sortByRead bool, limit int, exclude []string) ([]repo.Case, int, error) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 
 	q := query{
 		table:           "cases",
@@ -287,8 +287,8 @@ func (c *CasesDB) GetAll(stateFilter []pb.OrderState, searchTerm string, sortByA
 }
 
 func (c *CasesDB) GetCaseMetadata(caseID string) (buyerContract, vendorContract *pb.RicardianContract, buyerValidationErrors, vendorValidationErrors []string, state pb.OrderState, read bool, timestamp time.Time, buyerOpened bool, claim string, resolution *pb.DisputeResolution, err error) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	stmt, err := c.db.Prepare("select buyerContract, vendorContract, buyerValidationErrors, vendorValidationErrors, state, read, timestamp, buyerOpened, claim, disputeResolution from cases where caseID=?")
 	defer stmt.Close()
 	var buyerCon []byte
@@ -360,8 +360,8 @@ func (c *CasesDB) GetCaseMetadata(caseID string) (buyerContract, vendorContract 
 }
 
 func (c *CasesDB) GetPayoutDetails(caseID string) (buyerContract, vendorContract *pb.RicardianContract, buyerPayoutAddress, vendorPayoutAddress string, buyerOutpoints, vendorOutpoints []*pb.Outpoint, state pb.OrderState, err error) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	stmt, err := c.db.Prepare("select buyerContract, vendorContract, buyerPayoutAddress, vendorPayoutAddress, buyerOutpoints, vendorOutpoints, state from cases where caseID=?")
 	var buyerCon []byte
 	var vendorCon []byte
@@ -424,8 +424,8 @@ func (c *CasesDB) GetPayoutDetails(caseID string) (buyerContract, vendorContract
 }
 
 func (c *CasesDB) Count() int {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	row := c.db.QueryRow("select Count(*) from cases")
 	var count int
 	row.Scan(&count)

--- a/repo/db/cases_test.go
+++ b/repo/db/cases_test.go
@@ -22,7 +22,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	casesdb = CasesDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 	contract = new(pb.RicardianContract)

--- a/repo/db/cases_test.go
+++ b/repo/db/cases_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/golang/protobuf/ptypes"
+	"sync"
 )
 
 var casesdb CasesDB
@@ -22,6 +23,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	casesdb = CasesDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 	contract = new(pb.RicardianContract)
 	listing := new(pb.Listing)

--- a/repo/db/chat.go
+++ b/repo/db/chat.go
@@ -10,7 +10,7 @@ import (
 
 type ChatDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (c *ChatDB) Put(messageId string, peerId string, subject string, message string, timestamp time.Time, read bool, outgoing bool) error {
@@ -55,8 +55,8 @@ func (c *ChatDB) Put(messageId string, peerId string, subject string, message st
 }
 
 func (c *ChatDB) GetConversations() []repo.ChatConversation {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	var ret []repo.ChatConversation
 
 	stm := "select distinct peerID from chat where subject='' order by timestamp desc;"
@@ -103,8 +103,8 @@ func (c *ChatDB) GetConversations() []repo.ChatConversation {
 }
 
 func (c *ChatDB) GetMessages(peerID string, subject string, offsetId string, limit int) []repo.ChatMessage {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	var ret []repo.ChatMessage
 
 	var peerStm string

--- a/repo/db/chat_test.go
+++ b/repo/db/chat_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"testing"
 	"time"
+	"sync"
 )
 
 var chdb ChatDB
@@ -17,6 +18,7 @@ func setupDB() {
 	initDatabaseTables(conn, "")
 	chdb = ChatDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 }
 

--- a/repo/db/chat_test.go
+++ b/repo/db/chat_test.go
@@ -2,9 +2,9 @@ package db
 
 import (
 	"database/sql"
+	"sync"
 	"testing"
 	"time"
-	"sync"
 )
 
 var chdb ChatDB
@@ -17,7 +17,7 @@ func setupDB() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	chdb = ChatDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 }

--- a/repo/db/coupons.go
+++ b/repo/db/coupons.go
@@ -9,7 +9,7 @@ import (
 
 type CouponDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (c *CouponDB) Put(coupons []repo.Coupon) error {
@@ -30,8 +30,8 @@ func (c *CouponDB) Put(coupons []repo.Coupon) error {
 }
 
 func (c *CouponDB) Get(slug string) ([]repo.Coupon, error) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	var stm string
 	stm = "select slug, code, hash from coupons where slug='" + slug + "';"
 	rows, err := c.db.Query(stm)

--- a/repo/db/coupons_test.go
+++ b/repo/db/coupons_test.go
@@ -3,8 +3,8 @@ package db
 import (
 	"database/sql"
 	"github.com/OpenBazaar/openbazaar-go/repo"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var coup CouponDB
@@ -13,7 +13,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	coup = CouponDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 }

--- a/repo/db/coupons_test.go
+++ b/repo/db/coupons_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"github.com/OpenBazaar/openbazaar-go/repo"
 	"testing"
+	"sync"
 )
 
 var coup CouponDB
@@ -13,6 +14,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	coup = CouponDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 }
 

--- a/repo/db/followers.go
+++ b/repo/db/followers.go
@@ -9,7 +9,7 @@ import (
 
 type FollowerDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (f *FollowerDB) Put(follower string, proof []byte) error {
@@ -29,8 +29,8 @@ func (f *FollowerDB) Put(follower string, proof []byte) error {
 }
 
 func (f *FollowerDB) Get(offsetId string, limit int) ([]repo.Follower, error) {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
+	f.lock.Lock()
+	defer f.lock.Unlock()
 	var stm string
 	if offsetId != "" {
 		stm = "select peerID, proof from followers order by rowid desc limit " + strconv.Itoa(limit) + " offset ((select coalesce(max(rowid)+1, 0) from followers)-(select rowid from followers where peerID='" + offsetId + "'))"
@@ -61,8 +61,8 @@ func (f *FollowerDB) Delete(follower string) error {
 }
 
 func (f *FollowerDB) Count() int {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
+	f.lock.Lock()
+	defer f.lock.Unlock()
 	row := f.db.QueryRow("select Count(*) from followers")
 	var count int
 	row.Scan(&count)
@@ -70,8 +70,8 @@ func (f *FollowerDB) Count() int {
 }
 
 func (f *FollowerDB) FollowsMe(peerId string) bool {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
+	f.lock.Lock()
+	defer f.lock.Unlock()
 	stmt, err := f.db.Prepare("select peerID from followers where peerID=?")
 	defer stmt.Close()
 	var follower string

--- a/repo/db/followers_test.go
+++ b/repo/db/followers_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"strconv"
 	"testing"
+	"sync"
 )
 
 var fdb FollowerDB
@@ -14,6 +15,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	fdb = FollowerDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 }
 

--- a/repo/db/followers_test.go
+++ b/repo/db/followers_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"database/sql"
 	"strconv"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var fdb FollowerDB
@@ -14,7 +14,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	fdb = FollowerDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 }

--- a/repo/db/following.go
+++ b/repo/db/following.go
@@ -8,7 +8,7 @@ import (
 
 type FollowingDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (f *FollowingDB) Put(follower string) error {
@@ -27,8 +27,8 @@ func (f *FollowingDB) Put(follower string) error {
 }
 
 func (f *FollowingDB) Get(offsetId string, limit int) ([]string, error) {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
+	f.lock.Lock()
+	defer f.lock.Unlock()
 	var stm string
 	if offsetId != "" {
 		stm = "select peerID from following order by rowid desc limit " + strconv.Itoa(limit) + " offset ((select coalesce(max(rowid)+1, 0) from following)-(select rowid from following where peerID='" + offsetId + "'))"
@@ -57,8 +57,8 @@ func (f *FollowingDB) Delete(follower string) error {
 }
 
 func (f *FollowingDB) Count() int {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
+	f.lock.Lock()
+	defer f.lock.Unlock()
 	row := f.db.QueryRow("select Count(*) from following")
 	var count int
 	row.Scan(&count)
@@ -66,8 +66,8 @@ func (f *FollowingDB) Count() int {
 }
 
 func (f *FollowingDB) IsFollowing(peerId string) bool {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
+	f.lock.Lock()
+	defer f.lock.Unlock()
 	stmt, err := f.db.Prepare("select peerID from following where peerID=?")
 	defer stmt.Close()
 	var follower string

--- a/repo/db/following_test.go
+++ b/repo/db/following_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"strconv"
 	"testing"
+	"sync"
 )
 
 var fldb FollowingDB
@@ -13,6 +14,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	fldb = FollowingDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 }
 

--- a/repo/db/following_test.go
+++ b/repo/db/following_test.go
@@ -3,8 +3,8 @@ package db
 import (
 	"database/sql"
 	"strconv"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var fldb FollowingDB
@@ -13,7 +13,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	fldb = FollowingDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 }

--- a/repo/db/inventory.go
+++ b/repo/db/inventory.go
@@ -10,7 +10,7 @@ import (
 
 type InventoryDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (i *InventoryDB) Put(slug string, variantIndex int, count int) error {
@@ -35,8 +35,8 @@ func (i *InventoryDB) Put(slug string, variantIndex int, count int) error {
 }
 
 func (i *InventoryDB) GetSpecific(slug string, variantIndex int) (int, error) {
-	i.lock.RLock()
-	defer i.lock.RUnlock()
+	i.lock.Lock()
+	defer i.lock.Unlock()
 	stmt, err := i.db.Prepare("select count from inventory where slug=? and variantIndex=?")
 	if err != nil {
 		return 0, err
@@ -51,8 +51,8 @@ func (i *InventoryDB) GetSpecific(slug string, variantIndex int) (int, error) {
 }
 
 func (i *InventoryDB) Get(slug string) (map[int]int, error) {
-	i.lock.RLock()
-	defer i.lock.RUnlock()
+	i.lock.Lock()
+	defer i.lock.Unlock()
 	ret := make(map[int]int)
 	stmt, err := i.db.Prepare("select slug, variantIndex, count from inventory where slug=?")
 	if err != nil {
@@ -75,8 +75,8 @@ func (i *InventoryDB) Get(slug string) (map[int]int, error) {
 }
 
 func (i *InventoryDB) GetAll() (map[string]map[int]int, error) {
-	i.lock.RLock()
-	defer i.lock.RUnlock()
+	i.lock.Lock()
+	defer i.lock.Unlock()
 
 	ret := make(map[string]map[int]int)
 	stm := "select slug, variantIndex, count from inventory"

--- a/repo/db/inventory_test.go
+++ b/repo/db/inventory_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"testing"
+	"sync"
 )
 
 var ivdb InventoryDB
@@ -12,6 +13,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	ivdb = InventoryDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 }
 

--- a/repo/db/inventory_test.go
+++ b/repo/db/inventory_test.go
@@ -2,8 +2,8 @@ package db
 
 import (
 	"database/sql"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var ivdb InventoryDB
@@ -12,7 +12,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	ivdb = InventoryDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 }

--- a/repo/db/keys.go
+++ b/repo/db/keys.go
@@ -12,7 +12,7 @@ import (
 
 type KeysDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (k *KeysDB) Put(scriptAddress []byte, keyPath wallet.KeyPath) error {
@@ -80,8 +80,8 @@ func (k *KeysDB) MarkKeyAsUsed(scriptAddress []byte) error {
 }
 
 func (k *KeysDB) GetLastKeyIndex(purpose wallet.KeyPurpose) (int, bool, error) {
-	k.lock.RLock()
-	defer k.lock.RUnlock()
+	k.lock.Lock()
+	defer k.lock.Unlock()
 
 	stm := "select keyIndex, used from keys where purpose=" + strconv.Itoa(int(purpose)) + " order by rowid desc limit 1"
 	stmt, err := k.db.Prepare(stm)
@@ -102,8 +102,8 @@ func (k *KeysDB) GetLastKeyIndex(purpose wallet.KeyPurpose) (int, bool, error) {
 }
 
 func (k *KeysDB) GetPathForKey(scriptAddress []byte) (wallet.KeyPath, error) {
-	k.lock.RLock()
-	defer k.lock.RUnlock()
+	k.lock.Lock()
+	defer k.lock.Unlock()
 
 	stmt, err := k.db.Prepare("select purpose, keyIndex from keys where scriptAddress=?")
 	if err != nil {
@@ -146,8 +146,8 @@ func (k *KeysDB) GetKey(scriptAddress []byte) (*btcec.PrivateKey, error) {
 }
 
 func (k *KeysDB) GetImported() ([]*btcec.PrivateKey, error) {
-	k.lock.RLock()
-	defer k.lock.RUnlock()
+	k.lock.Lock()
+	defer k.lock.Unlock()
 	var ret []*btcec.PrivateKey
 	stm := "select key from keys where purpose=-1"
 	rows, err := k.db.Query(stm)
@@ -172,8 +172,8 @@ func (k *KeysDB) GetImported() ([]*btcec.PrivateKey, error) {
 }
 
 func (k *KeysDB) GetUnused(purpose wallet.KeyPurpose) ([]int, error) {
-	k.lock.RLock()
-	defer k.lock.RUnlock()
+	k.lock.Lock()
+	defer k.lock.Unlock()
 	var ret []int
 	stm := "select keyIndex from keys where purpose=" + strconv.Itoa(int(purpose)) + " and used=0 order by rowid asc"
 	rows, err := k.db.Query(stm)
@@ -193,8 +193,8 @@ func (k *KeysDB) GetUnused(purpose wallet.KeyPurpose) ([]int, error) {
 }
 
 func (k *KeysDB) GetAll() ([]wallet.KeyPath, error) {
-	k.lock.RLock()
-	defer k.lock.RUnlock()
+	k.lock.Lock()
+	defer k.lock.Unlock()
 	var ret []wallet.KeyPath
 	stm := "select purpose, keyIndex from keys"
 	rows, err := k.db.Query(stm)
@@ -218,8 +218,8 @@ func (k *KeysDB) GetAll() ([]wallet.KeyPath, error) {
 }
 
 func (k *KeysDB) GetLookaheadWindows() map[wallet.KeyPurpose]int {
-	k.lock.RLock()
-	defer k.lock.RUnlock()
+	k.lock.Lock()
+	defer k.lock.Unlock()
 	windows := make(map[wallet.KeyPurpose]int)
 	for i := 0; i < 2; i++ {
 		stm := "select used from keys where purpose=" + strconv.Itoa(i) + " order by rowid desc"

--- a/repo/db/keys_test.go
+++ b/repo/db/keys_test.go
@@ -7,8 +7,8 @@ import (
 	"encoding/hex"
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/btcec"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var kdb KeysDB
@@ -17,7 +17,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	kdb = KeysDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 }

--- a/repo/db/keys_test.go
+++ b/repo/db/keys_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/btcec"
 	"testing"
+	"sync"
 )
 
 var kdb KeysDB
@@ -17,6 +18,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	kdb = KeysDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 }
 

--- a/repo/db/moderatedstores.go
+++ b/repo/db/moderatedstores.go
@@ -8,7 +8,7 @@ import (
 
 type ModeratedDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (m *ModeratedDB) Put(peerId string) error {
@@ -28,8 +28,8 @@ func (m *ModeratedDB) Put(peerId string) error {
 }
 
 func (m *ModeratedDB) Get(offsetId string, limit int) ([]string, error) {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	var stm string
 	if offsetId != "" {
 		stm = "select peerID from moderatedstores order by rowid desc limit " + strconv.Itoa(limit) + " offset ((select coalesce(max(rowid)+1, 0) from moderatedstores)-(select rowid from moderatedstores where peerID='" + offsetId + "'))"

--- a/repo/db/moderatedstores_test.go
+++ b/repo/db/moderatedstores_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"strconv"
 	"testing"
+	"sync"
 )
 
 var modDB ModeratedDB
@@ -13,6 +14,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	modDB = ModeratedDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 }
 

--- a/repo/db/moderatedstores_test.go
+++ b/repo/db/moderatedstores_test.go
@@ -3,8 +3,8 @@ package db
 import (
 	"database/sql"
 	"strconv"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var modDB ModeratedDB
@@ -13,7 +13,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	modDB = ModeratedDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 }

--- a/repo/db/notifications.go
+++ b/repo/db/notifications.go
@@ -13,7 +13,7 @@ import (
 
 type NotficationsDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (n *NotficationsDB) Put(notifID string, notification notif.Data, notifType string, timestamp time.Time) error {
@@ -34,8 +34,8 @@ func (n *NotficationsDB) Put(notifID string, notification notif.Data, notifType 
 func (n *NotficationsDB) GetAll(offsetId string, limit int, typeFilter []string) ([]notif.Notification, int, error) {
 	var ret []notif.Notification
 
-	n.lock.RLock()
-	defer n.lock.RUnlock()
+	n.lock.Lock()
+	defer n.lock.Unlock()
 
 	var stm string
 	var cstm string

--- a/repo/db/notifications_test.go
+++ b/repo/db/notifications_test.go
@@ -3,9 +3,9 @@ package db
 import (
 	"database/sql"
 	notif "github.com/OpenBazaar/openbazaar-go/api/notifications"
+	"sync"
 	"testing"
 	"time"
-	"sync"
 )
 
 var notifDB NotficationsDB
@@ -14,7 +14,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	notifDB = NotficationsDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 }

--- a/repo/db/notifications_test.go
+++ b/repo/db/notifications_test.go
@@ -5,6 +5,7 @@ import (
 	notif "github.com/OpenBazaar/openbazaar-go/api/notifications"
 	"testing"
 	"time"
+	"sync"
 )
 
 var notifDB NotficationsDB
@@ -14,6 +15,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	notifDB = NotficationsDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 }
 

--- a/repo/db/offinemessages.go
+++ b/repo/db/offinemessages.go
@@ -8,7 +8,7 @@ import (
 
 type OfflineMessagesDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (o *OfflineMessagesDB) Put(url string) error {
@@ -33,8 +33,8 @@ func (o *OfflineMessagesDB) Put(url string) error {
 }
 
 func (o *OfflineMessagesDB) Has(url string) bool {
-	o.lock.RLock()
-	defer o.lock.RUnlock()
+	o.lock.Lock()
+	defer o.lock.Unlock()
 	stmt, err := o.db.Prepare("select url from offlinemessages where url=?")
 	if err != nil {
 		return false
@@ -59,8 +59,8 @@ func (o *OfflineMessagesDB) SetMessage(url string, message []byte) error {
 }
 
 func (o *OfflineMessagesDB) GetMessages() (map[string][]byte, error) {
-	o.lock.RLock()
-	defer o.lock.RUnlock()
+	o.lock.Lock()
+	defer o.lock.Unlock()
 	stm := "select url, message from offlinemessages where message is not null"
 
 	ret := make(map[string][]byte)

--- a/repo/db/offlinemessages_test.go
+++ b/repo/db/offlinemessages_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"testing"
+	"sync"
 )
 
 var odb OfflineMessagesDB
@@ -13,6 +14,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	odb = OfflineMessagesDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 }
 

--- a/repo/db/offlinemessages_test.go
+++ b/repo/db/offlinemessages_test.go
@@ -3,8 +3,8 @@ package db
 import (
 	"bytes"
 	"database/sql"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var odb OfflineMessagesDB
@@ -13,7 +13,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	odb = OfflineMessagesDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 }

--- a/repo/db/pointers.go
+++ b/repo/db/pointers.go
@@ -14,7 +14,7 @@ import (
 
 type PointersDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (p *PointersDB) Put(pointer ipfs.Pointer) error {
@@ -63,8 +63,8 @@ func (p *PointersDB) DeleteAll(purpose ipfs.Purpose) error {
 }
 
 func (p *PointersDB) GetAll() ([]ipfs.Pointer, error) {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	stm := "select * from pointers"
 	rows, err := p.db.Query(stm)
 	if err != nil {
@@ -118,8 +118,8 @@ func (p *PointersDB) GetAll() ([]ipfs.Pointer, error) {
 }
 
 func (p *PointersDB) GetByPurpose(purpose ipfs.Purpose) ([]ipfs.Pointer, error) {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	stm := "select * from pointers where purpose=" + strconv.Itoa(int(purpose))
 	rows, err := p.db.Query(stm)
 	if err != nil {
@@ -173,8 +173,8 @@ func (p *PointersDB) GetByPurpose(purpose ipfs.Purpose) ([]ipfs.Pointer, error) 
 }
 
 func (p *PointersDB) Get(id peer.ID) (ipfs.Pointer, error) {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	stm := "select * from pointers where pointerID=?"
 	row := p.db.QueryRow(stm, id.Pretty())
 	var pointer ipfs.Pointer

--- a/repo/db/pointers_test.go
+++ b/repo/db/pointers_test.go
@@ -11,6 +11,7 @@ import (
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
 	"testing"
 	"time"
+	"sync"
 )
 
 var pdb PointersDB
@@ -21,6 +22,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	pdb = PointersDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 	randBytes := make([]byte, 32)
 	rand.Read(randBytes)

--- a/repo/db/pointers_test.go
+++ b/repo/db/pointers_test.go
@@ -9,9 +9,9 @@ import (
 	multihash "gx/ipfs/QmU9a9NV9RdPNwZQDYd5uKsm6N6LJLSvLbywDDYFbaaC6P/go-multihash"
 	ma "gx/ipfs/QmXY77cVe7rVRQXZZQRioukUM7aRW3BTcAgJe12MCtb3Ji/go-multiaddr"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
+	"sync"
 	"testing"
 	"time"
-	"sync"
 )
 
 var pdb PointersDB
@@ -21,7 +21,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	pdb = PointersDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 	randBytes := make([]byte, 32)

--- a/repo/db/purchases.go
+++ b/repo/db/purchases.go
@@ -14,7 +14,7 @@ import (
 
 type PurchasesDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (p *PurchasesDB) Put(orderID string, contract pb.RicardianContract, state pb.OrderState, read bool) error {
@@ -129,8 +129,8 @@ func (p *PurchasesDB) Delete(orderID string) error {
 }
 
 func (p *PurchasesDB) GetAll(stateFilter []pb.OrderState, searchTerm string, sortByAscending bool, sortByRead bool, limit int, exclude []string) ([]repo.Purchase, int, error) {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 
 	q := query{
 		table:           "purchases",
@@ -206,8 +206,8 @@ func (p *PurchasesDB) GetAll(stateFilter []pb.OrderState, searchTerm string, sor
 }
 
 func (p *PurchasesDB) GetByPaymentAddress(addr btc.Address) (*pb.RicardianContract, pb.OrderState, bool, []*wallet.TransactionRecord, error) {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	stmt, err := p.db.Prepare("select contract, state, funded, transactions from purchases where paymentAddr=?")
 	defer stmt.Close()
 	var contract []byte
@@ -233,8 +233,8 @@ func (p *PurchasesDB) GetByPaymentAddress(addr btc.Address) (*pb.RicardianContra
 }
 
 func (p *PurchasesDB) GetByOrderId(orderId string) (*pb.RicardianContract, pb.OrderState, bool, []*wallet.TransactionRecord, bool, error) {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	stmt, err := p.db.Prepare("select contract, state, funded, transactions, read from purchases where orderID=?")
 	defer stmt.Close()
 	var contract []byte
@@ -265,8 +265,8 @@ func (p *PurchasesDB) GetByOrderId(orderId string) (*pb.RicardianContract, pb.Or
 }
 
 func (p *PurchasesDB) Count() int {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	row := p.db.QueryRow("select Count(*) from purchases")
 	var count int
 	row.Scan(&count)

--- a/repo/db/purchases_test.go
+++ b/repo/db/purchases_test.go
@@ -21,7 +21,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	purdb = PurchasesDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 	contract = new(pb.RicardianContract)

--- a/repo/db/purchases_test.go
+++ b/repo/db/purchases_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil"
 	"github.com/golang/protobuf/ptypes"
+	"sync"
 )
 
 var purdb PurchasesDB
@@ -21,6 +22,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	purdb = PurchasesDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 	contract = new(pb.RicardianContract)
 	listing := new(pb.Listing)

--- a/repo/db/sales_test.go
+++ b/repo/db/sales_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil"
 	"github.com/golang/protobuf/ptypes"
+	"sync"
 )
 
 var saldb SalesDB
@@ -20,6 +21,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	saldb = SalesDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 	contract = new(pb.RicardianContract)
 	listing := new(pb.Listing)

--- a/repo/db/sales_test.go
+++ b/repo/db/sales_test.go
@@ -20,7 +20,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	saldb = SalesDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 	contract = new(pb.RicardianContract)

--- a/repo/db/settings.go
+++ b/repo/db/settings.go
@@ -13,7 +13,7 @@ var SettingsNotSetError error = errors.New("Settings not set")
 
 type SettingsDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (s *SettingsDB) Put(settings repo.SettingsData) error {
@@ -43,8 +43,8 @@ func (s *SettingsDB) Put(settings repo.SettingsData) error {
 }
 
 func (s *SettingsDB) Get() (repo.SettingsData, error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	settings := repo.SettingsData{}
 	stmt, err := s.db.Prepare("select value from config where key=?")
 	if err != nil {

--- a/repo/db/settings_test.go
+++ b/repo/db/settings_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"github.com/OpenBazaar/openbazaar-go/repo"
 	"testing"
+	"sync"
 )
 
 var sdb SettingsDB
@@ -15,6 +16,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	sdb = SettingsDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 	c := "UNITED_STATES"
 	settings = repo.SettingsData{

--- a/repo/db/settings_test.go
+++ b/repo/db/settings_test.go
@@ -4,8 +4,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"github.com/OpenBazaar/openbazaar-go/repo"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var sdb SettingsDB
@@ -15,7 +15,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	sdb = SettingsDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 	c := "UNITED_STATES"

--- a/repo/db/stxo.go
+++ b/repo/db/stxo.go
@@ -13,7 +13,7 @@ import (
 
 type StxoDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (s *StxoDB) Put(stxo wallet.Stxo) error {
@@ -41,8 +41,8 @@ func (s *StxoDB) Put(stxo wallet.Stxo) error {
 }
 
 func (s *StxoDB) GetAll() ([]wallet.Stxo, error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	var ret []wallet.Stxo
 	stm := "select outpoint, value, height, scriptPubKey, watchOnly, spendHeight, spendTxid from stxos"
 	rows, err := s.db.Query(stm)

--- a/repo/db/stxo_test.go
+++ b/repo/db/stxo_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"strconv"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var sxdb StxoDB
@@ -19,7 +19,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	sxdb = StxoDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 	sh1, _ := chainhash.NewHashFromStr("e941e1c32b3dd1a68edc3af9f7fe711f35aaca60f758c2dd49561e45ca2c41c0")

--- a/repo/db/stxo_test.go
+++ b/repo/db/stxo_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"strconv"
 	"testing"
+	"sync"
 )
 
 var sxdb StxoDB
@@ -19,6 +20,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	sxdb = StxoDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 	sh1, _ := chainhash.NewHashFromStr("e941e1c32b3dd1a68edc3af9f7fe711f35aaca60f758c2dd49561e45ca2c41c0")
 	sh2, _ := chainhash.NewHashFromStr("82998e18760a5f6e5573cd789269e7853e3ebaba07a8df0929badd69dc644c5f")

--- a/repo/db/txmetadata.go
+++ b/repo/db/txmetadata.go
@@ -8,7 +8,7 @@ import (
 
 type TxMetadataDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (t *TxMetadataDB) Put(m repo.Metadata) error {
@@ -55,8 +55,8 @@ func (t *TxMetadataDB) Get(txid string) (repo.Metadata, error) {
 }
 
 func (t *TxMetadataDB) GetAll() (map[string]repo.Metadata, error) {
-	t.lock.RLock()
-	defer t.lock.RUnlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
 	ret := make(map[string]repo.Metadata)
 	stm := "select txid, address, memo, orderID, thumbnail, canBumpFee from txmetadata"
 	rows, err := t.db.Query(stm)

--- a/repo/db/txmetadata_test.go
+++ b/repo/db/txmetadata_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"github.com/OpenBazaar/openbazaar-go/repo"
 	"testing"
+	"sync"
 )
 
 var metDB TxMetadataDB
@@ -14,6 +15,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	metDB = TxMetadataDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 	m = repo.Metadata{"16e4a210d8c798f7d7a32584038c1f55074377bdd19f4caa24edb657fff9538f", "1Xtkf3Rdq6eix4tFXpEuHdXfubt3Mt452", "Some memo", "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG", "QmZY1kx6VrNjgDB4SJDByxvSVuiBfsisRLdUMJRDppTTsS", false}
 }

--- a/repo/db/txmetadata_test.go
+++ b/repo/db/txmetadata_test.go
@@ -3,8 +3,8 @@ package db
 import (
 	"database/sql"
 	"github.com/OpenBazaar/openbazaar-go/repo"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var metDB TxMetadataDB
@@ -14,7 +14,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	metDB = TxMetadataDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 	m = repo.Metadata{"16e4a210d8c798f7d7a32584038c1f55074377bdd19f4caa24edb657fff9538f", "1Xtkf3Rdq6eix4tFXpEuHdXfubt3Mt452", "Some memo", "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG", "QmZY1kx6VrNjgDB4SJDByxvSVuiBfsisRLdUMJRDppTTsS", false}

--- a/repo/db/txns.go
+++ b/repo/db/txns.go
@@ -12,7 +12,7 @@ import (
 
 type TxnsDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (t *TxnsDB) Put(txn *wire.MsgTx, value, height int, timestamp time.Time, watchOnly bool) error {

--- a/repo/db/txns_test.go
+++ b/repo/db/txns_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"testing"
 	"time"
+	"sync"
 )
 
 var txdb TxnsDB
@@ -16,6 +17,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	txdb = TxnsDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 }
 

--- a/repo/db/txns_test.go
+++ b/repo/db/txns_test.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"github.com/btcsuite/btcd/wire"
+	"sync"
 	"testing"
 	"time"
-	"sync"
 )
 
 var txdb TxnsDB
@@ -16,7 +16,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	txdb = TxnsDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 }

--- a/repo/db/utxos.go
+++ b/repo/db/utxos.go
@@ -13,7 +13,7 @@ import (
 
 type UtxoDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (u *UtxoDB) Put(utxo wallet.Utxo) error {
@@ -41,8 +41,8 @@ func (u *UtxoDB) Put(utxo wallet.Utxo) error {
 }
 
 func (u *UtxoDB) GetAll() ([]wallet.Utxo, error) {
-	u.lock.RLock()
-	defer u.lock.RUnlock()
+	u.lock.Lock()
+	defer u.lock.Unlock()
 	var ret []wallet.Utxo
 	stm := "select outpoint, value, height, scriptPubKey, watchOnly from utxos"
 	rows, err := u.db.Query(stm)

--- a/repo/db/utxos_test.go
+++ b/repo/db/utxos_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"strconv"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var uxdb UtxoDB
@@ -19,7 +19,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	uxdb = UtxoDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 	sh1, _ := chainhash.NewHashFromStr("e941e1c32b3dd1a68edc3af9f7fe711f35aaca60f758c2dd49561e45ca2c41c0")

--- a/repo/db/utxos_test.go
+++ b/repo/db/utxos_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"strconv"
 	"testing"
+	"sync"
 )
 
 var uxdb UtxoDB
@@ -19,6 +20,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	uxdb = UtxoDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 	sh1, _ := chainhash.NewHashFromStr("e941e1c32b3dd1a68edc3af9f7fe711f35aaca60f758c2dd49561e45ca2c41c0")
 	outpoint := wire.NewOutPoint(sh1, 0)

--- a/repo/db/watched_scripts.go
+++ b/repo/db/watched_scripts.go
@@ -8,7 +8,7 @@ import (
 
 type WatchedScriptsDB struct {
 	db   *sql.DB
-	lock sync.RWMutex
+	lock *sync.Mutex
 }
 
 func (w *WatchedScriptsDB) Put(scriptPubKey []byte) error {
@@ -31,8 +31,8 @@ func (w *WatchedScriptsDB) Put(scriptPubKey []byte) error {
 }
 
 func (w *WatchedScriptsDB) GetAll() ([][]byte, error) {
-	w.lock.RLock()
-	defer w.lock.RUnlock()
+	w.lock.Lock()
+	defer w.lock.Unlock()
 	var ret [][]byte
 	stm := "select scriptPubKey from watchedscripts"
 	rows, err := w.db.Query(stm)

--- a/repo/db/watched_scripts_test.go
+++ b/repo/db/watched_scripts_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"testing"
+	"sync"
 )
 
 var wsdb WatchedScriptsDB
@@ -14,6 +15,7 @@ func init() {
 	initDatabaseTables(conn, "")
 	wsdb = WatchedScriptsDB{
 		db: conn,
+		lock: new(sync.Mutex),
 	}
 }
 

--- a/repo/db/watched_scripts_test.go
+++ b/repo/db/watched_scripts_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/hex"
-	"testing"
 	"sync"
+	"testing"
 )
 
 var wsdb WatchedScriptsDB
@@ -14,7 +14,7 @@ func init() {
 	conn, _ := sql.Open("sqlite3", ":memory:")
 	initDatabaseTables(conn, "")
 	wsdb = WatchedScriptsDB{
-		db: conn,
+		db:   conn,
 		lock: new(sync.Mutex),
 	}
 }


### PR DESCRIPTION
It appears the the RWMutex is not playing well with the sqlcipher encryption
as it causes an error to be thrown stating that the db is encrypted. This
commit reverts back to using a regular mutex.