### PR TITLE
Add wallet support for Zcoin

### DIFF
--- a/bitcoin/zcoind/address.go
+++ b/bitcoin/zcoind/address.go
@@ -1,0 +1,334 @@
+package zcoind
+
+import (
+	"errors"
+
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcutil/base58"
+	"golang.org/x/crypto/ripemd160"
+)
+
+var (
+	// ErrChecksumMismatch describes an error where decoding failed due
+	// to a bad checksum.
+	ErrChecksumMismatch = errors.New("checksum mismatch")
+
+	// ErrUnknownAddressType describes an error where an address can not
+	// decoded as a specific address type due to the string encoding
+	// begining with an identifier byte unknown to any standard or
+	// registered (via chaincfg.Register) network.
+	ErrUnknownAddressType = errors.New("unknown address type")
+
+	// ErrAddressCollision describes an error where an address can not
+	// be uniquely determined as either a pay-to-pubkey-hash or
+	// pay-to-script-hash address since the leading identifier is used for
+	// describing both address kinds, but for different networks.  Rather
+	// than assuming or defaulting to one or the other, this error is
+	// returned and the caller must decide how to decode the address.
+	ErrAddressCollision = errors.New("address collision")
+
+	// ErrInvalidFormat describes an error where decoding failed due to invalid version
+	ErrInvalidFormat = errors.New("invalid format: version and/or checksum bytes missing")
+
+	NetIDs map[string]NetID
+)
+
+type NetID struct {
+	AddressPubKeyHash []byte
+	AddressScriptHash []byte
+}
+
+func init() {
+	NetIDs = make(map[string]NetID)
+	NetIDs[chaincfg.MainNetParams.Name] = NetID{[]byte{0x52}, []byte{0x07}}
+	NetIDs[chaincfg.TestNet3Params.Name] = NetID{[]byte{0x41}, []byte{0xb2}}
+	NetIDs[chaincfg.RegressionNetParams.Name] = NetID{[]byte{0x6f}, []byte{0xc4}}
+}
+
+// checksum: first four bytes of sha256^2
+func checksum(input []byte) (cksum [4]byte) {
+	h := sha256.Sum256(input)
+	h2 := sha256.Sum256(h[:])
+	copy(cksum[:], h2[:4])
+	return
+}
+
+// CheckEncode prepends a version byte and appends a four byte checksum.
+func CheckEncode(input []byte, version []byte) string {
+	b := make([]byte, 0, 1+len(input)+4)
+	b = append(b, version...)
+	b = append(b, input[:]...)
+	cksum := checksum(b)
+	b = append(b, cksum[:]...)
+	return base58.Encode(b)
+}
+
+// CheckDecode decodes a string that was encoded with CheckEncode and verifies the checksum.
+func CheckDecode(input string) (result []byte, version []byte, err error) {
+	decoded := base58.Decode(input)
+	if len(decoded) < 5 {
+		return nil, nil, ErrInvalidFormat
+	}
+	version = append(version, decoded[0:1]...)
+	var cksum [4]byte
+	copy(cksum[:], decoded[len(decoded)-4:])
+	if checksum(decoded[:len(decoded)-4]) != cksum {
+		return nil, nil, ErrChecksumMismatch
+	}
+	payload := decoded[1 : len(decoded)-4]
+	result = append(result, payload...)
+	return
+}
+
+// encodeAddress returns a human-readable payment address given a ripemd160 hash
+// and netID which encodes the Zcoin network and address type.  It is used
+// in both pay-to-pubkey-hash (P2PKH) and pay-to-script-hash (P2SH) address
+// encoding.
+func encodeAddress(hash160 []byte, netID []byte) string {
+	// Format is 1 bytes for a network and address class (i.e. P2PKH vs
+	// P2SH), 20 bytes for a RIPEMD160 hash, and 4 bytes of checksum.
+	return CheckEncode(hash160[:ripemd160.Size], netID)
+}
+
+// DecodeAddress decodes the string encoding of an address and returns
+// the Address if addr is a valid encoding for a known address type.
+//
+// The Zcoin network the address is associated with is extracted if possible.
+func DecodeAddress(addr string, defaultNet *chaincfg.Params) (btcutil.Address, error) {
+
+	checkID, ok := NetIDs[defaultNet.Name]
+	if !ok {
+		return nil, errors.New("unknown network parameters")
+	}
+
+	// Switch on decoded length to determine the type.
+	decoded, netID, err := CheckDecode(addr)
+	if err != nil {
+		if err == base58.ErrChecksum {
+			return nil, ErrChecksumMismatch
+		}
+		return nil, errors.New("decoded address is of unknown format")
+	}
+	switch len(decoded) {
+	case ripemd160.Size: // P2PKH or P2SH
+		isP2PKH := bytes.Equal(netID, checkID.AddressPubKeyHash)
+		isP2SH := bytes.Equal(netID, checkID.AddressScriptHash)
+		switch hash160 := decoded; {
+		case isP2PKH && isP2SH:
+			return nil, ErrAddressCollision
+		case isP2PKH:
+			return newAddressPubKeyHash(hash160, defaultNet)
+		case isP2SH:
+			return newAddressScriptHashFromHash(hash160, defaultNet)
+		default:
+			return nil, ErrUnknownAddressType
+		}
+
+	default:
+		return nil, errors.New("decoded address is of unknown size")
+	}
+}
+
+// AddressPubKeyHash is an Address for a pay-to-pubkey-hash (P2PKH)
+// transaction.
+type AddressPubKeyHash struct {
+	hash  [ripemd160.Size]byte
+	netID []byte
+}
+
+// NewAddressPubKeyHash returns a new AddressPubKeyHash.  pkHash mustbe 20
+// bytes.
+func NewAddressPubKeyHash(pkHash []byte, net *chaincfg.Params) (*AddressPubKeyHash, error) {
+	return newAddressPubKeyHash(pkHash, net)
+}
+
+// newAddressPubKeyHash is the internal API to create a pubkey hash address
+// with a known leading identifier byte for a network, rather than looking
+// it up through its parameters.  This is useful when creating a new address
+// structure from a string encoding where the identifer byte is already
+// known.
+func newAddressPubKeyHash(pkHash []byte, net *chaincfg.Params) (*AddressPubKeyHash, error) {
+	// Check for a valid pubkey hash length.
+	if len(pkHash) != ripemd160.Size {
+		return nil, errors.New("pkHash must be 20 bytes")
+	}
+
+	netID, ok := NetIDs[net.Name]
+	if !ok {
+		return nil, errors.New("unknown network parameters")
+	}
+
+	addr := &AddressPubKeyHash{netID: netID.AddressPubKeyHash}
+	copy(addr.hash[:], pkHash)
+	return addr, nil
+}
+
+// EncodeAddress returns the string encoding of a pay-to-pubkey-hash
+// address.  Part of the Address interface.
+func (a *AddressPubKeyHash) EncodeAddress() string {
+	return encodeAddress(a.hash[:], a.netID)
+}
+
+// ScriptAddress returns the bytes to be included in a txout script to pay
+// to a pubkey hash.  Part of the Address interface.
+func (a *AddressPubKeyHash) ScriptAddress() []byte {
+	return a.hash[:]
+}
+
+// IsForNet returns whether or not the pay-to-pubkey-hash address is associated
+// with the passed Zcoin network.
+func (a *AddressPubKeyHash) IsForNet(net *chaincfg.Params) bool {
+	checkID, ok := NetIDs[net.Name]
+	if !ok {
+		return false
+	}
+	return bytes.Equal(a.netID, checkID.AddressPubKeyHash)
+}
+
+// String returns a human-readable string for the pay-to-pubkey-hash address.
+// This is equivalent to calling EncodeAddress, but is provided so the type can
+// be used as a fmt.Stringer.
+func (a *AddressPubKeyHash) String() string {
+	return a.EncodeAddress()
+}
+
+// Hash160 returns the underlying array of the pubkey hash.  This can be useful
+// when an array is more appropiate than a slice (for example, when used as map
+// keys).
+func (a *AddressPubKeyHash) Hash160() *[ripemd160.Size]byte {
+	return &a.hash
+}
+
+// AddressScriptHash is an Address for a pay-to-script-hash (P2SH)
+// transaction.
+type AddressScriptHash struct {
+	hash  [ripemd160.Size]byte
+	netID []byte
+}
+
+// NewAddressScriptHash returns a new AddressScriptHash.
+func NewAddressScriptHash(serializedScript []byte, net *chaincfg.Params) (*AddressScriptHash, error) {
+	scriptHash := btcutil.Hash160(serializedScript)
+	return newAddressScriptHashFromHash(scriptHash, net)
+}
+
+// NewAddressScriptHashFromHash returns a new AddressScriptHash.  scriptHash
+// must be 20 bytes.
+func NewAddressScriptHashFromHash(scriptHash []byte, net *chaincfg.Params) (*AddressScriptHash, error) {
+	return newAddressScriptHashFromHash(scriptHash, net)
+}
+
+// newAddressScriptHashFromHash is the internal API to create a script hash
+// address with a known leading identifier byte for a network, rather than
+// looking it up through its parameters.  This is useful when creating a new
+// address structure from a string encoding where the identifer byte is already
+// known.
+func newAddressScriptHashFromHash(scriptHash []byte, net *chaincfg.Params) (*AddressScriptHash, error) {
+	// Check for a valid script hash length.
+	if len(scriptHash) != ripemd160.Size {
+		return nil, errors.New("scriptHash must be 20 bytes")
+	}
+
+	netID, ok := NetIDs[net.Name]
+	if !ok {
+		return nil, errors.New("unknown network parameters")
+	}
+
+	addr := &AddressScriptHash{netID: netID.AddressScriptHash}
+	copy(addr.hash[:], scriptHash)
+	return addr, nil
+}
+
+// EncodeAddress returns the string encoding of a pay-to-script-hash
+// address.  Part of the Address interface.
+func (a *AddressScriptHash) EncodeAddress() string {
+	return encodeAddress(a.hash[:], a.netID)
+}
+
+// ScriptAddress returns the bytes to be included in a txout script to pay
+// to a script hash.  Part of the Address interface.
+func (a *AddressScriptHash) ScriptAddress() []byte {
+	return a.hash[:]
+}
+
+// IsForNet returns whether or not the pay-to-script-hash address is associated
+// with the passed zCash network.
+func (a *AddressScriptHash) IsForNet(net *chaincfg.Params) bool {
+	checkID, ok := NetIDs[net.Name]
+	if !ok {
+		return false
+	}
+	return bytes.Equal(a.netID, checkID.AddressScriptHash)
+}
+
+// String returns a human-readable string for the pay-to-script-hash address.
+// This is equivalent to calling EncodeAddress, but is provided so the type can
+// be used as a fmt.Stringer.
+func (a *AddressScriptHash) String() string {
+	return a.EncodeAddress()
+}
+
+// Hash160 returns the underlying array of the script hash.  This can be useful
+// when an array is more appropiate than a slice (for example, when used as map
+// keys).
+func (a *AddressScriptHash) Hash160() *[ripemd160.Size]byte {
+	return &a.hash
+}
+
+// PayToAddrScript creates a new script to pay a transaction output to a the
+// specified address.
+func PayToAddrScript(addr btcutil.Address) ([]byte, error) {
+	const nilAddrErrStr = "unable to generate payment script for nil address"
+
+	switch addr := addr.(type) {
+	case *AddressPubKeyHash:
+		if addr == nil {
+			return nil, errors.New(nilAddrErrStr)
+		}
+		return payToPubKeyHashScript(addr.ScriptAddress())
+
+	case *AddressScriptHash:
+		if addr == nil {
+			return nil, errors.New(nilAddrErrStr)
+		}
+		return payToScriptHashScript(addr.ScriptAddress())
+	}
+	return nil, fmt.Errorf("unable to generate payment script for unsupported "+
+		"address type %T", addr)
+}
+
+// payToPubKeyHashScript creates a new script to pay a transaction
+// output to a 20-byte pubkey hash. It is expected that the input is a valid
+// hash.
+func payToPubKeyHashScript(pubKeyHash []byte) ([]byte, error) {
+	return txscript.NewScriptBuilder().AddOp(txscript.OP_DUP).AddOp(txscript.OP_HASH160).
+		AddData(pubKeyHash).AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG).
+		Script()
+}
+
+// payToScriptHashScript creates a new script to pay a transaction output to a
+// script hash. It is expected that the input is a valid hash.
+func payToScriptHashScript(scriptHash []byte) ([]byte, error) {
+	return txscript.NewScriptBuilder().AddOp(txscript.OP_HASH160).AddData(scriptHash).
+		AddOp(txscript.OP_EQUAL).Script()
+}
+
+// ExtractPkScriptAddrs returns the type of script, addresses and required
+// signatures associated with the passed PkScript.  Note that it only works for
+// 'standard' transaction script types.  Any data such as public keys which are
+// invalid are omitted from the results.
+func ExtractPkScriptAddrs(pkScript []byte, chainParams *chaincfg.Params) (btcutil.Address, error) {
+	// No valid addresses or required signatures if the script doesn't
+	// parse.
+	if len(pkScript) == 1+1+20+1 && pkScript[0] == 0xa9 && pkScript[1] == 0x14 && pkScript[22] == 0x87 {
+		return NewAddressScriptHashFromHash(pkScript[2:22], chainParams)
+	} else if len(pkScript) == 1+1+1+20+1+1 && pkScript[0] == 0x76 && pkScript[1] == 0xa9 && pkScript[2] == 0x14 && pkScript[23] == 0x88 && pkScript[24] == 0xac {
+		return NewAddressPubKeyHash(pkScript[3:23], chainParams)
+	}
+	return nil, errors.New("unknown script type")
+}

