### PR TITLE
Update to Dockerfile to build on go 1.9; dev service in docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@
 dist
 docs
 node_modules
-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - Create static binary
-FROM golang:1.8.1
+FROM golang:1.9
 WORKDIR /go/src/github.com/OpenBazaar/openbazaar-go
 COPY . .
 RUN go build --ldflags '-extldflags "-static"' -o /opt/openbazaard .

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,25 @@
+FROM golang:1.9
+EXPOSE 4001 4002 9005
+VOLUME /var/lib/openbazaar
+
+RUN wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz && \
+    tar xvf Python-3.6.0.tgz && \
+    cd Python-3.6.0 && \
+    ./configure --enable-optimizations && \
+    make -j8
+RUN apt-get update && apt-get install -yq zlib1g-dev libssl-dev
+RUN cd Python-3.6.0 && \
+    make altinstall && \
+    ln -s /usr/local/bin/python3.6 /usr/local/bin/python3
+
+RUN pip3.6 install requests python-bitcoinlib && \
+    wget https://bitcoin.org/bin/bitcoin-core-0.13.0/bitcoin-0.13.0-x86_64-linux-gnu.tar.gz && \
+    tar -xvzf bitcoin-0.13.0-x86_64-linux-gnu.tar.gz -C /opt
+
+WORKDIR /go/src/github.com/OpenBazaar/openbazaar-go
+RUN go get -u github.com/gogo/protobuf/proto \
+              github.com/icrowley/fake
+
+COPY . .
+
+ENTRYPOINT ["/bin/bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 version: '3'
 
 services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - obdata_dev:/var/lib/openbazaar
+      - .:/go/src/github.com/OpenBazaar/openbazaar-go
   server:
     image: openbazaar/server
     ports:
@@ -12,3 +19,4 @@ services:
 
 volumes:
   obdata:
+  obdata_dev:


### PR DESCRIPTION
I've bumped the go version number and created a `dev` docker service to use for development and debugging purposes. You can `docker-compose run dev` to start go environment with openbazaar as the current working directory complete with python and go dependancies for testing.