### PR TITLE
Remove unexpected error cases

### DIFF
--- a/core/listings.go
+++ b/core/listings.go
@@ -1054,8 +1054,6 @@ func verifySignaturesOnListing(sl *pb.SignedListing) error {
 		sl.Listing.VendorID.PeerID,
 	); err != nil {
 		switch err.(type) {
-		case noSigError:
-			return errors.New("Contract does not contain listing signature")
 		case invalidSigError:
 			return errors.New("Vendor's identity signature on contact failed to verify")
 		case matchKeyError:

--- a/core/posts.go
+++ b/core/posts.go
@@ -547,8 +547,6 @@ func verifySignaturesOnPost(sl *pb.SignedPost) error {
 		sl.Post.VendorID.PeerID,
 	); err != nil {
 		switch err.(type) {
-		case noSigError:
-			return errors.New("Post does not contain signature")
 		case invalidSigError:
 			return errors.New("Vendor's identity signature on post failed to verify")
 		case matchKeyError:


### PR DESCRIPTION
It's tiny changes.

I thought the `verifySignature` function (`core/signatures.go`) doesn't return `noSigError` type.