### PR TITLE
843 fix notification interval constants

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -2177,17 +2177,16 @@ func (i *jsonAPIHandler) POSTReleaseEscrow(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
-		fourtyFiveDaysInHours := 45 * 24
-		disputeDuration := time.Duration(fourtyFiveDaysInHours) * time.Hour
+		disputeDuration := time.Duration(repo.DisputeTotalDurationHours) * time.Hour
 
 		// Time hack until we can stub this more nicely in test env
 		if i.node.TestNetworkEnabled() || i.node.RegressionNetworkEnabled() {
 			disputeDuration = time.Duration(10) * time.Second
 		}
 
-		disputeTimeout := disputeStart.Add(disputeDuration)
-		if time.Now().Before(disputeTimeout) {
-			expiresIn := disputeTimeout.Sub(time.Now())
+		disputeExpiration := disputeStart.Add(disputeDuration)
+		if time.Now().Before(disputeExpiration) {
+			expiresIn := disputeExpiration.Sub(time.Now())
 			ErrorResponse(w, http.StatusUnauthorized, fmt.Sprintf("releaseescrow can only be called when in dispute for %s or longer, expires in %s", disputeDuration.String(), expiresIn.String()))
 			return
 		}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -866,23 +866,23 @@ func (x *Start) Execute(args []string) error {
 }
 
 func setTestmodeRecordAgingIntervals() {
-	repo.VendorDisputeTimeout_lastInterval = time.Duration(5) * time.Minute
+	repo.VendorDisputeTimeout_lastInterval = time.Duration(60) * time.Minute
 
-	repo.ModeratorDisputeExpiry_firstInterval = time.Duration(1) * time.Minute
-	repo.ModeratorDisputeExpiry_secondInterval = time.Duration(3) * time.Minute
-	repo.ModeratorDisputeExpiry_thirdInterval = time.Duration(4) * time.Minute
-	repo.ModeratorDisputeExpiry_lastInterval = time.Duration(5) * time.Minute
+	repo.ModeratorDisputeExpiry_firstInterval = time.Duration(20) * time.Minute
+	repo.ModeratorDisputeExpiry_secondInterval = time.Duration(40) * time.Minute
+	repo.ModeratorDisputeExpiry_thirdInterval = time.Duration(59) * time.Minute
+	repo.ModeratorDisputeExpiry_lastInterval = time.Duration(60) * time.Minute
 
-	repo.BuyerDisputeTimeout_firstInterval = time.Duration(1) * time.Minute
-	repo.BuyerDisputeTimeout_secondInterval = time.Duration(3) * time.Minute
-	repo.BuyerDisputeTimeout_thirdInterval = time.Duration(4) * time.Minute
-	repo.BuyerDisputeTimeout_lastInterval = time.Duration(5) * time.Minute
-	repo.BuyerDisputeTimeout_totalDuration = time.Duration(5) * time.Minute
+	repo.BuyerDisputeTimeout_firstInterval = time.Duration(20) * time.Minute
+	repo.BuyerDisputeTimeout_secondInterval = time.Duration(40) * time.Minute
+	repo.BuyerDisputeTimeout_thirdInterval = time.Duration(59) * time.Minute
+	repo.BuyerDisputeTimeout_lastInterval = time.Duration(60) * time.Minute
+	repo.BuyerDisputeTimeout_totalDuration = time.Duration(60) * time.Minute
 
-	repo.BuyerDisputeExpiry_firstInterval = time.Duration(1) * time.Minute
-	repo.BuyerDisputeExpiry_secondInterval = time.Duration(3) * time.Minute
-	repo.BuyerDisputeExpiry_lastInterval = time.Duration(4) * time.Minute
-	repo.BuyerDisputeExpiry_totalDuration = time.Duration(5) * time.Minute
+	repo.BuyerDisputeExpiry_firstInterval = time.Duration(20) * time.Minute
+	repo.BuyerDisputeExpiry_secondInterval = time.Duration(40) * time.Minute
+	repo.BuyerDisputeExpiry_lastInterval = time.Duration(59) * time.Minute
+	repo.BuyerDisputeExpiry_totalDuration = time.Duration(60) * time.Minute
 }
 
 // Prints the addresses of the host

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -747,6 +747,10 @@ func (x *Start) Execute(args []string) error {
 		return err
 	}
 
+	if x.Testnet {
+		setTestmodeRecordAgingIntervals()
+	}
+
 	// OpenBazaar node setup
 	core.Node = &core.OpenBazaarNode{
 		Context:              ctx,
@@ -859,6 +863,26 @@ func (x *Start) Execute(args []string) error {
 	}
 
 	return nil
+}
+
+func setTestmodeRecordAgingIntervals() {
+	repo.VendorDisputeTimeout_lastInterval = time.Duration(5) * time.Minute
+
+	repo.ModeratorDisputeExpiry_firstInterval = time.Duration(1) * time.Minute
+	repo.ModeratorDisputeExpiry_secondInterval = time.Duration(3) * time.Minute
+	repo.ModeratorDisputeExpiry_thirdInterval = time.Duration(4) * time.Minute
+	repo.ModeratorDisputeExpiry_lastInterval = time.Duration(5) * time.Minute
+
+	repo.BuyerDisputeTimeout_firstInterval = time.Duration(1) * time.Minute
+	repo.BuyerDisputeTimeout_secondInterval = time.Duration(3) * time.Minute
+	repo.BuyerDisputeTimeout_thirdInterval = time.Duration(4) * time.Minute
+	repo.BuyerDisputeTimeout_lastInterval = time.Duration(5) * time.Minute
+	repo.BuyerDisputeTimeout_totalDuration = time.Duration(5) * time.Minute
+
+	repo.BuyerDisputeExpiry_firstInterval = time.Duration(1) * time.Minute
+	repo.BuyerDisputeExpiry_secondInterval = time.Duration(3) * time.Minute
+	repo.BuyerDisputeExpiry_lastInterval = time.Duration(4) * time.Minute
+	repo.BuyerDisputeExpiry_totalDuration = time.Duration(5) * time.Minute
 }
 
 // Prints the addresses of the host

--- a/core/record_aging_notifier.go
+++ b/core/record_aging_notifier.go
@@ -9,6 +9,11 @@ import (
 	"github.com/op/go-logging"
 )
 
+const (
+	notifierTestingInterval = time.Duration(1) * time.Minute
+	notifierRegularInterval = time.Duration(10) * time.Minute
+)
+
 type recordAgingNotifier struct {
 	// PerformTask dependancies
 	datastore repo.Datastore
@@ -26,10 +31,17 @@ func (n *OpenBazaarNode) StartRecordAgingNotifier() {
 	n.RecordAgingNotifier = &recordAgingNotifier{
 		datastore:     n.Datastore,
 		broadcast:     n.Broadcast,
-		intervalDelay: time.Duration(10) * time.Minute,
+		intervalDelay: n.intervalDelay(),
 		logger:        logging.MustGetLogger("recordAgingNotifier"),
 	}
 	go n.RecordAgingNotifier.Run()
+}
+
+func (n *OpenBazaarNode) intervalDelay() time.Duration {
+	if n.TestnetEnable {
+		return notifierTestingInterval
+	}
+	return notifierRegularInterval
 }
 
 func (notifier *recordAgingNotifier) RunCount() int { return notifier.runCount }

--- a/core/record_aging_notifier_test.go
+++ b/core/record_aging_notifier_test.go
@@ -575,10 +575,10 @@ func TestPerformTaskCreatesBuyerDisputeTimeoutNotifications(t *testing.T) {
 		checkFourtyDayPurchase_LastNotificationSeen       bool
 		checkFourtyFourDayPurchase_LastNotificationSeen   bool
 
-		firstInterval_ExpectedExpiresIn  = uint((repo.BuyerDisputeTimeout_lastInterval - repo.BuyerDisputeTimeout_firstInterval).Seconds())
-		secondInterval_ExpectedExpiresIn = uint((repo.BuyerDisputeTimeout_lastInterval - repo.BuyerDisputeTimeout_secondInterval).Seconds())
-		thirdInterval_ExpectedExpiresIn  = uint((repo.BuyerDisputeTimeout_lastInterval - repo.BuyerDisputeTimeout_thirdInterval).Seconds())
-		lastInterval_ExpectedExpiresIn   = uint(0)
+		firstInterval_ExpectedExpiresIn  = uint((repo.BuyerDisputeTimeout_totalDuration - repo.BuyerDisputeTimeout_firstInterval).Seconds())
+		secondInterval_ExpectedExpiresIn = uint((repo.BuyerDisputeTimeout_totalDuration - repo.BuyerDisputeTimeout_secondInterval).Seconds())
+		thirdInterval_ExpectedExpiresIn  = uint((repo.BuyerDisputeTimeout_totalDuration - repo.BuyerDisputeTimeout_thirdInterval).Seconds())
+		lastInterval_ExpectedExpiresIn   = uint((repo.BuyerDisputeTimeout_totalDuration - repo.BuyerDisputeTimeout_lastInterval).Seconds())
 	)
 	for rows.Next() {
 		var (

--- a/repo/constants.go
+++ b/repo/constants.go
@@ -1,6 +1,8 @@
 package repo
 
 const (
+	DisputeTotalDurationHours int = 45 * 24
+
 	NotifierTypeBuyerDisputeTimeout           NotificationType = "buyerDisputeTimeout"
 	NotifierTypeBuyerDisputeExpiry            NotificationType = "buyerDisputeExpiry"
 	NotifierTypeChatMessage                   NotificationType = "chatMessage"

--- a/repo/constants.go
+++ b/repo/constants.go
@@ -1,6 +1,9 @@
 package repo
 
 const (
+	// Number of hours after purchase before a dispute may no longer be opened
+	DisputeOptionTimeoutHours int = 45 * 24
+	// Number of hours after dispute begins before it is resolved automatically
 	DisputeTotalDurationHours int = 45 * 24
 
 	NotifierTypeBuyerDisputeTimeout           NotificationType = "buyerDisputeTimeout"

--- a/repo/db/purchases.go
+++ b/repo/db/purchases.go
@@ -331,7 +331,7 @@ func (p *PurchasesDB) GetPurchasesForDisputeTimeoutNotification() ([]*repo.Purch
 	defer p.lock.Unlock()
 
 	s := fmt.Sprintf("select orderID, contract, state, timestamp, lastDisputeTimeoutNotifiedAt from purchases where (lastDisputeTimeoutNotifiedAt - timestamp) < %d and state in (%d, %d, %d)",
-		int(repo.BuyerDisputeTimeout_lastInterval.Seconds()),
+		int(repo.BuyerDisputeTimeout_totalDuration.Seconds()),
 		pb.OrderState_PENDING,
 		pb.OrderState_AWAITING_FULFILLMENT,
 		pb.OrderState_FULFILLED,

--- a/repo/purchase_record.go
+++ b/repo/purchase_record.go
@@ -16,7 +16,7 @@ var (
 	BuyerDisputeExpiry_secondInterval = time.Duration(40*24) * time.Hour
 	BuyerDisputeExpiry_lastInterval   = time.Duration(44*24) * time.Hour
 
-	BuyerDisputeExpiry_totalDuration = time.Duration(45*24) * time.Hour
+	BuyerDisputeExpiry_totalDuration = time.Duration(DisputeTotalDurationHours) * time.Hour
 )
 
 // PurchaseRecord represents a one-to-one relationship with records

--- a/repo/purchase_record.go
+++ b/repo/purchase_record.go
@@ -11,12 +11,12 @@ var (
 	BuyerDisputeTimeout_secondInterval = time.Duration(40*24) * time.Hour
 	BuyerDisputeTimeout_thirdInterval  = time.Duration(44*24) * time.Hour
 	BuyerDisputeTimeout_lastInterval   = time.Duration(45*24) * time.Hour
+	BuyerDisputeTimeout_totalDuration  = time.Duration(DisputeOptionTimeoutHours) * time.Hour
 
 	BuyerDisputeExpiry_firstInterval  = time.Duration(15*24) * time.Hour
 	BuyerDisputeExpiry_secondInterval = time.Duration(40*24) * time.Hour
 	BuyerDisputeExpiry_lastInterval   = time.Duration(44*24) * time.Hour
-
-	BuyerDisputeExpiry_totalDuration = time.Duration(DisputeTotalDurationHours) * time.Hour
+	BuyerDisputeExpiry_totalDuration  = time.Duration(DisputeTotalDurationHours) * time.Hour
 )
 
 // PurchaseRecord represents a one-to-one relationship with records
@@ -69,7 +69,7 @@ func (r *PurchaseRecord) BuildBuyerDisputeTimeoutLastNotification(createdAt time
 }
 
 func (r *PurchaseRecord) buildBuyerDisputeTimeout(interval time.Duration, createdAt time.Time) *Notification {
-	timeRemaining := BuyerDisputeTimeout_lastInterval - interval
+	timeRemaining := BuyerDisputeTimeout_totalDuration - interval
 	notification := &BuyerDisputeTimeout{
 		ID:        NewNotificationID(),
 		ExpiresIn: uint(timeRemaining.Seconds()),

--- a/repo/sale_record.go
+++ b/repo/sale_record.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"strings"
 	"time"
 
 	"github.com/OpenBazaar/openbazaar-go/pb"
@@ -26,10 +27,14 @@ type SaleRecord struct {
 func (r *SaleRecord) SupportsTimedEscrowRelease() bool {
 	if len(r.Contract.VendorListings) > 0 &&
 		len(r.Contract.VendorListings[0].Metadata.AcceptedCurrencies) > 0 {
-		switch r.Contract.VendorListings[0].Metadata.AcceptedCurrencies[0] {
+		switch strings.ToUpper(r.Contract.VendorListings[0].Metadata.AcceptedCurrencies[0]) {
 		case "BTC":
 			return true
+		case "TBTC":
+			return true
 		case "BCH":
+			return true
+		case "TBCH":
 			return true
 		case "ZEC":
 			return false

--- a/test/factory/purchase_record.go
+++ b/test/factory/purchase_record.go
@@ -16,7 +16,7 @@ func NewPurchaseRecord() *repo.PurchaseRecord {
 
 func NewExpiredPurchaseRecord() *repo.PurchaseRecord {
 	purchase := NewPurchaseRecord()
-	purchase.Timestamp = time.Now().Add(-repo.BuyerDisputeTimeout_lastInterval)
+	purchase.Timestamp = time.Now().Add(-repo.BuyerDisputeTimeout_totalDuration)
 	return purchase
 }
 


### PR DESCRIPTION
Some cleanup of constants and allow test mode to shorten the interval of the `RecordAgingNotifier` as well as the period between notifications produced by that worker: `BuyerDisputeTimeout`, `VendorDisputeTimeout`, `ModeratorDisputeExpiry` and `BuyerDisputeExpiry`