### PR TITLE
Add DoneChan to message retriever

### DIFF
--- a/openbazaard.go
+++ b/openbazaard.go
@@ -37,6 +37,7 @@ func main() {
 			if core.Node != nil {
 				if core.Node.MessageRetriever != nil {
 					close(core.Node.MessageRetriever.DoneChan)
+					core.Node.MessageRetriever.Wait()
 				}
 				core.OfflineMessageWaitGroup.Wait()
 				core.PublishLock.Lock()

--- a/openbazaard.go
+++ b/openbazaard.go
@@ -36,7 +36,7 @@ func main() {
 			log.Info("OpenBazaar Server shutting down...")
 			if core.Node != nil {
 				if core.Node.MessageRetriever != nil {
-					core.Node.MessageRetriever.Wait()
+					close(core.Node.MessageRetriever.DoneChan)
 				}
 				core.OfflineMessageWaitGroup.Wait()
 				core.PublishLock.Lock()


### PR DESCRIPTION
When shutting down the message retriever use a done chan that will prevent
blocking until the IPFS timeout is reached. This must be done before the
pointer is recorded in the DB so that we will attempt another download on
next startup.