### PR TITLE
[#843] Improve generateModeratorDisputeExpiryNotifications to handle missing vendor and/or buyer contract

### DIFF
--- a/repo/db/cases.go
+++ b/repo/db/cases.go
@@ -502,11 +502,15 @@ func (c *CasesDB) GetDisputesForDisputeExpiryNotification() ([]*repo.DisputeCase
 		if err := rows.Scan(&r.CaseID, &buyerContract, &vendorContract, &timestamp, &isBuyerInitiated, &lastDisputeExpiryNotifiedAt); err != nil {
 			return nil, fmt.Errorf("scanning dispute case: %s", err.Error())
 		}
-		if err := jsonpb.UnmarshalString(string(buyerContract), r.BuyerContract); err != nil {
-			return nil, fmt.Errorf("unmarshaling buyer contract: %s\n", err.Error())
+		if r.BuyerContract != nil {
+			if err := jsonpb.UnmarshalString(string(buyerContract), r.BuyerContract); err != nil {
+				return nil, fmt.Errorf("unmarshaling buyer contract: %s\n", err.Error())
+			}
 		}
-		if err := jsonpb.UnmarshalString(string(vendorContract), r.VendorContract); err != nil {
-			return nil, fmt.Errorf("unmarshaling vendor contract: %s\n", err.Error())
+		if r.VendorContract != nil {
+			if err := jsonpb.UnmarshalString(string(vendorContract), r.VendorContract); err != nil {
+				return nil, fmt.Errorf("unmarshaling vendor contract: %s\n", err.Error())
+			}
 		}
 		if isBuyerInitiated != 0 {
 			r.IsBuyerInitiated = true


### PR DESCRIPTION
Resolves `Improve generateModeratorDisputeExpiryNotifications to handle missing vendor and/or buyer contract` in #843

Note: This PR should remove the first commits that change the duration timeouts before merging.