### PR TITLE
[#843] Hasty modification broke the /ob/wallet/balance API test

### DIFF
--- a/api/jsonapi_data_test.go
+++ b/api/jsonapi_data_test.go
@@ -390,7 +390,7 @@ const walletMneumonicJSONResponse = `{"mnemonic": "correct horse battery staple"
 
 const walletAddressJSONResponse = `{"address": "moLsBry5Dk8AN3QT3i1oxZdwD12MYRfTL5"}`
 
-const walletBalanceJSONResponse = `{"confirmed": 0, "unconfirmed": 0}`
+const walletBalanceJSONResponse = `{"confirmed": 0, "unconfirmed": 0, "height": 1151136}`
 
 //
 // Spending


### PR DESCRIPTION
Introduced by commit d9239a5ec6abd2a138ed755b06f13ae3a8fae12e

This value appears to be fixed in vendor/github.com/OpenBazaar/spvwallet/checkpoints.go:59 so it's probably not going to change until the vendored package does.