--- a/bitcoin/zcoind/notify.go
+++ b/bitcoin/zcoind/notify.go
@@ -1,0 +1,105 @@
+package zcoind
+
+import (
+	"encoding/json"
+	"github.com/OpenBazaar/wallet-interface"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	btcrpcclient "github.com/btcsuite/btcd/rpcclient"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+type NotificationListener struct {
+	client    *btcrpcclient.Client
+	listeners []func(wallet.TransactionCallback)
+}
+
+func (l *NotificationListener) notify(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+	txid := string(b)
+	hash, err := chainhash.NewHashFromStr(txid)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	tx, err := l.client.GetRawTransaction(hash)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	watchOnly := false
+	txInfo, err := l.client.GetTransaction(hash, &watchOnly)
+	if err != nil {
+		watchOnly = true
+	}
+	var outputs []wallet.TransactionOutput
+	for i, txout := range tx.MsgTx().TxOut {
+		out := wallet.TransactionOutput{ScriptPubKey: txout.PkScript, Value: txout.Value, Index: uint32(i)}
+		outputs = append(outputs, out)
+	}
+	var inputs []wallet.TransactionInput
+	for _, txin := range tx.MsgTx().TxIn {
+		in := wallet.TransactionInput{OutpointHash: txin.PreviousOutPoint.Hash.CloneBytes(), OutpointIndex: txin.PreviousOutPoint.Index}
+		prev, err := l.client.GetRawTransaction(&txin.PreviousOutPoint.Hash)
+		if err != nil {
+			inputs = append(inputs, in)
+			continue
+		}
+		in.LinkedScriptPubKey = prev.MsgTx().TxOut[txin.PreviousOutPoint.Index].PkScript
+		in.Value = prev.MsgTx().TxOut[txin.PreviousOutPoint.Index].Value
+		inputs = append(inputs, in)
+	}
+
+	height := int32(0)
+	if txInfo.Confirmations > 0 {
+		hash, err := chainhash.NewHashFromStr(txInfo.BlockHash)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		h := ``
+		if hash != nil {
+			h += `"` + hash.String() + `"`
+		}
+		resp, err := l.client.RawRequest("getblockheader", []json.RawMessage{json.RawMessage(h)})
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		type Respose struct {
+			Height int32 `json:"height"`
+		}
+		r := new(Respose)
+		err = json.Unmarshal([]byte(resp), r)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		height = r.Height
+	}
+	cb := wallet.TransactionCallback{
+		Txid:      tx.Hash().CloneBytes(),
+		Inputs:    inputs,
+		Outputs:   outputs,
+		WatchOnly: watchOnly,
+		Value:     int64(txInfo.Amount * 100000000),
+		Timestamp: time.Unix(txInfo.TimeReceived, 0),
+		Height:    height,
+	}
+	for _, lis := range l.listeners {
+		lis(cb)
+	}
+}
+
+func StartNotificationListener(client *btcrpcclient.Client, listeners []func(wallet.TransactionCallback)) {
+	l := NotificationListener{
+		client:    client,
+		listeners: listeners,
+	}
+	http.HandleFunc("/", l.notify)
+	http.ListenAndServe(":8330", nil)
+}

--- a/bitcoin/zcoind/prices.go
+++ b/bitcoin/zcoind/prices.go
@@ -1,0 +1,198 @@
+package zcoind
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/OpenBazaar/openbazaar-go/bitcoin/exchange"
+	"golang.org/x/net/proxy"
+	"net"
+	"net/http"
+	"reflect"
+	"sync"
+	"time"
+)
+
+type ExchangeRateProvider struct {
+	fetchUrl        string
+	cache           map[string]float64
+	client          *http.Client
+	decoder         ExchangeRateDecoder
+	bitcoinProvider *exchange.BitcoinPriceFetcher
+}
+
+type ExchangeRateDecoder interface {
+	decode(dat interface{}, cache map[string]float64, bp *exchange.BitcoinPriceFetcher) (err error)
+}
+
+type OpenBazaarDecoder struct{}
+type BittrexDecoder struct{}
+
+type zcoinPriceFetcher struct {
+	sync.Mutex
+	cache     map[string]float64
+	providers []*ExchangeRateProvider
+}
+
+func NewzcoinPriceFetcher(dialer proxy.Dialer) *zcoinPriceFetcher {
+	bp := exchange.NewBitcoinPriceFetcher(dialer)
+	z := zcoinPriceFetcher{
+		cache: make(map[string]float64),
+	}
+	dial := net.Dial
+	if dialer != nil {
+		dial = dialer.Dial
+	}
+	tbTransport := &http.Transport{Dial: dial}
+	client := &http.Client{Transport: tbTransport, Timeout: time.Minute}
+
+	z.providers = []*ExchangeRateProvider{
+		{"https://ticker.openbazaar.org/api", z.cache, client, OpenBazaarDecoder{}, nil},
+		{"https://bittrex.com/api/v1.1/public/getticker?market=btc-xzc", z.cache, client, BittrexDecoder{}, bp},
+	}
+	go z.run()
+	return &z
+}
+
+func (z *zcoinPriceFetcher) GetExchangeRate(currencyCode string) (float64, error) {
+	z.Lock()
+	defer z.Unlock()
+	price, ok := z.cache[currencyCode]
+	if !ok {
+		return 0, errors.New("Currency not tracked")
+	}
+	return price, nil
+}
+
+func (z *zcoinPriceFetcher) GetLatestRate(currencyCode string) (float64, error) {
+	z.fetchCurrentRates()
+	z.Lock()
+	defer z.Unlock()
+	price, ok := z.cache[currencyCode]
+	if !ok {
+		return 0, errors.New("Currency not tracked")
+	}
+	return price, nil
+}
+
+func (z *zcoinPriceFetcher) GetAllRates(cacheOK bool) (map[string]float64, error) {
+	if !cacheOK {
+		err := z.fetchCurrentRates()
+		if err != nil {
+			return nil, err
+		}
+	}
+	z.Lock()
+	defer z.Unlock()
+	return z.cache, nil
+}
+
+func (z *zcoinPriceFetcher) UnitsPerCoin() int {
+	return exchange.SatoshiPerBTC
+}
+
+func (z *zcoinPriceFetcher) fetchCurrentRates() error {
+	z.Lock()
+	defer z.Unlock()
+	for _, provider := range z.providers {
+		err := provider.fetch()
+		if err == nil {
+			return nil
+		}
+	}
+	log.Error("Failed to fetch zcoin exchange rates")
+	return errors.New("All exchange rate API queries failed")
+}
+
+func (z *zcoinPriceFetcher) run() {
+	z.fetchCurrentRates()
+	ticker := time.NewTicker(time.Minute * 15)
+	for range ticker.C {
+		z.fetchCurrentRates()
+	}
+}
+
+func (provider *ExchangeRateProvider) fetch() (err error) {
+	if len(provider.fetchUrl) == 0 {
+		err = errors.New("Provider has no fetchUrl")
+		return err
+	}
+	resp, err := provider.client.Get(provider.fetchUrl)
+	if err != nil {
+		log.Error("Failed to fetch from "+provider.fetchUrl, err)
+		return err
+	}
+	decoder := json.NewDecoder(resp.Body)
+	var dataMap interface{}
+	err = decoder.Decode(&dataMap)
+	if err != nil {
+		log.Error("Failed to decode JSON from "+provider.fetchUrl, err)
+		return err
+	}
+	return provider.decoder.decode(dataMap, provider.cache, provider.bitcoinProvider)
+}
+
+func (b OpenBazaarDecoder) decode(dat interface{}, cache map[string]float64, bp *exchange.BitcoinPriceFetcher) (err error) {
+	data := dat.(map[string]interface{})
+
+	xzc, ok := data["XZC"]
+	if !ok {
+		return errors.New(reflect.TypeOf(b).Name() + ".decode: Type assertion failed, missing 'XZC' field")
+	}
+	val, ok := xzc.(map[string]interface{})
+	if !ok {
+		return errors.New(reflect.TypeOf(b).Name() + ".decode: Type assertion failed")
+	}
+	xzcRate, ok := val["last"].(float64)
+	if !ok {
+		return errors.New(reflect.TypeOf(b).Name() + ".decode: Type assertion failed, missing 'last' (float) field")
+	}
+	for k, v := range data {
+		if k != "timestamp" {
+			val, ok := v.(map[string]interface{})
+			if !ok {
+				return errors.New(reflect.TypeOf(b).Name() + ".decode: Type assertion failed")
+			}
+			price, ok := val["last"].(float64)
+			if !ok {
+				return errors.New(reflect.TypeOf(b).Name() + ".decode: Type assertion failed, missing 'last' (float) field")
+			}
+			cache[k] = price * (1 / xzcRate)
+		}
+	}
+	return nil
+}
+
+func (b BittrexDecoder) decode(dat interface{}, cache map[string]float64, bp *exchange.BitcoinPriceFetcher) (err error) {
+	rates, err := bp.GetAllRates(false)
+	if err != nil {
+		return err
+	}
+	obj, ok := dat.(map[string]interface{})
+	if !ok {
+		return errors.New("BittrexDecoder type assertion failure")
+	}
+	result, ok := obj["result"]
+	if !ok {
+		return errors.New("BittrexDecoder: field `result` not found")
+	}
+	resultMap, ok := result.(map[string]interface{})
+	if !ok {
+		return errors.New("BittrexDecoder type assertion failure")
+	}
+	exRate, ok := resultMap["Last"]
+	if !ok {
+		return errors.New("BittrexDecoder: field `Last` not found")
+	}
+	rate, ok := exRate.(float64)
+	if !ok {
+		return errors.New("BittrexDecoder type assertion failure")
+	}
+
+	if rate == 0 {
+		return errors.New("Bitcoin-zcoin price data not available")
+	}
+	for k, v := range rates {
+		cache[k] = v * rate
+	}
+	return nil
+}

