### PR TITLE
Refactor zcash resync function

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -648,6 +648,7 @@ func (x *Start) Execute(args []string) error {
 		if !x.DisableExchangeRates {
 			exchangeRates = zcashd.NewZcashPriceFetcher(torDialer)
 		}
+		resyncManager = resync.NewResyncManager(sqliteDB.Sales(), cryptoWallet)
 	default:
 		log.Fatal("Unknown wallet type")
 	}

--- a/core/confirmation.go
+++ b/core/confirmation.go
@@ -117,6 +117,10 @@ func (n *OpenBazaarNode) ConfirmOfflineOrder(contract *pb.RicardianContract, rec
 			}
 		}
 
+		if len(utxos) == 0 {
+			return errors.New("Cannot accept order because utxo has already been spent")
+		}
+
 		chaincode, err := hex.DecodeString(contract.BuyerOrder.Payment.Chaincode)
 		if err != nil {
 			return err


### PR DESCRIPTION
This refactor allows us to resync zcash from a specific height rather than restarting
the binary with the -rescan flag and rescanning from genesis.

Since this now works we can hook up the resync manager to zcash.