### PR TITLE
Refactor MessageRetriever

### DIFF
--- a/bitcoin/resync/resync_manager.go
+++ b/bitcoin/resync/resync_manager.go
@@ -23,11 +23,11 @@ func NewResyncManager(salesDB repo.Sales, w wallet.Wallet) *ResyncManager {
 func (r *ResyncManager) Start() {
 	t := time.NewTicker(ResyncInterval)
 	for ; true; <-t.C {
-		r.checkUnfunded()
+		r.CheckUnfunded()
 	}
 }
 
-func (r *ResyncManager) checkUnfunded() {
+func (r *ResyncManager) CheckUnfunded() {
 	unfunded, err := r.sales.GetNeedsResync()
 	if err != nil {
 		log.Error(err)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -831,6 +831,10 @@ func (x *Start) Execute(args []string) error {
 			go cryptoWallet.Start()
 			if resyncManager != nil {
 				go resyncManager.Start()
+				go func() {
+					MR.Wait()
+					resyncManager.CheckUnfunded()
+				}()
 			}
 		}
 		core.PublishLock.Unlock()

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -817,7 +817,10 @@ func (x *Start) Execute(args []string) error {
 		go PR.Run()
 		core.Node.PointerRepublisher = PR
 		if !x.DisableWallet {
-			MR.Wait()
+			// If the wallet doesn't allow resyncing from a specific height to scan for unpaid orders, wait for all messages to process before continuing.
+			if resyncManager == nil {
+				MR.Wait()
+			}
 			TL := lis.NewTransactionListener(core.Node.Datastore, core.Node.Broadcast, core.Node.Wallet)
 			WL := lis.NewWalletListener(core.Node.Datastore, core.Node.Broadcast)
 			cryptoWallet.AddTransactionListener(TL.OnTransactionReceived)

--- a/net/retriever/retriever.go
+++ b/net/retriever/retriever.go
@@ -375,6 +375,9 @@ var MessageProcessingOrder = []pb.Message_MessageType{
 // from the databse.
 func (m *MessageRetriever) processQueuedMessages() {
 	messageQueue := make(map[pb.Message_MessageType][]offlineMessage)
+	for _, messageType := range MessageProcessingOrder {
+		messageQueue[messageType] = []offlineMessage{}
+	}
 
 	// Load stored messages from database
 	messages, err := m.db.OfflineMessages().GetMessages()

--- a/qa/purchase_moderated_offline.py
+++ b/qa/purchase_moderated_offline.py
@@ -165,7 +165,7 @@ class PurchaseModeratedOfflineTest(OpenBazaarTestFramework):
             raise TestFailure("PurchaseModeratedOfflineTest - FAIL: Couldn't load order from Alice %s", r.status_code)
         resp = json.loads(r.text)
         if resp["state"] != "PENDING":
-            raise TestFailure("PurchaseModeratedOfflineTest - FAIL: Alice failed to detect payment")
+            raise TestFailure("PurchaseModeratedOfflineTest - FAIL: Alice failed to detect initial payment")
         if resp["funded"] == False:
             raise TestFailure("PurchaseModeratedOfflineTest - FAIL: Alice incorrectly saved as unfunded")
 

--- a/qa/test_framework/test_framework.py
+++ b/qa/test_framework/test_framework.py
@@ -77,7 +77,7 @@ class OpenBazaarTestFramework(object):
         for node in BOOTSTRAP_NODES:
             if config["Addresses"]["Swarm"][0] not in node:
                 to_boostrap.append(node)
-        config["Bootstrap"] = to_boostrap
+        config["Bootstrap-testnet"] = to_boostrap
         config["Wallet"]["TrustedPeer"] = "127.0.0.1:18444"
         config["Wallet"]["FeeAPI"] = ""
         config["Crosspost-gateways"] = []


### PR DESCRIPTION
Currently the MessageRetriever waits until all messages are downloaded before
passing them to the respective handlers. This has two issues. One, message
downloads can take up to five minutes to time out meaning that previously
downloaded messages may not get processed for at least five minutes. Impatient
users might close out the app assuming it's not working right.

Second this blocks the wallet from starting up which again could be up to five
minutes.

This commit refactors the MessageRetriever so that it attempts to process messages
immediately unless the message was received out of order. Only then is it put on
a queue to be processed later. For the vast majority of messages this should mean
the process instantly. Second, since the SPV wallets can make use of the
ResyncManager we don't need to block wallet startup until the MessageRetriever
finishes. Unfortunately for bitcoind/zcashd we still need to wait since they
cannot use the ResyncManager.