### PR TITLE
Fix BuyerDisputeTimeout and DisputeExpiry notification order

### DIFF
--- a/core/record_aging_notifier.go
+++ b/core/record_aging_notifier.go
@@ -145,17 +145,18 @@ func (notifier *recordAgingNotifier) generateBuyerDisputeTimeoutNotifications() 
 
 	for _, p := range purchases {
 		var timeSinceCreation = executedAt.Sub(p.Timestamp)
+		// Extra seconds added to creation time is a hack to order SQL results
 		if p.LastNotifiedAt.Before(p.Timestamp.Add(repo.BuyerDisputeTimeout_firstInterval)) && timeSinceCreation > repo.BuyerDisputeTimeout_firstInterval {
-			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutFirstNotification(executedAt))
+			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutFirstNotification(executedAt.Add(time.Duration(0)*time.Second)))
 		}
 		if p.LastNotifiedAt.Before(p.Timestamp.Add(repo.BuyerDisputeTimeout_secondInterval)) && timeSinceCreation > repo.BuyerDisputeTimeout_secondInterval {
-			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutSecondNotification(executedAt))
+			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutSecondNotification(executedAt.Add(time.Duration(1)*time.Second)))
 		}
 		if p.LastNotifiedAt.Before(p.Timestamp.Add(repo.BuyerDisputeTimeout_thirdInterval)) && timeSinceCreation > repo.BuyerDisputeTimeout_thirdInterval {
-			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutThirdNotification(executedAt))
+			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutThirdNotification(executedAt.Add(time.Duration(2)*time.Second)))
 		}
 		if p.LastNotifiedAt.Before(p.Timestamp.Add(repo.BuyerDisputeTimeout_lastInterval)) && timeSinceCreation > repo.BuyerDisputeTimeout_lastInterval {
-			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutLastNotification(executedAt))
+			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutLastNotification(executedAt.Add(time.Duration(3)*time.Second)))
 		}
 		if len(notificationsToAdd) > 0 {
 			p.LastNotifiedAt = executedAt

--- a/core/record_aging_notifier.go
+++ b/core/record_aging_notifier.go
@@ -216,17 +216,18 @@ func (notifier *recordAgingNotifier) generateModeratorDisputeExpiryNotifications
 
 	for _, d := range disputes {
 		var timeSinceCreation = executedAt.Sub(d.Timestamp)
+		// Extra seconds added to creation time is a hack to order SQL results
 		if d.LastNotifiedAt.Before(d.Timestamp.Add(repo.ModeratorDisputeExpiry_firstInterval)) && timeSinceCreation > repo.ModeratorDisputeExpiry_firstInterval {
-			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpiryFirstNotification(executedAt))
+			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpiryFirstNotification(executedAt.Add(time.Duration(0)*time.Second)))
 		}
 		if d.LastNotifiedAt.Before(d.Timestamp.Add(repo.ModeratorDisputeExpiry_secondInterval)) && timeSinceCreation > repo.ModeratorDisputeExpiry_secondInterval {
-			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpirySecondNotification(executedAt))
+			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpirySecondNotification(executedAt.Add(time.Duration(1)*time.Second)))
 		}
 		if d.LastNotifiedAt.Before(d.Timestamp.Add(repo.ModeratorDisputeExpiry_thirdInterval)) && timeSinceCreation > repo.ModeratorDisputeExpiry_thirdInterval {
-			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpiryThirdNotification(executedAt))
+			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpiryThirdNotification(executedAt.Add(time.Duration(2)*time.Second)))
 		}
 		if d.LastNotifiedAt.Before(d.Timestamp.Add(repo.ModeratorDisputeExpiry_lastInterval)) && timeSinceCreation > repo.ModeratorDisputeExpiry_lastInterval {
-			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpiryLastNotification(executedAt))
+			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpiryLastNotification(executedAt.Add(time.Duration(3)*time.Second)))
 		}
 		if len(notificationsToAdd) > 0 {
 			d.LastNotifiedAt = executedAt

--- a/core/record_aging_notifier_test.go
+++ b/core/record_aging_notifier_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/op/go-logging"
 )
 
