### PR TITLE
[#843] Add height to /wallet/balance API response

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -710,8 +710,9 @@ func (i *jsonAPIHandler) GETBalance(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}*/
+	height, _ := i.node.Wallet.ChainTip()
 	confirmed, unconfirmed := i.node.Wallet.Balance()
-	SanitizedResponse(w, fmt.Sprintf(`{"confirmed": %d, "unconfirmed": %d}`, int(confirmed), int(unconfirmed)))
+	SanitizedResponse(w, fmt.Sprintf(`{"confirmed": %d, "unconfirmed": %d, "height": %d}`, int(confirmed), int(unconfirmed), height))
 }
 
 func (i *jsonAPIHandler) POSTSpendCoins(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Completes `GETBalance API endpoint should return current block height` in #843

This could probably be quickly tested with a FakeWallet implementation with the right values stubbed in. Would just need a nice way to create the Node with our FakeWallet. LMK if you guys agree to do this tech debt and I'll add the issue.