### PR TITLE
Protect disputes being opened on orders which are old

### DIFF
--- a/core/completion.go
+++ b/core/completion.go
@@ -270,7 +270,7 @@ func (n *OpenBazaarNode) CompleteOrder(orderRatings *OrderRatings, contract *pb.
 var EscrowTimeLockedError error
 
 func (n *OpenBazaarNode) ReleaseFundsAfterTimeout(contract *pb.RicardianContract, records []*wallet.TransactionRecord) error {
-	minConfirms := contract.VendorListings[0].Metadata.EscrowTimeoutHours * 6
+	minConfirms := contract.VendorListings[0].Metadata.EscrowTimeoutHours * ConfirmationsPerHour
 	var utxos []wallet.Utxo
 	for _, r := range records {
 		if !r.Spent && r.Value > 0 {

--- a/core/disputes.go
+++ b/core/disputes.go
@@ -24,13 +24,16 @@ import (
 	dht "gx/ipfs/QmUCS9EnqNq1kCnJds2eLDypBiS21aSiCf1MVzSUVB9TGA/go-libp2p-kad-dht"
 )
 
+// ConfirmationsPerHour is temporary until the Wallet interface has Attributes() to provide this value
+const ConfirmationsPerHour = 6
+
 var DisputeWg = new(sync.WaitGroup)
 
 var ErrCaseNotFound = errors.New("Case not found")
 var ErrOpenFailureOrderExpired = errors.New("Unable to open case. Order is too old to dispute.")
 
 func (n *OpenBazaarNode) OpenDispute(orderID string, contract *pb.RicardianContract, records []*wallet.TransactionRecord, claim string) error {
-	if ok := n.verifyEscrowFundsAreDisputeable(contract, records); !ok {
+	if !n.verifyEscrowFundsAreDisputeable(contract, records) {
 		return ErrOpenFailureOrderExpired
 	}
 	var isPurchase bool
@@ -118,7 +121,7 @@ func (n *OpenBazaarNode) OpenDispute(orderID string, contract *pb.RicardianContr
 }
 
 func (n *OpenBazaarNode) verifyEscrowFundsAreDisputeable(contract *pb.RicardianContract, records []*wallet.TransactionRecord) bool {
-	confirmationsForTimeout := contract.VendorListings[0].Metadata.EscrowTimeoutHours * 6
+	confirmationsForTimeout := contract.VendorListings[0].Metadata.EscrowTimeoutHours * ConfirmationsPerHour
 	for _, r := range records {
 		hash, err := chainhash.NewHashFromStr(r.Txid)
 		if err != nil {

--- a/core/record_aging_notifier_test.go
+++ b/core/record_aging_notifier_test.go
@@ -24,10 +24,10 @@ func TestPerformTaskCreatesModeratorDisputeExpiryNotifications(t *testing.T) {
 		broadcastChannel = make(chan repo.Notifier, 0)
 		timeStart        = time.Now().Add(time.Duration(-50*24) * time.Hour)
 		twelveHours      = time.Duration(12) * time.Hour
-		fifteenDays      = time.Duration(15*24) * time.Hour
-		fourtyDays       = time.Duration(40*24) * time.Hour
-		fourtyFourDays   = time.Duration(44*24) * time.Hour
-		fourtyFiveDays   = time.Duration(45*24) * time.Hour
+		firstInterval    = repo.ModeratorDisputeExpiry_firstInterval
+		secondInterval   = repo.ModeratorDisputeExpiry_secondInterval
+		thirdInterval    = repo.ModeratorDisputeExpiry_thirdInterval
+		lastInterval     = repo.ModeratorDisputeExpiry_lastInterval
 
 		// Produces notification for 15, 40, 44 and 45 days
 		neverNotified = &repo.DisputeCaseRecord{
@@ -50,7 +50,7 @@ func TestPerformTaskCreatesModeratorDisputeExpiryNotifications(t *testing.T) {
 		notifiedUpToFifteenDay = &repo.DisputeCaseRecord{
 			CaseID:         "notifiedUpToFifteenDay",
 			Timestamp:      timeStart,
-			LastNotifiedAt: timeStart.Add(fifteenDays + twelveHours),
+			LastNotifiedAt: timeStart.Add(firstInterval + twelveHours),
 			BuyerContract: &pb.RicardianContract{
 				VendorListings: []*pb.Listing{
 					{Item: &pb.Listing_Item{Images: []*pb.Listing_Item_Image{{}}}},
@@ -67,7 +67,7 @@ func TestPerformTaskCreatesModeratorDisputeExpiryNotifications(t *testing.T) {
 		notifiedUpToFourtyDays = &repo.DisputeCaseRecord{
 			CaseID:         "notifiedUpToFourtyDay",
 			Timestamp:      timeStart,
-			LastNotifiedAt: timeStart.Add(fourtyDays + twelveHours),
+			LastNotifiedAt: timeStart.Add(secondInterval + twelveHours),
 			BuyerContract: &pb.RicardianContract{
 				VendorListings: []*pb.Listing{
 					{Item: &pb.Listing_Item{Images: []*pb.Listing_Item_Image{{Tiny: "fourty-buyer-tinyimagehash", Small: "fourty-buyer-smallimagehash"}}}},
@@ -84,7 +84,7 @@ func TestPerformTaskCreatesModeratorDisputeExpiryNotifications(t *testing.T) {
 		notifiedUpToFourtyFourDays = &repo.DisputeCaseRecord{
 			CaseID:         "notifiedUpToFourtyFourDays",
 			Timestamp:      timeStart,
-			LastNotifiedAt: timeStart.Add(fourtyFourDays + twelveHours),
+			LastNotifiedAt: timeStart.Add(thirdInterval + twelveHours),
 			BuyerContract: &pb.RicardianContract{
 				VendorListings: []*pb.Listing{
 					{Item: &pb.Listing_Item{Images: []*pb.Listing_Item_Image{{}}}},
@@ -101,7 +101,7 @@ func TestPerformTaskCreatesModeratorDisputeExpiryNotifications(t *testing.T) {
 		notifiedUpToFourtyFiveDays = &repo.DisputeCaseRecord{
 			CaseID:         "notifiedUpToFourtyFiveDays",
 			Timestamp:      timeStart,
-			LastNotifiedAt: timeStart.Add(fourtyFiveDays + twelveHours),
+			LastNotifiedAt: timeStart.Add(lastInterval + twelveHours),
 			BuyerContract: &pb.RicardianContract{
 				VendorListings: []*pb.Listing{
 					{Item: &pb.Listing_Item{Images: []*pb.Listing_Item_Image{{}}}},
@@ -378,10 +378,10 @@ func TestPerformTaskCreatesBuyerDisputeTimeoutNotifications(t *testing.T) {
 		broadcastChannel = make(chan repo.Notifier, 0)
 		timeStart        = time.Now().Add(time.Duration(-50*24) * time.Hour)
 		twelveHours      = time.Duration(12) * time.Hour
-		fifteenDays      = time.Duration(15*24) * time.Hour
-		fourtyDays       = time.Duration(40*24) * time.Hour
-		fourtyFourDays   = time.Duration(44*24) * time.Hour
-		fourtyFiveDays   = time.Duration(45*24) * time.Hour
+		firstInterval    = repo.BuyerDisputeTimeout_firstInterval
+		secondInterval   = repo.BuyerDisputeTimeout_secondInterval
+		thirdInterval    = repo.BuyerDisputeTimeout_thirdInterval
+		lastInterval     = repo.BuyerDisputeTimeout_lastInterval
 
 		// Produces no notifications as contract is undisputeable
 		neverNotifiedButUndisputeable = &repo.PurchaseRecord{
@@ -405,7 +405,7 @@ func TestPerformTaskCreatesBuyerDisputeTimeoutNotifications(t *testing.T) {
 			OrderID:        "notifiedUpToFifteenDay",
 			OrderState:     pb.OrderState(pb.OrderState_PENDING),
 			Timestamp:      timeStart,
-			LastNotifiedAt: timeStart.Add(fifteenDays + twelveHours),
+			LastNotifiedAt: timeStart.Add(firstInterval + twelveHours),
 		}
 		// Produces notification for 44 and 45 days
 		notifiedUpToFourtyDay = &repo.PurchaseRecord{
@@ -413,7 +413,7 @@ func TestPerformTaskCreatesBuyerDisputeTimeoutNotifications(t *testing.T) {
 			OrderID:        "notifiedUpToFourtyDay",
 			OrderState:     pb.OrderState(pb.OrderState_PENDING),
 			Timestamp:      timeStart,
-			LastNotifiedAt: timeStart.Add(fourtyDays + twelveHours),
+			LastNotifiedAt: timeStart.Add(secondInterval + twelveHours),
 		}
 		// Produces notification for 45 days
 		notifiedUpToFourtyFourDays = &repo.PurchaseRecord{
@@ -421,7 +421,7 @@ func TestPerformTaskCreatesBuyerDisputeTimeoutNotifications(t *testing.T) {
 			OrderID:        "notifiedUpToFourtyFourDays",
 			OrderState:     pb.OrderState(pb.OrderState_PENDING),
 			Timestamp:      timeStart,
-			LastNotifiedAt: timeStart.Add(fourtyFourDays + twelveHours),
+			LastNotifiedAt: timeStart.Add(thirdInterval + twelveHours),
 		}
 		// Produces no notifications as all have already been created
 		notifiedUpToFourtyFiveDays = &repo.PurchaseRecord{
@@ -429,7 +429,7 @@ func TestPerformTaskCreatesBuyerDisputeTimeoutNotifications(t *testing.T) {
 			OrderID:        "notifiedUpToFourtyFiveDays",
 			OrderState:     pb.OrderState(pb.OrderState_PENDING),
 			Timestamp:      timeStart,
-			LastNotifiedAt: timeStart.Add(fourtyFiveDays + twelveHours),
+			LastNotifiedAt: timeStart.Add(lastInterval + twelveHours),
 		}
 		existingRecords = []*repo.PurchaseRecord{
 			neverNotifiedButUndisputeable,
@@ -689,7 +689,7 @@ func TestPerformTaskCreatesVendorDisputeTimeoutNotifications(t *testing.T) {
 		broadcastChannel = make(chan repo.Notifier, 0)
 		timeStart        = time.Now().Add(time.Duration(-50*24) * time.Hour)
 		twelveHours      = time.Duration(12) * time.Hour
-		fourtyFiveDays   = time.Duration(45*24) * time.Hour
+		lastInterval     = repo.VendorDisputeTimeout_lastInterval
 
 		// Produces notification for 45 days
 		neverNotified = &repo.SaleRecord{
@@ -705,7 +705,7 @@ func TestPerformTaskCreatesVendorDisputeTimeoutNotifications(t *testing.T) {
 			OrderID:        "notifiedUpToFourtyFiveDays",
 			OrderState:     pb.OrderState(pb.OrderState_FULFILLED),
 			Timestamp:      timeStart,
-			LastNotifiedAt: timeStart.Add(fourtyFiveDays + twelveHours),
+			LastNotifiedAt: timeStart.Add(lastInterval + twelveHours),
 		}
 		// Produces no notifications as contract is undisputeable
 		neverNotifiedButUndisputeable = &repo.SaleRecord{

--- a/repo/db/cases.go
+++ b/repo/db/cases.go
@@ -444,8 +444,9 @@ func (c *CasesDB) GetDisputesForDisputeExpiryNotification() ([]*repo.DisputeCase
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	fourtyFiveDays := time.Duration(45*24) * time.Hour
-	rows, err := c.db.Query("select caseID, buyerContract, vendorContract, timestamp, buyerOpened, lastNotifiedAt from cases where (lastNotifiedAt - timestamp) < ?", int(fourtyFiveDays.Seconds()))
+	rows, err := c.db.Query("select caseID, buyerContract, vendorContract, timestamp, buyerOpened, lastNotifiedAt from cases where (lastNotifiedAt - timestamp) < ?",
+		int(repo.ModeratorDisputeExpiry_lastInterval.Seconds()),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("selecting dispute case: %s", err.Error())
 	}

--- a/repo/db/sales.go
+++ b/repo/db/sales.go
@@ -328,9 +328,8 @@ func (s *SalesDB) GetSalesForDisputeTimeoutNotification() ([]*repo.SaleRecord, e
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	fourtyFiveDays := time.Duration(45*24) * time.Hour
 	stmt := fmt.Sprintf("select orderID, contract, state, timestamp, lastNotifiedAt from sales where (lastNotifiedAt - timestamp) < %d and state in (%d, %d)",
-		int(fourtyFiveDays.Seconds()),
+		int(repo.VendorDisputeTimeout_lastInterval.Seconds()),
 		pb.OrderState_PARTIALLY_FULFILLED,
 		pb.OrderState_FULFILLED,
 	)


### PR DESCRIPTION
Completes `prevent dispute from being opened 45 days after purchase/sale` in #843 

This does not include a unit test due to the external `Wallet.GetConfirmation()` dependency. A solution to this in the short term might be to create a fake which meets the Wallet interface but allows the internal state to be manipulated (like forcing certain responses). This scope is too large for this feature and recommend considering this as technical debt for later.

This also fixes a bug that @jjeffryes found when toying around with new timeout values and the new values not being considered in the SQL lookup.