### PR TITLE
[#843] Guard escrow during dispute

### DIFF
--- a/bitcoin/bitcoind/wallet.go
+++ b/bitcoin/bitcoind/wallet.go
@@ -98,6 +98,21 @@ func NewBitcoindWallet(mnemonic string, params *chaincfg.Params, repoPath string
 	return &w, nil
 }
 
+// TestNetworkEnabled indicates if the current network being used is Test Network
+func (w *BitcoindWallet) TestNetworkEnabled() bool {
+	return w.params.Name == chaincfg.TestNet3Params.Name
+}
+
+// RegressionNetworkEnabled indicates if the current network being used is Regression Network
+func (w *BitcoindWallet) RegressionNetworkEnabled() bool {
+	return w.params.Name == chaincfg.RegressionNetParams.Name
+}
+
+// MainNetworkEnabled indicates if the current network being used is the live Network
+func (w *BitcoindWallet) MainNetworkEnabled() bool {
+	return w.params.Name == chaincfg.MainNetParams.Name
+}
+
 func GetCredentials(repoPath string) (username, password string, err error) {
 	p := path.Join(repoPath, "bitcoin", "bitcoin.conf")
 	if _, err := os.Stat(p); os.IsNotExist(err) {
@@ -177,9 +192,9 @@ func (w *BitcoindWallet) BuildArguments(rescan bool) []string {
 	}
 	args = append(args, "-torcontrol=127.0.0.1:"+strconv.Itoa(w.controlPort))
 
-	if w.params.Name == chaincfg.TestNet3Params.Name {
+	if w.TestNetworkEnabled() {
 		args = append(args, "-testnet")
-	} else if w.params.Name == chaincfg.RegressionNetParams.Name {
+	} else if w.RegressionNetworkEnabled() {
 		args = append(args, "-regtest")
 	}
 	if w.trustedPeer != "" {
@@ -232,7 +247,7 @@ func (w *BitcoindWallet) shutdownIfActive() {
 }
 
 func (w *BitcoindWallet) CurrencyCode() string {
-	if w.params.Name == chaincfg.MainNetParams.Name {
+	if w.MainNetworkEnabled() {
 		return "btc"
 	} else {
 		return "tbtc"

--- a/bitcoin/zcashd/wallet.go
+++ b/bitcoin/zcashd/wallet.go
@@ -98,6 +98,21 @@ func NewZcashdWallet(mnemonic string, params *chaincfg.Params, repoPath string, 
 	return &w, nil
 }
 
+// TestNetworkEnabled indicates if the current network being used is Test Network
+func (w *ZcashdWallet) TestNetworkEnabled() bool {
+	return w.params.Name == chaincfg.TestNet3Params.Name
+}
+
+// RegressionNetworkEnabled indicates if the current network being used is Regression Network
+func (w *ZcashdWallet) RegressionNetworkEnabled() bool {
+	return w.params.Name == chaincfg.RegressionNetParams.Name
+}
+
+// MainNetworkEnabled indicates if the current network being used is the live Network
+func (w *ZcashdWallet) MainNetworkEnabled() bool {
+	return w.params.Name == chaincfg.MainNetParams.Name
+}
+
 func GetCredentials(repoPath string) (username, password string, err error) {
 	p := path.Join(repoPath, "zcash", "zcash.conf")
 	if _, err := os.Stat(p); os.IsNotExist(err) {
@@ -173,9 +188,9 @@ func (w *ZcashdWallet) BuildArguments(rescan bool) []string {
 	}
 	args = append(args, "-torcontrol=127.0.0.1:"+strconv.Itoa(w.controlPort))
 
-	if w.params.Name == chaincfg.TestNet3Params.Name {
+	if w.TestNetworkEnabled() {
 		args = append(args, "-testnet")
-	} else if w.params.Name == chaincfg.RegressionNetParams.Name {
+	} else if w.RegressionNetworkEnabled() {
 		args = append(args, "-regtest")
 	}
 	if w.trustedPeer != "" {
@@ -232,7 +247,7 @@ func (w *ZcashdWallet) shutdownIfActive() {
 }
 
 func (w *ZcashdWallet) CurrencyCode() string {
-	if w.params.Name == chaincfg.MainNetParams.Name {
+	if w.MainNetworkEnabled() {
 		return "zec"
 	} else {
 		return "tzec"

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -752,20 +752,22 @@ func (x *Start) Execute(args []string) error {
 
 	// OpenBazaar node setup
 	core.Node = &core.OpenBazaarNode{
-		Context:             ctx,
-		IpfsNode:            nd,
-		RootHash:            ipath.Path(e.Value).String(),
-		RepoPath:            repoPath,
-		Datastore:           sqliteDB,
-		Wallet:              cryptoWallet,
-		NameSystem:          ns,
-		ExchangeRates:       exchangeRates,
-		PushNodes:           pushNodes,
-		AcceptStoreRequests: dataSharing.AcceptStoreRequests,
-		TorDialer:           torDialer,
-		UserAgent:           core.USERAGENT,
-		BanManager:          bm,
-		IPNSBackupAPI:       cfg.Ipns.BackUpAPI,
+		Context:              ctx,
+		IpfsNode:             nd,
+		RootHash:             ipath.Path(e.Value).String(),
+		RepoPath:             repoPath,
+		Datastore:            sqliteDB,
+		Wallet:               cryptoWallet,
+		NameSystem:           ns,
+		ExchangeRates:        exchangeRates,
+		PushNodes:            pushNodes,
+		AcceptStoreRequests:  dataSharing.AcceptStoreRequests,
+		TorDialer:            torDialer,
+		UserAgent:            core.USERAGENT,
+		BanManager:           bm,
+		IPNSBackupAPI:        cfg.Ipns.BackUpAPI,
+		TestnetEnable:        x.Testnet,
+		RegressionTestEnable: x.Regtest,
 	}
 	core.PublishLock.Lock()
 

--- a/core/core.go
+++ b/core/core.go
@@ -99,12 +99,21 @@ type OpenBazaarNode struct {
 
 	// Last ditch API to find records that dropped out of the DHT
 	IPNSBackupAPI string
+
+	TestnetEnable        bool
+	RegressionTestEnable bool
 }
 
 // Unpin the current node repo, re-add it, then publish to IPNS
 var seedLock sync.Mutex
 var PublishLock sync.Mutex
 var InitalPublishComplete bool = false
+
+// TestNetworkEnabled indicates whether the node is operating with test parameters
+func (n *OpenBazaarNode) TestNetworkEnabled() bool { return n.TestnetEnable }
+
+// RegressionNetworkEnabled indicates whether the node is operating with regression parameters
+func (n *OpenBazaarNode) RegressionNetworkEnabled() bool { return n.RegressionTestEnable }
 
 func (n *OpenBazaarNode) SeedNode() error {
 	seedLock.Lock()

--- a/core/listings.go
+++ b/core/listings.go
@@ -19,7 +19,6 @@ import (
 	"github.com/OpenBazaar/openbazaar-go/ipfs"
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/openbazaar-go/repo"
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/golang/protobuf/proto"
 	"github.com/kennygrant/sanitize"
 	"github.com/microcosm-cc/bluemonday"
@@ -105,15 +104,13 @@ func (n *OpenBazaarNode) SignListing(listing *pb.Listing) (*pb.SignedListing, er
 
 	sl := new(pb.SignedListing)
 
-	// Set hardcode escrow timeout. This may change in the future
-	var testnet bool
-	if n.Wallet.Params().Name == chaincfg.MainNetParams.Name {
-		listing.Metadata.EscrowTimeoutHours = EscrowTimeout
-	} else {
-		testnet = true
+	// Temporary hack to work around test env shortcomings
+	if n.TestNetworkEnabled() {
 		if listing.Metadata.EscrowTimeoutHours == 0 {
 			listing.Metadata.EscrowTimeoutHours = 1
 		}
+	} else {
+		listing.Metadata.EscrowTimeoutHours = EscrowTimeout
 	}
 
 	// Set crypto currency
@@ -138,7 +135,7 @@ func (n *OpenBazaarNode) SignListing(listing *pb.Listing) (*pb.SignedListing, er
 	}
 
 	// Check the listing data is correct for continuing
-	if err := validateListing(listing, testnet); err != nil {
+	if err := validateListing(listing, n.TestNetworkEnabled()); err != nil {
 		return sl, err
 	}
 

--- a/core/listings.go
+++ b/core/listings.go
@@ -105,7 +105,7 @@ func (n *OpenBazaarNode) SignListing(listing *pb.Listing) (*pb.SignedListing, er
 	sl := new(pb.SignedListing)
 
 	// Temporary hack to work around test env shortcomings
-	if n.TestNetworkEnabled() {
+	if n.TestNetworkEnabled() || n.RegressionNetworkEnabled() {
 		if listing.Metadata.EscrowTimeoutHours == 0 {
 			listing.Metadata.EscrowTimeoutHours = 1
 		}
@@ -135,7 +135,8 @@ func (n *OpenBazaarNode) SignListing(listing *pb.Listing) (*pb.SignedListing, er
 	}
 
 	// Check the listing data is correct for continuing
-	if err := validateListing(listing, n.TestNetworkEnabled()); err != nil {
+	testingEnabled := n.TestNetworkEnabled() || n.RegressionNetworkEnabled()
+	if err := validateListing(listing, testingEnabled); err != nil {
 		return sl, err
 	}
 

--- a/core/order.go
+++ b/core/order.go
@@ -513,7 +513,7 @@ func (n *OpenBazaarNode) createContractWithOrder(data *PurchaseData) (*pb.Ricard
 			if err := validateVendorID(sl.Listing); err != nil {
 				return nil, err
 			}
-			if err := validateListing(sl.Listing, n.TestNetworkEnabled()); err != nil {
+			if err := validateListing(sl.Listing, n.TestNetworkEnabled() || n.RegressionNetworkEnabled()); err != nil {
 				return nil, fmt.Errorf("Listing failed to validate, reason: %q", err.Error())
 			}
 			if err := verifySignaturesOnListing(sl); err != nil {

--- a/core/order.go
+++ b/core/order.go
@@ -18,7 +18,6 @@ import (
 	"github.com/OpenBazaar/openbazaar-go/ipfs"
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/wallet-interface"
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	hd "github.com/btcsuite/btcutil/hdkeychain"
@@ -514,11 +513,7 @@ func (n *OpenBazaarNode) createContractWithOrder(data *PurchaseData) (*pb.Ricard
 			if err := validateVendorID(sl.Listing); err != nil {
 				return nil, err
 			}
-			testnet := false
-			if n.Wallet.Params().Name != chaincfg.MainNetParams.Name {
-				testnet = true
-			}
-			if err := validateListing(sl.Listing, testnet); err != nil {
+			if err := validateListing(sl.Listing, n.TestNetworkEnabled()); err != nil {
 				return nil, fmt.Errorf("Listing failed to validate, reason: %q", err.Error())
 			}
 			if err := verifySignaturesOnListing(sl); err != nil {

--- a/qa/reject_disputed_escrow_release.py
+++ b/qa/reject_disputed_escrow_release.py
@@ -1,0 +1,293 @@
+import requests
+import json
+import time
+from collections import OrderedDict
+from test_framework.test_framework import OpenBazaarTestFramework, TestFailure
+
+
+class RejectDisputedEscrowRelease(OpenBazaarTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
+
+    def run_test(self):
+        merchant = self.nodes[0]
+        customer = self.nodes[1]
+        moderator = self.nodes[2]
+
+        escrow_timeout_hours = 1
+
+        # generate some coins and send them to customer
+        time.sleep(4)
+        api_url = customer["gateway_url"] + "wallet/address"
+        r = requests.get(api_url)
+        if r.status_code == 200:
+            resp = json.loads(r.text)
+            address = resp["address"]
+        elif r.status_code == 404:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Address endpoint not found")
+        else:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Unknown response")
+        self.send_bitcoin_cmd("sendtoaddress", address, 10)
+        time.sleep(20)
+
+        # create a profile for moderator
+        pro = {"name": "Moderator"}
+        api_url = moderator["gateway_url"] + "ob/profile"
+        r = requests.post(api_url, data=json.dumps(pro, indent=4))
+        if r.status_code == 404:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Profile post endpoint not found")
+        elif r.status_code != 200:
+            resp = json.loads(r.text)
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Profile POST failed. Reason: %s", resp["reason"])
+        time.sleep(4)
+
+        # make moderator a moderator
+        with open('testdata/moderation.json') as listing_file:
+            moderation_json = json.load(listing_file, object_pairs_hook=OrderedDict)
+        api_url = moderator["gateway_url"] + "ob/moderator"
+        r = requests.put(api_url, data=json.dumps(moderation_json, indent=4))
+        if r.status_code == 404:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Moderator post endpoint not found")
+        elif r.status_code != 200:
+            resp = json.loads(r.text)
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Moderator POST failed. Reason: %s", resp["reason"])
+        moderatorId = moderator["peerId"]
+        time.sleep(4)
+
+        # post profile for merchant
+        with open('testdata/profile.json') as profile_file:
+            profile_json = json.load(profile_file, object_pairs_hook=OrderedDict)
+        api_url = merchant["gateway_url"] + "ob/profile"
+        requests.post(api_url, data=json.dumps(profile_json, indent=4))
+
+        # post listing to merchant
+        with open('testdata/listing.json') as listing_file:
+            listing_json = json.load(listing_file, object_pairs_hook=OrderedDict)
+        if self.bitcoincash:
+            listing_json["metadata"]["pricingCurrency"] = "tbch"
+        slug = listing_json["slug"]
+        listing_json["moderators"] = [moderatorId]
+        listing_json["metadata"]["escrowTimeoutHours"] = escrow_timeout_hours
+        api_url = merchant["gateway_url"] + "ob/listing"
+        r = requests.post(api_url, data=json.dumps(listing_json, indent=4))
+        if r.status_code == 404:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Listing post endpoint not found")
+        elif r.status_code != 200:
+            resp = json.loads(r.text)
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Listing POST failed. Reason: %s", resp["reason"])
+        resp = json.loads(r.text)
+        slug = resp["slug"]
+        time.sleep(4)
+
+        # get listing hash
+        api_url = merchant["gateway_url"] + "ipns/" + merchant["peerId"] + "/listings.json"
+        r = requests.get(api_url)
+        if r.status_code != 200:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Couldn't get listing index")
+        resp = json.loads(r.text)
+        listingId = resp[0]["hash"]
+
+        # customer send order
+        with open('testdata/order_direct.json') as order_file:
+            order_json = json.load(order_file, object_pairs_hook=OrderedDict)
+        order_json["items"][0]["listingHash"] = listingId
+        order_json["moderator"] = moderatorId
+        api_url = customer["gateway_url"] + "ob/purchase"
+        r = requests.post(api_url, data=json.dumps(order_json, indent=4))
+        if r.status_code == 404:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Purchase post endpoint not found")
+        elif r.status_code != 200:
+            resp = json.loads(r.text)
+            self.print_logs(merchant, "ob.log")
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Purchase POST failed. Reason: %s", resp["reason"])
+        resp = json.loads(r.text)
+        orderId = resp["orderId"]
+        payment_address = resp["paymentAddress"]
+        payment_amount = resp["amount"]
+
+        # check the purchase saved correctly
+        api_url = customer["gateway_url"] + "ob/order/" + orderId
+        r = requests.get(api_url)
+        if r.status_code != 200:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Couldn't load order from Customer")
+        resp = json.loads(r.text)
+        if resp["state"] != "AWAITING_PAYMENT":
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Customer purchase saved in incorrect state")
+        if resp["funded"] == True:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Customer incorrectly saved as funded")
+
+        # check the sale saved correctly
+        api_url = merchant["gateway_url"] + "ob/order/" + orderId
+        r = requests.get(api_url)
+        if r.status_code != 200:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Couldn't load order from Merchant")
+        resp = json.loads(r.text)
+        if resp["state"] != "AWAITING_PAYMENT":
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Merchant purchase saved in incorrect state")
+        if resp["funded"] == True:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Merchant incorrectly saved as funded")
+
+        # fund order
+        spend = {
+            "address": payment_address,
+            "amount": payment_amount,
+            "feeLevel": "NORMAL"
+        }
+        api_url = customer["gateway_url"] + "wallet/spend"
+        r = requests.post(api_url, data=json.dumps(spend, indent=4))
+        if r.status_code == 404:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Spend post endpoint not found")
+        elif r.status_code != 200:
+            resp = json.loads(r.text)
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Spend POST failed. Reason: %s", resp["reason"])
+        time.sleep(20)
+
+        # check customer detected payment
+        api_url = customer["gateway_url"] + "ob/order/" + orderId
+        r = requests.get(api_url)
+        if r.status_code != 200:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Couldn't load order from Customer")
+        resp = json.loads(r.text)
+        if resp["state"] != "AWAITING_FULFILLMENT":
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Customer failed to detect his payment")
+        if resp["funded"] == False:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Customer incorrectly saved as unfunded")
+
+        # check merchant detected payment
+        api_url = merchant["gateway_url"] + "ob/order/" + orderId
+        r = requests.get(api_url)
+        if r.status_code != 200:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Couldn't load order from Merchant")
+        resp = json.loads(r.text)
+        if resp["state"] != "AWAITING_FULFILLMENT":
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Merchant failed to detect payment")
+        if resp["funded"] == False:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Merchant incorrectly saved as unfunded")
+
+        # merchant send order fulfillment
+        with open('testdata/fulfillment.json') as fulfillment_file:
+            fulfillment_json = json.load(fulfillment_file, object_pairs_hook=OrderedDict)
+        fulfillment_json["slug"] = slug
+        fulfillment_json["orderId"] = orderId
+        api_url = merchant["gateway_url"] + "ob/orderfulfillment"
+        r = requests.post(api_url, data=json.dumps(fulfillment_json, indent=4))
+        if r.status_code == 404:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Fulfillment post endpoint not found")
+        elif r.status_code != 200:
+            resp = json.loads(r.text)
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Fulfillment POST failed. Reason: %s", resp["reason"])
+        time.sleep(4)
+
+        # check customer received fulfillment
+        api_url = customer["gateway_url"] + "ob/order/" + orderId
+        r = requests.get(api_url)
+        if r.status_code != 200:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Couldn't load order from Customer")
+        resp = json.loads(r.text)
+        if resp["state"] != "FULFILLED":
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Customer failed to detect order fulfillment")
+
+        # check merchant set fulfillment correctly
+        api_url = merchant["gateway_url"] + "ob/order/" + orderId
+        r = requests.get(api_url)
+        if r.status_code != 200:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Couldn't load order from Customer")
+        resp = json.loads(r.text)
+        if resp["state"] != "FULFILLED":
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Merchant failed to order fulfillment")
+
+        # Customer open dispute
+        dispute = {
+            "orderId": orderId,
+            "claim": "Bastard ripped me off"
+        }
+        api_url = customer["gateway_url"] + "ob/opendispute/"
+        r = requests.post(api_url, data=json.dumps(dispute, indent=4))
+        if r.status_code == 404:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: OpenDispute post endpoint not found")
+        elif r.status_code != 200:
+            resp = json.loads(r.text)
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: OpenDispute POST failed. Reason: %s", resp["reason"])
+        time.sleep(4)
+
+        # Customer check dispute opened correctly
+        api_url = customer["gateway_url"] + "ob/order/" + orderId
+        r = requests.get(api_url)
+        if r.status_code != 200:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Couldn't load order from Customer")
+        resp = json.loads(r.text)
+        if resp["state"] != "DISPUTED":
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Customer failed to detect his dispute")
+
+        # Merchant check dispute opened correctly
+        api_url = merchant["gateway_url"] + "ob/order/" + orderId
+        r = requests.get(api_url)
+        if r.status_code != 200:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Couldn't load case from Marchant")
+        resp = json.loads(r.text, object_pairs_hook=OrderedDict)
+        if resp["state"] != "DISPUTED":
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Merchant failed to detect the dispute")
+
+        # Moderator check dispute opened correctly
+        api_url = moderator["gateway_url"] + "ob/case/" + orderId
+        r = requests.get(api_url)
+        if r.status_code != 200:
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Couldn't load case from Moderator")
+        resp = json.loads(r.text, object_pairs_hook=OrderedDict)
+        if resp["state"] != "DISPUTED":
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Moderator failed to detect the dispute")
+
+        # Merchant attempt to release funds before dispute timeout hits
+        release = {
+            "OrderID": orderId,
+        }
+        api_url = merchant["gateway_url"] + "ob/releaseescrow/"
+        r = requests.post(api_url, data=json.dumps(release, indent=4))
+        if r.status_code == 500:
+            resp = json.loads(r.text)
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Release escrow internal server error %s", resp["reason"])
+        elif r.status_code != 401:
+            resp = json.loads(r.text)
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Failed to raise error when releasing escrow after escrow timeout but before dispute timeout")
+
+        # A hack allows dispute timeout to only be 10 seconds while running the server on testnet.
+        time.sleep(20)
+
+        for i in range(6):
+            self.send_bitcoin_cmd("generate", 1)
+            time.sleep(3)
+
+        # Merchant attempt to release funds after timeout
+        release = {
+            "OrderID": orderId,
+        }
+        api_url = merchant["gateway_url"] + "ob/releaseescrow/"
+        r = requests.post(api_url, data=json.dumps(release, indent=4))
+        if r.status_code != 200:
+            resp = json.loads(r.text)
+            raise TestFailure("RejectDisputedEscrowRelease - FAIL: Release escrow error %s", resp["reason"])
+
+        time.sleep(20)
+
+        self.send_bitcoin_cmd("generate", 1)
+        time.sleep(2)
+
+        # Check the funds moved into merchant's wallet
+        api_url = merchant["gateway_url"] + "wallet/balance"
+        r = requests.get(api_url)
+        if r.status_code == 200:
+            resp = json.loads(r.text)
+            confirmed = int(resp["confirmed"])
+            #unconfirmed = int(resp["unconfirmed"])
+            if confirmed <= 0:
+                raise TestFailure("RefundDirectTest - FAIL: Merchant failed to receive the multisig payout")
+        else:
+            raise TestFailure("RefundDirectTest - FAIL: Failed to query Merchant's balance")
+
+        print("RejectDisputedEscrowRelease - PASS")
+
+if __name__ == '__main__':
+    print("Running RejectDisputedEscrowRelease")
+    RejectDisputedEscrowRelease().main(["--regtest", "--disableexchangerates"])


### PR DESCRIPTION
This abstracts some methods for testing which mode the node is running in. This begs the question whether the modes are mutually exclusive or not. Then we use the abstractions to protect escrow from being released while the order is in dispute.