### PR TITLE
cmd/encrypt: enhance success message

### DIFF
--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -126,6 +126,6 @@ func (x *EncryptDatabase) Execute(args []string) error {
 		return err
 	}
 	os.RemoveAll(path.Join(tmpPath))
-	fmt.Println("Success! You must now run openbazaard start with the --password flag.")
+	fmt.Println("Success! You must now run openbazaard start with a password.")
 	return nil
 }


### PR DESCRIPTION
the message to provide the password on the command line is a
bit misleading, as it is also possible to provide the password
via stdin when invoking 'start'

providing it via stdin has the advantage not to be visible later
in the shell's history

Signed-off-by: Maximilian Meister <mmeister@suse.de>