### PR TITLE
Refactor Message Retreiver waitgroup

### DIFF
--- a/openbazaard.go
+++ b/openbazaard.go
@@ -35,6 +35,9 @@ func main() {
 			log.Noticef("Received %s\n", sig)
 			log.Info("OpenBazaar Server shutting down...")
 			if core.Node != nil {
+				if core.Node.MessageRetriever != nil {
+					core.Node.MessageRetriever.Wait()
+				}
 				core.OfflineMessageWaitGroup.Wait()
 				core.PublishLock.Lock()
 				core.Node.Datastore.Close()


### PR DESCRIPTION
Recator the wait group that is part of the message retreiver so we can block
shutdown if we're in the middle of processing transactions.