--- a/bitcoin/zcoind/wallet.go
+++ b/bitcoin/zcoind/wallet.go
@@ -1,0 +1,960 @@
+package zcoind
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/OpenBazaar/spvwallet"
+	"github.com/OpenBazaar/wallet-interface"
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	btcrpcclient "github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	btc "github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcutil/coinset"
+	hd "github.com/btcsuite/btcutil/hdkeychain"
+	"github.com/btcsuite/btcutil/txsort"
+	"github.com/btcsuite/btcwallet/wallet/txrules"
+	"github.com/op/go-logging"
+	b39 "github.com/tyler-smith/go-bip39"
+	"os"
+	"os/exec"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var log = logging.MustGetLogger("zcoind")
+
+type ZcoindWallet struct {
+	params           *chaincfg.Params
+	repoPath         string
+	trustedPeer      string
+	masterPrivateKey *hd.ExtendedKey
+	masterPublicKey  *hd.ExtendedKey
+	listeners        []func(wallet.TransactionCallback)
+	rpcClient        *btcrpcclient.Client
+	binary           string
+	controlPort      int
+	useTor           bool
+	addrsToWatch     []btc.Address
+	initChan         chan struct{}
+}
+
+var connCfg *btcrpcclient.ConnConfig = &btcrpcclient.ConnConfig{
+	Host:                 "localhost:8888",
+	HTTPPostMode:         true, // Zcoin core only supports HTTP POST mode
+	DisableTLS:           true, // Zcoin core does not provide TLS by default
+	DisableAutoReconnect: false,
+	DisableConnectOnNew:  false,
+}
+
+func NewZcoindWallet(mnemonic string, params *chaincfg.Params, repoPath string, trustedPeer string, binary string, useTor bool, torControlPort int) (*ZcoindWallet, error) {
+	seed := b39.NewSeed(mnemonic, "")
+	mPrivKey, _ := hd.NewMaster(seed, params)
+	mPubKey, _ := mPrivKey.Neuter()
+
+	if params.Name == chaincfg.TestNet3Params.Name || params.Name == chaincfg.RegressionNetParams.Name {
+		connCfg.Host = "localhost:18888"
+	}
+
+	dataDir := path.Join(repoPath, "zcoin")
+	var err error
+	connCfg.User, connCfg.Pass, err = GetCredentials(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if trustedPeer != "" {
+		trustedPeer = strings.Split(trustedPeer, ":")[0]
+	}
+
+	w := ZcoindWallet{
+		params:           params,
+		repoPath:         dataDir,
+		trustedPeer:      trustedPeer,
+		masterPrivateKey: mPrivKey,
+		masterPublicKey:  mPubKey,
+		binary:           binary,
+		controlPort:      torControlPort,
+		useTor:           useTor,
+		initChan:         make(chan struct{}),
+	}
+	return &w, nil
+}
+
+// TestNetworkEnabled indicates if the current network being used is Test Network
+func (w *ZcoindWallet) TestNetworkEnabled() bool {
+	return w.params.Name == chaincfg.TestNet3Params.Name
+}
+
+// RegressionNetworkEnabled indicates if the current network being used is Regression Network
+func (w *ZcoindWallet) RegressionNetworkEnabled() bool {
+	return w.params.Name == chaincfg.RegressionNetParams.Name
+}
+
+// MainNetworkEnabled indicates if the current network being used is the live Network
+func (w *ZcoindWallet) MainNetworkEnabled() bool {
+	return w.params.Name == chaincfg.MainNetParams.Name
+}
+
+func GetCredentials(repoPath string) (username, password string, err error) {
+	p := path.Join(repoPath, "zcoin", "zcoin.conf")
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		dataDir := path.Join(repoPath, "zcoin")
+		os.Mkdir(dataDir, os.ModePerm)
+
+		r := make([]byte, 32)
+		_, err := rand.Read(r)
+		if err != nil {
+			return "", "", err
+		}
+		password := base64.StdEncoding.EncodeToString(r)
+
+		user := fmt.Sprintf(`rpcuser=%s`, "OpenBazaar")
+		pass := fmt.Sprintf(`rpcpassword=%s`, password)
+
+		f, err := os.Create(p)
+		if err != nil {
+			return "", "", err
+		}
+		defer f.Close()
+		wr := bufio.NewWriter(f)
+		fmt.Fprintln(wr, user)
+		fmt.Fprintln(wr, pass)
+		wr.Flush()
+		return "OpenBazaar", password, nil
+	} else {
+		file, err := os.Open(p)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		var unExists, pwExists bool
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), "rpcuser=") {
+				username = scanner.Text()[8:]
+				unExists = true
+			} else if strings.Contains(scanner.Text(), "rpcpassword=") {
+				password = scanner.Text()[12:]
+				pwExists = true
+			}
+		}
+		if !unExists || !pwExists {
+			return "", "", errors.New("Zcoin config file does not contain a username and password")
+		}
+
+		if err := scanner.Err(); err != nil {
+			return "", "", err
+		}
+		return username, password, nil
+	}
+}
+
+func (w *ZcoindWallet) addQueuedWatchAddresses() {
+	for _, addr := range w.addrsToWatch {
+		w.addWatchedScript(addr)
+	}
+}
+
+func (w *ZcoindWallet) InitChan() chan struct{} {
+	return w.initChan
+}
+
+func (w *ZcoindWallet) BuildArguments(rescan bool) []string {
+	var notify string
+	switch runtime.GOOS {
+	case "windows":
+		notify = `powershell.exe Invoke-WebRequest -Uri http://localhost:8330/ -Method POST -Body %s`
+	default:
+		notify = `curl -d %s http://localhost:8330/`
+	}
+	args := []string{"-walletnotify=" + notify, "-server", "-wallet=ob-wallet.dat", "-conf=" + path.Join(w.repoPath, "zcoin.conf")}
+	if rescan {
+		args = append(args, "-rescan")
+	}
+	args = append(args, "-torcontrol=127.0.0.1:"+strconv.Itoa(w.controlPort))
+
+	if w.TestNetworkEnabled() {
+		args = append(args, "-testnet")
+	} else if w.RegressionNetworkEnabled() {
+		args = append(args, "-regtest")
+	}
+	if w.trustedPeer != "" {
+		args = append(args, "-connect="+w.trustedPeer)
+	}
+	if w.useTor {
+		socksPort := DefaultSocksPort(w.controlPort)
+		args = append(args, "-listen", "-proxy:127.0.0.1:"+strconv.Itoa(socksPort), "-onlynet=onion")
+	}
+	return args
+}
+
+func (w *ZcoindWallet) Start() {
+	w.shutdownIfActive()
+	args := w.BuildArguments(false)
+	client, _ := btcrpcclient.New(connCfg, nil)
+	w.rpcClient = client
+	go StartNotificationListener(client, w.listeners)
+
+	cmd := exec.Command(w.binary, args...)
+	go cmd.Start()
+	ticker := time.NewTicker(time.Second * 30)
+	go func() {
+		for range ticker.C {
+			log.Fatal("Failed to connect to zcoind")
+		}
+	}()
+	for {
+		_, err := client.GetBlockCount()
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	ticker.Stop()
+	log.Info("Connected to zcoind")
+	close(w.initChan)
+	go w.addQueuedWatchAddresses()
+}
+
+// If zcoind is already running let's shut it down so we restart it with our options
+func (w *ZcoindWallet) shutdownIfActive() {
+	client, err := btcrpcclient.New(connCfg, nil)
+	if err != nil {
+		return
+	}
+	client.RawRequest("stop", []json.RawMessage{})
+	client.Shutdown()
+	time.Sleep(5 * time.Second)
+}
+
+func (w *ZcoindWallet) CurrencyCode() string {
+	if w.MainNetworkEnabled() {
+		return "xzc"
+	} else {
+		return "txzc"
+	}
+}
+
+func (w *ZcoindWallet) IsDust(amount int64) bool {
+	return txrules.IsDustAmount(btc.Amount(amount), 25, txrules.DefaultRelayFeePerKb)
+}
+
+func (w *ZcoindWallet) MasterPrivateKey() *hd.ExtendedKey {
+	return w.masterPrivateKey
+}
+
+func (w *ZcoindWallet) MasterPublicKey() *hd.ExtendedKey {
+	return w.masterPublicKey
+}
+
+func (w *ZcoindWallet) CurrentAddress(purpose wallet.KeyPurpose) btc.Address {
+	<-w.initChan
+
+	resp, _ := w.rpcClient.RawRequest("getaccountaddress", []json.RawMessage{json.RawMessage([]byte(`""`))})
+	var a string
+	json.Unmarshal(resp, &a)
+	addr, _ := DecodeAddress(a, w.params)
+	return addr
+}
+
+func (w *ZcoindWallet) NewAddress(purpose wallet.KeyPurpose) btc.Address {
+	<-w.initChan
+
+	resp, _ := w.rpcClient.RawRequest("getnewaddress", []json.RawMessage{json.RawMessage([]byte(`""`))})
+	var a string
+	json.Unmarshal(resp, &a)
+	addr, _ := DecodeAddress(a, w.params)
+	return addr
+}
+
+func (w *ZcoindWallet) DecodeAddress(addr string) (btc.Address, error) {
+	return DecodeAddress(addr, w.params)
+}
+
+func (w *ZcoindWallet) ScriptToAddress(script []byte) (btc.Address, error) {
+	return ExtractPkScriptAddrs(script, w.params)
+}
+
+func (w *ZcoindWallet) AddressToScript(addr btc.Address) ([]byte, error) {
+	return PayToAddrScript(addr)
+}
+
+func (w *ZcoindWallet) HasKey(addr btc.Address) bool {
+	<-w.initChan
+	_, err := w.rpcClient.DumpPrivKey(addr)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+func (w *ZcoindWallet) Balance() (confirmed, unconfirmed int64) {
+	<-w.initChan
+	resp, _ := w.rpcClient.RawRequest("getwalletinfo", []json.RawMessage{})
+	type walletInfo struct {
+		Balance     float64 `json:"balance"`
+		Unconfirmed float64 `json:"unconfirmed_balance"`
+	}
+	respBytes, _ := resp.MarshalJSON()
+	i := new(walletInfo)
+	json.Unmarshal(respBytes, i)
+	c, _ := btc.NewAmount(i.Balance)
+	u, _ := btc.NewAmount(i.Unconfirmed)
+	return int64(c.ToUnit(btc.AmountSatoshi)), int64(u.ToUnit(btc.AmountSatoshi))
+}
+
+func (w *ZcoindWallet) GetBlockHeight(hash *chainhash.Hash) (int32, error) {
+	<-w.initChan
+	blockinfo, err := w.rpcClient.GetBlockHeaderVerbose(hash)
+	if err != nil {
+		return 0, err
+	}
+	return blockinfo.Height, nil
+}
+
+func (w *ZcoindWallet) Transactions() ([]wallet.Txn, error) {
+	<-w.initChan
+	var ret []wallet.Txn
+	resp, err := w.rpcClient.ListTransactions("")
+	if err != nil {
+		return ret, err
+	}
+	for _, r := range resp {
+		amt, err := btc.NewAmount(r.Amount)
+		if err != nil {
+			return ret, err
+		}
+		ts := time.Unix(r.TimeReceived, 0)
+		height := int32(0)
+		if r.Confirmations > 0 {
+			h, err := chainhash.NewHashFromStr(r.BlockHash)
+			if err != nil {
+				return ret, err
+			}
+			height, err = w.GetBlockHeight(h)
+			if err != nil {
+				return ret, err
+			}
+		}
+		t := wallet.Txn{
+			Txid:      r.TxID,
+			Value:     int64(amt.ToUnit(btc.AmountSatoshi)),
+			Height:    height,
+			Timestamp: ts,
+		}
+		ret = append(ret, t)
+	}
+	return ret, nil
+}
+
+func (w *ZcoindWallet) GetTransaction(txid chainhash.Hash) (wallet.Txn, error) {
+	<-w.initChan
+	includeWatchOnly := false
+	t := wallet.Txn{}
+	resp, err := w.rpcClient.GetTransaction(&txid, &includeWatchOnly)
+	if err != nil {
+		return t, err
+	}
+	t.Txid = resp.TxID
+	t.Value = int64(resp.Amount * 100000000)
+	t.Height = int32(resp.BlockIndex)
+	t.Timestamp = time.Unix(resp.TimeReceived, 0)
+	t.WatchOnly = false
+	return t, nil
+}
+
+func (w *ZcoindWallet) GetConfirmations(txid chainhash.Hash) (uint32, uint32, error) {
+	<-w.initChan
+	includeWatchOnly := true
+	resp, err := w.rpcClient.GetTransaction(&txid, &includeWatchOnly)
+	if err != nil {
+		return 0, 0, err
+	}
+	return uint32(resp.Confirmations), uint32(resp.BlockIndex), nil
+}
+
+func (w *ZcoindWallet) ChainTip() (uint32, chainhash.Hash) {
+	<-w.initChan
+	var ch chainhash.Hash
+	info, err := w.rpcClient.GetInfo()
+	if err != nil {
+		return uint32(0), ch
+	}
+	h, err := w.rpcClient.GetBestBlockHash()
+	if err != nil {
+		return uint32(0), ch
+	}
+	return uint32(info.Blocks), *h
+}
+
+func (w *ZcoindWallet) gatherCoins() (map[coinset.Coin]*hd.ExtendedKey, error) {
+	<-w.initChan
+	m := make(map[coinset.Coin]*hd.ExtendedKey)
+	utxos, err := w.rpcClient.ListUnspent()
+	if err != nil {
+		return m, err
+	}
+	for _, u := range utxos {
+		if !u.Spendable {
+			continue
+		}
+		txhash, err := chainhash.NewHashFromStr(u.TxID)
+		if err != nil {
+			return m, err
+		}
+		addr, err := DecodeAddress(u.Address, w.params)
+		if err != nil {
+			return m, err
+		}
+		scriptPubkey, err := w.AddressToScript(addr)
+		if err != nil {
+			return m, err
+		}
+		c := spvwallet.NewCoin(txhash.CloneBytes(), u.Vout, btc.Amount(u.Amount*100000000), u.Confirmations, scriptPubkey)
+
+		wif, err := w.rpcClient.DumpPrivKey(addr)
+		if err != nil {
+			return m, err
+		}
+		key := hd.NewExtendedKey(
+			w.params.HDPrivateKeyID[:],
+			wif.PrivKey.Serialize(),
+			make([]byte, 32),
+			[]byte{0x00, 0x00, 0x00, 0x00},
+			0,
+			0,
+			true)
+		m[c] = key
+	}
+	return m, nil
+}
+
+func (w *ZcoindWallet) Spend(amount int64, addr btc.Address, feeLevel wallet.FeeLevel) (*chainhash.Hash, error) {
+	<-w.initChan
+	tx, err := w.buildTx(amount, addr, feeLevel)
+	if err != nil {
+		return nil, err
+	}
+	return w.rpcClient.SendRawTransaction(tx, false)
+}
+
+func (w *ZcoindWallet) buildTx(amount int64, addr btc.Address, feeLevel wallet.FeeLevel) (*wire.MsgTx, error) {
+	script, _ := PayToAddrScript(addr)
+	if txrules.IsDustAmount(btc.Amount(amount), len(script), txrules.DefaultRelayFeePerKb) {
+		return nil, wallet.ErrorDustAmount
+	}
+
+	var additionalPrevScripts map[wire.OutPoint][]byte
+	var additionalKeysByAddress map[string]*btc.WIF
+
+	// Create input source
+	coinMap, err := w.gatherCoins()
+	if err != nil {
+		return nil, err
+	}
+	coins := make([]coinset.Coin, 0, len(coinMap))
+	for k := range coinMap {
+		coins = append(coins, k)
+	}
+	inputSource := func(target btc.Amount) (total btc.Amount, inputs []*wire.TxIn, scripts [][]byte, err error) {
+		coinSelector := coinset.MaxValueAgeCoinSelector{MaxInputs: 10000, MinChangeAmount: btc.Amount(0)}
+		coins, err := coinSelector.CoinSelect(target, coins)
+		if err != nil {
+			return total, inputs, scripts, wallet.ErrorInsuffientFunds
+		}
+		additionalPrevScripts = make(map[wire.OutPoint][]byte)
+		additionalKeysByAddress = make(map[string]*btc.WIF)
+		for _, c := range coins.Coins() {
+			total += c.Value()
+			outpoint := wire.NewOutPoint(c.Hash(), c.Index())
+			in := wire.NewTxIn(outpoint, []byte{}, [][]byte{})
+			in.Sequence = 0 // Opt-in RBF so we can bump fees
+			inputs = append(inputs, in)
+			additionalPrevScripts[*outpoint] = c.PkScript()
+			key := coinMap[c]
+			addr, err := key.Address(w.params)
+			if err != nil {
+				continue
+			}
+			privKey, err := key.ECPrivKey()
+			if err != nil {
+				continue
+			}
+			wif, _ := btc.NewWIF(privKey, w.params, true)
+			additionalKeysByAddress[addr.EncodeAddress()] = wif
+		}
+		return total, inputs, scripts, nil
+	}
+
+	// Get the fee per kilobyte
+	feePerKB := int64(w.GetFeePerByte(feeLevel)) * 1000
+
+	// outputs
+	out := wire.NewTxOut(amount, script)
+
+	// Create change source
+	changeSource := func() ([]byte, error) {
+		addr := w.CurrentAddress(wallet.INTERNAL)
+		script, err := PayToAddrScript(addr)
+		if err != nil {
+			return []byte{}, err
+		}
+		return script, nil
+	}
+
+	outputs := []*wire.TxOut{out}
+	authoredTx, err := spvwallet.NewUnsignedTransaction(outputs, btc.Amount(feePerKB), inputSource, changeSource)
+	if err != nil {
+		return nil, err
+	}
+
+	// BIP 69 sorting
+	txsort.InPlaceSort(authoredTx.Tx)
+
+	// Sign tx
+	getKey := txscript.KeyClosure(func(addr btc.Address) (*btcec.PrivateKey, bool, error) {
+		addrStr := addr.EncodeAddress()
+		wif := additionalKeysByAddress[addrStr]
+		return wif.PrivKey, wif.CompressPubKey, nil
+	})
+	getScript := txscript.ScriptClosure(func(
+		addr btc.Address) ([]byte, error) {
+		return []byte{}, nil
+	})
+	for i, txIn := range authoredTx.Tx.TxIn {
+		prevOutScript := additionalPrevScripts[txIn.PreviousOutPoint]
+		script, err := txscript.SignTxOutput(w.params,
+			authoredTx.Tx, i, prevOutScript, txscript.SigHashAll, getKey,
+			getScript, txIn.SignatureScript)
+		if err != nil {
+			return nil, errors.New("Failed to sign transaction")
+		}
+		txIn.SignatureScript = script
+	}
+	return authoredTx.Tx, nil
+}
+
+func (w *ZcoindWallet) BumpFee(txid chainhash.Hash) (*chainhash.Hash, error) {
+	<-w.initChan
+	includeWatchOnly := false
+	tx, err := w.rpcClient.GetTransaction(&txid, &includeWatchOnly)
+	if err != nil {
+		return nil, err
+	}
+	if tx.Confirmations > 0 {
+		return nil, spvwallet.BumpFeeAlreadyConfirmedError
+	}
+	unspent, err := w.rpcClient.ListUnspent()
+	if err != nil {
+		return nil, err
+	}
+	for _, u := range unspent {
+		if u.TxID == txid.String() {
+			if u.Confirmations > 0 {
+				return nil, spvwallet.BumpFeeAlreadyConfirmedError
+			}
+			h, err := chainhash.NewHashFromStr(u.TxID)
+			if err != nil {
+				continue
+			}
+			op := wire.NewOutPoint(h, u.Vout)
+			script, err := hex.DecodeString(u.ScriptPubKey)
+			if err != nil {
+				continue
+			}
+			utxo := wallet.Utxo{
+				Op:           *op,
+				Value:        int64(u.Amount / 100000000),
+				ScriptPubkey: script,
+			}
+			addr, err := DecodeAddress(u.Address, w.params)
+			if err != nil {
+				continue
+			}
+			key, err := w.rpcClient.DumpPrivKey(addr)
+			if err != nil {
+				continue
+			}
+			hdKey := hd.NewExtendedKey(w.Params().HDPrivateKeyID[:], key.PrivKey.Serialize(), make([]byte, 32), make([]byte, 4), 0, 0, true)
+			transactionID, err := w.SweepAddress([]wallet.Utxo{utxo}, nil, hdKey, nil, wallet.FEE_BUMP)
+			if err != nil {
+				return nil, err
+			}
+			return transactionID, nil
+
+		}
+	}
+	return nil, spvwallet.BumpFeeNotFoundError
+}
+
+func (w *ZcoindWallet) GetFeePerByte(feeLevel wallet.FeeLevel) uint64 {
+	<-w.initChan
+	defautlFee := uint64(100)
+	var nBlocks json.RawMessage
+	switch feeLevel {
+	case wallet.PRIOIRTY:
+		nBlocks = json.RawMessage([]byte(`1`))
+	case wallet.NORMAL:
+		nBlocks = json.RawMessage([]byte(`3`))
+	case wallet.ECONOMIC:
+		nBlocks = json.RawMessage([]byte(`6`))
+	default:
+		return defautlFee
+	}
+	resp, err := w.rpcClient.RawRequest("estimatefee", []json.RawMessage{nBlocks})
+	if err != nil {
+		return defautlFee
+	}
+	feePerKb, err := strconv.Atoi(string(resp))
+	if err != nil {
+		return defautlFee
+	}
+	if feePerKb <= 0 {
+		return defautlFee
+	}
+	fee := feePerKb / 1000
+	return uint64(fee)
+}
+
+func (w *ZcoindWallet) EstimateFee(ins []wallet.TransactionInput, outs []wallet.TransactionOutput, feePerByte uint64) uint64 {
+	tx := wire.NewMsgTx(wire.TxVersion)
+	for _, out := range outs {
+		output := wire.NewTxOut(out.Value, out.ScriptPubKey)
+		tx.TxOut = append(tx.TxOut, output)
+	}
+	estimatedSize := spvwallet.EstimateSerializeSize(len(ins), tx.TxOut, false, spvwallet.P2PKH)
+	fee := estimatedSize * int(feePerByte)
+	return uint64(fee)
+}
+
+func (w *ZcoindWallet) EstimateSpendFee(amount int64, feeLevel wallet.FeeLevel) (uint64, error) {
+	<-w.initChan
+	// Since this is an estimate we can use a dummy output address. Let's use a long one so we don't under estimate.
+	addr, err := DecodeAddress("a6ZnqgeVpN7STnBE3yNUuhbgSH7GrFwi4s", &chaincfg.MainNetParams)
+	if err != nil {
+		return 0, err
+	}
+	tx, err := w.buildTx(amount, addr, feeLevel)
+	if err != nil {
+		return 0, err
+	}
+	var outval int64
+	for _, output := range tx.TxOut {
+		outval += output.Value
+	}
+	var inval int64
+	utxos, err := w.rpcClient.ListUnspent()
+	if err != nil {
+		return 0, err
+	}
+	for _, input := range tx.TxIn {
+		for _, utxo := range utxos {
+			if utxo.TxID == input.PreviousOutPoint.Hash.String() && utxo.Vout == input.PreviousOutPoint.Index {
+				inval += int64(utxo.Amount * 100000000)
+				break
+			}
+		}
+	}
+	if inval < outval {
+		return 0, errors.New("Error building transaction: inputs less than outputs")
+	}
+	return uint64(inval - outval), err
+}
+
+func (w *ZcoindWallet) CreateMultisigSignature(ins []wallet.TransactionInput, outs []wallet.TransactionOutput, key *hd.ExtendedKey, redeemScript []byte, feePerByte uint64) ([]wallet.Signature, error) {
+
+	var sigs []wallet.Signature
+	tx := wire.NewMsgTx(wire.TxVersion)
+	for _, in := range ins {
+		ch, err := chainhash.NewHashFromStr(hex.EncodeToString(in.OutpointHash))
+		if err != nil {
+			return sigs, err
+		}
+		outpoint := wire.NewOutPoint(ch, in.OutpointIndex)
+		input := wire.NewTxIn(outpoint, []byte{}, [][]byte{})
+		tx.TxIn = append(tx.TxIn, input)
+	}
+	for _, out := range outs {
+		output := wire.NewTxOut(out.Value, out.ScriptPubKey)
+		tx.TxOut = append(tx.TxOut, output)
+	}
+
+	// Subtract fee
+	estimatedSize := spvwallet.EstimateSerializeSize(len(ins), tx.TxOut, false, spvwallet.P2SH_2of3_Multisig)
+	fee := estimatedSize * int(feePerByte)
+	feePerOutput := fee / len(tx.TxOut)
+	for _, output := range tx.TxOut {
+		output.Value -= int64(feePerOutput)
+	}
+
+	// BIP 69 sorting
+	txsort.InPlaceSort(tx)
+
+	signingKey, err := key.ECPrivKey()
+	if err != nil {
+		return sigs, err
+	}
+
+	for i := range tx.TxIn {
+		sig, err := txscript.RawTxInSignature(tx, i, redeemScript, txscript.SigHashAll, signingKey)
+		if err != nil {
+			continue
+		}
+		bs := wallet.Signature{InputIndex: uint32(i), Signature: sig}
+		sigs = append(sigs, bs)
+	}
+	return sigs, nil
+}
+
+func (w *ZcoindWallet) Multisign(ins []wallet.TransactionInput, outs []wallet.TransactionOutput, sigs1 []wallet.Signature, sigs2 []wallet.Signature, redeemScript []byte, feePerByte uint64, broadcast bool) ([]byte, error) {
+
+	<-w.initChan
+	tx := wire.NewMsgTx(wire.TxVersion)
+	for _, in := range ins {
+		ch, err := chainhash.NewHashFromStr(hex.EncodeToString(in.OutpointHash))
+		if err != nil {
+			return nil, err
+		}
+		outpoint := wire.NewOutPoint(ch, in.OutpointIndex)
+		input := wire.NewTxIn(outpoint, []byte{}, [][]byte{})
+		tx.TxIn = append(tx.TxIn, input)
+	}
+	for _, out := range outs {
+		output := wire.NewTxOut(out.Value, out.ScriptPubKey)
+		tx.TxOut = append(tx.TxOut, output)
+	}
+
+	// Subtract fee
+	estimatedSize := spvwallet.EstimateSerializeSize(len(ins), tx.TxOut, false, spvwallet.P2SH_2of3_Multisig)
+	fee := estimatedSize * int(feePerByte)
+	feePerOutput := fee / len(tx.TxOut)
+	for _, output := range tx.TxOut {
+		output.Value -= int64(feePerOutput)
+	}
+
+	// BIP 69 sorting
+	txsort.InPlaceSort(tx)
+
+	for i, input := range tx.TxIn {
+		var sig1 []byte
+		var sig2 []byte
+		for _, sig := range sigs1 {
+			if int(sig.InputIndex) == i {
+				sig1 = sig.Signature
+			}
+		}
+		for _, sig := range sigs2 {
+			if int(sig.InputIndex) == i {
+				sig2 = sig.Signature
+			}
+		}
+		builder := txscript.NewScriptBuilder()
+		builder.AddOp(txscript.OP_0)
+		builder.AddData(sig1)
+		builder.AddData(sig2)
+		builder.AddData(redeemScript)
+		scriptSig, err := builder.Script()
+		if err != nil {
+			return nil, err
+		}
+		input.SignatureScript = scriptSig
+	}
+	// Broadcast
+	if broadcast {
+		_, err := w.rpcClient.SendRawTransaction(tx, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var buf bytes.Buffer
+	tx.BtcEncode(&buf, 1, wire.BaseEncoding)
+	return buf.Bytes(), nil
+}
+
+func (w *ZcoindWallet) SweepAddress(utxos []wallet.Utxo, address *btc.Address, key *hd.ExtendedKey, redeemScript *[]byte, feeLevel wallet.FeeLevel) (*chainhash.Hash, error) {
+	<-w.initChan
+	var internalAddr btc.Address
+	if address != nil {
+		internalAddr = *address
+	} else {
+		internalAddr = w.CurrentAddress(wallet.INTERNAL)
+	}
+	script, err := PayToAddrScript(internalAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	var val int64
+	var inputs []*wire.TxIn
+	additionalPrevScripts := make(map[wire.OutPoint][]byte)
+	for _, u := range utxos {
+		val += u.Value
+		in := wire.NewTxIn(&u.Op, []byte{}, [][]byte{})
+		inputs = append(inputs, in)
+		additionalPrevScripts[u.Op] = u.ScriptPubkey
+	}
+	out := wire.NewTxOut(val, script)
+
+	txType := spvwallet.P2PKH
+	if redeemScript != nil {
+		txType = spvwallet.P2SH_1of2_Multisig
+	}
+
+	estimatedSize := spvwallet.EstimateSerializeSize(len(utxos), []*wire.TxOut{out}, false, txType)
+
+	// Calculate the fee
+	feePerByte := int(w.GetFeePerByte(feeLevel))
+	fee := estimatedSize * feePerByte
+
+	outVal := val - int64(fee)
+	if outVal < 0 {
+		outVal = 0
+	}
+	out.Value = outVal
+
+	tx := &wire.MsgTx{
+		Version:  wire.TxVersion,
+		TxIn:     inputs,
+		TxOut:    []*wire.TxOut{out},
+		LockTime: 0,
+	}
+
+	// BIP 69 sorting
+	txsort.InPlaceSort(tx)
+
+	// Sign tx
+	getKey := txscript.KeyClosure(func(addr btc.Address) (*btcec.PrivateKey, bool, error) {
+		privKey, err := key.ECPrivKey()
+		if err != nil {
+			return nil, false, err
+		}
+		wif, err := btc.NewWIF(privKey, w.params, true)
+		if err != nil {
+			return nil, false, err
+		}
+		return wif.PrivKey, wif.CompressPubKey, nil
+	})
+	getScript := txscript.ScriptClosure(func(addr btc.Address) ([]byte, error) {
+		if redeemScript == nil {
+			return []byte{}, nil
+		}
+		return *redeemScript, nil
+	})
+
+	for i, txIn := range tx.TxIn {
+		prevOutScript := additionalPrevScripts[txIn.PreviousOutPoint]
+		script, err := txscript.SignTxOutput(w.params,
+			tx, i, prevOutScript, txscript.SigHashAll, getKey,
+			getScript, txIn.SignatureScript)
+		if err != nil {
+			return nil, errors.New("Failed to sign transaction")
+		}
+		txIn.SignatureScript = script
+	}
+
+	// Broadcast
+	_, err = w.rpcClient.SendRawTransaction(tx, false)
+	if err != nil {
+		return nil, err
+	}
+	txid := tx.TxHash()
+	return &txid, nil
+}
+
+func (w *ZcoindWallet) Params() *chaincfg.Params {
+	return w.params
+}
+
+func (w *ZcoindWallet) AddTransactionListener(callback func(wallet.TransactionCallback)) {
+	w.listeners = append(w.listeners, callback)
+}
+
+func (w *ZcoindWallet) GenerateMultisigScript(keys []hd.ExtendedKey, threshold int, timeout time.Duration, timeoutKey *hd.ExtendedKey) (addr btc.Address, redeemScript []byte, err error) {
+
+	var addrPubKeys []*btc.AddressPubKey
+	for _, key := range keys {
+		ecKey, err := key.ECPubKey()
+		if err != nil {
+			return nil, nil, err
+		}
+		k, err := btc.NewAddressPubKey(ecKey.SerializeCompressed(), w.params)
+		if err != nil {
+			return nil, nil, err
+		}
+		addrPubKeys = append(addrPubKeys, k)
+	}
+	redeemScript, err = txscript.MultiSigScript(addrPubKeys, threshold)
+	if err != nil {
+		return nil, nil, err
+	}
+	addr, err = NewAddressScriptHash(redeemScript, w.params)
+	if err != nil {
+		return nil, nil, err
+	}
+	return addr, redeemScript, nil
+}
+
+func (w *ZcoindWallet) AddWatchedScript(script []byte) error {
+	addr, err := ExtractPkScriptAddrs(script, w.params)
+	if err != nil {
+		return err
+	}
+	select {
+	case <-w.initChan:
+		return w.addWatchedScript(addr)
+	default:
+		w.addrsToWatch = append(w.addrsToWatch, addr)
+	}
+	return nil
+}
+
+func (w *ZcoindWallet) addWatchedScript(addr btc.Address) error {
+	a := `"` + addr.EncodeAddress() + `"`
+	_, err := w.rpcClient.RawRequest("importaddress", []json.RawMessage{json.RawMessage(a), json.RawMessage(`""`), json.RawMessage(`false`)})
+	return err
+}
+
+func (w *ZcoindWallet) ReSyncBlockchain(fromDate time.Time) {
+	<-w.initChan
+	w.rpcClient.RawRequest("stop", []json.RawMessage{})
+	w.rpcClient.Shutdown()
+	time.Sleep(5 * time.Second)
+	args := w.BuildArguments(true)
+	cmd := exec.Command(w.binary, args...)
+	cmd.Start()
+
+	client, err := btcrpcclient.New(connCfg, nil)
+	if err != nil {
+		log.Error("Could not connect to zcoind during rescan")
+	}
+	w.rpcClient = client
+}
+
+func (w *ZcoindWallet) Close() {
+	if w.rpcClient != nil {
+		w.rpcClient.RawRequest("stop", []json.RawMessage{})
+		w.rpcClient.Shutdown()
+	}
+}
+
+func DefaultSocksPort(controlPort int) int {
+	socksPort := 9050
+	if controlPort == 9151 || controlPort == 9051 {
+		controlPort--
+		socksPort = controlPort
+	}
+	return socksPort
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -23,6 +23,7 @@ import (
 	"github.com/OpenBazaar/openbazaar-go/bitcoin/exchange"
 	lis "github.com/OpenBazaar/openbazaar-go/bitcoin/listeners"
 	"github.com/OpenBazaar/openbazaar-go/bitcoin/resync"
+	"github.com/OpenBazaar/openbazaar-go/bitcoin/zcoind"
 	"github.com/OpenBazaar/openbazaar-go/core"
 	"github.com/OpenBazaar/openbazaar-go/ipfs"
 	obns "github.com/OpenBazaar/openbazaar-go/namesys"
@@ -649,6 +650,23 @@ func (x *Start) Execute(args []string) error {
 			exchangeRates = zcashd.NewZcashPriceFetcher(torDialer)
 		}
 		resyncManager = resync.NewResyncManager(sqliteDB.Sales(), cryptoWallet)
+	case "zcoind":
+		walletTypeStr = "zcoind"
+		if walletCfg.Binary == "" {
+			return errors.New("The path to the zcoind binary must be specified in the config file when using zcoind")
+		}
+		usetor := false
+		if usingTor && !usingClearnet {
+			usetor = true
+		}
+		cryptoWallet, err = zcoind.NewZcoindWallet(mn, &params, repoPath, walletCfg.TrustedPeer, walletCfg.Binary, usetor, controlPort)
+		if err != nil {
+			return err
+		}
+
+		if !x.DisableExchangeRates {
+			exchangeRates = zcoind.NewzcoinPriceFetcher(torDialer)
+		}
 	default:
 		log.Fatal("Unknown wallet type")
 	}


### PR DESCRIPTION
Zcoin wallet can be configured by setting the wallet config as follows:
  "Wallet": {
    "Binary": "/Applications/Zcoin-Qt.app/Contents/MacOS/Zcoin-Qt",
    "FeeAPI": "",
    "HighFeeDefault": 160,
    "LowFeeDefault": 20,
    "MaxFee": 2000,
    "MediumFeeDefault": 60,
    "TrustedPeer": "",
    "Type": "zcoind"
  }