### PR TITLE
[#843] Fix Migration008 to use jsonpb Marshaling

### DIFF
--- a/repo/migrations/Migration008.go
+++ b/repo/migrations/Migration008.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/OpenBazaar/jsonpb"
 	"github.com/OpenBazaar/openbazaar-go/pb"
-	"github.com/golang/protobuf/proto"
 )
 
 const (
@@ -122,7 +122,7 @@ func (Migration008) Up(repoPath, databasePassword string, testnetEnabled bool) e
 		if err := updateDisputedAtRows.Scan(&orderID, &contractData); err != nil {
 			return err
 		}
-		if err := proto.Unmarshal([]byte(contractData), contract); err != nil {
+		if err := jsonpb.UnmarshalString(contractData, contract); err != nil {
 			return err
 		}
 		if contract.Dispute != nil && contract.Dispute.Timestamp != nil {

--- a/repo/migrations/Migration008_test.go
+++ b/repo/migrations/Migration008_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OpenBazaar/jsonpb"
 	"github.com/OpenBazaar/openbazaar-go/repo/migrations"
 	"github.com/OpenBazaar/openbazaar-go/schema"
 	"github.com/OpenBazaar/openbazaar-go/test/factory"
-	"github.com/golang/protobuf/proto"
 )
 
 func TestMigration008(t *testing.T) {
@@ -49,7 +49,13 @@ func TestMigration008(t *testing.T) {
 		executedAt               = time.Now()
 	)
 
-	disputedPurchaseContractData, err := proto.Marshal(disputedPurchaseContract)
+	m := jsonpb.Marshaler{
+		EnumsAsInts:  false,
+		EmitDefaults: true,
+		Indent:       "    ",
+		OrigName:     false,
+	}
+	disputedPurchaseContractData, err := m.MarshalToString(disputedPurchaseContract)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Data stored in the DB is mashalled as a JSON-serialized protobuf and not
as binary data. This migration was failing when attempting to migrate
real data created.