### PR TITLE
fixed typo

### DIFF
--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -898,7 +898,7 @@ func (service *OpenBazaarService) handleOrderCompletion(p peer.ID, pmes *pb.Mess
 	}
 
 	if rc.BuyerOrderCompletion == nil {
-		return nil, errors.New("Recieved ORDER_COMPLETION with nil BuyerOrderCompletion object")
+		return nil, errors.New("Received ORDER_COMPLETION with nil BuyerOrderCompletion object")
 	}
 
 	// Load the order


### PR DESCRIPTION
go report reported a typo in `net/services/handler.go`. 

(sorry for the really stupid pull request, I'm still dipping my toes into open-source contribution)