+// DISPUTE CASES
 func TestPerformTaskCreatesModeratorDisputeExpiryNotifications(t *testing.T) {
 	// Start each case 50 days ago and have the lastNotifiedAt at a day after
 	// each notification is suppose to be sent. With no notifications already queued,
@@ -370,6 +371,96 @@ func TestPerformTaskCreatesModeratorDisputeExpiryNotifications(t *testing.T) {
 	}
 }
 
+func TestDisputeExpiryNotificationsAreReturnedInOrderWhenCreatedAsABatch(t *testing.T) {
+	var (
+		broadcastChannel = make(chan repo.Notifier, 5)
+		subject          = factory.NewExpiredDisputeCaseRecord()
+
+		appSchema = schema.MustNewCustomSchemaManager(schema.SchemaContext{
+			DataPath:        schema.GenerateTempPath(),
+			TestModeEnabled: true,
+		})
+	)
+
+	if err := appSchema.BuildSchemaDirectories(); err != nil {
+		t.Fatal(err)
+	}
+	defer appSchema.DestroySchemaDirectories()
+	if err := appSchema.InitializeDatabase(); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := appSchema.OpenDatabase()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := database.Prepare("insert into cases (caseID, buyerContract, vendorContract, timestamp, buyerOpened, lastNotifiedAt) values (?, ?, ?, ?, ?, ?)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := jsonpb.Marshaler{
+		EnumsAsInts:  false,
+		EmitDefaults: true,
+		Indent:       "    ",
+		OrigName:     false,
+	}
+	var isBuyerInitiated int = 0
+	if subject.IsBuyerInitiated {
+		isBuyerInitiated = 1
+	}
+	buyerContractData, err := m.MarshalToString(subject.BuyerContract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vendorContractData, err := m.MarshalToString(subject.VendorContract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.Exec(subject.CaseID, buyerContractData, vendorContractData, int(subject.Timestamp.Unix()), isBuyerInitiated, int(subject.LastNotifiedAt.Unix()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	datastore := db.NewSQLiteDatastore(database, new(sync.Mutex))
+	worker := &recordAgingNotifier{
+		datastore: datastore,
+		broadcast: broadcastChannel,
+		logger:    logging.MustGetLogger("testRecordAgingNotifier"),
+	}
+
+	worker.PerformTask()
+
+	actual, _, err := datastore.Notifications().GetAll("", -1, []string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		firstInterval_expiresIn  = uint((repo.BuyerDisputeTimeout_lastInterval - repo.BuyerDisputeTimeout_firstInterval).Seconds())
+		secondInterval_expiresIn = uint((repo.BuyerDisputeTimeout_lastInterval - repo.BuyerDisputeTimeout_secondInterval).Seconds())
+		thirdInterval_expiresIn  = uint((repo.BuyerDisputeTimeout_lastInterval - repo.BuyerDisputeTimeout_thirdInterval).Seconds())
+		lastInterval_expiresIn   = uint((repo.BuyerDisputeTimeout_lastInterval - repo.BuyerDisputeTimeout_lastInterval).Seconds())
+	)
+	if actual[0].NotifierData.(repo.ModeratorDisputeExpiry).ExpiresIn != lastInterval_expiresIn {
+		t.Errorf("Expected last interval notification first, where ExpiresIn is %d, but was not", lastInterval_expiresIn)
+		t.Logf("Actual Notification: %+v\n", actual[0])
+	}
+	if actual[1].NotifierData.(repo.ModeratorDisputeExpiry).ExpiresIn != thirdInterval_expiresIn {
+		t.Errorf("Expected third interval notification second, where ExpiresIn is %d, but was not", thirdInterval_expiresIn)
+		t.Logf("Actual Notification: %+v\n", actual[1])
+	}
+	if actual[2].NotifierData.(repo.ModeratorDisputeExpiry).ExpiresIn != secondInterval_expiresIn {
+		t.Logf("Actual Notification: %+v\n", actual[2])
+	}
+	if actual[3].NotifierData.(repo.ModeratorDisputeExpiry).ExpiresIn != firstInterval_expiresIn {
+		t.Errorf("Expected first interval notification last, where ExpiresIn is %d, but was not", firstInterval_expiresIn)
+		t.Logf("Actual Notification: %+v\n", actual[3])
+		t.Errorf("Expected second interval notification third, where ExpiresIn is %d, but was not", secondInterval_expiresIn)
+	}
+}
+
+// PURCHASES
 func TestPerformTaskCreatesBuyerDisputeTimeoutNotifications(t *testing.T) {
 	// Start each purchase 50 days ago and have the lastNotifiedAt at a day after
 	// each notification is suppose to be sent. With no notifications already queued,
@@ -683,16 +774,7 @@ func TestPerformTaskCreatesBuyerDisputeTimeoutNotifications(t *testing.T) {
 func TestBuyerDisputeTimeoutsAreReturnedInOrderWhenCreatedAsABatch(t *testing.T) {
 	var (
 		broadcastChannel = make(chan repo.Notifier, 5)
-		timeStart        = time.Now().Add(time.Duration(-50*24) * time.Hour)
-
-		// Produces notification for 15, 40, 44 and 45 days
-		subject = &repo.PurchaseRecord{
-			Contract:       factory.NewDisputeableContract(),
-			OrderID:        "neverNotified",
-			OrderState:     pb.OrderState(pb.OrderState_PENDING),
-			Timestamp:      timeStart,
-			LastNotifiedAt: time.Unix(0, 0),
-		}
+		subject          = factory.NewExpiredDisputeablePurchaseRecord()
 
 		appSchema = schema.MustNewCustomSchemaManager(schema.SchemaContext{
 			DataPath:        schema.GenerateTempPath(),

--- a/test/factory/dispute_case_record.go
+++ b/test/factory/dispute_case_record.go
@@ -9,9 +9,10 @@ import (
 
 func NewDisputeCaseRecord() *repo.DisputeCaseRecord {
 	dispute := &repo.DisputeCaseRecord{
-		BuyerContract: NewDisputeableContract(),
-		Timestamp:     time.Now(),
-		OrderState:    pb.OrderState_DISPUTED,
+		BuyerContract:  NewDisputeableContract(),
+		VendorContract: NewDisputeableContract(),
+		Timestamp:      time.Now(),
+		OrderState:     pb.OrderState_DISPUTED,
 	}
 	return dispute
 }

--- a/test/factory/purchase_record.go
+++ b/test/factory/purchase_record.go
@@ -1,6 +1,8 @@
 package factory
 
 import (
+	"time"
+
 	"github.com/OpenBazaar/openbazaar-go/repo"
 )
 
@@ -10,4 +12,16 @@ func NewPurchaseRecord() *repo.PurchaseRecord {
 		Contract: contract,
 		OrderID:  "anOrderIDforaPurchaseRecord",
 	}
+}
+
+func NewExpiredPurchaseRecord() *repo.PurchaseRecord {
+	purchase := NewPurchaseRecord()
+	purchase.Timestamp = time.Now().Add(-repo.BuyerDisputeTimeout_lastInterval)
+	return purchase
+}
+
+func NewExpiredDisputeablePurchaseRecord() *repo.PurchaseRecord {
+	purchase := NewExpiredPurchaseRecord()
+	purchase.Contract = NewDisputeableContract()
+	return purchase
 }


### PR DESCRIPTION
Fixes #959 and applies to #843 .

When a set of notifications are produced at the same time, the order by
timestamp is undefined. This commit varies the produced notifications'
createdAt timestamp by a second to produce the desired sort in this
special case.

This path was chosen because:
1) the data we intend to sort on is marshalled in SQL and unable to be
   sorted in the database.
2) Notifications().GetAll() call probably shouldn't be aware of any
   specific notification content for the sake of sorting.
3) This change was minimal for support and testing purposes until the
   ExpiresAt data can be sorted in SQL should we decide to pay that debt