### PR TITLE
Ensure calls to POST /ob/releaseescrow w ZEC sales fail

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -2155,6 +2155,11 @@ func (i *jsonAPIHandler) POSTReleaseEscrow(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	if !(&repo.SaleRecord{Contract: contract}).SupportsTimedEscrowRelease() {
+		ErrorResponse(w, http.StatusBadRequest, "Escrow does not support automatic release of funds to vendor")
+		return
+	}
+
 	switch state {
 	case pb.OrderState_DISPUTED:
 		disputeStart, err := ptypes.Timestamp(contract.GetDispute().Timestamp)

--- a/repo/sale_record.go
+++ b/repo/sale_record.go
@@ -20,6 +20,21 @@ type SaleRecord struct {
 	LastNotifiedAt time.Time
 }
 
+func (r *SaleRecord) SupportsTimedEscrowRelease() bool {
+	if len(r.Contract.VendorListings) > 0 &&
+		len(r.Contract.VendorListings[0].Metadata.AcceptedCurrencies) > 0 {
+		switch r.Contract.VendorListings[0].Metadata.AcceptedCurrencies[0] {
+		case "BTC":
+			return true
+		case "BCH":
+			return true
+		case "ZEC":
+			return false
+		}
+	}
+	return false
+}
+
 // IsDisputeable returns whether the Sale is in a state that it can be disputed with a
 // third-party moderator
 func (r *SaleRecord) IsDisputeable() bool {

--- a/repo/sale_record.go
+++ b/repo/sale_record.go
@@ -20,6 +20,9 @@ type SaleRecord struct {
 	LastNotifiedAt time.Time
 }
 
+// SupportsTimedEscrowRelease indicates whether the underlying AcceptedCurrency supports
+// a time-bassed release behavior.
+// TODO: Express this from the wallet-interface instead
 func (r *SaleRecord) SupportsTimedEscrowRelease() bool {
 	if len(r.Contract.VendorListings) > 0 &&
 		len(r.Contract.VendorListings[0].Metadata.AcceptedCurrencies) > 0 {

--- a/repo/sale_record_test.go
+++ b/repo/sale_record_test.go
@@ -60,3 +60,26 @@ func TestSaleRecordIsDisputeable(t *testing.T) {
 		}
 	}
 }
+
+func TestSaleRecordKnowsWhetherItSupportsTimedEscrowRelease(t *testing.T) {
+	subject := factory.NewSaleRecord()
+	subject.Contract.VendorListings[0].Metadata.AcceptedCurrencies = []string{"ZEC"}
+	if subject.SupportsTimedEscrowRelease() == true {
+		t.Error("Expected Sales with ZEC as the only accepted currency to NOT support Timed Escrow Release")
+	}
+
+	subject.Contract.VendorListings[0].Metadata.AcceptedCurrencies = []string{""}
+	if subject.SupportsTimedEscrowRelease() == true {
+		t.Error("Expected Sales with an undefined case to NOT support Timed Escrow Release")
+	}
+
+	subject.Contract.VendorListings[0].Metadata.AcceptedCurrencies = []string{"BTC"}
+	if subject.SupportsTimedEscrowRelease() == false {
+		t.Error("Expected Sales with ZEC as the only accepted currency to support Timed Escrow Release, but did NOT")
+	}
+
+	subject.Contract.VendorListings[0].Metadata.AcceptedCurrencies = []string{"BCH"}
+	if subject.SupportsTimedEscrowRelease() == false {
+		t.Error("Expected Sales with ZEC as the only accepted currency to support Timed Escrow Release, but did NOT")
+	}
+}

--- a/test/factory/contract.go
+++ b/test/factory/contract.go
@@ -32,7 +32,12 @@ func NewContract() *pb.RicardianContract {
 	)
 	return &pb.RicardianContract{
 		VendorListings: []*pb.Listing{
-			{Item: &pb.Listing_Item{Images: images}},
+			{
+				Item: &pb.Listing_Item{Images: images},
+				Metadata: &pb.Listing_Metadata{
+					AcceptedCurrencies: []string{"BTC"},
+				},
+			},
 		},
 		BuyerOrder: order,
 	}


### PR DESCRIPTION
Completes `return error on POSTReleaseEscrow when Node uses ZEC` in #843