### PR TITLE
[WIP] Auto-document JSON API with Swagger

### DIFF
--- a/api/create_swagger.sh
+++ b/api/create_swagger.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+swagger generate spec -b . -o ./swagger.json --scan-models
+swagger flatten swagger.json > flatten.json
+swagger serve -F=swagger flatten.json

--- a/api/definitions.json
+++ b/api/definitions.json
@@ -139,7 +139,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/VendorListing"
+          "$ref": "definitions.json#/VendorListing"
         }
       },
       "signatures": {
@@ -152,7 +152,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Signature"
+          "$ref": "definitions.json#/Signature"
         }
       }
     },
@@ -231,13 +231,13 @@
         "type": "string"
       },
       "vendorID": {
-        "$ref": "#/definitions/VendorID"
+        "$ref": "definitions.json#/VendorID"
       },
       "metadata": {
-        "$ref": "#/definitions/Metadata"
+        "$ref": "definitions.json#/Metadata"
       },
       "item": {
-        "$ref": "#/definitions/Item"
+        "$ref": "definitions.json#/Item"
       },
       "shippingOptions": {
         "description": "",
@@ -258,7 +258,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/ShippingOption"
+          "$ref": "definitions.json#/ShippingOption"
         }
       }
     },
@@ -288,7 +288,7 @@
         "type": "string"
       },
       "pubkeys": {
-        "$ref": "#/definitions/Pubkeys"
+        "$ref": "definitions.json#/Pubkeys"
       },
       "bitcoinSig": {
         "description": "",
@@ -455,7 +455,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Image"
+          "$ref": "definitions.json#/Image"
         }
       },
       "categories": {
@@ -581,7 +581,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Service"
+          "$ref": "definitions.json#/Service"
         }
       }
     },
@@ -778,7 +778,7 @@
         }
       },
       "fee": {
-        "$ref": "#/definitions/Fee"
+        "$ref": "definitions.json#/Fee"
       }
     },
     "required": [
@@ -806,7 +806,7 @@
         "type": "string"
       },
       "fixedFee": {
-        "$ref": "#/definitions/FixedFee"
+        "$ref": "definitions.json#/FixedFee"
       },
       "percentage": {
         "description": "",
@@ -888,7 +888,7 @@
         }
       },
       "fee": {
-        "$ref": "#/definitions/Fee"
+        "$ref": "definitions.json#/Fee"
       }
     },
     "required": [
@@ -1216,7 +1216,7 @@
     "type": "object",
     "properties": {
       "contract": {
-        "$ref": "#/definitions/Contract"
+        "$ref": "definitions.json#/Contract"
       },
       "state": {
         "description": "",
@@ -1244,7 +1244,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Transaction"
+          "$ref": "definitions.json#/Transaction"
         }
       }
     },
@@ -1763,14 +1763,14 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/VendorListing32"
+          "$ref": "definitions.json#/VendorListing32"
         }
       },
       "buyerOrder": {
-        "$ref": "#/definitions/BuyerOrder"
+        "$ref": "definitions.json#/BuyerOrder"
       },
       "vendorOrderConfirmation": {
-        "$ref": "#/definitions/VendorOrderConfirmation"
+        "$ref": "definitions.json#/VendorOrderConfirmation"
       },
       "vendorOrderFulfillment": {
         "description": "",
@@ -1795,7 +1795,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/VendorOrderFulfillment"
+          "$ref": "definitions.json#/VendorOrderFulfillment"
         }
       },
       "signatures": {
@@ -1820,7 +1820,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Signature"
+          "$ref": "definitions.json#/Signature"
         }
       }
     },
@@ -2038,13 +2038,13 @@
         "type": "string"
       },
       "vendorID": {
-        "$ref": "#/definitions/VendorID33"
+        "$ref": "definitions.json#/VendorID33"
       },
       "metadata": {
-        "$ref": "#/definitions/Metadata35"
+        "$ref": "definitions.json#/Metadata35"
       },
       "item": {
-        "$ref": "#/definitions/Item36"
+        "$ref": "definitions.json#/Item36"
       },
       "shippingOptions": {
         "description": "",
@@ -2071,7 +2071,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/ShippingOption40"
+          "$ref": "definitions.json#/ShippingOption40"
         }
       },
       "termsAndConditions": {
@@ -2118,7 +2118,7 @@
         "type": "string"
       },
       "pubkeys": {
-        "$ref": "#/definitions/Pubkeys"
+        "$ref": "definitions.json#/Pubkeys"
       },
       "bitcoinSig": {
         "description": "",
@@ -2422,7 +2422,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Image"
+          "$ref": "definitions.json#/Image"
         }
       },
       "categories": {
@@ -2470,7 +2470,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Option"
+          "$ref": "definitions.json#/Option"
         }
       },
       "skus": {
@@ -2560,7 +2560,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Sku"
+          "$ref": "definitions.json#/Sku"
         }
       }
     },
@@ -2730,7 +2730,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Service41"
+          "$ref": "definitions.json#/Service41"
         }
       }
     },
@@ -2846,10 +2846,10 @@
         "format": "int32"
       },
       "shipping": {
-        "$ref": "#/definitions/Shipping"
+        "$ref": "definitions.json#/Shipping"
       },
       "buyerID": {
-        "$ref": "#/definitions/BuyerID"
+        "$ref": "definitions.json#/BuyerID"
       },
       "timestamp": {
         "description": "",
@@ -2881,11 +2881,11 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Item46"
+          "$ref": "definitions.json#/Item46"
         }
       },
       "payment": {
-        "$ref": "#/definitions/Payment"
+        "$ref": "definitions.json#/Payment"
       },
       "ratingKeys": {
         "description": "",
@@ -2995,7 +2995,7 @@
         "type": "string"
       },
       "pubkeys": {
-        "$ref": "#/definitions/Pubkeys"
+        "$ref": "definitions.json#/Pubkeys"
       },
       "bitcoinSig": {
         "description": "",
@@ -3058,11 +3058,11 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Option47"
+          "$ref": "definitions.json#/Option47"
         }
       },
       "shippingOption": {
-        "$ref": "#/definitions/ShippingOption48"
+        "$ref": "definitions.json#/ShippingOption48"
       },
       "memo": {
         "description": "",
@@ -3273,11 +3273,11 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/PhysicalDelivery"
+          "$ref": "definitions.json#/PhysicalDelivery"
         }
       },
       "ratingSignature": {
-        "$ref": "#/definitions/RatingSignature"
+        "$ref": "definitions.json#/RatingSignature"
       }
     },
     "required": [
@@ -3323,7 +3323,7 @@
     "type": "object",
     "properties": {
       "metadata": {
-        "$ref": "#/definitions/Metadata54"
+        "$ref": "definitions.json#/Metadata54"
       },
       "signature": {
         "description": "",
@@ -3584,7 +3584,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Item59"
+          "$ref": "definitions.json#/Item59"
         }
       },
       "moderator": {
@@ -3654,11 +3654,11 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Option47"
+          "$ref": "definitions.json#/Option47"
         }
       },
       "shipping": {
-        "$ref": "#/definitions/Shipping61"
+        "$ref": "definitions.json#/Shipping61"
       },
       "memo": {
         "description": "",
@@ -3804,7 +3804,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/PhysicalDelivery"
+          "$ref": "definitions.json#/PhysicalDelivery"
         }
       },
       "digitalDelivery": {
@@ -3817,7 +3817,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/DigitalDelivery"
+          "$ref": "definitions.json#/DigitalDelivery"
         }
       }
     },
@@ -3891,7 +3891,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Rating"
+          "$ref": "definitions.json#/Rating"
         }
       }
     },
@@ -4377,7 +4377,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/VendorListing72"
+          "$ref": "definitions.json#/VendorListing72"
         }
       },
       "signatures": {
@@ -4390,7 +4390,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Signature"
+          "$ref": "definitions.json#/Signature"
         }
       }
     },
@@ -4585,13 +4585,13 @@
         "type": "string"
       },
       "vendorID": {
-        "$ref": "#/definitions/VendorID"
+        "$ref": "definitions.json#/VendorID"
       },
       "metadata": {
-        "$ref": "#/definitions/Metadata"
+        "$ref": "definitions.json#/Metadata"
       },
       "item": {
-        "$ref": "#/definitions/Item76"
+        "$ref": "definitions.json#/Item76"
       },
       "shippingOptions": {
         "description": "",
@@ -4617,7 +4617,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/ShippingOption80"
+          "$ref": "definitions.json#/ShippingOption80"
         }
       },
       "taxes": {
@@ -4873,7 +4873,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Image"
+          "$ref": "definitions.json#/Image"
         }
       },
       "categories": {
@@ -4915,7 +4915,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Option"
+          "$ref": "definitions.json#/Option"
         }
       },
       "skus": {
@@ -4987,7 +4987,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Sku79"
+          "$ref": "definitions.json#/Sku79"
         }
       }
     },
@@ -5095,7 +5095,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Service81"
+          "$ref": "definitions.json#/Service81"
         }
       }
     },
@@ -5180,7 +5180,7 @@
         "type": "string"
       },
       "hashes": {
-        "$ref": "#/definitions/Hashes"
+        "$ref": "definitions.json#/Hashes"
       }
     },
     "required": [
@@ -5277,7 +5277,7 @@
         "type": "string"
       },
       "hashes": {
-        "$ref": "#/definitions/Hashes"
+        "$ref": "definitions.json#/Hashes"
       }
     },
     "required": [
@@ -5491,10 +5491,10 @@
         "type": "string"
       },
       "thumbnail": {
-        "$ref": "#/definitions/Thumbnail"
+        "$ref": "definitions.json#/Thumbnail"
       },
       "price": {
-        "$ref": "#/definitions/Price"
+        "$ref": "definitions.json#/Price"
       },
       "shipsTo": {
         "description": "",
@@ -5692,7 +5692,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/VendorListing100"
+          "$ref": "definitions.json#/VendorListing100"
         }
       },
       "signatures": {
@@ -5705,7 +5705,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Signature"
+          "$ref": "definitions.json#/Signature"
         }
       }
     },
@@ -5768,13 +5768,13 @@
         "type": "string"
       },
       "vendorID": {
-        "$ref": "#/definitions/VendorID"
+        "$ref": "definitions.json#/VendorID"
       },
       "metadata": {
-        "$ref": "#/definitions/Metadata"
+        "$ref": "definitions.json#/Metadata"
       },
       "item": {
-        "$ref": "#/definitions/Item"
+        "$ref": "definitions.json#/Item"
       },
       "shippingOptions": {
         "description": "",
@@ -5903,10 +5903,10 @@
         "type": "string"
       },
       "metadata": {
-        "$ref": "#/definitions/Metadata108"
+        "$ref": "definitions.json#/Metadata108"
       },
       "item": {
-        "$ref": "#/definitions/Item109"
+        "$ref": "definitions.json#/Item109"
       },
       "shippingOptions": {
         "description": "",
@@ -5933,7 +5933,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/ShippingOption40"
+          "$ref": "definitions.json#/ShippingOption40"
         }
       },
       "taxes": {
@@ -6147,7 +6147,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Image"
+          "$ref": "definitions.json#/Image"
         }
       },
       "categories": {
@@ -6381,10 +6381,10 @@
         "type": "string"
       },
       "avatarHashes": {
-        "$ref": "#/definitions/AvatarHashes"
+        "$ref": "definitions.json#/AvatarHashes"
       },
       "headerHashes": {
-        "$ref": "#/definitions/HeaderHashes"
+        "$ref": "definitions.json#/HeaderHashes"
       },
       "followerCount": {
         "description": "",
@@ -6648,7 +6648,7 @@
         }
       },
       "smtpSettings": {
-        "$ref": "#/definitions/SmtpSettings"
+        "$ref": "definitions.json#/SmtpSettings"
       }
     },
     "required": [
@@ -6787,7 +6787,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/ShippingAddress"
+          "$ref": "definitions.json#/ShippingAddress"
         }
       },
       "localCurrency": {
@@ -6839,7 +6839,7 @@
         }
       },
       "smtpSettings": {
-        "$ref": "#/definitions/SmtpSettings"
+        "$ref": "definitions.json#/SmtpSettings"
       }
     },
     "required": [
@@ -6994,7 +6994,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/ShippingAddress130"
+          "$ref": "definitions.json#/ShippingAddress130"
         }
       },
       "localCurrency": {
@@ -7045,7 +7045,7 @@
         "format": "int32"
       },
       "smtpSettings": {
-        "$ref": "#/definitions/SmtpSettings"
+        "$ref": "definitions.json#/SmtpSettings"
       },
       "version": {
         "description": "",
@@ -8751,16 +8751,16 @@
         "type": "boolean"
       },
       "contactInfo": {
-        "$ref": "#/definitions/ContactInfo"
+        "$ref": "definitions.json#/ContactInfo"
       },
       "colors": {
-        "$ref": "#/definitions/Colors"
+        "$ref": "definitions.json#/Colors"
       },
       "avatarHashes": {
-        "$ref": "#/definitions/AvatarHashes"
+        "$ref": "definitions.json#/AvatarHashes"
       },
       "stats": {
-        "$ref": "#/definitions/Stats"
+        "$ref": "definitions.json#/Stats"
       },
       "bitcoinPubkey": {
         "description": "",
@@ -9027,7 +9027,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Social"
+          "$ref": "definitions.json#/Social"
         }
       },
       "avgRating": {
@@ -9081,10 +9081,10 @@
         "type": "string"
       },
       "avatarHashes": {
-        "$ref": "#/definitions/AvatarHashes"
+        "$ref": "definitions.json#/AvatarHashes"
       },
       "headerHashes": {
-        "$ref": "#/definitions/HeaderHashes"
+        "$ref": "definitions.json#/HeaderHashes"
       },
       "followerCount": {
         "description": "",
@@ -9307,10 +9307,10 @@
         "type": "string"
       },
       "avatarHashes": {
-        "$ref": "#/definitions/AvatarHashes"
+        "$ref": "definitions.json#/AvatarHashes"
       },
       "headerHashes": {
-        "$ref": "#/definitions/HeaderHashes"
+        "$ref": "definitions.json#/HeaderHashes"
       },
       "followerCount": {
         "description": "",
@@ -9416,7 +9416,7 @@
         "type": "string"
       },
       "contactInfo": {
-        "$ref": "#/definitions/ContactInfo"
+        "$ref": "definitions.json#/ContactInfo"
       },
       "nsfw": {
         "description": "",
@@ -9434,7 +9434,7 @@
         "type": "boolean"
       },
       "colors": {
-        "$ref": "#/definitions/Colors"
+        "$ref": "definitions.json#/Colors"
       }
     },
     "required": [
@@ -9544,19 +9544,19 @@
         "type": "boolean"
       },
       "contactInfo": {
-        "$ref": "#/definitions/ContactInfo"
+        "$ref": "definitions.json#/ContactInfo"
       },
       "colors": {
-        "$ref": "#/definitions/Colors"
+        "$ref": "definitions.json#/Colors"
       },
       "avatarHashes": {
-        "$ref": "#/definitions/AvatarHashes"
+        "$ref": "definitions.json#/AvatarHashes"
       },
       "headerHashes": {
-        "$ref": "#/definitions/HeaderHashes"
+        "$ref": "definitions.json#/HeaderHashes"
       },
       "stats": {
-        "$ref": "#/definitions/Stats"
+        "$ref": "definitions.json#/Stats"
       },
       "bitcoinPubkey": {
         "description": "",
@@ -9689,7 +9689,7 @@
         ],
         "type": "array",
         "items": {
-          "$ref": "#/definitions/Social"
+          "$ref": "definitions.json#/Social"
         }
       },
       "avgRating": {
@@ -9743,10 +9743,10 @@
         "type": "string"
       },
       "avatarHashes": {
-        "$ref": "#/definitions/AvatarHashes"
+        "$ref": "definitions.json#/AvatarHashes"
       },
       "headerHashes": {
-        "$ref": "#/definitions/HeaderHashes"
+        "$ref": "definitions.json#/HeaderHashes"
       },
       "followerCount": {
         "description": "",
@@ -9895,16 +9895,16 @@
         "type": "boolean"
       },
       "contactInfo": {
-        "$ref": "#/definitions/ContactInfo"
+        "$ref": "definitions.json#/ContactInfo"
       },
       "colors": {
-        "$ref": "#/definitions/Colors"
+        "$ref": "definitions.json#/Colors"
       },
       "avatarHashes": {
-        "$ref": "#/definitions/AvatarHashes"
+        "$ref": "definitions.json#/AvatarHashes"
       },
       "stats": {
-        "$ref": "#/definitions/Stats"
+        "$ref": "definitions.json#/Stats"
       },
       "bitcoinPubkey": {
         "description": "",

--- a/api/definitions.json
+++ b/api/definitions.json
@@ -1,0 +1,9938 @@
+{
+  "SushiListing": {
+    "title": "Sushi Listing",
+    "example": {
+      "vendorListings": [
+        {
+          "slug": "sushi-platter",
+          "vendorID": {
+            "guid": "QmXhBroy8AS1Hm9pMBjAfHoMuKdMaPaJr3oYHqawR6ivqK",
+            "pubkeys": {
+              "guid": "CAASpgQwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDyC2odUCZEdGnsGIAzATaX3W2QTMcbXwQZzuZQp+zQLuXw6H2TyK9QnSymCf7Hq3eStRFE4QGnClMpSaAJ87XB51lWH74MsTa+rQ4mCaH2Js1XXLEzD5wea3tEfd1+0cVDvQF0fgGS2RXP1LFD74/8Md9xRNQtXjxDpmRnA0P0g3g/zrJHuoZdOAHuJzFsyHCwxdixcAnRqFimbFQzwrpGccfGP7G17eV2nTPwu6Dt8iVrGHubKWUthmKtlU6K83cw4Cv1oarPBBploV3TpfOWkjLp+y1kU79FAx1EAZxQDUGQBy1hEfnyyP/GtE90t5JJseGcTvFTg6a9/QxUU/tUQUnKyvzGrBxL3y5i2gUAYKqqKR/obe/mJx6k+QD/Lw5tv360uMD6vhkspeaZ/e5VTL8/WTusZO/27vzQgWYUlrdGEQxG5e+zm1MsRgJu9tfrwXfODP7kYqNA4d2mUVEbCTAatIJuekgCzSaVQ4kcpaqCSAfRsLCGT5GB0BaW+4TepldxSPQ1r5qyGn+PDRUdqsu6rw0j2kTmbZLrRILUgHP8MdsBPCJOZf2A3HjaYQvqhroJLxemcExK92u79azpwPkDUZL8k0hAsxe6WICljNV7futRPUANkTgA5NrlqrwJqBxgByL4/o5zhv/NZ8r+1QlrwGIMGMIOr0cFJkC9jQIDAQAB",
+              "bitcoin": "ApaMJ74nWpuXz34PUinaucXj4hqfywE9zvs/k3yWYeRj"
+            },
+            "bitcoinSig": "MEUCIQDgmTVj2hDiIxD0J1rj51/KXzKaDgXGu58hUq+yHhBaGgIgSR2C9HgMoI4t0x8XXQ3FPR70EUUb+Er9blEu1nCKLZk="
+          },
+          "metadata": {
+            "version": 1,
+            "contractType": "PHYSICAL_GOOD",
+            "format": "FIXED_PRICE",
+            "expiry": "2037-12-30T14:00:00Z",
+            "acceptedCurrency": "btc",
+            "pricingCurrency": "USD"
+          },
+          "item": {
+            "title": "Sushi Platter",
+            "description": "<p>Das sushi platter</p>",
+            "price": 1500,
+            "tags": [],
+            "images": [
+              {
+                "filename": "IMG_0790.JPG",
+                "original": "QmbYjEfM2is7mQfn7i8WbdKiRQd2JgenRzMiTVV68rYR6W",
+                "large": "QmU8cbgQxA2BLDQh1cgj6npGJPaVTGx3Jc2iVMecBZVAFK",
+                "medium": "QmTAvFVqGsKYr5v1HH7nuaL8rUHz3j6bpD5oK95vydZtif",
+                "small": "Qmajg2QMt42kEkytsjH3H9Xkb825brSWePw31265KJJt6b",
+                "tiny": "QmUdhFfDhAavZ3AhM2Vhr9gSk96piiF6A9UX2jpfXSaJvx"
+              },
+              {
+                "filename": "B12.jpg",
+                "original": "QmSnu4YrUDgSjtKunVQ1ekonkhUzj62YCBreof3nV2GfDr",
+                "large": "QmbaMCk6dV3BAtf2ZTGjtUEjuKZ5ngWEbCt95cjhzWNHxH",
+                "medium": "QmeHEEa4eqi3GWeie9TDoH2p2mFAYBsJd85hKKCbkCNjLm",
+                "small": "QmXRGCQpRSWykK2RBhFwkNrTPaCj7QWyvEquGrxuxxeinX",
+                "tiny": "QmRU9U7fsKnf1ikrSxGYkamDvgXkLrT7ZcP2WMGQsaXaZT"
+              }
+            ],
+            "categories": [],
+            "condition": "NEW"
+          },
+          "shippingOptions": [
+            {
+              "name": "Australia",
+              "type": "FIXED_PRICE",
+              "regions": [
+                "AUSTRALIA"
+              ],
+              "services": [
+                {
+                  "name": "Standard",
+                  "estimatedDelivery": "5"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "signatures": [
+        {
+          "section": "LISTING",
+          "signatureBytes": "dqMhfv8C4tYfu23OuAHs7aymAB3nJXqXQOCbjqmomEozqrZaV9TzN5PQJ4osr8752WmqUgJVOnOczoBX7ed8K9a9SkR5I4xzxxgd8Qft0vLDhRJ9/z/5WDzTts4NDQW+bymd963iEjYJm86AEl8ZivHodpGHGniwamECJTBaylNGTB3SK7YXeauadd0SsHBII+ce9B6Z6pf82a0nN1Fu2Gcep/sb61bYhAvf3SUh//1LmNW+BIXL0dWTcUdZFNWVXe6qMmPxcTlVFSeYmjEw+mN+c57iC3TwGg6bGRh+nsQ5PsVzBEPyuGO6F8b1FFCoMHDmlgCm4h3YU2X2dC9qKgg5VZQpthKQohxdheyWu2PNzxqKicT3AR3IRj4nJDraaVvyj2oalG3lhW9Vm1WMQuPUWP1gax7XMiOFae6+u3ZIDwriJPFKHeA2sBXd9Wo0PYP5YwEr/IWaljG4U2DnYGsxDCDPAHneUVhwL4gYQHm4pBBNenZ2/IIL00s8nCJLmDpXcHfMf5Sjlhs7qa/qtBEx6Hu0Ney+T64RWHdJmFBDxcbhCpUU4e4rzLExdM5b5SHiycXKQ0qRxF7n2JN6iqwdTDAQKImm5wYvffhvQOOTxYFf7GPC/5vkh424LT0FM9YZR0dqG/q++WqT5mtuSMmmwCCcClJAjYIYvigHrKk="
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "vendorListings": {
+        "description": "",
+        "example": [
+          {
+            "slug": "sushi-platter",
+            "vendorID": {
+              "guid": "QmXhBroy8AS1Hm9pMBjAfHoMuKdMaPaJr3oYHqawR6ivqK",
+              "pubkeys": {
+                "guid": "CAASpgQwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDyC2odUCZEdGnsGIAzATaX3W2QTMcbXwQZzuZQp+zQLuXw6H2TyK9QnSymCf7Hq3eStRFE4QGnClMpSaAJ87XB51lWH74MsTa+rQ4mCaH2Js1XXLEzD5wea3tEfd1+0cVDvQF0fgGS2RXP1LFD74/8Md9xRNQtXjxDpmRnA0P0g3g/zrJHuoZdOAHuJzFsyHCwxdixcAnRqFimbFQzwrpGccfGP7G17eV2nTPwu6Dt8iVrGHubKWUthmKtlU6K83cw4Cv1oarPBBploV3TpfOWkjLp+y1kU79FAx1EAZxQDUGQBy1hEfnyyP/GtE90t5JJseGcTvFTg6a9/QxUU/tUQUnKyvzGrBxL3y5i2gUAYKqqKR/obe/mJx6k+QD/Lw5tv360uMD6vhkspeaZ/e5VTL8/WTusZO/27vzQgWYUlrdGEQxG5e+zm1MsRgJu9tfrwXfODP7kYqNA4d2mUVEbCTAatIJuekgCzSaVQ4kcpaqCSAfRsLCGT5GB0BaW+4TepldxSPQ1r5qyGn+PDRUdqsu6rw0j2kTmbZLrRILUgHP8MdsBPCJOZf2A3HjaYQvqhroJLxemcExK92u79azpwPkDUZL8k0hAsxe6WICljNV7futRPUANkTgA5NrlqrwJqBxgByL4/o5zhv/NZ8r+1QlrwGIMGMIOr0cFJkC9jQIDAQAB",
+                "bitcoin": "ApaMJ74nWpuXz34PUinaucXj4hqfywE9zvs/k3yWYeRj"
+              },
+              "bitcoinSig": "MEUCIQDgmTVj2hDiIxD0J1rj51/KXzKaDgXGu58hUq+yHhBaGgIgSR2C9HgMoI4t0x8XXQ3FPR70EUUb+Er9blEu1nCKLZk="
+            },
+            "metadata": {
+              "version": 1,
+              "contractType": "PHYSICAL_GOOD",
+              "format": "FIXED_PRICE",
+              "expiry": "2037-12-30T14:00:00Z",
+              "acceptedCurrency": "btc",
+              "pricingCurrency": "USD"
+            },
+            "item": {
+              "title": "Sushi Platter",
+              "description": "<p>Das sushi platter</p>",
+              "price": 1500,
+              "tags": [],
+              "images": [
+                {
+                  "filename": "IMG_0790.JPG",
+                  "original": "QmbYjEfM2is7mQfn7i8WbdKiRQd2JgenRzMiTVV68rYR6W",
+                  "large": "QmU8cbgQxA2BLDQh1cgj6npGJPaVTGx3Jc2iVMecBZVAFK",
+                  "medium": "QmTAvFVqGsKYr5v1HH7nuaL8rUHz3j6bpD5oK95vydZtif",
+                  "small": "Qmajg2QMt42kEkytsjH3H9Xkb825brSWePw31265KJJt6b",
+                  "tiny": "QmUdhFfDhAavZ3AhM2Vhr9gSk96piiF6A9UX2jpfXSaJvx"
+                },
+                {
+                  "filename": "B12.jpg",
+                  "original": "QmSnu4YrUDgSjtKunVQ1ekonkhUzj62YCBreof3nV2GfDr",
+                  "large": "QmbaMCk6dV3BAtf2ZTGjtUEjuKZ5ngWEbCt95cjhzWNHxH",
+                  "medium": "QmeHEEa4eqi3GWeie9TDoH2p2mFAYBsJd85hKKCbkCNjLm",
+                  "small": "QmXRGCQpRSWykK2RBhFwkNrTPaCj7QWyvEquGrxuxxeinX",
+                  "tiny": "QmRU9U7fsKnf1ikrSxGYkamDvgXkLrT7ZcP2WMGQsaXaZT"
+                }
+              ],
+              "categories": [],
+              "condition": "NEW"
+            },
+            "shippingOptions": [
+              {
+                "name": "Australia",
+                "type": "FIXED_PRICE",
+                "regions": [
+                  "AUSTRALIA"
+                ],
+                "services": [
+                  {
+                    "name": "Standard",
+                    "estimatedDelivery": "5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/VendorListing"
+        }
+      },
+      "signatures": {
+        "description": "",
+        "example": [
+          {
+            "section": "LISTING",
+            "signatureBytes": "dqMhfv8C4tYfu23OuAHs7aymAB3nJXqXQOCbjqmomEozqrZaV9TzN5PQJ4osr8752WmqUgJVOnOczoBX7ed8K9a9SkR5I4xzxxgd8Qft0vLDhRJ9/z/5WDzTts4NDQW+bymd963iEjYJm86AEl8ZivHodpGHGniwamECJTBaylNGTB3SK7YXeauadd0SsHBII+ce9B6Z6pf82a0nN1Fu2Gcep/sb61bYhAvf3SUh//1LmNW+BIXL0dWTcUdZFNWVXe6qMmPxcTlVFSeYmjEw+mN+c57iC3TwGg6bGRh+nsQ5PsVzBEPyuGO6F8b1FFCoMHDmlgCm4h3YU2X2dC9qKgg5VZQpthKQohxdheyWu2PNzxqKicT3AR3IRj4nJDraaVvyj2oalG3lhW9Vm1WMQuPUWP1gax7XMiOFae6+u3ZIDwriJPFKHeA2sBXd9Wo0PYP5YwEr/IWaljG4U2DnYGsxDCDPAHneUVhwL4gYQHm4pBBNenZ2/IIL00s8nCJLmDpXcHfMf5Sjlhs7qa/qtBEx6Hu0Ney+T64RWHdJmFBDxcbhCpUU4e4rzLExdM5b5SHiycXKQ0qRxF7n2JN6iqwdTDAQKImm5wYvffhvQOOTxYFf7GPC/5vkh424LT0FM9YZR0dqG/q++WqT5mtuSMmmwCCcClJAjYIYvigHrKk="
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Signature"
+        }
+      }
+    },
+    "required": [
+      "vendorListings",
+      "signatures"
+    ]
+  },
+  "VendorListing": {
+    "title": "VendorListing",
+    "example": {
+      "slug": "sushi-platter",
+      "vendorID": {
+        "guid": "QmXhBroy8AS1Hm9pMBjAfHoMuKdMaPaJr3oYHqawR6ivqK",
+        "pubkeys": {
+          "guid": "CAASpgQwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDyC2odUCZEdGnsGIAzATaX3W2QTMcbXwQZzuZQp+zQLuXw6H2TyK9QnSymCf7Hq3eStRFE4QGnClMpSaAJ87XB51lWH74MsTa+rQ4mCaH2Js1XXLEzD5wea3tEfd1+0cVDvQF0fgGS2RXP1LFD74/8Md9xRNQtXjxDpmRnA0P0g3g/zrJHuoZdOAHuJzFsyHCwxdixcAnRqFimbFQzwrpGccfGP7G17eV2nTPwu6Dt8iVrGHubKWUthmKtlU6K83cw4Cv1oarPBBploV3TpfOWkjLp+y1kU79FAx1EAZxQDUGQBy1hEfnyyP/GtE90t5JJseGcTvFTg6a9/QxUU/tUQUnKyvzGrBxL3y5i2gUAYKqqKR/obe/mJx6k+QD/Lw5tv360uMD6vhkspeaZ/e5VTL8/WTusZO/27vzQgWYUlrdGEQxG5e+zm1MsRgJu9tfrwXfODP7kYqNA4d2mUVEbCTAatIJuekgCzSaVQ4kcpaqCSAfRsLCGT5GB0BaW+4TepldxSPQ1r5qyGn+PDRUdqsu6rw0j2kTmbZLrRILUgHP8MdsBPCJOZf2A3HjaYQvqhroJLxemcExK92u79azpwPkDUZL8k0hAsxe6WICljNV7futRPUANkTgA5NrlqrwJqBxgByL4/o5zhv/NZ8r+1QlrwGIMGMIOr0cFJkC9jQIDAQAB",
+          "bitcoin": "ApaMJ74nWpuXz34PUinaucXj4hqfywE9zvs/k3yWYeRj"
+        },
+        "bitcoinSig": "MEUCIQDgmTVj2hDiIxD0J1rj51/KXzKaDgXGu58hUq+yHhBaGgIgSR2C9HgMoI4t0x8XXQ3FPR70EUUb+Er9blEu1nCKLZk="
+      },
+      "metadata": {
+        "version": 1,
+        "contractType": "PHYSICAL_GOOD",
+        "format": "FIXED_PRICE",
+        "expiry": "2037-12-30T14:00:00Z",
+        "acceptedCurrency": "btc",
+        "pricingCurrency": "USD"
+      },
+      "item": {
+        "title": "Sushi Platter",
+        "description": "<p>Das sushi platter</p>",
+        "price": 1500,
+        "tags": [],
+        "images": [
+          {
+            "filename": "IMG_0790.JPG",
+            "original": "QmbYjEfM2is7mQfn7i8WbdKiRQd2JgenRzMiTVV68rYR6W",
+            "large": "QmU8cbgQxA2BLDQh1cgj6npGJPaVTGx3Jc2iVMecBZVAFK",
+            "medium": "QmTAvFVqGsKYr5v1HH7nuaL8rUHz3j6bpD5oK95vydZtif",
+            "small": "Qmajg2QMt42kEkytsjH3H9Xkb825brSWePw31265KJJt6b",
+            "tiny": "QmUdhFfDhAavZ3AhM2Vhr9gSk96piiF6A9UX2jpfXSaJvx"
+          },
+          {
+            "filename": "B12.jpg",
+            "original": "QmSnu4YrUDgSjtKunVQ1ekonkhUzj62YCBreof3nV2GfDr",
+            "large": "QmbaMCk6dV3BAtf2ZTGjtUEjuKZ5ngWEbCt95cjhzWNHxH",
+            "medium": "QmeHEEa4eqi3GWeie9TDoH2p2mFAYBsJd85hKKCbkCNjLm",
+            "small": "QmXRGCQpRSWykK2RBhFwkNrTPaCj7QWyvEquGrxuxxeinX",
+            "tiny": "QmRU9U7fsKnf1ikrSxGYkamDvgXkLrT7ZcP2WMGQsaXaZT"
+          }
+        ],
+        "categories": [],
+        "condition": "NEW"
+      },
+      "shippingOptions": [
+        {
+          "name": "Australia",
+          "type": "FIXED_PRICE",
+          "regions": [
+            "AUSTRALIA"
+          ],
+          "services": [
+            {
+              "name": "Standard",
+              "estimatedDelivery": "5"
+            }
+          ]
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "slug": {
+        "description": "",
+        "example": "sushi-platter",
+        "type": "string"
+      },
+      "vendorID": {
+        "$ref": "#/definitions/VendorID"
+      },
+      "metadata": {
+        "$ref": "#/definitions/Metadata"
+      },
+      "item": {
+        "$ref": "#/definitions/Item"
+      },
+      "shippingOptions": {
+        "description": "",
+        "example": [
+          {
+            "name": "Australia",
+            "type": "FIXED_PRICE",
+            "regions": [
+              "AUSTRALIA"
+            ],
+            "services": [
+              {
+                "name": "Standard",
+                "estimatedDelivery": "5"
+              }
+            ]
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/ShippingOption"
+        }
+      }
+    },
+    "required": [
+      "slug",
+      "vendorID",
+      "metadata",
+      "item",
+      "shippingOptions"
+    ]
+  },
+  "VendorID": {
+    "title": "VendorID",
+    "example": {
+      "guid": "QmXhBroy8AS1Hm9pMBjAfHoMuKdMaPaJr3oYHqawR6ivqK",
+      "pubkeys": {
+        "guid": "CAASpgQwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDyC2odUCZEdGnsGIAzATaX3W2QTMcbXwQZzuZQp+zQLuXw6H2TyK9QnSymCf7Hq3eStRFE4QGnClMpSaAJ87XB51lWH74MsTa+rQ4mCaH2Js1XXLEzD5wea3tEfd1+0cVDvQF0fgGS2RXP1LFD74/8Md9xRNQtXjxDpmRnA0P0g3g/zrJHuoZdOAHuJzFsyHCwxdixcAnRqFimbFQzwrpGccfGP7G17eV2nTPwu6Dt8iVrGHubKWUthmKtlU6K83cw4Cv1oarPBBploV3TpfOWkjLp+y1kU79FAx1EAZxQDUGQBy1hEfnyyP/GtE90t5JJseGcTvFTg6a9/QxUU/tUQUnKyvzGrBxL3y5i2gUAYKqqKR/obe/mJx6k+QD/Lw5tv360uMD6vhkspeaZ/e5VTL8/WTusZO/27vzQgWYUlrdGEQxG5e+zm1MsRgJu9tfrwXfODP7kYqNA4d2mUVEbCTAatIJuekgCzSaVQ4kcpaqCSAfRsLCGT5GB0BaW+4TepldxSPQ1r5qyGn+PDRUdqsu6rw0j2kTmbZLrRILUgHP8MdsBPCJOZf2A3HjaYQvqhroJLxemcExK92u79azpwPkDUZL8k0hAsxe6WICljNV7futRPUANkTgA5NrlqrwJqBxgByL4/o5zhv/NZ8r+1QlrwGIMGMIOr0cFJkC9jQIDAQAB",
+        "bitcoin": "ApaMJ74nWpuXz34PUinaucXj4hqfywE9zvs/k3yWYeRj"
+      },
+      "bitcoinSig": "MEUCIQDgmTVj2hDiIxD0J1rj51/KXzKaDgXGu58hUq+yHhBaGgIgSR2C9HgMoI4t0x8XXQ3FPR70EUUb+Er9blEu1nCKLZk="
+    },
+    "type": "object",
+    "properties": {
+      "guid": {
+        "description": "",
+        "example": "QmXhBroy8AS1Hm9pMBjAfHoMuKdMaPaJr3oYHqawR6ivqK",
+        "type": "string"
+      },
+      "pubkeys": {
+        "$ref": "#/definitions/Pubkeys"
+      },
+      "bitcoinSig": {
+        "description": "",
+        "example": "MEUCIQDgmTVj2hDiIxD0J1rj51/KXzKaDgXGu58hUq+yHhBaGgIgSR2C9HgMoI4t0x8XXQ3FPR70EUUb+Er9blEu1nCKLZk=",
+        "type": "string"
+      }
+    },
+    "required": [
+      "guid",
+      "pubkeys",
+      "bitcoinSig"
+    ]
+  },
+  "Pubkeys": {
+    "title": "Pubkeys",
+    "example": {
+      "guid": "CAASpgQwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDyC2odUCZEdGnsGIAzATaX3W2QTMcbXwQZzuZQp+zQLuXw6H2TyK9QnSymCf7Hq3eStRFE4QGnClMpSaAJ87XB51lWH74MsTa+rQ4mCaH2Js1XXLEzD5wea3tEfd1+0cVDvQF0fgGS2RXP1LFD74/8Md9xRNQtXjxDpmRnA0P0g3g/zrJHuoZdOAHuJzFsyHCwxdixcAnRqFimbFQzwrpGccfGP7G17eV2nTPwu6Dt8iVrGHubKWUthmKtlU6K83cw4Cv1oarPBBploV3TpfOWkjLp+y1kU79FAx1EAZxQDUGQBy1hEfnyyP/GtE90t5JJseGcTvFTg6a9/QxUU/tUQUnKyvzGrBxL3y5i2gUAYKqqKR/obe/mJx6k+QD/Lw5tv360uMD6vhkspeaZ/e5VTL8/WTusZO/27vzQgWYUlrdGEQxG5e+zm1MsRgJu9tfrwXfODP7kYqNA4d2mUVEbCTAatIJuekgCzSaVQ4kcpaqCSAfRsLCGT5GB0BaW+4TepldxSPQ1r5qyGn+PDRUdqsu6rw0j2kTmbZLrRILUgHP8MdsBPCJOZf2A3HjaYQvqhroJLxemcExK92u79azpwPkDUZL8k0hAsxe6WICljNV7futRPUANkTgA5NrlqrwJqBxgByL4/o5zhv/NZ8r+1QlrwGIMGMIOr0cFJkC9jQIDAQAB",
+      "bitcoin": "ApaMJ74nWpuXz34PUinaucXj4hqfywE9zvs/k3yWYeRj"
+    },
+    "type": "object",
+    "properties": {
+      "guid": {
+        "description": "",
+        "example": "CAASpgQwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDyC2odUCZEdGnsGIAzATaX3W2QTMcbXwQZzuZQp+zQLuXw6H2TyK9QnSymCf7Hq3eStRFE4QGnClMpSaAJ87XB51lWH74MsTa+rQ4mCaH2Js1XXLEzD5wea3tEfd1+0cVDvQF0fgGS2RXP1LFD74/8Md9xRNQtXjxDpmRnA0P0g3g/zrJHuoZdOAHuJzFsyHCwxdixcAnRqFimbFQzwrpGccfGP7G17eV2nTPwu6Dt8iVrGHubKWUthmKtlU6K83cw4Cv1oarPBBploV3TpfOWkjLp+y1kU79FAx1EAZxQDUGQBy1hEfnyyP/GtE90t5JJseGcTvFTg6a9/QxUU/tUQUnKyvzGrBxL3y5i2gUAYKqqKR/obe/mJx6k+QD/Lw5tv360uMD6vhkspeaZ/e5VTL8/WTusZO/27vzQgWYUlrdGEQxG5e+zm1MsRgJu9tfrwXfODP7kYqNA4d2mUVEbCTAatIJuekgCzSaVQ4kcpaqCSAfRsLCGT5GB0BaW+4TepldxSPQ1r5qyGn+PDRUdqsu6rw0j2kTmbZLrRILUgHP8MdsBPCJOZf2A3HjaYQvqhroJLxemcExK92u79azpwPkDUZL8k0hAsxe6WICljNV7futRPUANkTgA5NrlqrwJqBxgByL4/o5zhv/NZ8r+1QlrwGIMGMIOr0cFJkC9jQIDAQAB",
+        "type": "string"
+      },
+      "bitcoin": {
+        "description": "",
+        "example": "ApaMJ74nWpuXz34PUinaucXj4hqfywE9zvs/k3yWYeRj",
+        "type": "string"
+      }
+    },
+    "required": [
+      "guid",
+      "bitcoin"
+    ]
+  },
+  "Metadata": {
+    "title": "Metadata",
+    "example": {
+      "version": 1,
+      "contractType": "PHYSICAL_GOOD",
+      "format": "FIXED_PRICE",
+      "expiry": "2037-12-30T14:00:00Z",
+      "acceptedCurrency": "btc",
+      "pricingCurrency": "USD"
+    },
+    "type": "object",
+    "properties": {
+      "version": {
+        "description": "",
+        "example": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "contractType": {
+        "description": "",
+        "example": "PHYSICAL_GOOD",
+        "type": "string"
+      },
+      "format": {
+        "description": "",
+        "example": "FIXED_PRICE",
+        "type": "string"
+      },
+      "expiry": {
+        "description": "",
+        "example": "12/30/2037 2:00:00 PM",
+        "type": "string"
+      },
+      "acceptedCurrency": {
+        "description": "",
+        "example": "btc",
+        "type": "string"
+      },
+      "pricingCurrency": {
+        "description": "",
+        "example": "USD",
+        "type": "string"
+      }
+    },
+    "required": [
+      "version",
+      "contractType",
+      "format",
+      "expiry",
+      "acceptedCurrency",
+      "pricingCurrency"
+    ]
+  },
+  "Item": {
+    "title": "Item",
+    "example": {
+      "title": "Sushi Platter",
+      "description": "<p>Das sushi platter</p>",
+      "price": 1500,
+      "tags": [],
+      "images": [
+        {
+          "filename": "IMG_0790.JPG",
+          "original": "QmbYjEfM2is7mQfn7i8WbdKiRQd2JgenRzMiTVV68rYR6W",
+          "large": "QmU8cbgQxA2BLDQh1cgj6npGJPaVTGx3Jc2iVMecBZVAFK",
+          "medium": "QmTAvFVqGsKYr5v1HH7nuaL8rUHz3j6bpD5oK95vydZtif",
+          "small": "Qmajg2QMt42kEkytsjH3H9Xkb825brSWePw31265KJJt6b",
+          "tiny": "QmUdhFfDhAavZ3AhM2Vhr9gSk96piiF6A9UX2jpfXSaJvx"
+        },
+        {
+          "filename": "B12.jpg",
+          "original": "QmSnu4YrUDgSjtKunVQ1ekonkhUzj62YCBreof3nV2GfDr",
+          "large": "QmbaMCk6dV3BAtf2ZTGjtUEjuKZ5ngWEbCt95cjhzWNHxH",
+          "medium": "QmeHEEa4eqi3GWeie9TDoH2p2mFAYBsJd85hKKCbkCNjLm",
+          "small": "QmXRGCQpRSWykK2RBhFwkNrTPaCj7QWyvEquGrxuxxeinX",
+          "tiny": "QmRU9U7fsKnf1ikrSxGYkamDvgXkLrT7ZcP2WMGQsaXaZT"
+        }
+      ],
+      "categories": [],
+      "condition": "NEW"
+    },
+    "type": "object",
+    "properties": {
+      "title": {
+        "description": "",
+        "example": "Sushi Platter",
+        "type": "string"
+      },
+      "description": {
+        "description": "",
+        "example": "<p>Das sushi platter</p>",
+        "type": "string"
+      },
+      "price": {
+        "description": "",
+        "example": 1500,
+        "type": "integer",
+        "format": "int32"
+      },
+      "tags": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "images": {
+        "description": "",
+        "example": [
+          {
+            "filename": "IMG_0790.JPG",
+            "original": "QmbYjEfM2is7mQfn7i8WbdKiRQd2JgenRzMiTVV68rYR6W",
+            "large": "QmU8cbgQxA2BLDQh1cgj6npGJPaVTGx3Jc2iVMecBZVAFK",
+            "medium": "QmTAvFVqGsKYr5v1HH7nuaL8rUHz3j6bpD5oK95vydZtif",
+            "small": "Qmajg2QMt42kEkytsjH3H9Xkb825brSWePw31265KJJt6b",
+            "tiny": "QmUdhFfDhAavZ3AhM2Vhr9gSk96piiF6A9UX2jpfXSaJvx"
+          },
+          {
+            "filename": "B12.jpg",
+            "original": "QmSnu4YrUDgSjtKunVQ1ekonkhUzj62YCBreof3nV2GfDr",
+            "large": "QmbaMCk6dV3BAtf2ZTGjtUEjuKZ5ngWEbCt95cjhzWNHxH",
+            "medium": "QmeHEEa4eqi3GWeie9TDoH2p2mFAYBsJd85hKKCbkCNjLm",
+            "small": "QmXRGCQpRSWykK2RBhFwkNrTPaCj7QWyvEquGrxuxxeinX",
+            "tiny": "QmRU9U7fsKnf1ikrSxGYkamDvgXkLrT7ZcP2WMGQsaXaZT"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Image"
+        }
+      },
+      "categories": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "condition": {
+        "description": "",
+        "example": "NEW",
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "description",
+      "price",
+      "tags",
+      "images",
+      "categories",
+      "condition"
+    ]
+  },
+  "Image": {
+    "title": "Image",
+    "example": {
+      "filename": "IMG_0790.JPG",
+      "original": "QmbYjEfM2is7mQfn7i8WbdKiRQd2JgenRzMiTVV68rYR6W",
+      "large": "QmU8cbgQxA2BLDQh1cgj6npGJPaVTGx3Jc2iVMecBZVAFK",
+      "medium": "QmTAvFVqGsKYr5v1HH7nuaL8rUHz3j6bpD5oK95vydZtif",
+      "small": "Qmajg2QMt42kEkytsjH3H9Xkb825brSWePw31265KJJt6b",
+      "tiny": "QmUdhFfDhAavZ3AhM2Vhr9gSk96piiF6A9UX2jpfXSaJvx"
+    },
+    "type": "object",
+    "properties": {
+      "filename": {
+        "description": "",
+        "example": "IMG_0790.JPG",
+        "type": "string"
+      },
+      "original": {
+        "description": "",
+        "example": "QmbYjEfM2is7mQfn7i8WbdKiRQd2JgenRzMiTVV68rYR6W",
+        "type": "string"
+      },
+      "large": {
+        "description": "",
+        "example": "QmU8cbgQxA2BLDQh1cgj6npGJPaVTGx3Jc2iVMecBZVAFK",
+        "type": "string"
+      },
+      "medium": {
+        "description": "",
+        "example": "QmTAvFVqGsKYr5v1HH7nuaL8rUHz3j6bpD5oK95vydZtif",
+        "type": "string"
+      },
+      "small": {
+        "description": "",
+        "example": "Qmajg2QMt42kEkytsjH3H9Xkb825brSWePw31265KJJt6b",
+        "type": "string"
+      },
+      "tiny": {
+        "description": "",
+        "example": "QmUdhFfDhAavZ3AhM2Vhr9gSk96piiF6A9UX2jpfXSaJvx",
+        "type": "string"
+      }
+    },
+    "required": [
+      "filename",
+      "original",
+      "large",
+      "medium",
+      "small",
+      "tiny"
+    ]
+  },
+  "ShippingOption": {
+    "title": "ShippingOption",
+    "example": {
+      "name": "Australia",
+      "type": "FIXED_PRICE",
+      "regions": [
+        "AUSTRALIA"
+      ],
+      "services": [
+        {
+          "name": "Standard",
+          "estimatedDelivery": "5"
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Australia",
+        "type": "string"
+      },
+      "type": {
+        "description": "",
+        "example": "FIXED_PRICE",
+        "type": "string"
+      },
+      "regions": {
+        "description": "",
+        "example": [
+          "AUSTRALIA"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "services": {
+        "description": "",
+        "example": [
+          {
+            "name": "Standard",
+            "estimatedDelivery": "5"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Service"
+        }
+      }
+    },
+    "required": [
+      "name",
+      "type",
+      "regions",
+      "services"
+    ]
+  },
+  "Service": {
+    "title": "Service",
+    "example": {
+      "name": "Standard",
+      "estimatedDelivery": "5"
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Standard",
+        "type": "string"
+      },
+      "estimatedDelivery": {
+        "description": "",
+        "example": "5",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name",
+      "estimatedDelivery"
+    ]
+  },
+  "Signature": {
+    "title": "Signature",
+    "example": {
+      "section": "LISTING",
+      "signatureBytes": "dqMhfv8C4tYfu23OuAHs7aymAB3nJXqXQOCbjqmomEozqrZaV9TzN5PQJ4osr8752WmqUgJVOnOczoBX7ed8K9a9SkR5I4xzxxgd8Qft0vLDhRJ9/z/5WDzTts4NDQW+bymd963iEjYJm86AEl8ZivHodpGHGniwamECJTBaylNGTB3SK7YXeauadd0SsHBII+ce9B6Z6pf82a0nN1Fu2Gcep/sb61bYhAvf3SUh//1LmNW+BIXL0dWTcUdZFNWVXe6qMmPxcTlVFSeYmjEw+mN+c57iC3TwGg6bGRh+nsQ5PsVzBEPyuGO6F8b1FFCoMHDmlgCm4h3YU2X2dC9qKgg5VZQpthKQohxdheyWu2PNzxqKicT3AR3IRj4nJDraaVvyj2oalG3lhW9Vm1WMQuPUWP1gax7XMiOFae6+u3ZIDwriJPFKHeA2sBXd9Wo0PYP5YwEr/IWaljG4U2DnYGsxDCDPAHneUVhwL4gYQHm4pBBNenZ2/IIL00s8nCJLmDpXcHfMf5Sjlhs7qa/qtBEx6Hu0Ney+T64RWHdJmFBDxcbhCpUU4e4rzLExdM5b5SHiycXKQ0qRxF7n2JN6iqwdTDAQKImm5wYvffhvQOOTxYFf7GPC/5vkh424LT0FM9YZR0dqG/q++WqT5mtuSMmmwCCcClJAjYIYvigHrKk="
+    },
+    "type": "object",
+    "properties": {
+      "section": {
+        "description": "",
+        "example": "LISTING",
+        "type": "string"
+      },
+      "signatureBytes": {
+        "description": "",
+        "example": "dqMhfv8C4tYfu23OuAHs7aymAB3nJXqXQOCbjqmomEozqrZaV9TzN5PQJ4osr8752WmqUgJVOnOczoBX7ed8K9a9SkR5I4xzxxgd8Qft0vLDhRJ9/z/5WDzTts4NDQW+bymd963iEjYJm86AEl8ZivHodpGHGniwamECJTBaylNGTB3SK7YXeauadd0SsHBII+ce9B6Z6pf82a0nN1Fu2Gcep/sb61bYhAvf3SUh//1LmNW+BIXL0dWTcUdZFNWVXe6qMmPxcTlVFSeYmjEw+mN+c57iC3TwGg6bGRh+nsQ5PsVzBEPyuGO6F8b1FFCoMHDmlgCm4h3YU2X2dC9qKgg5VZQpthKQohxdheyWu2PNzxqKicT3AR3IRj4nJDraaVvyj2oalG3lhW9Vm1WMQuPUWP1gax7XMiOFae6+u3ZIDwriJPFKHeA2sBXd9Wo0PYP5YwEr/IWaljG4U2DnYGsxDCDPAHneUVhwL4gYQHm4pBBNenZ2/IIL00s8nCJLmDpXcHfMf5Sjlhs7qa/qtBEx6Hu0Ney+T64RWHdJmFBDxcbhCpUU4e4rzLExdM5b5SHiycXKQ0qRxF7n2JN6iqwdTDAQKImm5wYvffhvQOOTxYFf7GPC/5vkh424LT0FM9YZR0dqG/q++WqT5mtuSMmmwCCcClJAjYIYvigHrKk=",
+        "type": "string"
+      }
+    },
+    "required": [
+      "section",
+      "signatureBytes"
+    ]
+  },
+  "SendAChatMessagerequest": {
+    "title": "Send a chat messageRequest",
+    "example": {
+      "subject": "",
+      "message": "wassup...",
+      "peerId": "QmeRr7eJh3GYioe6mQm3oDb5H46maxkCbink4hygCPFyHR"
+    },
+    "type": "object",
+    "properties": {
+      "subject": {
+        "description": "",
+        "type": "string"
+      },
+      "message": {
+        "description": "",
+        "example": "wassup...",
+        "type": "string"
+      },
+      "peerId": {
+        "description": "",
+        "example": "QmeRr7eJh3GYioe6mQm3oDb5H46maxkCbink4hygCPFyHR",
+        "type": "string"
+      }
+    },
+    "required": [
+      "subject",
+      "message",
+      "peerId"
+    ]
+  },
+  "SetInventoryLevelsrequest": {
+    "title": "Set inventory levelsRequest",
+    "example": {
+      "slug": "/cool_tshirt/red/xl",
+      "quantity": 17
+    },
+    "type": "object",
+    "properties": {
+      "slug": {
+        "description": "",
+        "example": "/cool_tshirt/red/xl",
+        "type": "string"
+      },
+      "quantity": {
+        "description": "",
+        "example": 17,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "slug",
+      "quantity"
+    ]
+  },
+  "130117": {
+    "title": "13-01-17",
+    "example": {
+      "guid": "QmSiUTbcaWsi9Wzw57nSUJVVZJunCUbBA3GvPbqS4LopJZ",
+      "cryptoCurrency": "btc"
+    },
+    "type": "object",
+    "properties": {
+      "guid": {
+        "description": "",
+        "example": "QmSiUTbcaWsi9Wzw57nSUJVVZJunCUbBA3GvPbqS4LopJZ",
+        "type": "string"
+      },
+      "cryptoCurrency": {
+        "description": "",
+        "example": "btc",
+        "type": "string"
+      }
+    },
+    "required": [
+      "guid",
+      "cryptoCurrency"
+    ]
+  },
+  "IsSamOnline?": {
+    "title": "Is Sam online?",
+    "example": {
+      "status": "online"
+    },
+    "type": "object",
+    "properties": {
+      "status": {
+        "description": "",
+        "example": "online",
+        "type": "string"
+      }
+    },
+    "required": [
+      "status"
+    ]
+  },
+  "SetAsModeratorrequest": {
+    "title": "Set as moderatorRequest",
+    "example": {
+      "description": "Long time OpenBazaar moderator located in Chicago",
+      "termsAndConditions": "Will moderate anything and everything",
+      "languages": [
+        "English",
+        "Spanish"
+      ],
+      "fee": {
+        "feeType": "FIXED_PLUS_PERCENTAGE",
+        "fixedFee": {
+          "currencyCode": "USD",
+          "amount": 300
+        },
+        "percentage": 5
+      }
+    },
+    "type": "object",
+    "properties": {
+      "description": {
+        "description": "",
+        "example": "Long time OpenBazaar moderator located in Chicago",
+        "type": "string"
+      },
+      "termsAndConditions": {
+        "description": "",
+        "example": "Will moderate anything and everything",
+        "type": "string"
+      },
+      "languages": {
+        "description": "",
+        "example": [
+          "English",
+          "Spanish"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "fee": {
+        "$ref": "#/definitions/Fee"
+      }
+    },
+    "required": [
+      "description",
+      "termsAndConditions",
+      "languages",
+      "fee"
+    ]
+  },
+  "Fee": {
+    "title": "Fee",
+    "example": {
+      "feeType": "FIXED_PLUS_PERCENTAGE",
+      "fixedFee": {
+        "currencyCode": "USD",
+        "amount": 300
+      },
+      "percentage": 5
+    },
+    "type": "object",
+    "properties": {
+      "feeType": {
+        "description": "",
+        "example": "FIXED_PLUS_PERCENTAGE",
+        "type": "string"
+      },
+      "fixedFee": {
+        "$ref": "#/definitions/FixedFee"
+      },
+      "percentage": {
+        "description": "",
+        "example": 5,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "feeType",
+      "fixedFee",
+      "percentage"
+    ]
+  },
+  "FixedFee": {
+    "title": "FixedFee",
+    "example": {
+      "currencyCode": "USD",
+      "amount": 300
+    },
+    "type": "object",
+    "properties": {
+      "currencyCode": {
+        "description": "",
+        "example": "USD",
+        "type": "string"
+      },
+      "amount": {
+        "description": "",
+        "example": 300,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "currencyCode",
+      "amount"
+    ]
+  },
+  "UpdateModeratorInforequest": {
+    "title": "Update moderator infoRequest",
+    "example": {
+      "description": "Long time OpenBazaar moderator located in Chicago",
+      "termsAndConditions": "Will moderate anything and everything",
+      "languages": [
+        "English",
+        "Spanish"
+      ],
+      "fee": {
+        "feeType": "FIXED_PLUS_PERCENTAGE",
+        "fixedFee": {
+          "currencyCode": "USD",
+          "amount": 300
+        },
+        "percentage": 5
+      }
+    },
+    "type": "object",
+    "properties": {
+      "description": {
+        "description": "",
+        "example": "Long time OpenBazaar moderator located in Chicago",
+        "type": "string"
+      },
+      "termsAndConditions": {
+        "description": "",
+        "example": "Will moderate anything and everything",
+        "type": "string"
+      },
+      "languages": {
+        "description": "",
+        "example": [
+          "English",
+          "Spanish"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "fee": {
+        "$ref": "#/definitions/Fee"
+      }
+    },
+    "required": [
+      "description",
+      "termsAndConditions",
+      "languages",
+      "fee"
+    ]
+  },
+  "1.UnfundedOrder": {
+    "title": "1. Unfunded Order",
+    "example": {
+      "contract": {
+        "vendorListings": [
+          {
+            "slug": "vintage-nice-dress",
+            "vendorID": {
+              "guid": "QmPw9cuBbUZ8dumUdkyh1X6cwm5NDHrYUuxGHUi4pnnAHm",
+              "blockchainID": "",
+              "pubkeys": {
+                "guid": "CAESILFTUnupLRj9pU7bWB6QeM15KrK8XKe70oIqnFBzK7DN",
+                "bitcoin": "ArIO1ndu+kBb68QObjN61Uub3MBo5CaJ1QKLIq6P+bqY"
+              },
+              "bitcoinSig": "MEQCICgFzuOMS7ebkbZkGBtJ/x7vv4MuGVOLTpuYAt4PT+s/AiAp2hwbInpx50O8PMoRD7IQ5s1qOV6vHUDeKw3v015wVA=="
+            },
+            "metadata": {
+              "version": 1,
+              "contractType": "PHYSICAL_GOOD",
+              "format": "FIXED_PRICE",
+              "expiry": "2037-12-31T05:00:00Z",
+              "acceptedCurrency": "tbtc",
+              "pricingCurrency": "USD",
+              "language": ""
+            },
+            "item": {
+              "title": "YuooMuoo V-neck Knitted Dress",
+              "description": "This is a listing example.",
+              "processingTime": "3 days",
+              "price": 100,
+              "nsfw": false,
+              "tags": [
+                "vintage dress"
+              ],
+              "images": [
+                {
+                  "filename": "front",
+                  "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq",
+                  "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+                  "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+                  "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+                  "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz"
+                },
+                {
+                  "filename": "cream",
+                  "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny",
+                  "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+                  "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+                  "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+                  "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq"
+                },
+                {
+                  "filename": "black",
+                  "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr",
+                  "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+                  "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+                  "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+                  "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe"
+                },
+                {
+                  "filename": "other_red",
+                  "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF",
+                  "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+                  "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+                  "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+                  "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt"
+                }
+              ],
+              "categories": [
+                "👚 Apparel & Accessories"
+              ],
+              "grams": 0,
+              "condition": "New",
+              "options": [
+                {
+                  "name": "Color",
+                  "description": "Color of the dress.",
+                  "variants": [
+                    "Red",
+                    "Cream",
+                    "Black"
+                  ]
+                },
+                {
+                  "name": "Sizes",
+                  "description": "Size of the dress.",
+                  "variants": [
+                    "Small",
+                    "Medium",
+                    "Large"
+                  ]
+                }
+              ],
+              "skus": [
+                {
+                  "variantCombo": [
+                    0,
+                    0
+                  ],
+                  "productID": "dress-red-small",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    0,
+                    1
+                  ],
+                  "productID": "dress-red-medium",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    0,
+                    2
+                  ],
+                  "productID": "dress-red-large",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    1,
+                    0
+                  ],
+                  "productID": "dress-cream-small",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    1,
+                    1
+                  ],
+                  "productID": "dress-cream-medium",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    1,
+                    2
+                  ],
+                  "productID": "dress-cream-large",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    2,
+                    0
+                  ],
+                  "productID": "dress-black-small",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    2,
+                    1
+                  ],
+                  "productID": "dress-black-medium",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    2,
+                    2
+                  ],
+                  "productID": "dress-black-large",
+                  "surcharge": 0,
+                  "quantity": 0
+                }
+              ]
+            },
+            "shippingOptions": [
+              {
+                "name": "Worldwide",
+                "type": "FIXED_PRICE",
+                "regions": [
+                  "ALL"
+                ],
+                "services": [
+                  {
+                    "name": "Standard",
+                    "price": 0,
+                    "estimatedDelivery": "5 days"
+                  },
+                  {
+                    "name": "Express",
+                    "price": 50,
+                    "estimatedDelivery": "3 days"
+                  }
+                ]
+              }
+            ],
+            "termsAndConditions": "Terms and conditions.",
+            "refundPolicy": "Refund policy."
+          }
+        ],
+        "buyerOrder": {
+          "refundAddress": "mn647yciTydnRodUdQP1uuMNxW62No1Ew8",
+          "refundFee": 0,
+          "shipping": {
+            "shipTo": "Dr Washington Sanchez",
+            "address": "1060 W Addison",
+            "city": "Chicago",
+            "state": "Illinois",
+            "postalCode": "60613",
+            "country": "UNITED_STATES",
+            "addressNotes": ""
+          },
+          "buyerID": {
+            "guid": "QmYctWu2n5rnQzLpDWWWGjPTpeKVPyrZtQPbfvi9NqCtTD",
+            "blockchainID": "",
+            "pubkeys": {
+              "guid": "CAESIGUXMqWBGoFuhrjk8D3j5CWAwKDIe4Phk9lUqVD58OHW",
+              "bitcoin": "AkaP8SH6rDVCryBhsElt7lysZpZRJbGB/C5/z2B/EzEz"
+            },
+            "bitcoinSig": "MEUCIQDdaHdppvY6wbQoS9YsxCxhhb00O1GpgqS8Yk9aZ8gljAIgD8Ox4B0t22SLPx+GE9gW3YyAtxjWYIWF9hkuBwnhMAQ="
+          },
+          "timestamp": "2017-03-14T02:16:56Z",
+          "items": [
+            {
+              "listingHash": "Qmcc5TCP2c77ZcuYcn616v2B4cmqajKLHgr8HvGyMo8cr1",
+              "quantity": 1,
+              "options": [
+                {
+                  "name": "Color",
+                  "value": "Red"
+                },
+                {
+                  "name": "Sizes",
+                  "value": "Medium"
+                }
+              ],
+              "shippingOption": {
+                "name": "Worldwide",
+                "service": "Standard"
+              },
+              "memo": "thanks!"
+            }
+          ],
+          "payment": {
+            "method": "ADDRESS_REQUEST",
+            "moderator": "",
+            "amount": 80609,
+            "exchangeRate": 0,
+            "chaincode": "",
+            "address": "",
+            "redeemScript": ""
+          },
+          "ratingKeys": [
+            "AyTn5+dvbrPcwAHZq+odFXuCHXy5CcnasFgWs7mkJleV"
+          ],
+          "alternateContactInfo": ""
+        },
+        "vendorOrderConfirmation": {
+          "orderID": "QmXVXyHcmSPeirD8k9Yu77zQy2NbXPC2ZHAi1buJQRc9hJ",
+          "paymentAddress": "muw25YcT4muMfEwbMpX9sXk5Bz5aFgaZ1r",
+          "requestedAmount": 80643,
+          "payoutFee": 0,
+          "ratingSignatures": []
+        },
+        "vendorOrderFulfillment": [
+          {
+            "orderId": "QmXVXyHcmSPeirD8k9Yu77zQy2NbXPC2ZHAi1buJQRc9hJ",
+            "slug": "",
+            "physicalDelivery": [
+              {
+                "shipper": "UPS",
+                "trackingNumber": "1Z204E380338943508"
+              }
+            ],
+            "ratingSignature": {
+              "metadata": {
+                "listingSlug": "",
+                "ratingKey": "AyTn5+dvbrPcwAHZq+odFXuCHXy5CcnasFgWs7mkJleV"
+              },
+              "signature": "v/6+KWIOY5KVQ3gV1AKX4cRrnEb0dGbOYb1/UinzLR9GuGVFTy1768/qkPdHkWwqxyUv5a9GTmLD7Qi15gFTCg=="
+            }
+          }
+        ],
+        "signatures": [
+          {
+            "section": "LISTING",
+            "signatureBytes": "DOr4shlilhn1HSZIexGL9ORS0gJMfFtnG/pvAJfuwYGEU+G5k6uVAozHGm3mtoTY9HXfpEmktUlX14wpBxecDQ=="
+          },
+          {
+            "section": "ORDER",
+            "signatureBytes": "N0oAmSQn7EP2TpUK3W607HoWR3wNav+cTZExOYC46m/th0HKT6WpGp54VDXuhJQ/tbZP8mNgQ5HJZiP3GvUkCQ=="
+          },
+          {
+            "section": "ORDER_CONFIRMATION",
+            "signatureBytes": "OJtVEwJsMv31Em/pCa4yQRFd0I2BlNskvkJ9UaY9xOp7HKW1SE8n3wJsCniitlZWROBRTUnkBo092lNh0a4CDQ=="
+          },
+          {
+            "section": "ORDER_FULFILLMENT",
+            "signatureBytes": "GYagnVDebqDAIG27iHSQfOEiH4txrvVnIUzN8cf35SfZiZ9Nqj3YI9rmQ1UJSB+z23AwpG4CpCz9KkFZoJiMCQ=="
+          }
+        ]
+      },
+      "state": "FULFILLED",
+      "read": false,
+      "funded": true,
+      "transactions": [
+        {
+          "txid": "d8e74390da8ceb5925d2543c8774db19bb338f26612ed61bab3a0c9e8a32c3f7",
+          "value": 80642,
+          "confirmations": 0
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "contract": {
+        "$ref": "#/definitions/Contract"
+      },
+      "state": {
+        "description": "",
+        "example": "FULFILLED",
+        "type": "string"
+      },
+      "read": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "funded": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "transactions": {
+        "description": "",
+        "example": [
+          {
+            "txid": "d8e74390da8ceb5925d2543c8774db19bb338f26612ed61bab3a0c9e8a32c3f7",
+            "value": 80642,
+            "confirmations": 0
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Transaction"
+        }
+      }
+    },
+    "required": [
+      "contract",
+      "state",
+      "read",
+      "funded",
+      "transactions"
+    ]
+  },
+  "Contract": {
+    "title": "Contract",
+    "example": {
+      "vendorListings": [
+        {
+          "slug": "vintage-nice-dress",
+          "vendorID": {
+            "guid": "QmPw9cuBbUZ8dumUdkyh1X6cwm5NDHrYUuxGHUi4pnnAHm",
+            "blockchainID": "",
+            "pubkeys": {
+              "guid": "CAESILFTUnupLRj9pU7bWB6QeM15KrK8XKe70oIqnFBzK7DN",
+              "bitcoin": "ArIO1ndu+kBb68QObjN61Uub3MBo5CaJ1QKLIq6P+bqY"
+            },
+            "bitcoinSig": "MEQCICgFzuOMS7ebkbZkGBtJ/x7vv4MuGVOLTpuYAt4PT+s/AiAp2hwbInpx50O8PMoRD7IQ5s1qOV6vHUDeKw3v015wVA=="
+          },
+          "metadata": {
+            "version": 1,
+            "contractType": "PHYSICAL_GOOD",
+            "format": "FIXED_PRICE",
+            "expiry": "2037-12-31T05:00:00Z",
+            "acceptedCurrency": "tbtc",
+            "pricingCurrency": "USD",
+            "language": ""
+          },
+          "item": {
+            "title": "YuooMuoo V-neck Knitted Dress",
+            "description": "This is a listing example.",
+            "processingTime": "3 days",
+            "price": 100,
+            "nsfw": false,
+            "tags": [
+              "vintage dress"
+            ],
+            "images": [
+              {
+                "filename": "front",
+                "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq",
+                "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+                "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+                "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+                "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz"
+              },
+              {
+                "filename": "cream",
+                "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny",
+                "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+                "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+                "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+                "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq"
+              },
+              {
+                "filename": "black",
+                "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr",
+                "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+                "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+                "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+                "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe"
+              },
+              {
+                "filename": "other_red",
+                "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF",
+                "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+                "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+                "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+                "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt"
+              }
+            ],
+            "categories": [
+              "👚 Apparel & Accessories"
+            ],
+            "grams": 0,
+            "condition": "New",
+            "options": [
+              {
+                "name": "Color",
+                "description": "Color of the dress.",
+                "variants": [
+                  "Red",
+                  "Cream",
+                  "Black"
+                ]
+              },
+              {
+                "name": "Sizes",
+                "description": "Size of the dress.",
+                "variants": [
+                  "Small",
+                  "Medium",
+                  "Large"
+                ]
+              }
+            ],
+            "skus": [
+              {
+                "variantCombo": [
+                  0,
+                  0
+                ],
+                "productID": "dress-red-small",
+                "surcharge": 0,
+                "quantity": 0
+              },
+              {
+                "variantCombo": [
+                  0,
+                  1
+                ],
+                "productID": "dress-red-medium",
+                "surcharge": 0,
+                "quantity": 0
+              },
+              {
+                "variantCombo": [
+                  0,
+                  2
+                ],
+                "productID": "dress-red-large",
+                "surcharge": 0,
+                "quantity": 0
+              },
+              {
+                "variantCombo": [
+                  1,
+                  0
+                ],
+                "productID": "dress-cream-small",
+                "surcharge": 0,
+                "quantity": 0
+              },
+              {
+                "variantCombo": [
+                  1,
+                  1
+                ],
+                "productID": "dress-cream-medium",
+                "surcharge": 0,
+                "quantity": 0
+              },
+              {
+                "variantCombo": [
+                  1,
+                  2
+                ],
+                "productID": "dress-cream-large",
+                "surcharge": 0,
+                "quantity": 0
+              },
+              {
+                "variantCombo": [
+                  2,
+                  0
+                ],
+                "productID": "dress-black-small",
+                "surcharge": 0,
+                "quantity": 0
+              },
+              {
+                "variantCombo": [
+                  2,
+                  1
+                ],
+                "productID": "dress-black-medium",
+                "surcharge": 0,
+                "quantity": 0
+              },
+              {
+                "variantCombo": [
+                  2,
+                  2
+                ],
+                "productID": "dress-black-large",
+                "surcharge": 0,
+                "quantity": 0
+              }
+            ]
+          },
+          "shippingOptions": [
+            {
+              "name": "Worldwide",
+              "type": "FIXED_PRICE",
+              "regions": [
+                "ALL"
+              ],
+              "services": [
+                {
+                  "name": "Standard",
+                  "price": 0,
+                  "estimatedDelivery": "5 days"
+                },
+                {
+                  "name": "Express",
+                  "price": 50,
+                  "estimatedDelivery": "3 days"
+                }
+              ]
+            }
+          ],
+          "termsAndConditions": "Terms and conditions.",
+          "refundPolicy": "Refund policy."
+        }
+      ],
+      "buyerOrder": {
+        "refundAddress": "mn647yciTydnRodUdQP1uuMNxW62No1Ew8",
+        "refundFee": 0,
+        "shipping": {
+          "shipTo": "Dr Washington Sanchez",
+          "address": "1060 W Addison",
+          "city": "Chicago",
+          "state": "Illinois",
+          "postalCode": "60613",
+          "country": "UNITED_STATES",
+          "addressNotes": ""
+        },
+        "buyerID": {
+          "guid": "QmYctWu2n5rnQzLpDWWWGjPTpeKVPyrZtQPbfvi9NqCtTD",
+          "blockchainID": "",
+          "pubkeys": {
+            "guid": "CAESIGUXMqWBGoFuhrjk8D3j5CWAwKDIe4Phk9lUqVD58OHW",
+            "bitcoin": "AkaP8SH6rDVCryBhsElt7lysZpZRJbGB/C5/z2B/EzEz"
+          },
+          "bitcoinSig": "MEUCIQDdaHdppvY6wbQoS9YsxCxhhb00O1GpgqS8Yk9aZ8gljAIgD8Ox4B0t22SLPx+GE9gW3YyAtxjWYIWF9hkuBwnhMAQ="
+        },
+        "timestamp": "2017-03-14T02:16:56Z",
+        "items": [
+          {
+            "listingHash": "Qmcc5TCP2c77ZcuYcn616v2B4cmqajKLHgr8HvGyMo8cr1",
+            "quantity": 1,
+            "options": [
+              {
+                "name": "Color",
+                "value": "Red"
+              },
+              {
+                "name": "Sizes",
+                "value": "Medium"
+              }
+            ],
+            "shippingOption": {
+              "name": "Worldwide",
+              "service": "Standard"
+            },
+            "memo": "thanks!"
+          }
+        ],
+        "payment": {
+          "method": "ADDRESS_REQUEST",
+          "moderator": "",
+          "amount": 80609,
+          "exchangeRate": 0,
+          "chaincode": "",
+          "address": "",
+          "redeemScript": ""
+        },
+        "ratingKeys": [
+          "AyTn5+dvbrPcwAHZq+odFXuCHXy5CcnasFgWs7mkJleV"
+        ],
+        "alternateContactInfo": ""
+      },
+      "vendorOrderConfirmation": {
+        "orderID": "QmXVXyHcmSPeirD8k9Yu77zQy2NbXPC2ZHAi1buJQRc9hJ",
+        "paymentAddress": "muw25YcT4muMfEwbMpX9sXk5Bz5aFgaZ1r",
+        "requestedAmount": 80643,
+        "payoutFee": 0,
+        "ratingSignatures": []
+      },
+      "vendorOrderFulfillment": [
+        {
+          "orderId": "QmXVXyHcmSPeirD8k9Yu77zQy2NbXPC2ZHAi1buJQRc9hJ",
+          "slug": "",
+          "physicalDelivery": [
+            {
+              "shipper": "UPS",
+              "trackingNumber": "1Z204E380338943508"
+            }
+          ],
+          "ratingSignature": {
+            "metadata": {
+              "listingSlug": "",
+              "ratingKey": "AyTn5+dvbrPcwAHZq+odFXuCHXy5CcnasFgWs7mkJleV"
+            },
+            "signature": "v/6+KWIOY5KVQ3gV1AKX4cRrnEb0dGbOYb1/UinzLR9GuGVFTy1768/qkPdHkWwqxyUv5a9GTmLD7Qi15gFTCg=="
+          }
+        }
+      ],
+      "signatures": [
+        {
+          "section": "LISTING",
+          "signatureBytes": "DOr4shlilhn1HSZIexGL9ORS0gJMfFtnG/pvAJfuwYGEU+G5k6uVAozHGm3mtoTY9HXfpEmktUlX14wpBxecDQ=="
+        },
+        {
+          "section": "ORDER",
+          "signatureBytes": "N0oAmSQn7EP2TpUK3W607HoWR3wNav+cTZExOYC46m/th0HKT6WpGp54VDXuhJQ/tbZP8mNgQ5HJZiP3GvUkCQ=="
+        },
+        {
+          "section": "ORDER_CONFIRMATION",
+          "signatureBytes": "OJtVEwJsMv31Em/pCa4yQRFd0I2BlNskvkJ9UaY9xOp7HKW1SE8n3wJsCniitlZWROBRTUnkBo092lNh0a4CDQ=="
+        },
+        {
+          "section": "ORDER_FULFILLMENT",
+          "signatureBytes": "GYagnVDebqDAIG27iHSQfOEiH4txrvVnIUzN8cf35SfZiZ9Nqj3YI9rmQ1UJSB+z23AwpG4CpCz9KkFZoJiMCQ=="
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "vendorListings": {
+        "description": "",
+        "example": [
+          {
+            "slug": "vintage-nice-dress",
+            "vendorID": {
+              "guid": "QmPw9cuBbUZ8dumUdkyh1X6cwm5NDHrYUuxGHUi4pnnAHm",
+              "blockchainID": "",
+              "pubkeys": {
+                "guid": "CAESILFTUnupLRj9pU7bWB6QeM15KrK8XKe70oIqnFBzK7DN",
+                "bitcoin": "ArIO1ndu+kBb68QObjN61Uub3MBo5CaJ1QKLIq6P+bqY"
+              },
+              "bitcoinSig": "MEQCICgFzuOMS7ebkbZkGBtJ/x7vv4MuGVOLTpuYAt4PT+s/AiAp2hwbInpx50O8PMoRD7IQ5s1qOV6vHUDeKw3v015wVA=="
+            },
+            "metadata": {
+              "version": 1,
+              "contractType": "PHYSICAL_GOOD",
+              "format": "FIXED_PRICE",
+              "expiry": "2037-12-31T05:00:00Z",
+              "acceptedCurrency": "tbtc",
+              "pricingCurrency": "USD",
+              "language": ""
+            },
+            "item": {
+              "title": "YuooMuoo V-neck Knitted Dress",
+              "description": "This is a listing example.",
+              "processingTime": "3 days",
+              "price": 100,
+              "nsfw": false,
+              "tags": [
+                "vintage dress"
+              ],
+              "images": [
+                {
+                  "filename": "front",
+                  "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq",
+                  "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+                  "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+                  "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+                  "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz"
+                },
+                {
+                  "filename": "cream",
+                  "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny",
+                  "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+                  "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+                  "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+                  "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq"
+                },
+                {
+                  "filename": "black",
+                  "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr",
+                  "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+                  "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+                  "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+                  "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe"
+                },
+                {
+                  "filename": "other_red",
+                  "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF",
+                  "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+                  "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+                  "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+                  "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt"
+                }
+              ],
+              "categories": [
+                "👚 Apparel & Accessories"
+              ],
+              "grams": 0,
+              "condition": "New",
+              "options": [
+                {
+                  "name": "Color",
+                  "description": "Color of the dress.",
+                  "variants": [
+                    "Red",
+                    "Cream",
+                    "Black"
+                  ]
+                },
+                {
+                  "name": "Sizes",
+                  "description": "Size of the dress.",
+                  "variants": [
+                    "Small",
+                    "Medium",
+                    "Large"
+                  ]
+                }
+              ],
+              "skus": [
+                {
+                  "variantCombo": [
+                    0,
+                    0
+                  ],
+                  "productID": "dress-red-small",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    0,
+                    1
+                  ],
+                  "productID": "dress-red-medium",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    0,
+                    2
+                  ],
+                  "productID": "dress-red-large",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    1,
+                    0
+                  ],
+                  "productID": "dress-cream-small",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    1,
+                    1
+                  ],
+                  "productID": "dress-cream-medium",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    1,
+                    2
+                  ],
+                  "productID": "dress-cream-large",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    2,
+                    0
+                  ],
+                  "productID": "dress-black-small",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    2,
+                    1
+                  ],
+                  "productID": "dress-black-medium",
+                  "surcharge": 0,
+                  "quantity": 0
+                },
+                {
+                  "variantCombo": [
+                    2,
+                    2
+                  ],
+                  "productID": "dress-black-large",
+                  "surcharge": 0,
+                  "quantity": 0
+                }
+              ]
+            },
+            "shippingOptions": [
+              {
+                "name": "Worldwide",
+                "type": "FIXED_PRICE",
+                "regions": [
+                  "ALL"
+                ],
+                "services": [
+                  {
+                    "name": "Standard",
+                    "price": 0,
+                    "estimatedDelivery": "5 days"
+                  },
+                  {
+                    "name": "Express",
+                    "price": 50,
+                    "estimatedDelivery": "3 days"
+                  }
+                ]
+              }
+            ],
+            "termsAndConditions": "Terms and conditions.",
+            "refundPolicy": "Refund policy."
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/VendorListing32"
+        }
+      },
+      "buyerOrder": {
+        "$ref": "#/definitions/BuyerOrder"
+      },
+      "vendorOrderConfirmation": {
+        "$ref": "#/definitions/VendorOrderConfirmation"
+      },
+      "vendorOrderFulfillment": {
+        "description": "",
+        "example": [
+          {
+            "orderId": "QmXVXyHcmSPeirD8k9Yu77zQy2NbXPC2ZHAi1buJQRc9hJ",
+            "slug": "",
+            "physicalDelivery": [
+              {
+                "shipper": "UPS",
+                "trackingNumber": "1Z204E380338943508"
+              }
+            ],
+            "ratingSignature": {
+              "metadata": {
+                "listingSlug": "",
+                "ratingKey": "AyTn5+dvbrPcwAHZq+odFXuCHXy5CcnasFgWs7mkJleV"
+              },
+              "signature": "v/6+KWIOY5KVQ3gV1AKX4cRrnEb0dGbOYb1/UinzLR9GuGVFTy1768/qkPdHkWwqxyUv5a9GTmLD7Qi15gFTCg=="
+            }
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/VendorOrderFulfillment"
+        }
+      },
+      "signatures": {
+        "description": "",
+        "example": [
+          {
+            "section": "LISTING",
+            "signatureBytes": "DOr4shlilhn1HSZIexGL9ORS0gJMfFtnG/pvAJfuwYGEU+G5k6uVAozHGm3mtoTY9HXfpEmktUlX14wpBxecDQ=="
+          },
+          {
+            "section": "ORDER",
+            "signatureBytes": "N0oAmSQn7EP2TpUK3W607HoWR3wNav+cTZExOYC46m/th0HKT6WpGp54VDXuhJQ/tbZP8mNgQ5HJZiP3GvUkCQ=="
+          },
+          {
+            "section": "ORDER_CONFIRMATION",
+            "signatureBytes": "OJtVEwJsMv31Em/pCa4yQRFd0I2BlNskvkJ9UaY9xOp7HKW1SE8n3wJsCniitlZWROBRTUnkBo092lNh0a4CDQ=="
+          },
+          {
+            "section": "ORDER_FULFILLMENT",
+            "signatureBytes": "GYagnVDebqDAIG27iHSQfOEiH4txrvVnIUzN8cf35SfZiZ9Nqj3YI9rmQ1UJSB+z23AwpG4CpCz9KkFZoJiMCQ=="
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Signature"
+        }
+      }
+    },
+    "required": [
+      "vendorListings",
+      "buyerOrder",
+      "vendorOrderConfirmation",
+      "vendorOrderFulfillment",
+      "signatures"
+    ]
+  },
+  "VendorListing32": {
+    "title": "VendorListing32",
+    "example": {
+      "slug": "vintage-nice-dress",
+      "vendorID": {
+        "guid": "QmPw9cuBbUZ8dumUdkyh1X6cwm5NDHrYUuxGHUi4pnnAHm",
+        "blockchainID": "",
+        "pubkeys": {
+          "guid": "CAESILFTUnupLRj9pU7bWB6QeM15KrK8XKe70oIqnFBzK7DN",
+          "bitcoin": "ArIO1ndu+kBb68QObjN61Uub3MBo5CaJ1QKLIq6P+bqY"
+        },
+        "bitcoinSig": "MEQCICgFzuOMS7ebkbZkGBtJ/x7vv4MuGVOLTpuYAt4PT+s/AiAp2hwbInpx50O8PMoRD7IQ5s1qOV6vHUDeKw3v015wVA=="
+      },
+      "metadata": {
+        "version": 1,
+        "contractType": "PHYSICAL_GOOD",
+        "format": "FIXED_PRICE",
+        "expiry": "2037-12-31T05:00:00Z",
+        "acceptedCurrency": "tbtc",
+        "pricingCurrency": "USD",
+        "language": ""
+      },
+      "item": {
+        "title": "YuooMuoo V-neck Knitted Dress",
+        "description": "This is a listing example.",
+        "processingTime": "3 days",
+        "price": 100,
+        "nsfw": false,
+        "tags": [
+          "vintage dress"
+        ],
+        "images": [
+          {
+            "filename": "front",
+            "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq",
+            "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+            "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+            "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+            "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz"
+          },
+          {
+            "filename": "cream",
+            "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny",
+            "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+            "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+            "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+            "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq"
+          },
+          {
+            "filename": "black",
+            "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr",
+            "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+            "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+            "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+            "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe"
+          },
+          {
+            "filename": "other_red",
+            "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF",
+            "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+            "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+            "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+            "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt"
+          }
+        ],
+        "categories": [
+          "👚 Apparel & Accessories"
+        ],
+        "grams": 0,
+        "condition": "New",
+        "options": [
+          {
+            "name": "Color",
+            "description": "Color of the dress.",
+            "variants": [
+              "Red",
+              "Cream",
+              "Black"
+            ]
+          },
+          {
+            "name": "Sizes",
+            "description": "Size of the dress.",
+            "variants": [
+              "Small",
+              "Medium",
+              "Large"
+            ]
+          }
+        ],
+        "skus": [
+          {
+            "variantCombo": [
+              0,
+              0
+            ],
+            "productID": "dress-red-small",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              0,
+              1
+            ],
+            "productID": "dress-red-medium",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              0,
+              2
+            ],
+            "productID": "dress-red-large",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              1,
+              0
+            ],
+            "productID": "dress-cream-small",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              1,
+              1
+            ],
+            "productID": "dress-cream-medium",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              1,
+              2
+            ],
+            "productID": "dress-cream-large",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              2,
+              0
+            ],
+            "productID": "dress-black-small",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              2,
+              1
+            ],
+            "productID": "dress-black-medium",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              2,
+              2
+            ],
+            "productID": "dress-black-large",
+            "surcharge": 0,
+            "quantity": 0
+          }
+        ]
+      },
+      "shippingOptions": [
+        {
+          "name": "Worldwide",
+          "type": "FIXED_PRICE",
+          "regions": [
+            "ALL"
+          ],
+          "services": [
+            {
+              "name": "Standard",
+              "price": 0,
+              "estimatedDelivery": "5 days"
+            },
+            {
+              "name": "Express",
+              "price": 50,
+              "estimatedDelivery": "3 days"
+            }
+          ]
+        }
+      ],
+      "termsAndConditions": "Terms and conditions.",
+      "refundPolicy": "Refund policy."
+    },
+    "type": "object",
+    "properties": {
+      "slug": {
+        "description": "",
+        "example": "vintage-nice-dress",
+        "type": "string"
+      },
+      "vendorID": {
+        "$ref": "#/definitions/VendorID33"
+      },
+      "metadata": {
+        "$ref": "#/definitions/Metadata35"
+      },
+      "item": {
+        "$ref": "#/definitions/Item36"
+      },
+      "shippingOptions": {
+        "description": "",
+        "example": [
+          {
+            "name": "Worldwide",
+            "type": "FIXED_PRICE",
+            "regions": [
+              "ALL"
+            ],
+            "services": [
+              {
+                "name": "Standard",
+                "price": 0,
+                "estimatedDelivery": "5 days"
+              },
+              {
+                "name": "Express",
+                "price": 50,
+                "estimatedDelivery": "3 days"
+              }
+            ]
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/ShippingOption40"
+        }
+      },
+      "termsAndConditions": {
+        "description": "",
+        "example": "Terms and conditions.",
+        "type": "string"
+      },
+      "refundPolicy": {
+        "description": "",
+        "example": "Refund policy.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "slug",
+      "vendorID",
+      "metadata",
+      "item",
+      "shippingOptions",
+      "termsAndConditions",
+      "refundPolicy"
+    ]
+  },
+  "VendorID33": {
+    "title": "VendorID33",
+    "example": {
+      "guid": "QmPw9cuBbUZ8dumUdkyh1X6cwm5NDHrYUuxGHUi4pnnAHm",
+      "blockchainID": "",
+      "pubkeys": {
+        "guid": "CAESILFTUnupLRj9pU7bWB6QeM15KrK8XKe70oIqnFBzK7DN",
+        "bitcoin": "ArIO1ndu+kBb68QObjN61Uub3MBo5CaJ1QKLIq6P+bqY"
+      },
+      "bitcoinSig": "MEQCICgFzuOMS7ebkbZkGBtJ/x7vv4MuGVOLTpuYAt4PT+s/AiAp2hwbInpx50O8PMoRD7IQ5s1qOV6vHUDeKw3v015wVA=="
+    },
+    "type": "object",
+    "properties": {
+      "guid": {
+        "description": "",
+        "example": "QmPw9cuBbUZ8dumUdkyh1X6cwm5NDHrYUuxGHUi4pnnAHm",
+        "type": "string"
+      },
+      "blockchainID": {
+        "description": "",
+        "type": "string"
+      },
+      "pubkeys": {
+        "$ref": "#/definitions/Pubkeys"
+      },
+      "bitcoinSig": {
+        "description": "",
+        "example": "MEQCICgFzuOMS7ebkbZkGBtJ/x7vv4MuGVOLTpuYAt4PT+s/AiAp2hwbInpx50O8PMoRD7IQ5s1qOV6vHUDeKw3v015wVA==",
+        "type": "string"
+      }
+    },
+    "required": [
+      "guid",
+      "blockchainID",
+      "pubkeys",
+      "bitcoinSig"
+    ]
+  },
+  "Metadata35": {
+    "title": "Metadata35",
+    "example": {
+      "version": 1,
+      "contractType": "PHYSICAL_GOOD",
+      "format": "FIXED_PRICE",
+      "expiry": "2037-12-31T05:00:00Z",
+      "acceptedCurrency": "tbtc",
+      "pricingCurrency": "USD",
+      "language": ""
+    },
+    "type": "object",
+    "properties": {
+      "version": {
+        "description": "",
+        "example": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "contractType": {
+        "description": "",
+        "example": "PHYSICAL_GOOD",
+        "type": "string"
+      },
+      "format": {
+        "description": "",
+        "example": "FIXED_PRICE",
+        "type": "string"
+      },
+      "expiry": {
+        "description": "",
+        "example": "12/31/2037 5:00:00 AM",
+        "type": "string"
+      },
+      "acceptedCurrency": {
+        "description": "",
+        "example": "tbtc",
+        "type": "string"
+      },
+      "pricingCurrency": {
+        "description": "",
+        "example": "USD",
+        "type": "string"
+      },
+      "language": {
+        "description": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "version",
+      "contractType",
+      "format",
+      "expiry",
+      "acceptedCurrency",
+      "pricingCurrency",
+      "language"
+    ]
+  },
+  "Item36": {
+    "title": "Item36",
+    "example": {
+      "title": "YuooMuoo V-neck Knitted Dress",
+      "description": "This is a listing example.",
+      "processingTime": "3 days",
+      "price": 100,
+      "nsfw": false,
+      "tags": [
+        "vintage dress"
+      ],
+      "images": [
+        {
+          "filename": "front",
+          "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq",
+          "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+          "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+          "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+          "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz"
+        },
+        {
+          "filename": "cream",
+          "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny",
+          "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+          "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+          "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+          "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq"
+        },
+        {
+          "filename": "black",
+          "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr",
+          "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+          "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+          "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+          "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe"
+        },
+        {
+          "filename": "other_red",
+          "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF",
+          "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+          "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+          "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+          "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt"
+        }
+      ],
+      "categories": [
+        "👚 Apparel & Accessories"
+      ],
+      "grams": 0,
+      "condition": "New",
+      "options": [
+        {
+          "name": "Color",
+          "description": "Color of the dress.",
+          "variants": [
+            "Red",
+            "Cream",
+            "Black"
+          ]
+        },
+        {
+          "name": "Sizes",
+          "description": "Size of the dress.",
+          "variants": [
+            "Small",
+            "Medium",
+            "Large"
+          ]
+        }
+      ],
+      "skus": [
+        {
+          "variantCombo": [
+            0,
+            0
+          ],
+          "productID": "dress-red-small",
+          "surcharge": 0,
+          "quantity": 0
+        },
+        {
+          "variantCombo": [
+            0,
+            1
+          ],
+          "productID": "dress-red-medium",
+          "surcharge": 0,
+          "quantity": 0
+        },
+        {
+          "variantCombo": [
+            0,
+            2
+          ],
+          "productID": "dress-red-large",
+          "surcharge": 0,
+          "quantity": 0
+        },
+        {
+          "variantCombo": [
+            1,
+            0
+          ],
+          "productID": "dress-cream-small",
+          "surcharge": 0,
+          "quantity": 0
+        },
+        {
+          "variantCombo": [
+            1,
+            1
+          ],
+          "productID": "dress-cream-medium",
+          "surcharge": 0,
+          "quantity": 0
+        },
+        {
+          "variantCombo": [
+            1,
+            2
+          ],
+          "productID": "dress-cream-large",
+          "surcharge": 0,
+          "quantity": 0
+        },
+        {
+          "variantCombo": [
+            2,
+            0
+          ],
+          "productID": "dress-black-small",
+          "surcharge": 0,
+          "quantity": 0
+        },
+        {
+          "variantCombo": [
+            2,
+            1
+          ],
+          "productID": "dress-black-medium",
+          "surcharge": 0,
+          "quantity": 0
+        },
+        {
+          "variantCombo": [
+            2,
+            2
+          ],
+          "productID": "dress-black-large",
+          "surcharge": 0,
+          "quantity": 0
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "title": {
+        "description": "",
+        "example": "YuooMuoo V-neck Knitted Dress",
+        "type": "string"
+      },
+      "description": {
+        "description": "",
+        "example": "This is a listing example.",
+        "type": "string"
+      },
+      "processingTime": {
+        "description": "",
+        "example": "3 days",
+        "type": "string"
+      },
+      "price": {
+        "description": "",
+        "example": 100,
+        "type": "integer",
+        "format": "int32"
+      },
+      "nsfw": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "tags": {
+        "description": "",
+        "example": [
+          "vintage dress"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "images": {
+        "description": "",
+        "example": [
+          {
+            "filename": "front",
+            "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq",
+            "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+            "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+            "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+            "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz"
+          },
+          {
+            "filename": "cream",
+            "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny",
+            "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+            "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+            "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+            "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq"
+          },
+          {
+            "filename": "black",
+            "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr",
+            "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+            "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+            "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+            "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe"
+          },
+          {
+            "filename": "other_red",
+            "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF",
+            "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+            "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+            "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+            "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Image"
+        }
+      },
+      "categories": {
+        "description": "",
+        "example": [
+          "👚 Apparel & Accessories"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "grams": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "condition": {
+        "description": "",
+        "example": "New",
+        "type": "string"
+      },
+      "options": {
+        "description": "",
+        "example": [
+          {
+            "name": "Color",
+            "description": "Color of the dress.",
+            "variants": [
+              "Red",
+              "Cream",
+              "Black"
+            ]
+          },
+          {
+            "name": "Sizes",
+            "description": "Size of the dress.",
+            "variants": [
+              "Small",
+              "Medium",
+              "Large"
+            ]
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Option"
+        }
+      },
+      "skus": {
+        "description": "",
+        "example": [
+          {
+            "variantCombo": [
+              0,
+              0
+            ],
+            "productID": "dress-red-small",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              0,
+              1
+            ],
+            "productID": "dress-red-medium",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              0,
+              2
+            ],
+            "productID": "dress-red-large",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              1,
+              0
+            ],
+            "productID": "dress-cream-small",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              1,
+              1
+            ],
+            "productID": "dress-cream-medium",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              1,
+              2
+            ],
+            "productID": "dress-cream-large",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              2,
+              0
+            ],
+            "productID": "dress-black-small",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              2,
+              1
+            ],
+            "productID": "dress-black-medium",
+            "surcharge": 0,
+            "quantity": 0
+          },
+          {
+            "variantCombo": [
+              2,
+              2
+            ],
+            "productID": "dress-black-large",
+            "surcharge": 0,
+            "quantity": 0
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Sku"
+        }
+      }
+    },
+    "required": [
+      "title",
+      "description",
+      "processingTime",
+      "price",
+      "nsfw",
+      "tags",
+      "images",
+      "categories",
+      "grams",
+      "condition",
+      "options",
+      "skus"
+    ]
+  },
+  "Option": {
+    "title": "Option",
+    "example": {
+      "name": "Color",
+      "description": "Color of the dress.",
+      "variants": [
+        "Red",
+        "Cream",
+        "Black"
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Color",
+        "type": "string"
+      },
+      "description": {
+        "description": "",
+        "example": "Color of the dress.",
+        "type": "string"
+      },
+      "variants": {
+        "description": "",
+        "example": [
+          "Red",
+          "Cream",
+          "Black"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": [
+      "name",
+      "description",
+      "variants"
+    ]
+  },
+  "Sku": {
+    "title": "Sku",
+    "example": {
+      "variantCombo": [
+        0,
+        0
+      ],
+      "productID": "dress-red-small",
+      "surcharge": 0,
+      "quantity": 0
+    },
+    "type": "object",
+    "properties": {
+      "variantCombo": {
+        "description": "",
+        "example": [
+          0,
+          0
+        ],
+        "type": "array",
+        "items": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "productID": {
+        "description": "",
+        "example": "dress-red-small",
+        "type": "string"
+      },
+      "surcharge": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "quantity": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "variantCombo",
+      "productID",
+      "surcharge",
+      "quantity"
+    ]
+  },
+  "ShippingOption40": {
+    "title": "ShippingOption40",
+    "example": {
+      "name": "Worldwide",
+      "type": "FIXED_PRICE",
+      "regions": [
+        "ALL"
+      ],
+      "services": [
+        {
+          "name": "Standard",
+          "price": 0,
+          "estimatedDelivery": "5 days"
+        },
+        {
+          "name": "Express",
+          "price": 50,
+          "estimatedDelivery": "3 days"
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Worldwide",
+        "type": "string"
+      },
+      "type": {
+        "description": "",
+        "example": "FIXED_PRICE",
+        "type": "string"
+      },
+      "regions": {
+        "description": "",
+        "example": [
+          "ALL"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "services": {
+        "description": "",
+        "example": [
+          {
+            "name": "Standard",
+            "price": 0,
+            "estimatedDelivery": "5 days"
+          },
+          {
+            "name": "Express",
+            "price": 50,
+            "estimatedDelivery": "3 days"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Service41"
+        }
+      }
+    },
+    "required": [
+      "name",
+      "type",
+      "regions",
+      "services"
+    ]
+  },
+  "Service41": {
+    "title": "Service41",
+    "example": {
+      "name": "Standard",
+      "price": 0,
+      "estimatedDelivery": "5 days"
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Standard",
+        "type": "string"
+      },
+      "price": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "estimatedDelivery": {
+        "description": "",
+        "example": "5 days",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name",
+      "price",
+      "estimatedDelivery"
+    ]
+  },
+  "BuyerOrder": {
+    "title": "BuyerOrder",
+    "example": {
+      "refundAddress": "mn647yciTydnRodUdQP1uuMNxW62No1Ew8",
+      "refundFee": 0,
+      "shipping": {
+        "shipTo": "Dr Washington Sanchez",
+        "address": "1060 W Addison",
+        "city": "Chicago",
+        "state": "Illinois",
+        "postalCode": "60613",
+        "country": "UNITED_STATES",
+        "addressNotes": ""
+      },
+      "buyerID": {
+        "guid": "QmYctWu2n5rnQzLpDWWWGjPTpeKVPyrZtQPbfvi9NqCtTD",
+        "blockchainID": "",
+        "pubkeys": {
+          "guid": "CAESIGUXMqWBGoFuhrjk8D3j5CWAwKDIe4Phk9lUqVD58OHW",
+          "bitcoin": "AkaP8SH6rDVCryBhsElt7lysZpZRJbGB/C5/z2B/EzEz"
+        },
+        "bitcoinSig": "MEUCIQDdaHdppvY6wbQoS9YsxCxhhb00O1GpgqS8Yk9aZ8gljAIgD8Ox4B0t22SLPx+GE9gW3YyAtxjWYIWF9hkuBwnhMAQ="
+      },
+      "timestamp": "2017-03-14T02:16:56Z",
+      "items": [
+        {
+          "listingHash": "Qmcc5TCP2c77ZcuYcn616v2B4cmqajKLHgr8HvGyMo8cr1",
+          "quantity": 1,
+          "options": [
+            {
+              "name": "Color",
+              "value": "Red"
+            },
+            {
+              "name": "Sizes",
+              "value": "Medium"
+            }
+          ],
+          "shippingOption": {
+            "name": "Worldwide",
+            "service": "Standard"
+          },
+          "memo": "thanks!"
+        }
+      ],
+      "payment": {
+        "method": "ADDRESS_REQUEST",
+        "moderator": "",
+        "amount": 80609,
+        "exchangeRate": 0,
+        "chaincode": "",
+        "address": "",
+        "redeemScript": ""
+      },
+      "ratingKeys": [
+        "AyTn5+dvbrPcwAHZq+odFXuCHXy5CcnasFgWs7mkJleV"
+      ],
+      "alternateContactInfo": ""
+    },
+    "type": "object",
+    "properties": {
+      "refundAddress": {
+        "description": "",
+        "example": "mn647yciTydnRodUdQP1uuMNxW62No1Ew8",
+        "type": "string"
+      },
+      "refundFee": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "shipping": {
+        "$ref": "#/definitions/Shipping"
+      },
+      "buyerID": {
+        "$ref": "#/definitions/BuyerID"
+      },
+      "timestamp": {
+        "description": "",
+        "example": "3/14/2017 2:16:56 AM",
+        "type": "string"
+      },
+      "items": {
+        "description": "",
+        "example": [
+          {
+            "listingHash": "Qmcc5TCP2c77ZcuYcn616v2B4cmqajKLHgr8HvGyMo8cr1",
+            "quantity": 1,
+            "options": [
+              {
+                "name": "Color",
+                "value": "Red"
+              },
+              {
+                "name": "Sizes",
+                "value": "Medium"
+              }
+            ],
+            "shippingOption": {
+              "name": "Worldwide",
+              "service": "Standard"
+            },
+            "memo": "thanks!"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Item46"
+        }
+      },
+      "payment": {
+        "$ref": "#/definitions/Payment"
+      },
+      "ratingKeys": {
+        "description": "",
+        "example": [
+          "AyTn5+dvbrPcwAHZq+odFXuCHXy5CcnasFgWs7mkJleV"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "alternateContactInfo": {
+        "description": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "refundAddress",
+      "refundFee",
+      "shipping",
+      "buyerID",
+      "timestamp",
+      "items",
+      "payment",
+      "ratingKeys",
+      "alternateContactInfo"
+    ]
+  },
+  "Shipping": {
+    "title": "Shipping",
+    "example": {
+      "shipTo": "Dr Washington Sanchez",
+      "address": "1060 W Addison",
+      "city": "Chicago",
+      "state": "Illinois",
+      "postalCode": "60613",
+      "country": "UNITED_STATES",
+      "addressNotes": ""
+    },
+    "type": "object",
+    "properties": {
+      "shipTo": {
+        "description": "",
+        "example": "Dr Washington Sanchez",
+        "type": "string"
+      },
+      "address": {
+        "description": "",
+        "example": "1060 W Addison",
+        "type": "string"
+      },
+      "city": {
+        "description": "",
+        "example": "Chicago",
+        "type": "string"
+      },
+      "state": {
+        "description": "",
+        "example": "Illinois",
+        "type": "string"
+      },
+      "postalCode": {
+        "description": "",
+        "example": "60613",
+        "type": "string"
+      },
+      "country": {
+        "description": "",
+        "example": "UNITED_STATES",
+        "type": "string"
+      },
+      "addressNotes": {
+        "description": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "shipTo",
+      "address",
+      "city",
+      "state",
+      "postalCode",
+      "country",
+      "addressNotes"
+    ]
+  },
+  "BuyerID": {
+    "title": "BuyerID",
+    "example": {
+      "guid": "QmYctWu2n5rnQzLpDWWWGjPTpeKVPyrZtQPbfvi9NqCtTD",
+      "blockchainID": "",
+      "pubkeys": {
+        "guid": "CAESIGUXMqWBGoFuhrjk8D3j5CWAwKDIe4Phk9lUqVD58OHW",
+        "bitcoin": "AkaP8SH6rDVCryBhsElt7lysZpZRJbGB/C5/z2B/EzEz"
+      },
+      "bitcoinSig": "MEUCIQDdaHdppvY6wbQoS9YsxCxhhb00O1GpgqS8Yk9aZ8gljAIgD8Ox4B0t22SLPx+GE9gW3YyAtxjWYIWF9hkuBwnhMAQ="
+    },
+    "type": "object",
+    "properties": {
+      "guid": {
+        "description": "",
+        "example": "QmYctWu2n5rnQzLpDWWWGjPTpeKVPyrZtQPbfvi9NqCtTD",
+        "type": "string"
+      },
+      "blockchainID": {
+        "description": "",
+        "type": "string"
+      },
+      "pubkeys": {
+        "$ref": "#/definitions/Pubkeys"
+      },
+      "bitcoinSig": {
+        "description": "",
+        "example": "MEUCIQDdaHdppvY6wbQoS9YsxCxhhb00O1GpgqS8Yk9aZ8gljAIgD8Ox4B0t22SLPx+GE9gW3YyAtxjWYIWF9hkuBwnhMAQ=",
+        "type": "string"
+      }
+    },
+    "required": [
+      "guid",
+      "blockchainID",
+      "pubkeys",
+      "bitcoinSig"
+    ]
+  },
+  "Item46": {
+    "title": "Item46",
+    "example": {
+      "listingHash": "Qmcc5TCP2c77ZcuYcn616v2B4cmqajKLHgr8HvGyMo8cr1",
+      "quantity": 1,
+      "options": [
+        {
+          "name": "Color",
+          "value": "Red"
+        },
+        {
+          "name": "Sizes",
+          "value": "Medium"
+        }
+      ],
+      "shippingOption": {
+        "name": "Worldwide",
+        "service": "Standard"
+      },
+      "memo": "thanks!"
+    },
+    "type": "object",
+    "properties": {
+      "listingHash": {
+        "description": "",
+        "example": "Qmcc5TCP2c77ZcuYcn616v2B4cmqajKLHgr8HvGyMo8cr1",
+        "type": "string"
+      },
+      "quantity": {
+        "description": "",
+        "example": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "options": {
+        "description": "",
+        "example": [
+          {
+            "name": "Color",
+            "value": "Red"
+          },
+          {
+            "name": "Sizes",
+            "value": "Medium"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Option47"
+        }
+      },
+      "shippingOption": {
+        "$ref": "#/definitions/ShippingOption48"
+      },
+      "memo": {
+        "description": "",
+        "example": "thanks!",
+        "type": "string"
+      }
+    },
+    "required": [
+      "listingHash",
+      "quantity",
+      "options",
+      "shippingOption",
+      "memo"
+    ]
+  },
+  "Option47": {
+    "title": "Option47",
+    "example": {
+      "name": "Color",
+      "value": "Red"
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Color",
+        "type": "string"
+      },
+      "value": {
+        "description": "",
+        "example": "Red",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name",
+      "value"
+    ]
+  },
+  "ShippingOption48": {
+    "title": "ShippingOption48",
+    "example": {
+      "name": "Worldwide",
+      "service": "Standard"
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Worldwide",
+        "type": "string"
+      },
+      "service": {
+        "description": "",
+        "example": "Standard",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name",
+      "service"
+    ]
+  },
+  "Payment": {
+    "title": "Payment",
+    "example": {
+      "method": "ADDRESS_REQUEST",
+      "moderator": "",
+      "amount": 80609,
+      "exchangeRate": 0,
+      "chaincode": "",
+      "address": "",
+      "redeemScript": ""
+    },
+    "type": "object",
+    "properties": {
+      "method": {
+        "description": "",
+        "example": "ADDRESS_REQUEST",
+        "type": "string"
+      },
+      "moderator": {
+        "description": "",
+        "type": "string"
+      },
+      "amount": {
+        "description": "",
+        "example": 80609,
+        "type": "integer",
+        "format": "int32"
+      },
+      "exchangeRate": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "chaincode": {
+        "description": "",
+        "type": "string"
+      },
+      "address": {
+        "description": "",
+        "type": "string"
+      },
+      "redeemScript": {
+        "description": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "method",
+      "moderator",
+      "amount",
+      "exchangeRate",
+      "chaincode",
+      "address",
+      "redeemScript"
+    ]
+  },
+  "VendorOrderConfirmation": {
+    "title": "VendorOrderConfirmation",
+    "example": {
+      "orderID": "QmXVXyHcmSPeirD8k9Yu77zQy2NbXPC2ZHAi1buJQRc9hJ",
+      "paymentAddress": "muw25YcT4muMfEwbMpX9sXk5Bz5aFgaZ1r",
+      "requestedAmount": 80643,
+      "payoutFee": 0,
+      "ratingSignatures": []
+    },
+    "type": "object",
+    "properties": {
+      "orderID": {
+        "description": "",
+        "example": "QmXVXyHcmSPeirD8k9Yu77zQy2NbXPC2ZHAi1buJQRc9hJ",
+        "type": "string"
+      },
+      "paymentAddress": {
+        "description": "",
+        "example": "muw25YcT4muMfEwbMpX9sXk5Bz5aFgaZ1r",
+        "type": "string"
+      },
+      "requestedAmount": {
+        "description": "",
+        "example": 80643,
+        "type": "integer",
+        "format": "int32"
+      },
+      "payoutFee": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "ratingSignatures": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": [
+      "orderID",
+      "paymentAddress",
+      "requestedAmount",
+      "payoutFee",
+      "ratingSignatures"
+    ]
+  },
+  "VendorOrderFulfillment": {
+    "title": "VendorOrderFulfillment",
+    "example": {
+      "orderId": "QmXVXyHcmSPeirD8k9Yu77zQy2NbXPC2ZHAi1buJQRc9hJ",
+      "slug": "",
+      "physicalDelivery": [
+        {
+          "shipper": "UPS",
+          "trackingNumber": "1Z204E380338943508"
+        }
+      ],
+      "ratingSignature": {
+        "metadata": {
+          "listingSlug": "",
+          "ratingKey": "AyTn5+dvbrPcwAHZq+odFXuCHXy5CcnasFgWs7mkJleV"
+        },
+        "signature": "v/6+KWIOY5KVQ3gV1AKX4cRrnEb0dGbOYb1/UinzLR9GuGVFTy1768/qkPdHkWwqxyUv5a9GTmLD7Qi15gFTCg=="
+      }
+    },
+    "type": "object",
+    "properties": {
+      "orderId": {
+        "description": "",
+        "example": "QmXVXyHcmSPeirD8k9Yu77zQy2NbXPC2ZHAi1buJQRc9hJ",
+        "type": "string"
+      },
+      "slug": {
+        "description": "",
+        "type": "string"
+      },
+      "physicalDelivery": {
+        "description": "",
+        "example": [
+          {
+            "shipper": "UPS",
+            "trackingNumber": "1Z204E380338943508"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/PhysicalDelivery"
+        }
+      },
+      "ratingSignature": {
+        "$ref": "#/definitions/RatingSignature"
+      }
+    },
+    "required": [
+      "orderId",
+      "slug",
+      "physicalDelivery",
+      "ratingSignature"
+    ]
+  },
+  "PhysicalDelivery": {
+    "title": "PhysicalDelivery",
+    "example": {
+      "shipper": "UPS",
+      "trackingNumber": "1Z204E380338943508"
+    },
+    "type": "object",
+    "properties": {
+      "shipper": {
+        "description": "",
+        "example": "UPS",
+        "type": "string"
+      },
+      "trackingNumber": {
+        "description": "",
+        "example": "1Z204E380338943508",
+        "type": "string"
+      }
+    },
+    "required": [
+      "shipper",
+      "trackingNumber"
+    ]
+  },
+  "RatingSignature": {
+    "title": "RatingSignature",
+    "example": {
+      "metadata": {
+        "listingSlug": "",
+        "ratingKey": "AyTn5+dvbrPcwAHZq+odFXuCHXy5CcnasFgWs7mkJleV"
+      },
+      "signature": "v/6+KWIOY5KVQ3gV1AKX4cRrnEb0dGbOYb1/UinzLR9GuGVFTy1768/qkPdHkWwqxyUv5a9GTmLD7Qi15gFTCg=="
+    },
+    "type": "object",
+    "properties": {
+      "metadata": {
+        "$ref": "#/definitions/Metadata54"
+      },
+      "signature": {
+        "description": "",
+        "example": "v/6+KWIOY5KVQ3gV1AKX4cRrnEb0dGbOYb1/UinzLR9GuGVFTy1768/qkPdHkWwqxyUv5a9GTmLD7Qi15gFTCg==",
+        "type": "string"
+      }
+    },
+    "required": [
+      "metadata",
+      "signature"
+    ]
+  },
+  "Metadata54": {
+    "title": "Metadata54",
+    "example": {
+      "listingSlug": "",
+      "ratingKey": "AyTn5+dvbrPcwAHZq+odFXuCHXy5CcnasFgWs7mkJleV"
+    },
+    "type": "object",
+    "properties": {
+      "listingSlug": {
+        "description": "",
+        "type": "string"
+      },
+      "ratingKey": {
+        "description": "",
+        "example": "AyTn5+dvbrPcwAHZq+odFXuCHXy5CcnasFgWs7mkJleV",
+        "type": "string"
+      }
+    },
+    "required": [
+      "listingSlug",
+      "ratingKey"
+    ]
+  },
+  "Transaction": {
+    "title": "Transaction",
+    "example": {
+      "txid": "d8e74390da8ceb5925d2543c8774db19bb338f26612ed61bab3a0c9e8a32c3f7",
+      "value": 80642,
+      "confirmations": 0
+    },
+    "type": "object",
+    "properties": {
+      "txid": {
+        "description": "",
+        "example": "d8e74390da8ceb5925d2543c8774db19bb338f26612ed61bab3a0c9e8a32c3f7",
+        "type": "string"
+      },
+      "value": {
+        "description": "",
+        "example": 80642,
+        "type": "integer",
+        "format": "int32"
+      },
+      "confirmations": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "txid",
+      "value",
+      "confirmations"
+    ]
+  },
+  "SalesHistory": {
+    "title": "Sales History",
+    "example": {
+      "buyerHandle": "",
+      "buyerId": "QmYctWu2n5rnQzLpDWWWGjPTpeKVPyrZtQPbfvi9NqCtTD",
+      "orderId": "QmXRGXywXHmcr18PYpDNyKuhdQqB8C8iaTbhbasZCoN1QV",
+      "read": false,
+      "shippingAddress": "1060 w addison",
+      "shippingName": "dr washington sanchez",
+      "state": "CONFIRMED",
+      "thumbnail": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz",
+      "timestamp": "2017-03-13T06:42:08Z",
+      "title": "yuoomuoo v-neck knitted dress",
+      "total": 81967,
+      "unreadChatMessages": 0
+    },
+    "type": "object",
+    "properties": {
+      "buyerHandle": {
+        "description": "",
+        "type": "string"
+      },
+      "buyerId": {
+        "description": "",
+        "example": "QmYctWu2n5rnQzLpDWWWGjPTpeKVPyrZtQPbfvi9NqCtTD",
+        "type": "string"
+      },
+      "orderId": {
+        "description": "",
+        "example": "QmXRGXywXHmcr18PYpDNyKuhdQqB8C8iaTbhbasZCoN1QV",
+        "type": "string"
+      },
+      "read": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "shippingAddress": {
+        "description": "",
+        "example": "1060 w addison",
+        "type": "string"
+      },
+      "shippingName": {
+        "description": "",
+        "example": "dr washington sanchez",
+        "type": "string"
+      },
+      "state": {
+        "description": "",
+        "example": "CONFIRMED",
+        "type": "string"
+      },
+      "thumbnail": {
+        "description": "",
+        "example": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz",
+        "type": "string"
+      },
+      "timestamp": {
+        "description": "",
+        "example": "3/13/2017 6:42:08 AM",
+        "type": "string"
+      },
+      "title": {
+        "description": "",
+        "example": "yuoomuoo v-neck knitted dress",
+        "type": "string"
+      },
+      "total": {
+        "description": "",
+        "example": 81967,
+        "type": "integer",
+        "format": "int32"
+      },
+      "unreadChatMessages": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "buyerHandle",
+      "buyerId",
+      "orderId",
+      "read",
+      "shippingAddress",
+      "shippingName",
+      "state",
+      "thumbnail",
+      "timestamp",
+      "title",
+      "total",
+      "unreadChatMessages"
+    ]
+  },
+  "PurchaseAnItemrequest": {
+    "title": "Purchase an itemRequest",
+    "example": {
+      "shipTo": "Dr Washington Sanchez",
+      "address": "1060 W Addison",
+      "city": "Chicago",
+      "state": "Illinois",
+      "countryCode": "UNITED_STATES",
+      "postalCode": "60613",
+      "addressNotes": "Leave at reception",
+      "items": [
+        {
+          "listingHash": "zb2rhad6oPUEHTNMCCS6MQND541S2KSa7DrYAaBAxQgRDYQ8C",
+          "quantity": 1,
+          "options": [
+            {
+              "name": "Color",
+              "value": "Red"
+            },
+            {
+              "name": "Sizes",
+              "value": "Small"
+            }
+          ],
+          "shipping": {
+            "name": "Worldwide",
+            "service": "Standard"
+          },
+          "memo": "thanks!",
+          "coupons": []
+        }
+      ],
+      "moderator": "QmamG5uQjRqrdxAxp4DJK4TLvs2Yet8Nuiztip4ALD7i1U"
+    },
+    "type": "object",
+    "properties": {
+      "shipTo": {
+        "description": "",
+        "example": "Dr Washington Sanchez",
+        "type": "string"
+      },
+      "address": {
+        "description": "",
+        "example": "1060 W Addison",
+        "type": "string"
+      },
+      "city": {
+        "description": "",
+        "example": "Chicago",
+        "type": "string"
+      },
+      "state": {
+        "description": "",
+        "example": "Illinois",
+        "type": "string"
+      },
+      "countryCode": {
+        "description": "",
+        "example": "UNITED_STATES",
+        "type": "string"
+      },
+      "postalCode": {
+        "description": "",
+        "example": "60613",
+        "type": "string"
+      },
+      "addressNotes": {
+        "description": "",
+        "example": "Leave at reception",
+        "type": "string"
+      },
+      "items": {
+        "description": "",
+        "example": [
+          {
+            "listingHash": "zb2rhad6oPUEHTNMCCS6MQND541S2KSa7DrYAaBAxQgRDYQ8C",
+            "quantity": 1,
+            "options": [
+              {
+                "name": "Color",
+                "value": "Red"
+              },
+              {
+                "name": "Sizes",
+                "value": "Small"
+              }
+            ],
+            "shipping": {
+              "name": "Worldwide",
+              "service": "Standard"
+            },
+            "memo": "thanks!",
+            "coupons": []
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Item59"
+        }
+      },
+      "moderator": {
+        "description": "",
+        "example": "QmamG5uQjRqrdxAxp4DJK4TLvs2Yet8Nuiztip4ALD7i1U",
+        "type": "string"
+      }
+    },
+    "required": [
+      "shipTo",
+      "address",
+      "city",
+      "state",
+      "countryCode",
+      "postalCode",
+      "addressNotes",
+      "items",
+      "moderator"
+    ]
+  },
+  "Item59": {
+    "title": "Item59",
+    "example": {
+      "listingHash": "zb2rhad6oPUEHTNMCCS6MQND541S2KSa7DrYAaBAxQgRDYQ8C",
+      "quantity": 1,
+      "options": [
+        {
+          "name": "Color",
+          "value": "Red"
+        },
+        {
+          "name": "Sizes",
+          "value": "Small"
+        }
+      ],
+      "shipping": {
+        "name": "Worldwide",
+        "service": "Standard"
+      },
+      "memo": "thanks!",
+      "coupons": []
+    },
+    "type": "object",
+    "properties": {
+      "listingHash": {
+        "description": "",
+        "example": "zb2rhad6oPUEHTNMCCS6MQND541S2KSa7DrYAaBAxQgRDYQ8C",
+        "type": "string"
+      },
+      "quantity": {
+        "description": "",
+        "example": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "options": {
+        "description": "",
+        "example": [
+          {
+            "name": "Color",
+            "value": "Red"
+          },
+          {
+            "name": "Sizes",
+            "value": "Small"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Option47"
+        }
+      },
+      "shipping": {
+        "$ref": "#/definitions/Shipping61"
+      },
+      "memo": {
+        "description": "",
+        "example": "thanks!",
+        "type": "string"
+      },
+      "coupons": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": [
+      "listingHash",
+      "quantity",
+      "options",
+      "shipping",
+      "memo",
+      "coupons"
+    ]
+  },
+  "Shipping61": {
+    "title": "Shipping61",
+    "example": {
+      "name": "Worldwide",
+      "service": "Standard"
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Worldwide",
+        "type": "string"
+      },
+      "service": {
+        "description": "",
+        "example": "Standard",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name",
+      "service"
+    ]
+  },
+  "PurchaseOrder": {
+    "title": "Purchase order",
+    "example": {
+      "amount": 81967,
+      "orderId": "QmXRGXywXHmcr18PYpDNyKuhdQqB8C8iaTbhbasZCoN1QV",
+      "paymentAddress": "mhAoRQavWqaF6WPWtVwyhMVQ8sjqoWEESF",
+      "vendorOnline": true
+    },
+    "type": "object",
+    "properties": {
+      "amount": {
+        "description": "",
+        "example": 81967,
+        "type": "integer",
+        "format": "int32"
+      },
+      "orderId": {
+        "description": "",
+        "example": "QmXRGXywXHmcr18PYpDNyKuhdQqB8C8iaTbhbasZCoN1QV",
+        "type": "string"
+      },
+      "paymentAddress": {
+        "description": "",
+        "example": "mhAoRQavWqaF6WPWtVwyhMVQ8sjqoWEESF",
+        "type": "string"
+      },
+      "vendorOnline": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "amount",
+      "orderId",
+      "paymentAddress",
+      "vendorOnline"
+    ]
+  },
+  "ConfirmAnOrder(offline)request": {
+    "title": "Confirm an order (offline)Request",
+    "example": {
+      "orderId": "QmamudHQGtztShX7Nc9HcczehdpGGWpFBWu2JvKWcpELxr",
+      "reject": false
+    },
+    "type": "object",
+    "properties": {
+      "orderId": {
+        "description": "",
+        "example": "QmamudHQGtztShX7Nc9HcczehdpGGWpFBWu2JvKWcpELxr",
+        "type": "string"
+      },
+      "reject": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "orderId",
+      "reject"
+    ]
+  },
+  "FulfillAnOrderrequest": {
+    "title": "Fulfill an orderRequest",
+    "example": {
+      "orderId": "QmXVXyHcmSPeirD8k9Yu77zQy2NbXPC2ZHAi1buJQRc9hJ",
+      "physicalDelivery": [
+        {
+          "shipper": "UPS",
+          "trackingNumber": "1Z204E380338943508"
+        }
+      ],
+      "digitalDelivery": [
+        {
+          "url": "http://example.com/download.mp3",
+          "password": "letmein"
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "orderId": {
+        "description": "",
+        "example": "QmXVXyHcmSPeirD8k9Yu77zQy2NbXPC2ZHAi1buJQRc9hJ",
+        "type": "string"
+      },
+      "physicalDelivery": {
+        "description": "",
+        "example": [
+          {
+            "shipper": "UPS",
+            "trackingNumber": "1Z204E380338943508"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/PhysicalDelivery"
+        }
+      },
+      "digitalDelivery": {
+        "description": "",
+        "example": [
+          {
+            "url": "http://example.com/download.mp3",
+            "password": "letmein"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/DigitalDelivery"
+        }
+      }
+    },
+    "required": [
+      "orderId",
+      "physicalDelivery",
+      "digitalDelivery"
+    ]
+  },
+  "DigitalDelivery": {
+    "title": "DigitalDelivery",
+    "example": {
+      "url": "http://example.com/download.mp3",
+      "password": "letmein"
+    },
+    "type": "object",
+    "properties": {
+      "url": {
+        "description": "",
+        "example": "http://example.com/download.mp3",
+        "type": "string"
+      },
+      "password": {
+        "description": "",
+        "example": "letmein",
+        "type": "string"
+      }
+    },
+    "required": [
+      "url",
+      "password"
+    ]
+  },
+  "CompleteAnOrderrequest": {
+    "title": "Complete an orderRequest",
+    "example": {
+      "orderId": "QmP9rtg9tm5zv8RrPTJpyDc3bfqwnaogjbneBTPaf8TjA9",
+      "ratings": [
+        {
+          "slug": "vintage-nice-dress",
+          "overall": 3,
+          "quality": 4,
+          "description": 5,
+          "deliverySpeed": 5,
+          "customerService": 3,
+          "review": "This rocks!",
+          "anonymous": true
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "orderId": {
+        "description": "",
+        "example": "QmP9rtg9tm5zv8RrPTJpyDc3bfqwnaogjbneBTPaf8TjA9",
+        "type": "string"
+      },
+      "ratings": {
+        "description": "",
+        "example": [
+          {
+            "slug": "vintage-nice-dress",
+            "overall": 3,
+            "quality": 4,
+            "description": 5,
+            "deliverySpeed": 5,
+            "customerService": 3,
+            "review": "This rocks!",
+            "anonymous": true
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Rating"
+        }
+      }
+    },
+    "required": [
+      "orderId",
+      "ratings"
+    ]
+  },
+  "Rating": {
+    "title": "Rating",
+    "example": {
+      "slug": "vintage-nice-dress",
+      "overall": 3,
+      "quality": 4,
+      "description": 5,
+      "deliverySpeed": 5,
+      "customerService": 3,
+      "review": "This rocks!",
+      "anonymous": true
+    },
+    "type": "object",
+    "properties": {
+      "slug": {
+        "description": "",
+        "example": "vintage-nice-dress",
+        "type": "string"
+      },
+      "overall": {
+        "description": "",
+        "example": 3,
+        "type": "integer",
+        "format": "int32"
+      },
+      "quality": {
+        "description": "",
+        "example": 4,
+        "type": "integer",
+        "format": "int32"
+      },
+      "description": {
+        "description": "",
+        "example": 5,
+        "type": "integer",
+        "format": "int32"
+      },
+      "deliverySpeed": {
+        "description": "",
+        "example": 5,
+        "type": "integer",
+        "format": "int32"
+      },
+      "customerService": {
+        "description": "",
+        "example": 3,
+        "type": "integer",
+        "format": "int32"
+      },
+      "review": {
+        "description": "",
+        "example": "This rocks!",
+        "type": "string"
+      },
+      "anonymous": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "slug",
+      "overall",
+      "quality",
+      "description",
+      "deliverySpeed",
+      "customerService",
+      "review",
+      "anonymous"
+    ]
+  },
+  "RefundAnOrderrequest": {
+    "title": "Refund an orderRequest",
+    "example": {
+      "orderId": "QmamudHQGtztShX7Nc9HcczehdpGGWpFBWu2JvKWcpELxr"
+    },
+    "type": "object",
+    "properties": {
+      "orderId": {
+        "description": "",
+        "example": "QmamudHQGtztShX7Nc9HcczehdpGGWpFBWu2JvKWcpELxr",
+        "type": "string"
+      }
+    },
+    "required": [
+      "orderId"
+    ]
+  },
+  "CancelAnOfflineOrderrequest": {
+    "title": "Cancel an offline orderRequest",
+    "example": {
+      "orderId": "QmamudHQGtztShX7Nc9HcczehdpGGWpFBWu2JvKWcpELxr"
+    },
+    "type": "object",
+    "properties": {
+      "orderId": {
+        "description": "",
+        "example": "QmamudHQGtztShX7Nc9HcczehdpGGWpFBWu2JvKWcpELxr",
+        "type": "string"
+      }
+    },
+    "required": [
+      "orderId"
+    ]
+  },
+  "ListingExample": {
+    "title": "Listing Example",
+    "example": {
+      "vendorListings": [
+        {
+          "slug": "vintage-nice-dress",
+          "vendorID": {
+            "guid": "QmYctWu2n5rnQzLpDWWWGjPTpeKVPyrZtQPbfvi9NqCtTD",
+            "pubkeys": {
+              "guid": "CAESIGUXMqWBGoFuhrjk8D3j5CWAwKDIe4Phk9lUqVD58OHW",
+              "bitcoin": "AkaP8SH6rDVCryBhsElt7lysZpZRJbGB/C5/z2B/EzEz"
+            },
+            "bitcoinSig": "MEUCIQDdaHdppvY6wbQoS9YsxCxhhb00O1GpgqS8Yk9aZ8gljAIgD8Ox4B0t22SLPx+GE9gW3YyAtxjWYIWF9hkuBwnhMAQ="
+          },
+          "metadata": {
+            "version": 1,
+            "contractType": "PHYSICAL_GOOD",
+            "format": "FIXED_PRICE",
+            "expiry": "2037-12-31T05:00:00Z",
+            "acceptedCurrency": "tbtc",
+            "pricingCurrency": "USD"
+          },
+          "item": {
+            "title": "YuooMuoo V-neck Knitted Dress v2",
+            "description": "This is a listing example.",
+            "processingTime": "3 days",
+            "price": 200,
+            "tags": [
+              "vintage dress"
+            ],
+            "images": [
+              {
+                "filename": "front",
+                "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq",
+                "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+                "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+                "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+                "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz"
+              },
+              {
+                "filename": "cream",
+                "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny",
+                "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+                "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+                "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+                "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq"
+              },
+              {
+                "filename": "black",
+                "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr",
+                "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+                "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+                "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+                "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe"
+              },
+              {
+                "filename": "other_red",
+                "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF",
+                "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+                "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+                "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+                "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt"
+              }
+            ],
+            "categories": [
+              "👚 Apparel & Accessories"
+            ],
+            "condition": "New",
+            "options": [
+              {
+                "name": "Color",
+                "description": "Color of the dress.",
+                "variants": [
+                  "Red",
+                  "Cream",
+                  "Black"
+                ]
+              },
+              {
+                "name": "Sizes",
+                "description": "Size of the dress.",
+                "variants": [
+                  "Small",
+                  "Medium",
+                  "Large"
+                ]
+              }
+            ],
+            "skus": [
+              {
+                "variantCombo": [
+                  0,
+                  0
+                ],
+                "productID": "dress-red-small"
+              },
+              {
+                "variantCombo": [
+                  0,
+                  1
+                ],
+                "productID": "dress-red-medium"
+              },
+              {
+                "variantCombo": [
+                  0,
+                  2
+                ],
+                "productID": "dress-red-large"
+              },
+              {
+                "variantCombo": [
+                  1,
+                  0
+                ],
+                "productID": "dress-cream-small"
+              },
+              {
+                "variantCombo": [
+                  1,
+                  1
+                ],
+                "productID": "dress-cream-medium"
+              },
+              {
+                "variantCombo": [
+                  1,
+                  2
+                ],
+                "productID": "dress-cream-large"
+              },
+              {
+                "variantCombo": [
+                  2,
+                  0
+                ],
+                "productID": "dress-black-small"
+              },
+              {
+                "variantCombo": [
+                  2,
+                  1
+                ],
+                "productID": "dress-black-medium"
+              },
+              {
+                "variantCombo": [
+                  2,
+                  2
+                ],
+                "productID": "dress-black-large"
+              }
+            ]
+          },
+          "shippingOptions": [
+            {
+              "name": "Worldwide",
+              "type": "FIXED_PRICE",
+              "regions": [
+                "ALL"
+              ],
+              "services": [
+                {
+                  "name": "Standard",
+                  "estimatedDelivery": "5 days"
+                },
+                {
+                  "name": "Express",
+                  "price": 50,
+                  "estimatedDelivery": "3 days"
+                }
+              ]
+            }
+          ],
+          "taxes": [],
+          "coupons": [],
+          "moderators": [],
+          "termsAndConditions": "Terms and conditions.",
+          "refundPolicy": "Refund policy."
+        }
+      ],
+      "signatures": [
+        {
+          "section": "LISTING",
+          "signatureBytes": "j1jCg/m2oGgbCkm7JPamPtUauMFfN27tZs0gc45epi+gJWQDQy85gvOBs/k5hlo7tojuU3l/FX34Kztpl//zCA=="
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "vendorListings": {
+        "description": "",
+        "example": [
+          {
+            "slug": "vintage-nice-dress",
+            "vendorID": {
+              "guid": "QmYctWu2n5rnQzLpDWWWGjPTpeKVPyrZtQPbfvi9NqCtTD",
+              "pubkeys": {
+                "guid": "CAESIGUXMqWBGoFuhrjk8D3j5CWAwKDIe4Phk9lUqVD58OHW",
+                "bitcoin": "AkaP8SH6rDVCryBhsElt7lysZpZRJbGB/C5/z2B/EzEz"
+              },
+              "bitcoinSig": "MEUCIQDdaHdppvY6wbQoS9YsxCxhhb00O1GpgqS8Yk9aZ8gljAIgD8Ox4B0t22SLPx+GE9gW3YyAtxjWYIWF9hkuBwnhMAQ="
+            },
+            "metadata": {
+              "version": 1,
+              "contractType": "PHYSICAL_GOOD",
+              "format": "FIXED_PRICE",
+              "expiry": "2037-12-31T05:00:00Z",
+              "acceptedCurrency": "tbtc",
+              "pricingCurrency": "USD"
+            },
+            "item": {
+              "title": "YuooMuoo V-neck Knitted Dress v2",
+              "description": "This is a listing example.",
+              "processingTime": "3 days",
+              "price": 200,
+              "tags": [
+                "vintage dress"
+              ],
+              "images": [
+                {
+                  "filename": "front",
+                  "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq",
+                  "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+                  "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+                  "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+                  "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz"
+                },
+                {
+                  "filename": "cream",
+                  "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny",
+                  "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+                  "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+                  "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+                  "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq"
+                },
+                {
+                  "filename": "black",
+                  "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr",
+                  "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+                  "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+                  "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+                  "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe"
+                },
+                {
+                  "filename": "other_red",
+                  "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF",
+                  "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+                  "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+                  "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+                  "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt"
+                }
+              ],
+              "categories": [
+                "👚 Apparel & Accessories"
+              ],
+              "condition": "New",
+              "options": [
+                {
+                  "name": "Color",
+                  "description": "Color of the dress.",
+                  "variants": [
+                    "Red",
+                    "Cream",
+                    "Black"
+                  ]
+                },
+                {
+                  "name": "Sizes",
+                  "description": "Size of the dress.",
+                  "variants": [
+                    "Small",
+                    "Medium",
+                    "Large"
+                  ]
+                }
+              ],
+              "skus": [
+                {
+                  "variantCombo": [
+                    0,
+                    0
+                  ],
+                  "productID": "dress-red-small"
+                },
+                {
+                  "variantCombo": [
+                    0,
+                    1
+                  ],
+                  "productID": "dress-red-medium"
+                },
+                {
+                  "variantCombo": [
+                    0,
+                    2
+                  ],
+                  "productID": "dress-red-large"
+                },
+                {
+                  "variantCombo": [
+                    1,
+                    0
+                  ],
+                  "productID": "dress-cream-small"
+                },
+                {
+                  "variantCombo": [
+                    1,
+                    1
+                  ],
+                  "productID": "dress-cream-medium"
+                },
+                {
+                  "variantCombo": [
+                    1,
+                    2
+                  ],
+                  "productID": "dress-cream-large"
+                },
+                {
+                  "variantCombo": [
+                    2,
+                    0
+                  ],
+                  "productID": "dress-black-small"
+                },
+                {
+                  "variantCombo": [
+                    2,
+                    1
+                  ],
+                  "productID": "dress-black-medium"
+                },
+                {
+                  "variantCombo": [
+                    2,
+                    2
+                  ],
+                  "productID": "dress-black-large"
+                }
+              ]
+            },
+            "shippingOptions": [
+              {
+                "name": "Worldwide",
+                "type": "FIXED_PRICE",
+                "regions": [
+                  "ALL"
+                ],
+                "services": [
+                  {
+                    "name": "Standard",
+                    "estimatedDelivery": "5 days"
+                  },
+                  {
+                    "name": "Express",
+                    "price": 50,
+                    "estimatedDelivery": "3 days"
+                  }
+                ]
+              }
+            ],
+            "taxes": [],
+            "coupons": [],
+            "moderators": [],
+            "termsAndConditions": "Terms and conditions.",
+            "refundPolicy": "Refund policy."
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/VendorListing72"
+        }
+      },
+      "signatures": {
+        "description": "",
+        "example": [
+          {
+            "section": "LISTING",
+            "signatureBytes": "j1jCg/m2oGgbCkm7JPamPtUauMFfN27tZs0gc45epi+gJWQDQy85gvOBs/k5hlo7tojuU3l/FX34Kztpl//zCA=="
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Signature"
+        }
+      }
+    },
+    "required": [
+      "vendorListings",
+      "signatures"
+    ]
+  },
+  "VendorListing72": {
+    "title": "VendorListing72",
+    "example": {
+      "slug": "vintage-nice-dress",
+      "vendorID": {
+        "guid": "QmYctWu2n5rnQzLpDWWWGjPTpeKVPyrZtQPbfvi9NqCtTD",
+        "pubkeys": {
+          "guid": "CAESIGUXMqWBGoFuhrjk8D3j5CWAwKDIe4Phk9lUqVD58OHW",
+          "bitcoin": "AkaP8SH6rDVCryBhsElt7lysZpZRJbGB/C5/z2B/EzEz"
+        },
+        "bitcoinSig": "MEUCIQDdaHdppvY6wbQoS9YsxCxhhb00O1GpgqS8Yk9aZ8gljAIgD8Ox4B0t22SLPx+GE9gW3YyAtxjWYIWF9hkuBwnhMAQ="
+      },
+      "metadata": {
+        "version": 1,
+        "contractType": "PHYSICAL_GOOD",
+        "format": "FIXED_PRICE",
+        "expiry": "2037-12-31T05:00:00Z",
+        "acceptedCurrency": "tbtc",
+        "pricingCurrency": "USD"
+      },
+      "item": {
+        "title": "YuooMuoo V-neck Knitted Dress v2",
+        "description": "This is a listing example.",
+        "processingTime": "3 days",
+        "price": 200,
+        "tags": [
+          "vintage dress"
+        ],
+        "images": [
+          {
+            "filename": "front",
+            "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq",
+            "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+            "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+            "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+            "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz"
+          },
+          {
+            "filename": "cream",
+            "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny",
+            "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+            "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+            "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+            "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq"
+          },
+          {
+            "filename": "black",
+            "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr",
+            "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+            "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+            "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+            "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe"
+          },
+          {
+            "filename": "other_red",
+            "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF",
+            "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+            "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+            "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+            "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt"
+          }
+        ],
+        "categories": [
+          "👚 Apparel & Accessories"
+        ],
+        "condition": "New",
+        "options": [
+          {
+            "name": "Color",
+            "description": "Color of the dress.",
+            "variants": [
+              "Red",
+              "Cream",
+              "Black"
+            ]
+          },
+          {
+            "name": "Sizes",
+            "description": "Size of the dress.",
+            "variants": [
+              "Small",
+              "Medium",
+              "Large"
+            ]
+          }
+        ],
+        "skus": [
+          {
+            "variantCombo": [
+              0,
+              0
+            ],
+            "productID": "dress-red-small"
+          },
+          {
+            "variantCombo": [
+              0,
+              1
+            ],
+            "productID": "dress-red-medium"
+          },
+          {
+            "variantCombo": [
+              0,
+              2
+            ],
+            "productID": "dress-red-large"
+          },
+          {
+            "variantCombo": [
+              1,
+              0
+            ],
+            "productID": "dress-cream-small"
+          },
+          {
+            "variantCombo": [
+              1,
+              1
+            ],
+            "productID": "dress-cream-medium"
+          },
+          {
+            "variantCombo": [
+              1,
+              2
+            ],
+            "productID": "dress-cream-large"
+          },
+          {
+            "variantCombo": [
+              2,
+              0
+            ],
+            "productID": "dress-black-small"
+          },
+          {
+            "variantCombo": [
+              2,
+              1
+            ],
+            "productID": "dress-black-medium"
+          },
+          {
+            "variantCombo": [
+              2,
+              2
+            ],
+            "productID": "dress-black-large"
+          }
+        ]
+      },
+      "shippingOptions": [
+        {
+          "name": "Worldwide",
+          "type": "FIXED_PRICE",
+          "regions": [
+            "ALL"
+          ],
+          "services": [
+            {
+              "name": "Standard",
+              "estimatedDelivery": "5 days"
+            },
+            {
+              "name": "Express",
+              "price": 50,
+              "estimatedDelivery": "3 days"
+            }
+          ]
+        }
+      ],
+      "taxes": [],
+      "coupons": [],
+      "moderators": [],
+      "termsAndConditions": "Terms and conditions.",
+      "refundPolicy": "Refund policy."
+    },
+    "type": "object",
+    "properties": {
+      "slug": {
+        "description": "",
+        "example": "vintage-nice-dress",
+        "type": "string"
+      },
+      "vendorID": {
+        "$ref": "#/definitions/VendorID"
+      },
+      "metadata": {
+        "$ref": "#/definitions/Metadata"
+      },
+      "item": {
+        "$ref": "#/definitions/Item76"
+      },
+      "shippingOptions": {
+        "description": "",
+        "example": [
+          {
+            "name": "Worldwide",
+            "type": "FIXED_PRICE",
+            "regions": [
+              "ALL"
+            ],
+            "services": [
+              {
+                "name": "Standard",
+                "estimatedDelivery": "5 days"
+              },
+              {
+                "name": "Express",
+                "price": 50,
+                "estimatedDelivery": "3 days"
+              }
+            ]
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/ShippingOption80"
+        }
+      },
+      "taxes": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "coupons": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "moderators": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "termsAndConditions": {
+        "description": "",
+        "example": "Terms and conditions.",
+        "type": "string"
+      },
+      "refundPolicy": {
+        "description": "",
+        "example": "Refund policy.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "slug",
+      "vendorID",
+      "metadata",
+      "item",
+      "shippingOptions",
+      "taxes",
+      "coupons",
+      "moderators",
+      "termsAndConditions",
+      "refundPolicy"
+    ]
+  },
+  "Item76": {
+    "title": "Item76",
+    "example": {
+      "title": "YuooMuoo V-neck Knitted Dress v2",
+      "description": "This is a listing example.",
+      "processingTime": "3 days",
+      "price": 200,
+      "tags": [
+        "vintage dress"
+      ],
+      "images": [
+        {
+          "filename": "front",
+          "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq",
+          "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+          "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+          "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+          "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz"
+        },
+        {
+          "filename": "cream",
+          "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny",
+          "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+          "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+          "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+          "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq"
+        },
+        {
+          "filename": "black",
+          "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr",
+          "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+          "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+          "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+          "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe"
+        },
+        {
+          "filename": "other_red",
+          "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF",
+          "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+          "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+          "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+          "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt"
+        }
+      ],
+      "categories": [
+        "👚 Apparel & Accessories"
+      ],
+      "condition": "New",
+      "options": [
+        {
+          "name": "Color",
+          "description": "Color of the dress.",
+          "variants": [
+            "Red",
+            "Cream",
+            "Black"
+          ]
+        },
+        {
+          "name": "Sizes",
+          "description": "Size of the dress.",
+          "variants": [
+            "Small",
+            "Medium",
+            "Large"
+          ]
+        }
+      ],
+      "skus": [
+        {
+          "variantCombo": [
+            0,
+            0
+          ],
+          "productID": "dress-red-small"
+        },
+        {
+          "variantCombo": [
+            0,
+            1
+          ],
+          "productID": "dress-red-medium"
+        },
+        {
+          "variantCombo": [
+            0,
+            2
+          ],
+          "productID": "dress-red-large"
+        },
+        {
+          "variantCombo": [
+            1,
+            0
+          ],
+          "productID": "dress-cream-small"
+        },
+        {
+          "variantCombo": [
+            1,
+            1
+          ],
+          "productID": "dress-cream-medium"
+        },
+        {
+          "variantCombo": [
+            1,
+            2
+          ],
+          "productID": "dress-cream-large"
+        },
+        {
+          "variantCombo": [
+            2,
+            0
+          ],
+          "productID": "dress-black-small"
+        },
+        {
+          "variantCombo": [
+            2,
+            1
+          ],
+          "productID": "dress-black-medium"
+        },
+        {
+          "variantCombo": [
+            2,
+            2
+          ],
+          "productID": "dress-black-large"
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "title": {
+        "description": "",
+        "example": "YuooMuoo V-neck Knitted Dress v2",
+        "type": "string"
+      },
+      "description": {
+        "description": "",
+        "example": "This is a listing example.",
+        "type": "string"
+      },
+      "processingTime": {
+        "description": "",
+        "example": "3 days",
+        "type": "string"
+      },
+      "price": {
+        "description": "",
+        "example": 200,
+        "type": "integer",
+        "format": "int32"
+      },
+      "tags": {
+        "description": "",
+        "example": [
+          "vintage dress"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "images": {
+        "description": "",
+        "example": [
+          {
+            "filename": "front",
+            "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq",
+            "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+            "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+            "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+            "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz"
+          },
+          {
+            "filename": "cream",
+            "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny",
+            "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+            "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+            "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+            "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq"
+          },
+          {
+            "filename": "black",
+            "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr",
+            "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+            "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+            "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+            "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe"
+          },
+          {
+            "filename": "other_red",
+            "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF",
+            "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+            "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+            "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+            "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Image"
+        }
+      },
+      "categories": {
+        "description": "",
+        "example": [
+          "👚 Apparel & Accessories"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "condition": {
+        "description": "",
+        "example": "New",
+        "type": "string"
+      },
+      "options": {
+        "description": "",
+        "example": [
+          {
+            "name": "Color",
+            "description": "Color of the dress.",
+            "variants": [
+              "Red",
+              "Cream",
+              "Black"
+            ]
+          },
+          {
+            "name": "Sizes",
+            "description": "Size of the dress.",
+            "variants": [
+              "Small",
+              "Medium",
+              "Large"
+            ]
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Option"
+        }
+      },
+      "skus": {
+        "description": "",
+        "example": [
+          {
+            "variantCombo": [
+              0,
+              0
+            ],
+            "productID": "dress-red-small"
+          },
+          {
+            "variantCombo": [
+              0,
+              1
+            ],
+            "productID": "dress-red-medium"
+          },
+          {
+            "variantCombo": [
+              0,
+              2
+            ],
+            "productID": "dress-red-large"
+          },
+          {
+            "variantCombo": [
+              1,
+              0
+            ],
+            "productID": "dress-cream-small"
+          },
+          {
+            "variantCombo": [
+              1,
+              1
+            ],
+            "productID": "dress-cream-medium"
+          },
+          {
+            "variantCombo": [
+              1,
+              2
+            ],
+            "productID": "dress-cream-large"
+          },
+          {
+            "variantCombo": [
+              2,
+              0
+            ],
+            "productID": "dress-black-small"
+          },
+          {
+            "variantCombo": [
+              2,
+              1
+            ],
+            "productID": "dress-black-medium"
+          },
+          {
+            "variantCombo": [
+              2,
+              2
+            ],
+            "productID": "dress-black-large"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Sku79"
+        }
+      }
+    },
+    "required": [
+      "title",
+      "description",
+      "processingTime",
+      "price",
+      "tags",
+      "images",
+      "categories",
+      "condition",
+      "options",
+      "skus"
+    ]
+  },
+  "Sku79": {
+    "title": "Sku79",
+    "example": {
+      "variantCombo": [
+        0,
+        0
+      ],
+      "productID": "dress-red-small"
+    },
+    "type": "object",
+    "properties": {
+      "variantCombo": {
+        "description": "",
+        "example": [
+          0,
+          0
+        ],
+        "type": "array",
+        "items": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "productID": {
+        "description": "",
+        "example": "dress-red-small",
+        "type": "string"
+      }
+    },
+    "required": [
+      "variantCombo",
+      "productID"
+    ]
+  },
+  "ShippingOption80": {
+    "title": "ShippingOption80",
+    "example": {
+      "name": "Worldwide",
+      "type": "FIXED_PRICE",
+      "regions": [
+        "ALL"
+      ],
+      "services": [
+        {
+          "name": "Standard",
+          "estimatedDelivery": "5 days"
+        },
+        {
+          "name": "Express",
+          "price": 50,
+          "estimatedDelivery": "3 days"
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Worldwide",
+        "type": "string"
+      },
+      "type": {
+        "description": "",
+        "example": "FIXED_PRICE",
+        "type": "string"
+      },
+      "regions": {
+        "description": "",
+        "example": [
+          "ALL"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "services": {
+        "description": "",
+        "example": [
+          {
+            "name": "Standard",
+            "estimatedDelivery": "5 days"
+          },
+          {
+            "name": "Express",
+            "price": 50,
+            "estimatedDelivery": "3 days"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Service81"
+        }
+      }
+    },
+    "required": [
+      "name",
+      "type",
+      "regions",
+      "services"
+    ]
+  },
+  "Service81": {
+    "title": "Service81",
+    "example": {
+      "name": "Standard",
+      "estimatedDelivery": "5 days"
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Standard",
+        "type": "string"
+      },
+      "estimatedDelivery": {
+        "description": "",
+        "example": "5 days",
+        "type": "string"
+      },
+      "price": {
+        "description": "",
+        "example": 50,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "name",
+      "estimatedDelivery"
+    ]
+  },
+  "UploadImagerequest": {
+    "title": "Upload imageRequest",
+    "example": {
+      "filename": "cat",
+      "image": "/9j/4AAQSkZJRgABAQEBLAEsAAD/4QDiRXhpZgAATU0AKgAAAAgABAEPAAIAAAASAAAAPgEQAAIAAAAMAAAAUIKaAAUAAAABAAAAXIdpAAQAAAABAAAAZAAAAABOSUtPTiBDT1JQT1JBVElPTgBOSUtPTiBEMzIwMAAAAAAKAAAfQAAGgpoABQAAAAEAAACugp0ABQAAAAEAAAC2iCcAAwAAAAIBkAAAkAMAAgAAABQAAAC+kgkAAwAAAAIAEAAAkgoABQAAAAEAAADSAAAACgAAH0AAAAAmAAAACjIwMTU6MTE6MTUgMTE6NTQ6MzcAAAADUgAAAAr/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAGpAoADASIAAhEBAxEB/8QAHQAAAgMBAQEBAQAAAAAAAAAABQYDBAcCCAEACf/EAFYQAAIBAwIEAwYDBQUEBQoBDQECAwAEEQUhBhIxQRNRYQcUIjJxgUKRoRUjUrHBCDNictEWguHwJDVDc/E0NlNjdHWSorK0FyU3s8ImREVkdoOTo9L/xAAbAQACAwEBAQAAAAAAAAAAAAADBAECBQYAB//EADkRAAICAQMBBQYGAgMAAQUBAAECAAMRBBIhMQUTQVHwImFxkaHBFDKBsdHhBiNCUvHSFSQzQ2Jy/9oADAMBAAIRAxEAPwDyHfw/EzHJxk70qaxj4snO9PWrQiNGGxPcedI+r9SN9+9KaI5MY1gwIqTr8X1rhB5CppwQxx1FRID16VrY5mU3EmjHxZ38qvwABftVGMHG9XoTgYxt9KIvETt5k6dcYzjar1uB1O5qimdv+f1q/bg9hnO9X5ziJ2cCFbMZOMfemCwUEigVnjmB86YNP2wcdNq9Mu08ZjLppCYOd6NWp5yM9f0pftnAAUDbqfrTBpzcxz16AUjqeOYpQCXxC1pCxIBOcf8AO1MVjbqeUgHJwfKhNmFBXG2cHGOn+tMNiMgYGP61y+sJJnZdnoBiEraBQOma+XbLGu1WogBHnA32odqEgLkDpWI6EmdRQfZlYHnbI2qZSBgnzqCJh9Tn86lQ57iqNXiO189ZbQBsZH1xV+3yBjoMd6p2ihsHHQ4q2rhDnPSqBPCNgGQ3L/vcVXmPMvzA57etc3EvNIWByetRtJzKMAen1ond+UsvBn6IlcY3+1WUG+wH3qqpOcAmrlspO/YVOzMZUeM5e6mtZ1mt5eR1OVIGfqCDsR6HY1O8UOoW8l5p0IjljBee0GTyr3kj7lPNeq+o3FKfPOR96+QyS28qTwSvFLG3Ojo2CrDuDRBXgbTJPPIlaVvjBB29K7t5GLdaJm1t9fPNZRpb6oc89qoCx3J84uyyecfQ/h3+Gh0EbKxDKQwJUgjBBHUEdj6UwKyolQwYyC7mIbGeu1D7tQwBA2O/1q9dDmP3qnKg8P6URR0kEQJyF5Sd/vROy+Fc4PWq3hHxc4Iz5USjhAgx023o88BK16BIec/bFDZIjy82djRB258qfw9qhkhyMDqaLWBBPnMrWwLBlxt51ZFm9xLBaQL8bsF/XrXNrEVVmYYPNtTJodqscvvswHMwxGD/ADpTW6gaZCR1Mb09PedeghBNLEECWCMCkRy7D8R9aYrLmghRYUCnG5I6CqVlEj4ZjklizZphsFEi8zJ16LisOgGxi7dTG3O1cSzp8cwCygAnu7HYfQUXSK55chvFPkp2qG3V0T4VVcdNs1agS6l+ExFx2IbFala+Ez3OTPqe8KMPZnY9MZx+VWLaSNTmNGI8jGRXx9O1s4a1m5R1+FgCPrX2ObiSwk5LjT5JQe4IYGruSg5B+UmtQ/Qj5yzKtvKnOsMZPfBww/1r6LYhOdEZlPk+cfnViGbT74ATWbJL3DLXL2GnwEsJJ7cn8SHmX7is6+vvOVx+00Km2eyc5gDU7QM6yKT16E012+nJqPCFzAVXJiZd9+opa1VAilkmEnqBimHhN5p9Lnhd8jlo/Yrd3fgyO1kNukzPGmpeLba7f2EijMUrAY9DXVu2MH/hTTx/DY23GN9aJajn8Rg7KNs5paWLkdl2yD1862NfVsfJ8Zz+jt3JAHtBYx6C0g25DnPnTDwLrknEHBOn3cq5kgXw2IPbp/QUue0ZC3DcoQYzt9KGf2fNUubjTtR0GZt4mMiqT5+X5UxpEF2htr8Rg/KB1L7NWjeYx95qPiHGFBzWCf2hOGOJb/iHT9bg1e4vLS6jMcVrMzeFYmCNSSNyCCCSBy5zkb5Fb+ID2xikf2kTNpuu8C6hHOivDxAhSNlJSQ4QrzenOseaW7GJGtStTgMcH18ZbtHb+HY4zjkSh7GNY1O94fv9M1PRLWxuNJv/AHad4rFbV3uDEplhkUDPNCy8m/cnpnFPlzzvbSBVDHlJCnv6UQm0mHTJ5rK2aN0jnlPPGgUSuzlmk27sxLE9SSa493+EjHzDv5UtrdQb9S1jcHP7cfaF0yrXp1XrxLnBmkSycMXlvHJzSeDzlebPnkY9KW9UcW9lNK2RyoTTf7OmFndTWbOS7u7OCflJ6Y26bUo8bgafp18JlwVZlx5Vr9rhbBReP+S4+UT0VhrNtZPQ/vMV0oftXjMEY/vcn862F0yN1xsMbVlPsttHvOJ57rlBC5PTpWxmBgckYwPzrN1jAMB5R3TtjJgt0z1AFBNQtgbsFhtynf8AlTU1v2GT26UJ1K1Pjr8O+Pz2qmlsHerDW2ZWXhCsuluCQBynB8sb1mWrBbvViudo8DI/OtTQvHokxcYAT8tqydZOaSads/ETWlqlAsz7orp7PZIkun2Jub0Y3GenpTesQjQIMYG1UOGbMEGds53NGmiwM9/Ss66wM2I/R7IlFkyc527V9jgLSqPMb471YMWOvbvmpEjAZTynfpQa2w4jFrZrIgmaBY7gsmBnvTJHEDEhOMctCrq2w4ZATjrtRyxX/ocfN9SftTWrya8iJ0NhsThYdtu/TNDtXYonhqPvijRAVObuKXtWkJkIJ8+9ZyElsRtzxzF+7CqDk/Nt9K/afaGV1OO9dyKJnwDRnSbIcwYjYetNs+xeYEc8y5DbCOEAAH1qxHCSdqlYZBwO2MeVSwoeYbd6AGMswA5n1LcbA/SuBByzMoBIbYURjjHYZ+lfpoOV1k64IPpRq7drgmK2rkQDcQe73AbcA/yotymSBTndNutR6pBmJXRejE/arOm/v4uVh1Falw31mIqdrSo6NjYEVwVZTnYd6uSRkHlJ74x1r54O/mc461iMQBGwcmZhrceebGxOw2pC1lSCwO5PTG9aHrRHxZ6b49Kz7W1GWB23/Suq0B6Cc7rfy8xVuvnOd8+lRKvTapbgnnIGNqiAwc5rZMxzwJLHkHFW4ziq0Qyc/wBKsx4xgjeiCLPzLkYJ3FXYN2xiqduSQAOtX7YHmBqwHjEbTCtnvjIO9MFlsB2yN6BWYOwPSjURwoGN6mZduScQ3ZnmYbE0x6cDsSN+lLOm5YjApq09eUjAORSOq4EHp1BeMlkuFXOObp0pgsFJ6g77/egWnDmUEHbAP/IpjsY+UDbt9a5m9cnBnY6FMgYhDn5Yjt2oVdPkmrc8hUcuNhQ+XOcEnH0pE15nR6dMT7D06ZzUiD4sHtn71CmU2Odv1qxCAWGT3ob1ZmjUuDL9rgAd8V1ePyD4SB518jAUAj61FcNzg4AzQRVzmN4lTmLZJ69dq/RvzY8qjyQCuf8AjX2MfFjc/wA6MKxiWAlkL3Aq/AoSEt6VWiUHl7+lWHcRpgHpXlryIbmU5mw9cK3cdMYr9K2fvUJz065o4rzKzsBXJz9qPRzR67CsWoypHqQAEV3IeVbjySY9ObsJD9G8wChXmZcdKtzryxcvmMGr4xxPbM8yheQTwTy29zC0UsTFHjcYZWHUEdqoyjGQtMUU667CmnXjhb6JRHaXDnHiAbLBIf0Rj0PwnYjAGeNklaKRWV1YoysMFWGxBHYg9qsK8dJ5OTgyosWTzY2q9yYgJK9v1qOGPJCnG/r3qzcqEi5N96uEzCbcQLJHiXJBNSBSqr3IBzX6RM+WPOrNpC0sioULMSOnff8A4V6xhSpLSFq7w4n7TNPe+kZDsi/FIf6UaWIF4+TcfKoB6CoGVNMRo48lpCecD+VWdJiPNk52OT9+1cpqdQb33HpNeuoVr7MZNOtyeUnHkBTDbRyKBy4H2oRZBgAFTHqaLxy8pBa4Cgdd9qPUwURS0EmErVLlhhQQD5rV62hvI3w8iEYzgrgUHbUrSJQZr1EUeZODX1Nbs3UFLkt/uNg08lkVNTHoIzwpMuOWfkxuQDmiVnqKRjkn1CD6bb0nwXtpMCqqST35sfoTV5IrWQhmtFbH8LAkUytzKMiD/DgnDRziuVnA/c20mPwl9z96/SJpM4KtB7u56Enal23S1VQkFvMmO6kgCrPvdug8OYkqO/MSa93gsHtASwq2H2SYL161mszvZxyxk7OpJGKOcIWzNbyFUCc69B0oZNesJfDjUOjfXpTNw+T4b8oC/BS2nVU1K7Y1qmY6Ugzy37Y9IfSeMry6EyYmcN0/OlE24kZZUGzAE0/e3TTJH4vmuzIHTlHw56Gk7RIPerUofmhbGPStrtAmyrI6icnpm7s7Yoe0KELw3KCAfQ9RST7OIZeHeJdP1UE+BqLeC+PX/jWke06yKaAU5fmPc0unRprf2fxavBD4ktnKsoOOgByf5UDszUCplV+jNtPwIxLaw7gWHgM/Kay1qFkK+R27VmPt3vP2NacKaonK0lrrLzRwhyryMsDYAPYZIBPbIxWqaZP+09LsdTC7XNuj5Hc4FYx/anuzZ6Twqvgx5/aVxMsnWRGWEAADPQlt/UCltADp+1EQ/wDFpa9xbpz4gibXeWVlFcsmnQGK0CoYY8Y5VKKcY+pNVzbb9Om4rrh24Oo8I8MagZBP7xoVgWnBz4zrEEdz6l0bPqDV4wnOSOtJ9pf6tZdWPBm/eXoszUpz4CArO7utF18SwJ8E3K7HyIIH5bmgHt9vYbJJBspvh4i+RJ7inDWLNLe2XVprmOBIcliwzt9Kx3X+IIPbBqVrokVzFC9lN4bFBnIz1AJ+ldHo0bXdmL/2RuPgZn23d3qvcRz7sdJY9jmhGOwl1Fo/7w4B/wBK0V7TrjO350Q0nhEcL2MWlrhiiA8wXqKsNaY2wa5jU6gvaZpK/GQYDe0J3Yd8/eqN1Y80ycq7ZyKZ3tCcnl3qCWyPOsrKAE3Joen1GLVnns45i3qVs0GjNCoAZ1wAemO9ZW1n/wBJ8JAfnIx960fV9ejF8bZ0BUEp1/X60vaPpfvmsy/BlRJsa6ntMitFtHlEtHc2WJEK6Rp5t7JF5cZHYVYe2AGw3o2bPkQR42G1V5bcgk43Ncv+IyczWSyBWgKkEfau44cMpwAAc4q9Jb77qd658IKw7cpzRK7ssIzvDqRK11ZkjIBGN+mau2cJS0zjOD+RogbUSKGU8pIz0rtbYx2rYAGDvitrUJmkmJVW4sAge+lMUbbdQdqUNRuvjYjfHrvTHrk/KpGfTekyZ2nmIGcc24rPqXJyY6zZMuWERkcEqCScU12tv4EIUDc7nNCdGtgzKT2/nTAwCr9BiqWvkyymVsjPfGNqmgI5hg9/KoHZc7etdxMFYHJ8sUIGQ7ZhaHmBGRsOlSTAsmAPzqGBsjbv1yKnzgY26dv1qwJEAeesruiz27IeqjequlOUZou6nzq0OaKTlO4Y+VDnJtb/ADy4Vz2862dO+5OYjYu0wncxnxObfc9qjHKqsxxvvV2KP3iAMNiNx3qG8gWOJsY361l6isq5WMK+RMm1hwS5zjOcelIessSG696dNWckkjY0j6u5y2DkV1OimBrSMRWudpPLtXCb9OvSurn5+tcIcdP51siY7HykqEj4e3lVqLruc1VXJPT/AMatwDfGc1cQD9JehBBzsM0Stx0ND4BuBjftRO0GdiNxRF64mbeeYUtAFAJotAxY8pIOOgoXb5UYzjuMURtW5mG/oak++ZrZ6w7pyHmGd803acucDPXelawX5T16bHypu0tchQRkdqTvyRBUHNsZNKT5VYD+tMlunJHjyzQTS0w6nl2zjyo65Kx4x18q569eTO57MUFeJUmfLffpmomwVORjFSSDJ6CozkHAxvSjIB0nT6dATIiD1BwfKrNuCe2agTJO4zVmE8m+NzVSuRNEV4loPhCSKg5uYYz+lcTylF5cmoEkHN9aH3cKFn11+PfO9TRxjIONqgLEPnHpU0MnMME+vSrbfGWCkwhbqAM1DeSgNgnGBUsLYUdT22qjeSFmJ5sAHy71UJC7eJy79/SoGYMxVSfPavwbKYJzg1yNm5jTCriSExyZdtwOYDO+M1PeyfAF2O3WoLbPKCSAB51xcy+JmNWHlUbfOW2cSm0vNzIdwdvtV25mGsW7XTEnULRA0573EQ25/wDOvRvMYPUGh0nw74696ktZJLe5juLZuWSNuZSdx9/Q9CPWiDA6yoTxEntV58NnPepruIsiqBnOOlFbPRXmYXFpCRBOOeNf4PNPsf0xRyz4UeQpJOuB6ilrtVXpxljChN3SIw01pDyhDg9NqM2OmrYKlzIvTp6+tF9YS007lgiALnY4obqdw6QxRnfG7bdK53U9pNrCVH5RG00/cgHxMF6hBI17I6sGy22OlFdLtjEi8x+o9aGQy+NI0gA5c77d6N2BU4Oc0jnJjRUhcQ7awZGARnG9Xo9MeYAs5UDpgdap2sjKPhHQZwKuw3UnKPGmVQ3YHemksUeESZW8JJHoOl5zLeuWzkgb0Qg0jRAOVpCceZHWhUl+wk8C3Gw/ExNfHv7yCETOyRN+At/9X08qartA8JQ12NxujGtjYWQUCLHfdtxXwX9tBkQHwuX+FAT+ppTW6iuGAk1aSZz2QttXydbOEE++uDtkCQ4x61J1JPTiGTR4/OST8IwXetw+IA91cTt3B+DFdwamjLzx6c+R3b4qXYNR0sOI7efxZQewL4oxBc6jMR4EaNt0xiiV8nJP3l2rC8Y+0P6fq1zdTLC0EIXyA3py06MCKTBIylKfDdpeSv4l1Zxqc+VPOmQpzMj4GVO1Er3nULzEdYUFZCzzX7TrNrjiG+LHm5HyoP0pL4Zg8DXGilziVenatj9pOmwx8QTtGn96oYn9KzG8tJ7K7S7SIt4L52/hrXU5sek+M5BjtAYeEV/a5EkdtDZqoyzj+flRjTOGhd+z57LABmtz26HGaX+M9Qh4m1yzitFVlVsMQ2cGtb0rTxFpMNqVwPC5Dj6VmXK1RCjqDmHzlj8pnvsdupdW4IjgmlV5NMnktWx1AViB/Kse/thQG3veEZlgkB8O8Afmypw0Z5ceY659cVrvsbsk0viTjDh0y/u470zwqxHNhxnp9c1nn9q/Tje8eeznTBA6G8nMAmJyp57mNSvL6Zz961b0C9rLcOjDd81zEqW/+12nw4+Rx9poHsLvI9V9kHDRjbLWMc9i8fXw2WUyde+fF5vQkjtTyLb/AA0j/wBmnSBp3Ams8O3EExvND1ya0upHmBRbjncOiJj5eVEbOdy5rVvcQegrK/yCrZrncdGCsP1AP8wumf8A17fLP7zMvafoc+o8LXkcF89u5jK7bDGK8p+zrROJrDjOK+sOd1hl/vBkd/MV6r9vuppoPBNzMTglCo3wcnbalv8As76faXmiQvfWY8WRTICy9ab7Guup0drg9OkrcRwSPGahZC7uLG3kvSTN4YByc1I9pncr0ox7n2xj7V8a18hXIXXtY5c9TCBtowPCA3tM9qC8TTiy09z0+HPlmnI2u/y9KW+L7CC5sWgkXd1Ir1DlrQsh7Mjmea9Y4kmbXPd1kxzPsc1rvBGmI1oLllHORnNZ6PZ4bjiAyiInfIIHbNbLwjojWNoImJwg2Ga6ztrUCvTpXnwg6hgjE/TWmMgLVKa1O4VcUzz2g8qpS2xJ6etcmt2Y+rxaktSTjGfoKhktyFJHnk5o9La/4elVpbbmUjB37UZbscwytmcWhjeJC+xI2qxJCGtZAuebl2+1CreQxzrA+dtt/LNW9X1GOyZeQ7NtnPbvXYaewaikDzidrd0czPNdlkeVowNwcfehVtZvz+O/Y0yX1tDfXLXEPQsc4rmHS/HvIrWHBXP6Uu9RoXa3WO13bukv6Pp7Lb+Jy9atSROOwyM5o5HppihSLGCBuAKil0+QjoMGk2rYnkQvexbkDqd+g3rhHIYAg47UZm0l2PynJ/SoxocrEZB/LrXhUc5xPG4dTP1u4IB8x1FW13OM9Tv9a7i0eRACWNWhpbA/1zUip5XvB4GUpE5uV8Daq2q2JeJZ0PT0o7HprsMEZI2ruXTWktTGynan9ICvsmLWnPSVOHmWaEISMDapdXteVWUDfG1UtMjaxuREWIGds+VMF3bG6hUrjPQkd6ZtoNg3eUEtm04nnHVJOYtlsUm6sd29KZtRlyWJ6DO1K+oDnDZ61r6QbRMnVcxbuB8RJ89qhB3/AJVPefCarg43FaucTKYZ4llBkbAVag67Ej61UhOTjH0q1CQrVfHHEBZxCMAAG2+KJ2gAfr12NC7c9OmKKW+AOYfzoq4mVfCanYDbIPaiNl8w2xn1oXCxJGeporZAB68c4iLrxmNGlrnHTfrTZpiZHKNx2pV0obj4fKm/Sxhthn7UrbFaD/sjXpyZRSO2OlFJWypGKG6eQFwRtjcgdNqsGYEelYWoXJ4nedlvgTmTKk7feo3I5+uxrovnO+49apySkdT09aVwek7LSL5S3Ge/c1cUARgnf+lDIpAxI89queKFj5SwyPzr22aeyR3L5IwetVg4ICnz339ailmJzk53qLxR3/8AGvbMDMlU5l9mBAOd67hbBx64qkkxIwTnOwqS3m+ME4wO9e2QoQCGixEZwRiqLtzBt96/PcgRkDoexqt4wwd8kdKptMttwJ1GxViu24r8rAnHc7586rSTcrHfoa68Yk82TjtV9vjLAZhGNk8Pr8386rzZU8/3r48nLBzk+g2r5AWI+LcE7VU8CWInc1nLJFzKM8u236V3ptnLNIv7skZANMOgWfiusT45XHemvT+GYLfmm5Ad81hW9rCljWYYUcZEKcOR2EGnqkgUNjmAx3xQXiLiNLOJxCQNjjBr9qSXEEReAleXoR2pYuonvrwwunOsyk48vP8AWucvvfUtGKqlT2j0kNs8uo3bXswPhgfDv1NR3QErSu2d9sE+VTypJZJHaQ746jvVC8lC/AWwTgEHsTualf8AWuwSwHevuH6SFIhGEhTZc8xOdzR+0Aj2UdBjNA7H95OAw9Bmjkau8ykHbOOUV4+1xDWDHWE7cN8xY7j1rv8A6ZkfPy5+HB/pUMXheMAjZJ2I3o1bJC7KqLyMBnmPRQOpNFTYDiKN7PM5gt5FUytA8ijblJzzHy9B51ZTSfHk94urRA79idhUg1OEsEV15FXCDfJ/413Hdyq/7kIpPYg5pkWJ+VYIbx7Um/YzmLl5Uiz05RvUD6BpSkRzQC4kPzF/9O9Q397cqfhueUgdW6Chja00ALS6xliegP8ApR6+T0ngLD0MZrdNE0oYtLeBcDcFQN6rXWvSxuIbRFRGO5RcCgMutPcKGWXlHZipJNT2CatcyK3iYh/xjc0wbMcAy6afHtWfWPvDlxM6B5JSc05aShnnxv0pP0WIwooC4OKa9BuWF0fICraNWbUKW6RDWsvdtsiL7TtLMeoCXlG6gVjvtAtr1dFnlsWKOIzgg9TW3e0q9ae9Eajt5Vnuq20b2Eolj5hjoac11wq1BZPCcinPBnmf2KarJqnEdzp93FiWGb94WODnO21epY7cKqrjsK8vW9uNB9rTSWcfhC7+ZV6H1/OvUmkye+WME3cqBTfaTi9UuAxkCBoygKE9DEXRuGI9M9sF1f8AIqrrFkOXBwGeMnOfXDfoay7+0fZtP7bPZRp0UCLO98v7wyZwBcxnBT7Eg98+lb5xbo3iwW2swc63WlzLPGydSB1U+hGaxb2op+2v7W/s1to0WRbax98YqnxD52yx7jYY+9Oov4rS16odawVb4YOD9cQAPdu9X/Y5H6/2DD3C0R4U/tL8UcIW2fcuLdMbiJYmfA94wqtyD8R5kc/Q1sS2w7gVjP8AaU00aBxP7O/ajbWc5k0zV/2ZeTQk5S2k/eLnywyPg/4sVu6JFOq3EDh45AJEYbBlIyD+RpDXV9/pKL/EZQ/pyPofpC1ttdl/X7faebf7ULHUH0jhSJyGv7gAjGfhUZNNPs04bk4cn0yydQSLRVIHmd6BavZ/7cf2jINMliZrbRrPnbfKh3P+grR71jpvEtt4agqX5FGOnaq6FtgFR6HJk3r088Z+caWtAN+X0qI2vp1o0Yeb4sbsM1E0GO1c5ZpwpIkE5gdrTbYYzWfe0C+WwRgc5xgGtTkhCoSR0FefPbTrxtrtbZXySRt51bSaYG9cSp6gQ9wPbWupO1w8XxDYU8izjgXCKMUp+yqJm0mKV48FxzfnT/NBgbVPbTFnA8pCfmOYDmgHkKoSwjfpR2eAZORQ+aAntWGMiNI/EDTRA9qqyRddu9FZovixVZ4c52oy5jKNF3V9O54TPEeV13GO9IHE2rXksPhgt4kOds9R3rVdUVVtSDsSKyfXLSVryQINySB3Fdb2G2TtbpK2DcJBoOtwzWEr3Lcsw/CO9O3AOlSSRPqE6ks5yM4z6Vm2kaLdRXrtI/OC3NgjYVsnBkEnunMdlG2K0dc4aziVqJXiFWt/TcdxUZtu53JogU3yAa6EWT0260uo84wxg4WIbqv1rpdPUYJWisUOeoqc24Izy/8AGibYPd4QP7oOnLXSWh5sY2ombfG+KlSAeVeAzJzKcFkDg4BqSWzCLnl26HFEoIcYBFWHgDoVOMGj1Lg8SjGZdxPG9ldpLE5UHbFFeGtUS8cRzONuufSpOKbNTIYmTOO6n9azuLXJNP1VUAI3I61rphELRYjLYEx/UXIkb1/Sl+5fBbINH9at5YZd0JDfIw3DfSly+OAw3BHap0rBolqkPWAr44cj171VVqtTxNPkxnLA7L5/SqGSjEMCCD0NaQIJxM3HEuwNv3q9Cc9KGRtuKvQSZIJ29KIDFrBCdscY3x5bURhk6b9aEwyAEHfrV2KTcbmiiZtq5hm1YDb9KN2WSRjIx1pdt3zj02o9YNkjvVjzELRgRs0lgCMjypz01sqDjIA/OknSmAKj7dacdMfCjJyAM7UtcQBE9PnfgRmS4CKoAz2+1SeNzJkYHcY/lQkXIz5jOD6CpDeKYzliO+3esm1QZ2fZrHcJca65R82POqU1yBLjzqpPeYBPNuOvrVGa9DYIxkHzpXbg5nf6H2hD9rOMbE58qnkugq7Z3FAIL0cuM9a6mv8AsG6V4rnpNULiXpJyD12IPrURn3xkdaGy3oK8wbpUPvw2+LrUqPCQRg5hqK5AIyasx3A5jv13pcF4OYNk1cju8quGOTtVNuDCgZGYWmvd+XNQ++Z7/rVa4s7xEE/hsUJxnFTafp11eXkcCxn46g4HJkbhJHkZyuBjJxVmNZCoXB22p20/2W3V3GJCSF7UXi4AFtMhmUHkOD6ik7NZUnAMkHPSJdhpFzfQhVRsEYO3eimm6DdLGY7iA/CcAkVplnpunWMKqI02HlVPU54GDpbKvNjIx1rH1fagGVEMiM55i3bwHT41k7xnP2oonE6JFzMwKEbgVFJau9ms8wPI5KNt0oENDZ1aGIsyK2x7b1yGotNrkmaddakYMn1/itYbVxGuQwyD50P4Cvf2ktxfsd0kYLt8uR0rq54Wee28N2YI3wk826kGiXDWippdvc2gULIfjyBgMRvn71fTWqpyZ7UKndFVgybM+pPLgnqdq5n04Nes0ikocOc+YFFWshDfMpPwyAMp+tdmBZ0SRQTjZjjPoatZd1Mog24xA/uKwyGdF+UZq/BMqhSyYx8Rx22q+NPRxylt2AxtXEFgFguGYb8+PtQ1sLHAlywI5kVrcLGDPMQibkE9ftVy81ePTbfNwMtKgllBGCq9VT69z9vKuY9N8SSOaZMx26h+XszE/Cv3O59AarXejvqUgeXLeI/xlvxep+9OVlKwCep/aAbDtg9BObfXjKVkFqADsuTnbzqHVuJri2QrZlpJmBARRgk0Yi0UpMfDhVEUbd67sNAtRM91LF4jnp6CjLaCBiSDWDkiZ9PHxlrUijwpYUc7Bjgfl1o/pfCElqqtd3w8TYEH4m/0FODWwVliiiVR1P8ApXQ08FSQFWRzjIHSjCzAlm1RI2qMCV7O3tLdVxb/AC7c7/z3o/aiE8ojwSe9ApLKN5OQtIxXfbYZonZA2/72X4UHQUzRaMe1FLRu6GPGjWpkQDB3ohGW0u7VQuz0M4W1VZZVGAFz0NOV7pKahEk8IGV3rWGLqc1fmEyW/wBduLehmc8cAy3McvL82RmkjXR4emSnzUitR4x0xxahmT4k3rNOIrHUJrApa2M8nMcZEZC/mdv1rMvZ3fBHJmDqqhVacdJiF9w6t7xLa6kFOY+ZeYfpW0cEuz2LQFs+G21AeH+F5JvGNzNZxsvxqHuo2YfZCx/Sj/C0NnYam9q2qI3Pn4I4JCPzYKK0q99qPUfDkTPJAKnznz2oW+uSezziBOGw37SNhN7vynB5+U4wfOvGP9mD2i3L+2m21z2g6hfalINPfTbdnjM00bEjlVd9uhHev6CvbadJC0MhuZA4KkciKMH7mvInE3s99l/sX/tD8HXuhWOrgapcSySwvfp4UTu3LzAGMsRl+nMMVo9g3qLW0tg3B/DzIB4MBqvy94DjH8zZf7RujjXPY1q00d01uLB7fUSxyC0ccg51OPNGYU4cN3MY4G0y9WN4QunRnklzlCFxg59AKM8TaRba7w7qejPbB47y0kh5HPNzEqcfrisbteP30n+zjqfF99qbTz2qXCP48PK0cw28PlG+zDFRQDf2bdWvVGVsfHKn7SzD/avv4+eMfeA/7NH/AO1HHPG/G8igrLqD20JB5lKR/CCDWgcbxG21WKdPhKSg/bIoP/ZM4Vn4e9klhdXkbR3GqFruUFcYLkt/Wm32iWoP70r5EEVnhtt6hfA4h3bfaT+ny4jVaL4tnFIDnKCvrx4qDhiZbjRbdxk4QA/XFEXjxk4pXVJi1h74uDxgwNqmILKRzt8JryP7VWm1Xi+G3jJKGQD9a9U8a3gs9KlyRuK89z6E1/xTb3TKWUuG6VOjISzeZI49qavwDpos9LtYeXGIx/Km6aHPf9KGcOQhBHGOiqB0phmh26fpS2tr7w5lRgGApoe2CcelUJ4d8Y3o/NB12qjPb1lmj3QyGL88J7CqjR8p5umKNTw5oZqIEMBJ22q1enJbEZVjiKWv3ZDMiHpttSvd6eTaSalykFNxmmK8i95m5e5O9fNRtDcJDo8KgtL83pmt2snSoGHWFBgTg7Qxq1nPezqQxJK+op24YRYUe1KjmXPfc11p+lrolsloi4Veu1fHAsb9ZwSI5NjWtt3AN5wY4OYSdOUkEb19jCnscGrDxrKiyrg5G9QiMrsB/wCFCA28RjORJogPLIqyoDDONxVaPIqwpIO3eiAEyhnfhKdwK6VB1xUibjzrrkq209ZGZ9RcYOa6lYFGy3KMZrgsEU5oZqd/4UBVSMtsKMkqeYA1cLJLJ8WVGSP9KyPVLKefiDmjTmAc/DjrWu6lEP2dlY/3jmqWi8M293LHeSRYZOp9aaRifYlWwvMZ5f7JvBs5kl0TjF4pX3Mc37yMHywd6z/i3+xNxtePI2jXWmX0J3jnt5OSVR5FG2cffNaTot3qF7HjSuI1laMASc0R/dnzL/KcUy6PrPFdjOrRcQwTxLuTE2ACPPO35Vy636mpw6FvoZv2aaplKOB+08FccewT2ocAXjR8TcL30NozELdxwtJEy9jzLnl+hxSLd6ddRTNY6lAyTKAY58bMD0z6etf1lt/aNcS2pi1nTY7hVGGeIBlcHzG9BNY9nvsS9omnNpuqcM2duznP7pBE6Me4I3Faa9vXIwFoB+HB9efgZlN2LSQdhI+PI+H8eIn8pjHLBKUmjKlTircZ5GAHfcV7t4u/sC6Tq0Er8H8VKGIJhiugCV8l5h1Hr1rzbxn/AGePab7NnmsuKeErySyRyEvLdPFjx55XpW1pu29PcOfZPkePl4fpMPV9i3Vk7eR5j7/zMwjc8obtVyFiMHcA9PWrA4du4WMUscoRt45CuBnyPka5hhMMgs7xSEc5jkx8prYXUI59k5mDdpLU/MMS7av03o9YyDbG3nS3GktvKYZRhlOCKPWOTF8IJKbnHlRwwxmZF1ZBIIjfpUu4GfvTRZ3XINzvSXpUh/TvTDbTM+FRSSfLzoNx4iFSHvOIwG9BHMew8+9cG9PKW5z8Q3yKEh5QpXJx2zULzyRZL5286zHIHSdj2bWcgmEmundiBnGMGqkkkqsVfof5VxDdPaSpcSLmFjyt5AUYvtFuzaS3EY5lgAdCN+ZDWdbqFQjPjPoHZ1bbc4gmK+OOvTauJNQbrkYPrVO5SazJlYE28+CG8j5VWWGWVZYhklPjXA6iih1IzNF2OYSN4dirfCRneohdHmAznPSrNjoNxNbxScpbnk5QB6im7h/2UapfTLJMpVFfI+lDbUInJM91islpfSoJYoXKnqcdKa+EeFNQ1uZR4RCA55sVtOkezbT49KSOSNedRg+tSm303hi3ZYI1Vxkbbb1mWdqqFO3rCqGPAhDSeDdJbSktruFT8GDkDrX5eEtG0qX3mNEGO9AtP4lvrx2VX5R1A9KnvtUnmiZJHPKFxnyrCs1thzgw6acDho6Wmo24iCxBSPSqepvM3xBSQw2YDvSfoOrtAJLeSQuVwR51BqnHv7OcpcHAU5ANKPZk8mFWls4UQvrBv7XTpL3flAyMVnNlxi/7VQysQnPgnPStPj1my1zQ2liIdJkJGCMA46V5z4xmXTtWeOGRovjJBI2A7g0EqHOBGtKN+VcT0Kyz31k0NtIgjlXxEPqKH2N09tcJzJyt8vKejeY/Kkng/jqMWFsktwcxAdNyp8/pTpa3mj67MpS8ASfBABwx37HsQaWNO45lCWqyrDiS6hqIs52tW5HiY8yt0OD/AKVVubwRvHNDk4XLY7r3qG88drhdMuYkuJbaRvCnG3Ov8J+o2+tcFUiRL22fxbWQFCCcmNx8ynyOKVarDErCLtxzJo7lJ5YkcklGwrf4e35VYtZo4U8HAzHkP+dVbe2S3vBZqGkjuAZreQdAuMMp/nUsEJllWGMKGMbCVenMuKqynPM8ADwJdvSsFzAUf4XwR32rgXSKjkZyXIwe1C724mjt1ifIe0AIPmudjVzh1YrjUJLib4olBuGyNsAZx9zgfevKpztXxk93tQs3hDFyViW3tiBzR/FMP8bD+gwPzr7Gojt4uX4SxJ6UMs2upL24tbv4peZmJPc5z/Wr6FmXLZ5o3AIz2NestJOR08PhBirZxCEMGYZCZOZj69akizGzKAAQN6+oEjQxq2DtgVWCymeVycJkYPnV1sKYMHszmXGtoXlMznZVyNuhr7M0dpEJuX59l+tfI1Dx85z8W2Ks+AvhI0+AEY4JO2f60yljMcQLDHWVbuQwonhj94wy2RuKozzMLY3U3MFXfHQD6k7D70WaLxQUCczO3MWkGwHbb/Wkfj6aeWHklnPhp8KIOhNOoQq88mWoU2OF6Rr0LiC2xzR3KkjtH8Q/Pp+Wa0zhfiwyFbYkkeprz/wjb3PhB2Y8qgH6mtd4MtwZFlentG9otBTiT2jTSqnPM07XLOO+0xpYzhgvUda86e0GN438GZmc5Pzkt/OvREt2I9NYBtuWsK9olg9zMZ1XON/tmne1XRbUHj1nHvp3srNg8IG4FtQI3fHwnbFVtSP7J1qOXpl+XNHuELcRWOemaq8bWIaMXAXcYIPqKS0l+zUgnoeJj3DC/DmN9qwmhjlXcMOteRf7a2o/sTjbgjVoIwksEkrmTGxClGwfyr1ZwvcePpEJJBZRg151/tb8KjjLjDgbh25/dQXtzcQideqOYvh+xx+lPaCz8J2kjH/iSfkDB24dCp6HH1InovgzXbfifhbSuIrZlMd/axzgg7bivEHt5460iC/4g9lnCPEUl9b61xMs1zDETyxl2XxYsnY/Ge30869L/wBnLXNQi0jUPZpqsAM/Bvh2LSr0cb4/MYP3rx3/AGlOBL72c+3a/wBb0jQL2w0u7uYtRtLhoi8JmY5cq3yj48/CfOt/TIml7RspB9mweyf/AOWIYfSUpYugc5JXB/UcH6z+iXDmifsDh3S9JEPhC3tI0CZBxt6fSgfHdsHtSxHVapew3WdW4k9mukcQa1qHvd1exF3bwgnLv0AFHOMbbx7HA7gj9KxL0SjVMlZJUHgnrPVlsAv1kHAziTRUTO6HBpgZRj7UpezxitnNas393IevXem+Y8sTH0qNWM2kyTwSJmPtLvGIS1XfnYAigFjogSSK68MYwDVvjCZrrX44VOQGNMx08Q6TG4XfApcAqVAl24RR5z5w9/eqMYHemmSLIz2pX0MkTr23pxKfAPPFFuTPWUPWCpoObOKoywgdh6Uaki36VTmjFLGjxll4gGeEk9KVuIJgMRggYp1vVEUbufKs/wBYfxZWyTk7UzRQB7RjNfMGW0Y/eTOM8gzRLhfTDc3kmqzIMZ+EYqCO2Myx2sWeZj8QFOVlZJZ2qQoMADf61babXz4CF8YO1e3HJ4ijGetBpk8W3ZCAWTemq8jEkJBpaZeSUhj12rVoG5dplj0zJ9JufGg5HAyNqulATjY+VA7OT3S+aPm+Fv1pgTJAPn0xUsvMushVOVgSOtTLjrXYjHavqrirAT0ljHapcDuKjQDrX2WVY0ZyelTgESMSjfThW5Ac49aWbu694vggA5U361f1K75Y5JCT0OKXoZmZi2N2NeU7RmSFOIcs4jfyFQvwrt9aZNOsVs42hIG+/SqXDdkEVWZfvR67jCqHQAYo1Jx7Uo3PEy7k4lvrWO81LV9QhtmXnAnkEcS+QCjGT6D86JQ6m8UHPbTC7jtwFkmlZxGCRsoHc/SkloNU1O8hgv70z3MuORGfIiB/E/8ACMb4/M9q0P8AauicKSWui2nialdwKFgs7XA5Xb5priRvhQt15RkgYHpXOjTls4OJ19loQAYz7hLNhY6/Oh1O7itNLtgoZZbx2T4exCDBxTFomq6NdviTX1uvC6yWNrIFX6ux3oLfX4uljuL7SPeJGPMgNzyR+peSQZPoFFTnRbm6hjm1XiOPS7TYrEkXhod+isd2+wFebTbTgc+v0i/fixfb4+Hon9o+6frpjnHuutahN4ZyFMZO3ptTHae1FDcHTNXhS6iIAdHTfB81YVlkHDGoEBdCv9QKNuHt5ssw8yGxgfapJNL1azEaXvFNzDInwqtwnO2fLON6XdLFGFGPXvlVWlj+b+fpNE4n9lPsV9oMLe86LbWssyjEkA8Ng3ntWF8df2JJWglfhLVo723ALKkh5ZAd8FT51oCa80McUE+uK7g7GMhOfHnzUZ0zje7gm93AY4GcKTz49MZBqBfZS2aiVPu6fLpKvpQ6bXAYe8TxvqvsO4v0iF4OIdHlivLJsLJ4ZxNF6+ZHmKEabwjc2ty3iRP4LqVIx0/1r+h1jxhomsKtjrOni5yNvFiGR+dC9S9lPs4166d9PUW0xJbwyByk/etOrtjWqpGAwPlxj9PrMW7sHRWMDypHn4+un9zxVa8D3Lwq1uxLDyHWmvRvZxqs6xTQwtlfmBHzDzFenj7E7Wyw9pE0q82eZUVh+QNW4tAg0sCMW6Bl2wRyMfs2P0od3+RapF2suICn/EdGXDq2Zhl57IJbjTfeIFKyhRtik6b2bao5eCaAh91BxtntXqYT28JMEsRQjYhhg/kapy2WnPzMEXmNYw7cuGRmdMnY2nQhtv8Ac876D7Pbi4t5NL1O2wAeXmI/WnfhX2fvFay6bekvyoYeY9x2z9tq0xbXTxHI/IocDPTyqgNVtrWY4APMMnekNT2q9nU9ZpU6YIMIOkyX/wDC03SXGkSwfBztyHGB6Va0f2LNG6+8qcR8yEkfhPStctNTsbj4QqKxzv3zRi3urd7dWJViNmHnTNXalhX80iyrB5Ez+z9mujWKxL4S5Ug4x3Hejl3bDT+VbWNcbDamK505ZZR4R/vBlcn0pY1ma40ySMyk8r7fcCq2ayxvzGerrVjx1l2zmvZoU5VIG4IoZrWmQXAHjDd85zV3TOILOCOOdyApIU58zVrVoLa/5nt7hQoORvtmvCzIzIIKNg8RS/2fFtaNdWTh3Q4x6VUeBrUc9wQ6z7FemMiurtr+zWSCCZmLczcvcEDpS5FxD+0rUC5Z4yxbnB6jlONqG1pI4jaIeueJdja3F61ikgWTk5gc52AoZxbw5LqoMHMFklh/dn/EBnFU+DLa71biFr6OYMis0LAjbB+U006nLHPr9tbKrMVUSEN2YbH9aCSwbMZ4rYKsVfZ3d6joYj0i/jm8KZ2RyRnkcDJFJvtd0u6sLs6hAviJyF3B3V164+uK2u3Nrb6m9peRFJ7qPxYSy4HiJ1GD3KmqXEPBw4l4emKQ+PMjKsQGMOpBAG9XSzawsPjBhx3pPTM81WHEcOn3sU0UrG2ZeflU83hg439V7HyrXrG6057a21HTrtYbe62SQnKxynof8uds1ko4Fu+HtX5bppYLET+FNk5eykzs234cfpW0cKcDQ32n3Ol3VtHBOsbsvhsVhlznEiDouTsw6DINM6gV8MktYTjLQxw1ezalK0GoxKt1C5SU82RzKdiD59P086bbixtbqIo6yILqPMsa/AVderg9j39aA8D8MTQSiK8jeS45FhuEOztyD4ZB5OowD5jHam4QNBNGom54pUZJVx8RBPXB/nSbYycRN29rjwgXStPHNZQCUORM4jdRnn26jy6bj60VXTgXUSxcklsTGSO6EjIP0NWJtLl0i+V7Zle2uLiOZGDAeG4IVvzBGR60a1C3h1Ex36ry++RlZ/D6FlGM/XYVHdZXPlKG7DZ8ItzaD78rocAvIYQ3bI7ffriotA0JrNLq2duVr1jHEWHURjmP5sVH+7TTe2/u1vpeqWj88Uq4lQDbIx8XoRXzUYVnmtHgPNc2ZVMY2Yn4/ts2/wBKgUBck9enz/rMn8QzAKOn8f3iCH04yXFteyKqOIgsmO5XFfJ7AwS3Ky7tyiVSBTE6JdRJCiktDK+eUfDtjf8AOoWhSYFpd2kXw1AOfi7j6UFqsDiWW4nrALZeS3mRfhxjI6H61Ys1NwpXGTzkAY3NEP2eYtOY8uDDjc7DB864tLYoUeIYVoyxY9Sf9KDsK+00uXBGFkaKsPhxtgt5dQD/AFqa6ieSNU5sn5iT2HlX6GNZZssu6oWGe5qbJbAI+YYBoitn4QLDmcqqxRFsks64xSXrmkjULhuZeYJuB6mnabkRHdTkgbelURZ45GdSNuZs9803U+OTPIShyICs7A2MCxhR8WCcdqedAukgVFGB2pav8/CYk6nYAVJZXcsBLOD8IpxNYKTmRZWblmk3mpc9mIUbtSZxAkLwN44zgHrVE8R3TOIwpxnFWtXgur3TuZB8RHTuTS1upbW3hhF7NN3GnYYg7QgggYRjbNfuI4BLpzNjJSvui2c9nAYp1wwq3fRiW0ljx1U152ats+U4W1CGwYE4Au2ktJbY9Y3OR96zT+0eYrXifgDU+c+JDrsaBM9Q6MDT5wazW2tXNux2fcUg/wBqFVY8ISRriePXrUo/8O5z+lbdjZ11Tjo2PqImT/qPu+xhG6mX2ef2gtMu7WXwdO4+sua+DnEYmt0C831Ksn5U3f2h9MXU/YrxhbNbrK66XNIoZc4dF5gR6ggYod7beHbnW/ZiNX06CN9T0DwtSt3bYiNCPGUHtmLmFNvv2mcd+zf9oW4E1jrekMQA2cq8ZU79/rTvejUdm1XjlqW2H4dUP7r+khT3WoKnoTn68/Xn9Yp/2Z9RGp+xnQJPDK+DF4R32bB6jFaBrsRexbAyRv0rE/7FN5eTeyA2VxJzxWF/Lb2753ZBjOfvn863i9j8S2kXHVdq92qQuvsI8Tn58yFUqNp8IkcFyNDrNzbMcc2Djp0z/wAKcdRbwrR2yBtSVpoFpxOhIxz5Gf8An6U18TTrb6dIzH8JqdUCdre6EYZbHnModBf8TZJyA+K0nULTk0eMKOi0i8LW3vWs+MFOGfP61qN9biSyMeDstLgHefdCW/mAHhETS5PDuuUgbGnqL44lI7is+YNbX5XtzbZp70yYT2aEGnGTMhl5zOnTrVOaPfeiEgx36+VVZRt9PtUCvzlgMRZ4im8KAxrjcdKQ7hBNcAEbd6a+IrkPMyhunr3oBaW5mlJ68xxRWXasZVdq5lzQ7DMhuXXoNtqPH0PWura0EFuoA3IzX51I3JqFr28SVHjIJMbg9cdKXtTh5GblHU5FMMuTjOPOhWqQgx+Iucij1+wQ0IBniLl7GGjWdPmjxnFGdJvEuYVKsDgb0KkYJzIw2cVW0i590v2t3GzE4px1B5HjLgY6xyUA+oNSeEDv5VHAQwBHQ1aAFBXpLESIJ1xQ3VrgInhA4Jos55cnOKVdUui9yzc2y71VjiSBmB9an2WBGY+eKj0i1Mky9Sg657GqlzO1xcFubvj7UxaDbBVXPU71B5wJLDjEa9LjEMIwMHtV6TlkiK4+lVIGCoBUvinGAcdqKrQW2eftCNxaMdb1a68IMPGigT5m/hcj6/KD5Z8qZuHQxBniWLT1nJW2e4Y82D80gAHNIx8wO/zd6UWvJrSOOXkWW6kkAjjK5CbDBI7ncURskvmDzTXkhupxh7gseZVHUA9h16eprHWzHWdbbUWBM0ePUNJ4fRpLHTZNa1eVCI57whVB6EknZUB/kfLNS2Wo3KoNf1rU7QXDYEcyR83OT+GEEFuXO3MB26ilPT3V5I4p7YfEvjtzL0hUfAgU9PPJ2GR3NF7z3lreC7u+eTUNRPiJBGpZ5VGyjzCL2GwJ7Yo//wCTpM9k2nBkur683K1pHqd/c3Dnn5pZeSJM9MICWbPYsWzRHh+LUNWdLW+uLy9tV2aG4t1MLH+EeJk/UjFftH0Rbd0sFs/edbu/3kuACsIPUu3oPz7bU2xRppUDQ+9JE3LytK+OZiew8h38z9KqaT4mUa9VG1RIrCw4X0mOVJNB93WMZaS2YLHgfwh8/pjPlVrSo9FvpTJojWcTYyqy5SXPqd0J+jflQo6dpMTIrq17eTfE7TNzHHYsM4VfIbn0qeSO+jBFxf21uqL4fvDAKkKnoFTz+pz6DpS71hDkgSVsLeJhnVbzUtNjiguYbhzI2I2kVVz9D3oeOL5bW5C363QWPvHIrcp88A1U0yw0jSnlVdb1e/muVzIsuGix/wByRyAepGaFnTvZvrF46Q8NXCSxHElxZzlYlb/ui2PrgrS7ozng49ef/kZqdF/MMjzmgaZ7VGtJAy3rPbscBs7j6inbTuO9P1U+HdQQzxOm3ONjWGi1srGSaTRNH0zVRApE3upLvEuOskR+MfXlI9apQ+0L9nWQMlmi2yE5aEhuX6YO2PKlmssqO1+fjDfh0tGap6CubHR72E+5TC3Un+5l+NPsD0+2KBajwXdypJJplyqELnlZ8oT5Buq/fI9aQeFuO11SMxe/xXMIwUkQ4dPRhTCvGt1o92sJlBhlPn+dI3V0WNllxCKdRScA5ibr+ra5oE5t9Vs57Zn2+IHBHmD0I9RS1FxFdXE04UHnjAJUnqp7it0u9U0LiuzfTdRtophjKqezY6qeqk+Y28wazK84EhstRmvLHEtpGDkEYkjU9VkHl0IYbH0O1Zup0gq9pTkTU0mvRwVdcN9JX0W/uZpEkBJQkHbyP/Gmy1nMUa2zyENIpIJ7n/WlnT0W1iyMjwjyOezqTkGic94nxKzkujKyN6d/0pBMq3ELa/eHAjnZ6iXWO3ckyJGCp8waF8QeBdB45m2wqqc9GJ3oDpWqXDXQkdnYJF8OD1Aq1qNxDNcwgEuOrJnrncGnms3piJrXssirq8UsMkEMTsqSk4H+Ne1BtL46FnrLaFdy5Z+Z4+Y9x1FNut24flZWPigs8W2zPg/DWGcSySRa+mruUR7ZmPr1AOfzo2nGTjM0kAvQgibnFqNrq1uWacRtzqM4w2cbH6E5pW4usF/2hU6fFm3XTJp2UDA8bBYA4oVwxr082lrfvb4gEqWrFtzzqOcH9CPvTJqeoxnTRcxrzGZn+IDBMTrsR6Y/lTe3EzcNXZgTngJl0+9lto0xF4S8zlf+1CKSfTcmj8KWWqcRXF6luSFIh3GFVS2SM+e29VdEsHHDUVzHEA11aGdnO7cxO39fyoToV3q1teX14WKWzXy2z7Z2BU//AKx/Kl7cbiIWsGwlgYy8QQnWLqyNqvh3BiZ4ip+JW5SAd+vn9M0T4FuH1Dhy6eZD4kDbqUwykHckeYOenlS3puoyx8Ranp12ymWwuY57Zuzwsd8eex6U4cGeAmrTzwBhazSeBPGg3UqDhgO3Mo6eanzqqMScGVvTYnHh/wCzPvaNp1mJP2k1oq3aQCK4VVGXjfcEjuQdwf8AjQHhTUb+NWiiu3QQKMkdIvKQD+HpzDyJp79sOnRQ38slwHXmspTFLGpAeJCGT6kfGMfSs34YWW4nh1K1lSX3cNHeRhs+LEQdwo6nGdvI+lWOVyDHKMWUbprejwzz3aXkkTQXdsQkka5BAGDkHoVGdvQ0cnFpqFxEGURy+I3L4fTnG+QP8Xl51WW0McUd5YyRsq28c8EhY4khbA5c/iBDDB9M1LrMduosb21ByhheYt869id+/n61DK6L7UztyO2Vkz3YS1u7W5HjEj3q3YoCCYwGwR57Gr10s8E0rW3wwTyHEabgPgOGH+dT+ZpW1C9ZoWCZd4hIM8uObAww+4bP50Z07U1urGPxHPiPCjRk9CBuvTyyB9qhLsqc+vWJD04wYQVZZfdbOMYilkdWQjHKHw4PpvkYqOB1jvLm7bm+OWOUHGPhbIH2AxVqOWT3szSFQ/hSXGf4eWMnP5jNV4VnmsgA3M7QBQSuF+EfCTRt2a8+OT9P/YADDevXhJtOX3ezaRubmZWcgH8bSD4f5GuLoLcMJLZgqRkzjbAGRvvXaR5t5gCQiRgIMdXA6/r+oqCzmeOyitnTmbwPjA8z0WhH2hg8CFUYJI6y5b2wuNNELluWTDOfTtgH7V8FrJGCkoHUBfUZ6V2L4K0viPkhQBj8I6E/nsPoasRxiX4C5XIGe5yOgAqrbW6T3IlGW08G7lLH4sFVz51C8UoUMF+EjbHlRO8VpZOaJMMRynO5HqT0FfikCx+FzDPIFz/CP6UPuwekncQILCsYmdxhcgflXJ57uJp2wkS7ZzucdhVu4jGAAP3a5xnufOqFxzzYhQnlUYCjYn7dqkNt4MsBunLGCXlETqCo75OP0qqyxt8HioN9yQ25/Kroto7cgSuFAGTio7gKcGKLHl50N8sOZdMA4E7tNMgVOeSWFj/vf/8ANFrN1U/E8TL23P8ApQ5JAkYRuuKnimfwwAux6V5GCHInnBbrDLWNrcoSoHN1yKB31o9uxVl2ozYF1wWJ+lTanaieDnC4+1Os/fLk9ZznaehDLvTrMqiQ6bxAJ3PKhbGKzj+1NczrZcNeBgodZtST5DmzmtY4r0prqMtBlZF7jqKwT246zNd3XDmh3WTMNSt3Hryk5P5VvdlivtChDn/ZSeR5rOQvU1hl8CPuJ6W06CHVOH47K6XniurUwSg9CrqVI/I1mf8AZk1MTcJapwXHLLLBwnqcukQrcAeIsauygMB2yDWk6I//AOS7VRt+6FZzwJpUXD3t747tjexwftu3tdUt7dX5RIjrh25e7eKjb+vrVexHF6arTH/khYfFCD+xP6Qeo4YOPPHz9CIf9i6/iWTjzh+1ikitrDW5vBR3zygyyKFx6BRXpqReeJl7EGvMH9mKS5Pth9qMgijtoLjWbstAMKQ63Ljp9AT9TXqMYx169Ka7XYrqUZv+SIfoPnCnBd/iZmeqO2ncRQuo+EuMj9KL8camV0pPDI+MAdaEcewSQ3QvYgFMJ5s5xtSvf8QfttYYIXLmM5YfXpR7QTUth6QqjNi/CN3s9s/Ek8f8P0rQJF5kZTjcUvcFWAtNOD8uC3nTExpSlgef1kZ3MWiBxHa+BeiYDG9GuGbvmi8FjUvElgLiItjpvS9o92bS6UOx2OMGtQcrmXIyI7SD/hQ3U5xBAzedEQ/iRh17jNLPE93yp4StgnarqkuozFLUJGnlbIO5zV7RLHnlBZcBdjVFFMkoXG/b0pv0mxFva82PiYVYjc3whm8p9lTAx5VTmXBxiiEwwCapTjO5qdskSjJtkg1UnUSKVPcVamAHeqkrAeua8B5QoWK9+hiLr2BzjHagl9IySLdLuVO5zTHrcXx+KuSDsaV7hmAeBj16HP5UWtsrtMIR4x60K8W7tUYHtRlW5R9aQ+E9ReJjbucgHam6W7Crtt3qrkDme254nzUbpYIHOcZ2BpI1S85Y3YDLSHberXEmuIX8FZdgeoNLazm7m52YmMbDJpcvuMMiEDMu6fB4jhnHenLSUUKDjYUu2KDChep6YpkgYwxAdDioLY4EjGYS8YKNjXwXJHXah5usbjpVd7wHo1eD4ntmZjWmxh3tzI/xvI2SewJ6/XbFMdqxm8eeGFSFHhWwY/CWJ5edv8I6/b1pOtLlrd3kIPwghTnqx2otba015JHayStBZxNzzcm2UQE4/kKy6xmdXfk9I9WNpHHLHFGyO8zIZp5RlmA+XI7IPnIPptRlNVGp3q/7MN4HvLG1j1K6HxuE2Zo0/hG4HYk5JrM9N127vA12yvFbDcKd3k5mAA+p/QUWtpNXmuV0LTnX32+ULd3sj4W1th8yoOwxsOm+TWlW/QLMi6rByx5jlNxLNDqD8LcAxGaeXL6pq9xIBHGg/CD+I9zjbz7CiIuE0/wWjafU9TuR4dvnPKB3kbO0aAfiO52xk7UDkuNC4b09YppEED5ZFzs6ocAkdSgPRfxMeneiv+0VtpdpFJqK+G9w4a1thvLI38UgHQZ2A9O9GCRNm/6iMSRWeiWxu7y4hkupCHY7hQe22SfoPuarxC2Wb3rUJv2hdg+NHbuvLDar/GwHf6nJ9KDxrFJE1/qErOLc8wSQ8qGUndm88HYDf71+Iu9Wj+IeHbu2IreNOVnP8UjfXoKVuGOBJQZ6mMU08OpwSLqZEFqRvyyCPxT9Bv8AzoebnSdGtmFlbQ4x+EZC56fD6+dfILC3kmjt7aNXuEATqDy47k9BjrXFxFpsE8qWV0re77TT4yiN+LB/G/8Az6VnWnPQRqvAOCYB1G5WGcTuDHd/OotY8zIex5xsh+9VJtXXWnNvr+irqS4Ie7S6WDUI/wDM4Xw5evSQE+TCqOtx61xIDa6BdNbQtk+GwxHP6lx8lUV4YbSohacQTPqJxsjDCR7fKpUfF9Tk0obAgwD+nWadag4z193hDI4B4ms2Gr8BXQ1q2VQZLY/ur+3H+KHJ5wP4o2YUQTUbnV4YFmZ4bkHeNzy/F3ANB+HL+bSrxJopGuIoieRY2IngH55bH5itDfXtJ1+ILxJZtOJAAt7EFW6Q9mYn4Zh/nw3+IUjdZXZx+U/T+v1+cZzYpy3tfv8A39JFol3d6fMlteSsebLROT8w/hPrRC61u5stRhfxss2RFKCN+zKR326g7GqGowyWWni7iuV1LTIwEF/B/wBi4+UTIfihY9Pi2PZjSZrPFCrJChJKBiwb+Fx1H32rPsSxTtbg+uRLIBadw6Rtvp4LyaS50cqsiK4uLJTnmA38SEdSB+JOqjcZXoHfXklAwWHMmRlth2P1pH/2glS7W+tLqWKVg9xE6vhopB3HkQRmivv41zTzrWm26e/2Lh9StoxyrJC/zXUSdhvl0Hy7svwkhbfh94yBz69f1GgO6xu6Rs0bVJmhke0mBe0Krj6vg/bGKKWGpxT3tzdzRjEXOFGdub5SPtSpbRyaXdGXxFEV2Y+Uj+Dm+b7ZNMUcTTWkJgiCtb300d3GNudhJjP3G/rXhUSIOxlU/GEbyG5uNPRjIRIjM2V3+EdceXbesZ4u01vf7tJZhlgIWB2wxkVSc+g3+9bVBGy6K0LZjk8EgyH+AuD+YBpL4z4afU4LiaCNo7hlkklCnoUlXxB91DMPpV0/1sDC6a0DIPSZroutppPDtxYzSO80V+skak9XTmVznvkHH3FarwFFBxDptlNduzT6UP3kYOzwyF0DEHsOYf8AIrKuJeFpbfStZu1LZ0/VIYQqZI5XmjyR9sD704+zLjCLQtX0y01F43zc3GlXW3/YF2IP1GWb/drQXFuGPiYPVJ7B7rr1m3w6X4unWEMQ8P3eSISqjbsrSOjflg0maVFJbxfsu5eTmuL65ZcAEuYpSrH6jbb60+6bdyRCWGaP99bz+A6g8ueQEE/fnVvXNJ+qWFzCkN/HE5m0fULt2UdVi543O/4iXLg/5/pS11aoYlpLGbIPrr94sapqkNrxAl6shM1p0LHKmM/hPmQozj0pw4F4jtryeLVLVy1t+0v2ffoDvGZF54nXsMnOPUEd6zeLVYdR1HiDSdRKo2l3yWgfmDeIhU+Dv54518zyAUp+zPi5OFPaBfcL3ryfs/XfEsmUk+GHQq0TAnuHIAPqahNOTnzHMfsAdMePr0J6R9q+kT6joTcjMJYwwDA5ENwnXb+Fxg15p4Q1G60niiGbT7j3ZXnF1biY7RNuHjbbdQ4YH03r1bo15FxVookkl5J5gYJSY/lmj3JI7kHOR5fWvOntA4dtOHOKL23vIWghgn8YSRkN4SyYZXzjBHMrDyPQ4ySIydxHnLdnuNjVHqJ6j4I/Zep6JZywQmKNGkEESnKwAkmSAg5A5WLAeQfbbFS3PDb+5zFyrSRMwBK5JjOeU+uQv5jNZ37LOIZIdKkspbgNNbTBXxlRNgMkcuNjzbNEwO4ZFzWy2mo203isvK5JAKAY+AjIP/8As/Wn6imor2v4fxMLVK+muJWYvxRZXukIpBYN/eSbk/GV5vyK/wBKF8PazM1rZRnYh1UAnflxj+la1xdoEdwJYrmMeHcxwc2X33Rht6fBg/UViq6dPolwYGDHw5WYty4C7tJt5jlK1iais0FkPnNvR2rqUGes0/TryOWyunz8Udq5B7hSVUD/AOb9KsaPycgRsswnDbnYAAj+p/KlLRtZ8O3ukK83OqRDJ2GCCf5D86ZNBuFYSeGA3LhQR0JHzH6Z2+1ErsztHrrF7qNgaGoZ1GnvMImIKgKCfIkZ+p3P2oT4JhuppEB5G+PONmP4QPqc/qaOM0c6eFCzIMgB/Id29Nts+VUbyONpFWIgQRIVQdC52HMB/wA5p2+slBjoP38fX8xOlhk++UIUW6kWKHlysgEjDBDyDfH+VQfzo5pvOwkneRVgViObG7bfmfU0FgBmC28KFYVYcxUY8Q9eX6dc+govayNchrK1MLCIkTTfgRv4R/E36D16Vn1jJjdkml93Q8yoxifdE5TzOfP6VwljcznEkAjkbcL/AADzY9B/Or9vELZgsUhmuW+EuQGbPkB0z+WKse4TcjQ3U7xK2T4SMcsT15m6k/kPrTArJ5xF94EC3K2sOBJKz422/oP6mq72dsm8EEjyMMgYwAPOj50x7cqngooPRTscds1Hcv7qGV5IouY7nqzfQda8a/FuJIf/AK8wH+ynkXxXwue53xVN7ZhJhVZiO56UdLSzIPCDIB3cb/8AjXM2nOwAcfEwyIwcBR5n1qpQN0lhZg8wJPaiI45wXPWpIIOTDk5ANEJtG5SZGUZxgCuBDHAg5yWPYY2FUNRBhO8yOJLaSKr5dxt0Ao5EI57cgYzil+KEbyhcD1FEdPmPOBz7eVGqJU8+MBaocYgLW9OaJnfkyN+vevDv9qHjG90bjrSTFYEG0kEwkxswz0+te/8AXYGkgLAZ2zXmb2xcF6Tr/EOmLqFkknLdAjK+YrU7EsGj7RU4yCD+047tXTbFYiaH7M+Jm4m4UsNTKlTJAhwevTNBOJZLfQfb3wDxExghi1exv9I1GWZMqbeJo5QAT8r4kfB/0pl4V0y10fRoLO1QKqrjHQfSl32ypcJw7o2t2+oQ2P7F4i069nnlTnAt/E5ZUwN/iDKtB7E1y/8A12t2GFZipHufK/eYt6E1EA84z8uZjX9nnWXuP7RPH63V9G9xPq+pZeM5SbluXGVxtgDH5V668QhSQelfz5/sz8SQj233uuWUDRafqWoXPhxyOHkj8ZpJI1J2yQoAJxjNe/VlBQHm2Izmtn/KAKPw5B/44+X9S+P9rCYP/aS4sm4b4dmuoJiknyjY75P+lAfYXqcfFEMEyM0gGPEY9zVz+1SLW64VurchWbGQMZ3qj/ZY0ybTtFjhZNnIIPnRKNZW3ZWLPPiFtXYoYcGem7OFLa3SFOgFTbHrUKtgAdcV0G64NZNOoGZ4LgTi7hE0LKR2pH1aye3nMiKdvKn3OetAtfsS0TSRjtW1pbgw2k9YRYN0jia3W3NtcvyuBtmg2q3S3szujBl7b1nPtI1q80GFruGTkKHJ8xQbgr2lDV51gdmJYgHNaKoyr7Xzl1Gw8zX9E05pp+dkOAc03FQkYVewqnw9FHJYrOCOYirsox1FeXiWB3cylOPKqM4ODkiiMozmh84xkedXHuhVg+bBHr5UPnzuBtRGcHfAxQ6frv2qjcQywXqUYmhYYGRuKTNS5owXIzy7Hzp2n64pW1a3Hisrr8D/AMqEH2nMMBniDbG5aGaOdCQO4zTHf62ItPMiNlsY60nSXJ04vHMMjfYmgDcRyvctDLLyxdOufoKl0LjaJAIDZMJXeoPNOZHYkE7CvsGoYYIPrQ1pYpctE4znYVNYxSPKB0JPSk2zWOesb4fpHHR7x2Ic5wPOjTalkEdqBWi+DCB026VK829Lm4sZPdiEJL/IOM/Sq/vhzs1UzN1PN6Vwzb9T+dWFh8ZYIJml6HQMowM7n0/0qhLqEtlYSxRgFpCVyT1HUk/kBiiF2/ibqBj1O1B7myWZgoHMcjrVkXibrcdYZ0i4unsrJrmXL3EpaKJTnJTpnyUbk+Zpms9ctrCe6e4uOTxY8OkRy7E9Sx7bDAA7nJpBGsvah0sVbMMDQRN36b8o7DJr9w9Z3Wr2/wCzI5PChV+WWZmwCDvIxbsNsff1ppAQciJWrnrH/hjVLrWb9uINRtB4VqBMEbdQi/3Nug6LuQzHr96btCsbvWtUk4gvGklZHPNIEGWONxFnZRnbm3+vahemW1pHYrKyk2iFUgjI5TOF+Y47A+Z7Udn4hgs9NFzfpFbRk4jgXbKjpkeQ8sfXyoxOFmbYdxwsN3N5DDNbclvBPKmWgtw2Yk2+Yt3x3b8qmiuIZue61HUiyuSXmzyoAPwRDoF9eprNjr1rqniXsa3TQBsLGr8glx5t2X6da4stJ17ibUop9euJI9MQg21jDnkOO7HuB19aSsPOWhFqA6Rxl12TXZJtJ0KcWemWxze3MWQWH/ow/c464zVWe8W/YafdaeP2TCo8OHcSPjoxI6D0P3qXVNRl0GyTTdH0t3QkAER/FKx/EcfKKgZLq4tjFc26XMsg5mjcGM/Zh09M1m2WA/ljtaY6w4hDoW0zUII4UQh0fAOfIMOw8qpxwWk0RgfxGkHx+IN1/wCH6UmapEZJImW31DRUhOFWRS8TeeOXf7nrRWDiS5lsoktHhvnjXlSWJwGI9RsdvKs+4blyPX6xqtCDxGH9m2ZtluzGlyYSHEikJIp77jcj60NvtQ/cM0dzkRnl+o8jQ8cSiPEyoEbdZlPQHG4INAZNajjll2ISRSJEYE4XOxHnWeUZjH61J6w1qHF2saHeQ6voV9LbSleUSRH5k7qykEOvYqwIIO4r9cPw77Q4RHbXVjwxrwQmSCRvC0u8JPLzRuc+5yZIOGzCfOOlOTU42aTTZkR5BIHR1YfGNunrjp51d022jtuKrSF51a2vbUrG+AVaQggAjybOCKe057te7cZHl/HkfRBlrUAXvF4bz/nzHoQZZaRxHpmo6nomraTeWuq6Q7NcWcyFXCnZwR5EbgjIIIIzT5oml/s7SLW+0u6zLPZyR212rcrRzRMXjJPZsEKR0I9CRTvwld2upXiaDxPZteQ2lqptpCQbyyt5DyNHGxOZIg43hY4GQUKnrUThbUOFhPpeout1pkkrvZalEQ0MinZZPMMhblkQgMAQSOhJbaOO8Tp+x9/2PT9gk2t3nu34P7/D+P36yfVra11vRdI1ywgjgEMlsb+zUY93S4Xcrj8HMSMdiCPLPxrvNsJy/JLGIWZSNzIrgM2MbEBv61Q4R1aexsrmzSIXF3o6PJJZPu1zZO+Hh9QCMqeoOAO1fOLfedG0Ky4ztdQOpabO6KzMFDXESPhHfHSTw28KQd2UN0NBdQx3LK1khhWf0/iFNV1OKydZgpaC2nkt5+boGDjl+xB/MGmaDQV1WBtTsHDtLlvDByHdQQyEdiw29ayPiPXJdOn1xXInilaOdMr/AHiqQGYY/wABQ7+daN7NeIRLPfWsBIhE5urblbIeKRQxI/xKxbbuCfKgVIGYBvGGuDLVvWI3E+kfsvhi8miVzBcraygv2y0a5b1BjA37k1ieja9fadxqIAiNKbhfDEzYV5lIZASegYqyZ/8AWGvYWt8N22r6dqfDaIhHhvLbqGxk8rGSPfqFkAcD1PlXl72xcET6de32sWVsqfs42886hDiTnRWIB7hUD5HoaZ067G2P0MYo1S3IR4/aek+BNX/bdvcRT8iXd1bzQj3gFXSSF+X4h1BCRrzd+9EeLkS54WuHtmW3l3Lj8Xhycjnf+IAj+fasT9gPGrawtrHfSZ1PTrpbV3Y5FyifAjsTvzNA4ic9ysRPU1s+vanYPpIkeEhZGiQgDm5GEhDEn/Izr/uCq6n2GIJ9dYilZWwYExTTITo/th440jU4FOnzyxqwOByYkDxTqe2wbBH8JHekviXSpdM1sahqUNx4Mmqm3IjUc8HOhZWX1JUEdjgjO9alb6fd617R+I7S6iEAg0OMDIyvNFciRAT9JJBk91pM173q+tJuDtQv8ara3i20My/LMvM6RlsbbeLGc9jv3q1bAsG9w+U0MnBHjNW9mnE95pbiK9kBE0sQuCjEBZ3HLHLjO6yE8pPYsme9W/anptjqWlz6lDGZLg2CSwsYx8aJIpMbj+IczDHXrWbcGadccR6DFeeK1tcJG1lfxOSTHHKDyORtkR3CcrZ7MKZI+Kr65s7rQdVldrlYGjjlU5OWVHXcfxBW3z8wNBtQAYHUQVQIu3qfjBvs64hfS9YW0u5CLSaFRFK5+J4ZYwU+L0KsP9zzr0xDIGht7iORlZoIbecA55JVPw7+vLjNeW9CjhvbzSLS9xbSFfc+byRmaW2f7N46Z/8AVnzrefZ3r3vNrELxy8c9uIGRtsSodjnsfhP3zQabCLCh8ekt2pUHAtTqOvr9M/KaneWA1SztrjlC+BEWcKOq55wfsQRj1rLuKNEElyPDOIpHdPl6qAg279OYema1jTJVit4AZvEQwgkdjGc7/wDPnQTWdJhvbOWFi6+Gyw8yjDMAQWH3Cr+dP6vTC9Qw6zF0epND+6efra9lja8hUYMUoiGT1IbDYPptTVol/gpp8bEeGAZmBznvy59e/oD50sa1BLZOUEPL4qNcMcYwvOWOPopX7sPKqOh67MJxEox4j5cnuSd8nsvTP0xXPVsVbM662oW1kibfYSeJComdAjKC2/bGcH/Sh+qXi+CZfE5U5CzyfiK9gPr5j7ZNCtG1GHU0cMS9rC4Vw55fHcjYHG+OmQOwxRTULc3koRecxxDmVgBjYfMB5noPTfyrZLm2rCznwnd2+1A1jfvq9w9pAZYYwP3zBsMN/lH8P8xsOvR204IkMccCxwxrhAY+uPJewPm25oXpuixaVbgO/L4jhyEGGYbnGT5+f1+tXXuwMhFSNEHKCSR9RnGw69PX1oVWnaoZfrLXXrYcJ0hmE2tqhEcI8iQdwfJew+u/3qz74tovNFbxRMRkkuXc/bv9TtSuvEMUJPJIkZycSEgBRjr5/wBaoXXF1tbkhcRo7D95IR4sxxtgHoPU4owdUHXEX7p3OAI3SyXd6zNNeS+G2yoh3P2XA/WqrR2sKk80a5B+IuOY/TG9LJ4jaWIMk8SxONuQkgnuS34v5VXl18DZLscx+bK5P3NK23pnnkxmvTWHgRkE7wuGihbl7F/h++9ULni/T7Cc2sVwtxcE/GwIwn3rOOJeJdZnR7eyui0b7cwwMD+ZpStLHWbg8lnbu7OCWc/KPXP9aWXUEnCTSr7OG3dacT0Pa8Q6TPH4HvEUkjDMhD5xXy6FuwD2wUY8z0HrWI6bPqGjOIoy7uT8UrfiPmB2Ap/0nUH1BPCV9+UZGepp8WbxgiKW6XuuVPEYvf1lLKm5GxIqzarJs4OKDwYthgBVx+tEbfUoyPDBqfjAEY6QlPdGSExk7gYrEva5HJY3VlqBU8qXEefoTj+ta2Zcy4zisn/tF+NBwnLdwZ5oWVy3kAQaa0Q3aqtj4H9+Jjdq6fvKWx5Rj06TmtIXzkFcih/HmnjV+Cdcsz4fOLGW4iZ1yqSwjxUYjfIDICRjcVDwbqMepcM6feggmSJSd/QUD9s/CnEnG3s81LSOEuKb/RNSiR7qJ7PPNdhI3zbNghgHzjY9cZyM1g7Rpu0wlrFAr9fLB6/pOXVdwBE8kf2drGNtNvuK7Ys82l8S6WJmRSVEEkU2AGwB85J89hXvmXUEh0v3nOAE/pX80vYxqs1rqllo1zb3NlY3Vx4iyJ4kXvEq/CFdR8EgjJ3zuufM4r3vxfr8NpwjbFJMGeFOnmQM/pX0L/LdEPwddqnJ3/IFQMe/lc+HWK0EvcFI65/fP3mWe0O3u+N9QWyjyYi55/LG2BT/AOzDToNFvU0y3TCQIqgeuKrcG6MX0d9XuI/3jAsCe3YfpRTgvbiCYfQ/euSTUbtMax0BjV3tEnwHAmoq5rsOKrBq7V8jFKVW8iW2yyrb18mRZYmBAO3eow2d6g1G7W2t2cntW1pLCSJ7Exj2r8Nx60Xto03OR9DWfcAez+bR79zIpKhjgkHOM9c1tV43vkzsyhiW770waVwrbva+OIwGIz9a6OnWZ9hukIeFAMGcPX8unKlvMCFOwBpmkkWRBIhyCO1LWoWrW8jRlTkDY1Po2qEH3Scjfp60fG048JXoYVkYDbNU59tx+dW5cZqjcNt1ryNzzCLKNx3Oenehk/nRCdqHXDKcjPWvOYdYNuTjOOtCNQg8ZScHIFFrg43xQq6kABGNyMEHtSdjYjCxF4kURr43MST1Hes41S6czfujjG5ycZp84ynYZiRjlduvWs4u7ocxSQEEnYg7U7pHD9espcpHSHdG1EyhYiN870/6RbBkWYgYIzWb6DZuXEnKQvnWnaROrWwRSOYDHSl9cvBIhKCehl/nx5fSuDIT39a4O2/X0r4G23z1rKGOsd4E65j1ziuWbbANclgMjIrkvjYt1qd/lPcTPL20nsZGWRSF+nWhzzM/NGowzDAJIGBWja/paXLSKycrDIG1Zxq2g3Vs7MzNy56Cm9Oyt7LdZrFw4DzmK2hSTkWWNmKlFwTgZ6nA3Jp10mCy03SVkmnW1jIzgqFLL6jruaQbCSK2l+NSigEnB+JvTNT3Ooalq8vheGVTICgLgAfenNuIlZlziM8/tBmjLw6F8MxyDcSLzci9MLVKB9S1a6HvDy3MwACrIdz6t/CPr+VVki07TIVe4lUzHBIYgBR9uv0oxpS3epwNJa2ssdgch3RcNIPLmOFX6k0FmI5kBUHSXrexis7gvqGpQ3ksYDeEPht4j2Lnvjy6elXrvim8tLWT9ll724Y8gcKeUnyAHRR5d6Bz6jw8ka2Gsahp1rFG21pp4a8lT1cp8HMfV6YNCh4VgiS40Kwu7qaQHme5vFtPsVjDN+TikrfN+nvl0A/4jn15wfo2r8UafcSapqGoSm6YhFgLZGfUdBjypz03jqWeMjUI4Sg2Y28oV+Yeamqkd7bXi+AuicOW9yTyp71bSXZz580rsPzFUbib2iaRN41hfW9rFG6gDTbKzjGM7/LECfpmkbWRzknHwH/kMBxtx8z/AADDMvFtjqAazhuoiB8LrJjnQdid/wBaEXUcNyfB06W0llB5SGZdu4JIOR9TRGX2jce27BLnim+AQbASmIsPquMH0oZbe1Tj+11RoX4u1Oe1mO7SSLKR6FXU/wA6UapCchj8h/MPVvHskD5n+JVF9w9dlrbU7wXGpWw5ZILNgOdfIyHr9QPvUMGr+APfNM0DTUtxh5BNEblxjZ8mTIB3B2A2zRPinibjiGWK+tLrSNQfH7yG80SwlJ+7wc2/TGfvRPh/VdO1WSKW54F4caSWLMkSW1xp8gbGHQrDKEP3Q+deCVkZVvmP4zDlmrGWGfgf/BAXDfF2rTavPoMupCxMDlrWaCFEjdOoQhVyNjsRnBHrT5qzavJo0kst7FOYP+kRTSWcM/hd1kAK5Kk9cb/MOuKW34c9nfELSRabLruganbDmUJcQ3otyD2SQQuQOm0hODvTrodjqMt34Gl61pGtXfg/vNPRjY3z7fPHDPy5Y43VGdW2NXOnZ1BQ5Pu/jrFbLk3Zxj9Pv0+sFy6qlw2m8WajottbX9g6CW5tJmiilWTlAkQjKFGIGQQCGAO2KdkvPGefWeH7KS+tZybXXdDkHK8oAPLOi5OJE5tnTOVbG6jFBtM0+0trybRbiw5BOrRTabe2zQv4bfMBBJsR6DbuOlGZOHpvd4TpTRm9tEaK2mnlws8GQRH4g3V15flkGdvhYjNEqZwMj5fuMfbxi12wkD1698VOPbC44Y1Kw450l3uNMdhaXF6BySW4woAlA+U7AMp2Iwyny709tFu9Om4U1C7hSy1sme3mIPhwXXxL4mDsgO6Sr9GHSrUPHE8NzdaPr2myTJPGIry0njDeNEdirD/tB1ww3U4IJzylP4ys04cu/etOnF5wtrsvvWl3rHmFrcLgS20hHQ7ZI2O+fPA7ApXvKuniPj9vLyPHkSxSGYiuzr4Hzx9x9RFPiie799jtL6EQanpsklhcxyNygE/uzGx7AjGG6fLvuDTT7KtSk0+9s0gibxYh4FxA5IPJg8pbfPLkMh8jg0rcXr+3kSeANJquk2xju4mOHvdPUcqyAfikiACnGSUVT+E1J7I9asdbvrzhy51RrXiHTz4mj3F2AI7uIsCbR5wcAsWUxs4XDHlLENsNaTYMrzjn1/E0bXC1Yb4H15faennsNVfUraaOdnR45bKUvnMqOPEt7pG6cwVnRvPHSkD2laOur6LqFwtuLmfVLJniCjlC3Mdu6Oh9MyN552HY1qXDfi3WiPZ3EMyGLkvIIzGVe3PMTLAyn4lIwxBXcZYdhkHrWn3V43gyqJIIiJSYmHxrzN4UqN0OchW7564zR9TWe5Dr16/z9/jMTS37LsHwnj3geCTQeLUsnUpBqDYjIzzBzG8edu+cH6qtehZNels+HodY1GF5Lp7+3EsYf4XLgkOuB0cSAj6is8u+Hrey4pS+v7cGCzeO4mYZXkty8Rdx5FfGikx5Bx2NaU2gRDhC40a5m5Al1cWbTeIMwR+I0tpcg5/7NnaMjyx2UVms/wCIAZus6PU92jhh0Pr1+kJ3mgXOn8Xajf2MytDqOgu5UD42kDRsmM/h+Bz6ZPnWTcacMft28kvrCSKG5gax585Bd2hLIVbO+Ao6jfJ8q3fRLv8AaE37UvQIZQIyrSAYiWSJ4ZV8+UP4gxvuFNImpQ5n0uRraYu1uLKfChRHd2jR+HnfqfjBP8OakHuznMSptbJB68evkInTyPpmu3HFOmRCaHVLdLqWOM4DLNyiRCvmJQxHng9xTB+z4BrGm68i4TULF9OuIcgqZ4izRuPIGN8gjuopdi0/VrKDTgLUCOJZXW4cnLOk5b5f4SVY7k7SNV3TjNJDDbXMk7SWEvghBnEfIeZCGAGSYTy5z1FMBgesGysOhk0trJZXtnHdQx+DBL7t7wAQQpk8WEkf4ZRMpPTE3rTnpXENpapYX3MBbySEMvdBJMwVvXlfP5iqWp2ok0hpoJQ5gu5LVgy4LhZwoOPNlVM+rVSms4le7W2ZRHDcXEELOxCjllEykjy5AcetKXIc5xLpYLBhumefv+83XhbidZrOa1ldidPPIebtzFT+Wc0zi6SWRg5UBXMh38u/5AbVh3CWrS2uo3DNGVhvrRmyBzKORDv6bqw/KtC/a5zNMHJCx5bfIbA6/fc03VcRXk+vXEzLqAtmB4+v3zET2o6QtvF7wypGs0axc+fkVgXkBH15Bt5+lZQbi5s702sZUSyqGzn4huMDHmAyj6kmvQXFsEXEVjp2nSRK4meGSbmOByjnJG/UZUViunaLearxTfX95HurpyIx5QAytjPbGQ7fYCsm7TkW4XoZ0nZ+rXuCH8PQmlcI20kGlwQwxhiEJA5sgM2OZmP0xv5CnUBDGj27K6ZPxuOuOrH08h9aUrbUrW0i9yhnjjRmxJIT0jTAJ9M4/XHU0L1/2jaFpNtNc3GopFBEmxZgOVAepHr2HVmO2y1saZVrUD16/qYlosvfIHWNera7BAeaab9ypJPMcGVh+JvJRg7d++w3z3jP2w6PoAZb28HvIbEcK5YljjquMsx8sbCsW439vGoXMck2kNJZWskjCO6kQmViPwQp1ZsY36DGf8VZnp2m8b8c3vh2Nrf2VpdMFluDmSebJ/FIPkBzkhcepNMjSW6k56L5+J+AjIXT6IZv5byH3PhNT4s/tGCxf3O61iz0xmKs0ZBmmBA2Zo1BA+jdKFaH7TrXiK6jXSuIm1e5uHGEdOUx/wATd+XApp4P/sXWeqWkE9wJR4twiyyk5JiJ3ZQNgR6k+tZ5x77NJf7N/t7sdFmmFxpOqIngXJHKJYZPlbl7MHBUitG3/HRVR3jo3xOOf0gtL/kFdl4pq2/AA5+f79J6y4M4L990lLqK7Lu6fG3MWLegHYfrRyXgHULt/CPJCgbcKhzjyJNKnAt3JFE9mk00EXNz4hZkYggZ+LOR36Vreg6jaarZxSW0qva8o8LlcupA26/i3HXzrntXoamI2jEMdZdWSSYA0/2Y2CqQ5LjPxnqD6Udj4FsoLRovgRGXGMg5/wCH6UzQyWsS8qydF5vWrUIsXjL3ADOVIIz09P8AhR9Po6q/DmZ9uuusOSZjnEHAy25eS0j5UYczvzDJH9aXtLtZtLmaVCXRfxZ/ma3e/wBA0+TIkjDPgFUclgoPcjpSpqXCloFIZHUZOXxhfsB0odmmZW3L0jdOuBXY0X9PddRXnljQAbdatx6XK0nPC6KnWqEc9pp10bK3Yksd8nJpjsRacoZZWJPXeqkZ6yzEjkdJSjiEdyok7Uh+3OCDUOFL62MZf90cb4Faq2nLITNGnwikXjzSv2hA8HKORgVOe9EUmpd48OZn6s+zMp9i2otccFwW0jfvLVjGe3Q/6Vo9jIXuIkDEczqoI7ZOM1k3s+hl0PinWdALqYiVnRfqMH+QrTbK58O4ik68kit+RFZf+Rjfq+/UcWAN8xORpXC7fIkfKeR/Y5wrw/rljc6xfq02p6ImoRaU/jkRi354Eebwu7mZ5/iPcg7kDGt8a3zyxaPw6jFg6pGCDuDsP0xWceyPTNPstU4y0ATOZuH9U1nTk2APu/ixSrnuRzr0O3cdTlo4WupeKPaDZRMh5LCP4lP12P619K/yBlfs224HxrP6bP5548YlpAReD5b/ALTdY7JbDhiKBBjCeX5UucHsBxFKAdxim/WTyaa0a/hXA/KkHhG7C8WSxE/FgV8z0rFqHAj5TCTWQ31qVCc7VAretSKcd6FSTmWxLK48+1LnE9/yJ4Knr1xRuWYRxlz5GkTWdQ94u3JbbOBW9ouAWkAZOJNo9s11eonUZya0SCNYYVjAxgUp8HWeFNw602c5rV0zZO7znjyYF1+xE0RlQYIFJE/PFLzA4ZT5VpM4Dgqeh2NJXEOnmCQzIuxrXqYONhkDmX9OvlvLcAt8a9d6jue4INL+mXxt7gYyAdqYJyJEDrvkVZh5yyDHEF3D9Rn0oZcycuRmidyvUmhF0OtDLRlIMvLgqD03oDqF4I43dtuXfFFr4ncYpP4muzBblQd2FK2EmNIIqazdm7ndiTtSte2ivMpKjlB3GKK3UwDFT0znrXOn25uZNwD60Spu6G6WwHJBhHQbYpHyjIwP0o/pt0IbgRscA9Qf51SgUWaBAMGoZJzHIJR069aK7d6MwZ9kRu8QfN2rkybHB2G9D7W7Elsrbbdal8c775I9ayHUoxBjIbIzLDv1wpG9cGQ5+mx9PSoPHGxY965aUcuS2+ajMnI6Q9FcR69CY3RUnhXbb5h5Ut6rarMWSWMhlyCp2qeOWSC+S5iuCnhtnr2700yWFtrdqb62iCygZZAN/v5U+aO9XvE6iJdndo9ye4uPs+Ex/U9OdAfCVIyN9lyaEiF1QtPdMoJwSuCx/XH6046/bPEzxuuPQdDSe9sTKWdS57DsPrTFdhYYYTbK+IMljm0+xlWddOhdkGUe5Pjux7Hl2UfkaG6pxLql7ODfTXlzynEcOPgUdgqj4V+wqW5gvJQSgK46bVGmm6xdoIjNHGo3GSQT9TVm2jqZVFJ6eEsaVxLbWTCXVNAg8KLfk5cM31Pc046V7QvZ5qUYN/pFzpjL8KyKQw+oxSM/CE90ytdX64I2BGVz5Y619ThKGO4w92rSdQmWT9CP60lalLc85/WFXeZtdvq/D3gRCz1j3mBjnEsecA+uail1Cxw81pqUeSTsNs1mKQzWEaQAzIrdWROZR/rV+zliupPDvWz15Z4QcbfxL/pWRdQM5EbRMdYz6xJdTxiO4sxIXTPNjmDfcfKaTNWnZXFnK0kTAZhm8j/CaNftS94dlgOphrvTpPjjdD8SDzU9D9K71yzsLuP9oWMiT28wzzx74P08+2KEilOsMrKDtl3hfUW4k0d9L1FjJcQqVAx8e3Q+v1Gav8KanLb3X7C1d/e7XmZVMspWa3kB25WzzcpGdhuPWkOyuDZ6pHDZTBJrggxqflc/4D1Vv8J2p6m4e4j1stc67wxcW2FDe930kdnG4H8ZmZD/ALy7/wA6Ia8NwOsizABUnEYOIIYJtUgfSb2JNYQCQ2GoqVF8qjZo5Vx8eBgkDfbINXbyztNesozc6HKVgfxXtjOqXllN2e3nHwlcE5G3qM0J05rG3todJ1r2g8MCCN/3dvf3pvAgxtyywIwBHb4gfWmHSJW04rcW3G3DF3bOBCjEXbo3+EzCAhs+UgY+tVCEf3FTnjjn15Rk4a4m4ttFh0LUtR07XuH5FCQQ34Et/bEnb4XP71fVCr7dQa07S2lm0/le1ltZLc8ySCaSeIjy5iPeISP4ZVkA/jxvWS23B+gXyytYz6C8krfvrbxnjRmbspKDwyfMcoPfNHdL4L1y1uYpbFtXsVaMIgmiWflx1CXEDEMmB+MN/u9a0KLn6OufXn698QvqTqpx69eEbtf0nTLq1b33R4ZJIBzcvglgEb8aFc/Ac4LJlR5Cse1vTLHh69uBaX0s3D946jUbCdw6xSHZJc9Y2Un4ZSCpBKscErWq23EvFWkN+ytSv7HWYAC/u96jrKgzswPz77DmGR03HSk/jmaz1RTcWczxTQjmW2mcNLCfxKp2LqRnbJ27GlNYqp7dfyx6B9cQ2hZt2x+nn69e+Yhxbot9o2oqujXpX3WRJNOuypJhfqscmeiuCR3VxsCey5oEsp1p+I9Ht47a+s4RcXNmSP3S7LKvKdnhYMd9xy8pztsy65etp9y1vD4U9hKTGbU5DQ5OSqg7YPXlBCnY4VgGrPRcXNhxFDqejXh8SItJD4hKucDMiA48shgeuQSOuRUNuUgTedCFBPP3nt3gTjttQ0nT9R1G2kjMxMPPzcxEoGAVY778hBU9HQjyJtaxDHpuq2V7ZMZdN1ZXPhxNlJH5TzoAB8J5Qwx/lH4VrLPYjxVb3dleaHqr8jqiTIqqBHPaSgeHKuNuZHUo2Nxyqe2+j3s8nhTaZzgWN8wZCf8A91vlYNHIP4fiwD2IYUZrC1Y3fP8Amc41QquIHof1KuuaXZ2+r2t5cpa3EF1JJYySgYY+JC2AwI+VimP9/HaqlvZLqWntZQzo9ssi2k/iAAxyIIwC2P8A0kTxPnpkvRbUZ7C9hhkaFohdOA8SkFreVXEiY/yuCPMh8b7ig+g30eo2l5pV4kUc4jZEmXYM8PMAh8xyMeU9gzDfAxnCvBwOI8tpKZPhLFjL7hZWUkiuC87WVzzrk+KgIbP+8it2ySfOutasbayePVI357Ce9kuEDDOGkjZvh9cNtntnuKn0+4a+067+BHV74zuhIDiVN8gDzDSrk+Y8q610XH7KeJDG8KiwvIJlA+I8xGcHqCCo9BIPI15qsAkzy2bmxmKU9odVXS7Jo5I5oVgAiU/CoZjC4Bz8QzHkelVuH7eF9QtooZZFt1RopEmOzgIcDH+EOQOnyEVJd+8aHa2MkihZtN1Wa0knB3e2KrPA4HcKOaM56co9antkgs9Mlht3kNyZHtpGUnDcrh1cfc/kx7VI4OTCtyMD9P5+8KXMDyaZLG8cUU1mwuWySBIG8ORTnzBjC/SqGpaFcPeXdtE8BBWeZRITnxS6NEPuh5Cem+aYjy3gtNQR43jlkSaNDkho+WRWU+YIGR/lrnUtLi07WUMjvKt1pjrbBgCQypkxn/EFwQf8JqHIbgylJKnj3ylaW4tJEsHyiva8glDZKtIrbHz6rn1ps0OSR9FFteKXRVZUlBYleXnVfrhkIP8Axpfhube/hs5onBEuQHCjDPEevXbKlM/5T503cP6fDaWclnIhHjS3HKSfh+NwSQex2Jx6tRaV3uAOhxA3sVX2uuYR0+2PuNvLJhnijYc2PlACtg9zu3as/wBWsY9Fe9u5VQRJIqDA+YhckD6szD6A1pNvzWluWln5kaNW3P4jlD+eFNZD7Wtag07TTIZ+WJXGOUZLyE7ADy3yTR9XWqVrt69J7QFrbdvgZmPtB9oo0BTahg87DmIB6fNgbd8kn7VjGvcS3P7qfXVN7qdxiSz01WIULjaSX+FcDYDcjYY3NVuMOJTJfzatNi4nmZobGJkyq4O8rDuq9Bn5ifIGueFOGp7vUjeXzu11MFkZ5UPO7HqSTkdPyxgbU1p6E0lYtsGT4TR1esFX+mng+JnHss9w9o2vW13f3slxdM/LJCYx/wBHRTuqqNlTodu3XeveXAvs/wBB4f08fu45AIy3OOVUQ4PyDbA265NeFPZ9pf8A+G2q8SWdjHGdWjimZ2clXubZxzRoF7Lseg6geVe2OCfaHpUnBFjxHMyXPv8Ap8U9uqJzF/EjBGe22d/oa7urR1dnqmssIZLF3KfAcdPX2nzi7X2a8tSPZdTg+/3+vvNx4cu7G2t44rVFzIytkNkev6E14B/ty8V6Rxn7YI34TmintdM1D9nWs8ZLBnj8MuVJG48ViB2yDWi+0v298Q2Okto2neHp9+4Pi6lbjkkkiIxyIo2Gd8sa8wcHafNxd7RNOskDSafohN3MXOxAbnOfMluRf/CidodrU67TbKvif4h+yezbNNqRY568D9fH19p6+4HjupFFiZ2jiP7qSUkGQseoUdzj7DvW16Daw28a2tiP3afACTnP/Pn+VYf7NLS31SR7icOwWTmIXaMt0UZHzHbOPStsjvVjhW2jlYkj5guwA7ADvXzWx0zjwE7jVA7seMYbaZ/eAFVfDj+J3bYVYbWtMS6ZLYqZVPxzFs8ufIdPsKTr7UI4bcrJPh+X+72L7dWbBP5b+WaC6brMN/dosMr+5g/G+MeI+dx9PPH0pazUFDtlKtLvUt5TUbbUZbxmleXliOCrSbc/ry/6mvl45uwInukA8hglj50Du1laJLiaZ7aHkPIObPMB1AXuf+c1Nw9dx3EqxQqGbP8ACOb79hTKWktsMXNPs7x4RZ4o01dOk/aMFmilT8T8u+KraVr1tOBkAM3fGK0zX9JbVLUQyxxEEZPxDY1ifE+g6lot48qXAKZJVVHT7UHU1mp8jpG9JYty7W6zS7XUUCYaRceVBuJo4pbVpV3PbbYUh6NqupXEwV3cjP0p9uEZ9KLSHHw/U14P3lZEDraO7U4nnaeKTTfavHcSuyxXsDRjtkjf/WntXKuVzuCRST7Uo57a6tdcslHi2M4br1Gf9KaI71J4obtWBWdA+QeuaT7RT8T2dTeOqZQ/uJx6psvZfPn1+omD6bf2PB3tx9q2nNp3iftC3k1e3n5d4ZXSOSRM5xyusjde6LRP+zIbjXtU1TiiZTyyOFQ42CgbUjf2gdYveF/aNq1xpqMkuuaZa5Y4xITHJGRn6RYH0rv+ydxzLFcPw3K0qGQAphth55Fdpfpjr+wUYPj/AFoTx1KZH1+0VH+q5lxyW+hAP26T11qjc1i49DWaaFJ4PGQ7Myj+daJey5s2Gd8Y+tZvZjl4thkGBnI69a4HQLmp/hNBlxNljYkAmplYVQilJQeoqcS4XmJFVrGTI2yrr9/7tZtytuRikOJ3vbtYwCSzf1ojxdqZL8gbIHUCo+DrVrq5Fw42HStkHu6wo6meA2jcZoOkwC1s0TGDjer3iZFVVcKOVegGK+l81qUYCgQOJI7evSh2pW63VuyHGcVdJ2qJ9x0rRrJE8BMy1NJLC7KsPhzTBpF0tzbBCd8VHxdpvOhmQfFvQjh68CzmEnONqfXD8y5GRkQ3cruR5UJulzmj10gYc46GhU8ec0CxSDiGTmLl3GN8is64um5pygOy1p2pARwSSHsNvrWU8QkvI+Op6UqwywEMDE66Yuxyd+m4o5w7adHI9M0Me2M1yqBc4OMU5abp/gWqgJ8Xehah9q4hk4GZS1FCGwADnv5UOc84Krvijd/AWTP8jQNgVfbpU6O3KlTBWnHSW9LnMZMbHp+VXmYhyF6ZwKFQqyS84OcedEWBZVfsR286rq8D2xK1Xc4zOjOQMkmuWlwM83SoiCWHnnyr5g9MbdOlJBxDh5Y1geBzTDYk7HyqjoHFd/od2c3bzW8h+Nc5JorxLHiFl9Cay7VLye3dhExBz0FbHZtngZzF5wwImocRXFrq1u19ajLAZIyM1mp1PF34Y5uuCPTNWOCuIZhfNZ3Kc6SjB2yaKcQaF7nqKXUCYD9jtVtQe5u2kdek6rsy86ijk9JCtwhtfEXqe+KDXWoDmI8fw8dzRO/cR25RUKv+IY2pQ1aXkU8y4J71BAYzSqYqIWtrqUTBxrR5j8uRsPX0pgtH1u45TDdWsq9SeUEsPvWSXN/JEcwE5Bzmrencc6pY4BVlVcZJUnaq2aR3GVnu/RD7U1lri5kQxchjMYIY7g/XuKpyLqltIt3B4nOhHLLCwJ+46Gl/TOKrnWB4ccvJIN89Vx6k9KP6dxDYWzOk8EUk2MFkz4P5dT/L61k2VPWTkRyuxWEN2Oo2+vWMlrd2RMZyZZA4SJGH4vi2B9F39KqaX+ydEE0djdy8Rgnm8FJDbxRj/Ev97JjzHJUcqNqRXUBLJNGg6xYLRfROmPoKpPZ2U863CXVpM0O6868sg+xGf1pcEQuMnrC1zxNxDJbleHLi30WFxnk04LbP6gygGRvUOxr9onEaXbC31jVrWW6I/c3QuEknGPwtk5YfcUU0rX9OtrZ1Md5BI4y8tvK6kHoTkqQfuamukvbvTx/s1xjZTsmSq6lB4m3Ug9MfUVUtuG1xx68gZQnacqIRgvVkCxXVhYTlgoEllciM56Z5WOD9MjFEY7WC0maVNMmtppAFWUgBebOwbALHP8QP2pb0/WuMDIqSRaGZo8E+B7vySL6JJzN/Km+x4j1z3dYr/RXXxQQ3i21usa77HA5QR9D5UHBB4IniQeMTu0udLin91u/GspuYSCa31ONHXfcgNEjKc9961vgniJwkllccQ6veW5ARnnhtLsMD0JlhaNh9dzWUaxfaPHbxzahZiAhctNbo2xB65duUD86p6dfcBXssaXGiwzKxyZ2ljDLnof3RVz9iaJTqXobgcfE4+ki7SrqE5+x/eemYW0nUbWOxu5475lDmIXgZwM9omlJI9VD49KVuM+C7aaxa3hNxJDGhBWQEmLfZQfmIHlvjzpE0XVOALGf3TSeKksLkqEktru8uAAx6fBK24PpmmmObiaBDe2s1rLCrcwlhuo5RsP4TyHp2y3TamrrV1KYZflzMxaH01mVOPjxPO/HWhe5SFo7lnYEqCvzMPItuGGexwayjU9QeIyRrK7XELLIhmUrKHXo38LHsT+IdR3r0h7T+H7K6WfVb7TTHPOoaRra3KnmAPxNj5e3Y1541mwkWQA2UcrpKWhbxjzSEbkA5wcj9TSejIDFW8J0m/vaQwmqex/iy0n8BbuM2avA8AwcoGfGcEjKgNgZ3wQofYhhsOoa89nbzTzlriLKW9yF7AEczFfQNn1U98bebvZ/puhywS6lpepeBeQyJL7vIzYI3BjyvwsrdASqspDK2+M6lacRCW4IvllKzwNF8Q/dzxlcHcbBgcffnwcNRrQASq8TKsry27rNJ126u9O12a+tpFNtfwePb4XmDTIpLKR3PKGOOp5cdRS9bcYafeaxFAwMJ1Eq0Ds+0Ejg5QkdV5lb1BGe+KqtqUd5wfEouFW4t5EMEoc4YhlGd91fIH+/jsSKynWNVvtBvGWAbrPb3dueXEYLZYrt5lCP/ABoG3efZk0oGGG6jibHo/EUtvPczxhld4veYgi5/6RGDHcW7fXwwV33L/wCKnVPdFtLnSHMMtvLao0RO5MAJcqhH8Pi86+mf4a8/W/GTLq117vJNFdQXTXEcBchZA6Bih+pQEf4ga1Ph3X5L8QW1vexD3aVbW2Zmx4clxGxhLEduZFTP+IZ+aibPBoOxSvI9eUNWFs2qQyLNyLdPJbTw5ccrs6lZAP8ACXRsf95v1r9apBY6dpFrDbB4733uD96TzgomShJ35uXYZ/h9KCx64Ybu3ujarEYZL0NE/wA0TLAJQnquM48jEwpqvrgeEZUiR2tAroyuCwmSQqJAvcMmx8wp86VKbDDFiwAPrw/uX9DWM2cWlvI8rpA7QOF3KZ50ZcbZzLjpjDkdqYNUs/gjuhyeLaSRtGAccwADjr02Ykdug9KU4WOlNa3txBKn7KljWVl3YwvEEEg6ZxybjvyetP1xHY6gzrb3MbySc0MlvGeXJK86lcj/ABbZ23G5BrzpuQt5Qedrg+cWbDR7OG5W0s71Y4be595tnZSVjUqOZD/h5WQd9gD2p30HT7gusbwqyvIHCZ5uSXl5HQ+hyMEbUnOEsr9w6h4Ut0XcchKAlV79eXK47cuK0vhi3PuNskLkgIgVmJLLy+eeuxwT3GPKi9lsrWFSIPtFWVQ+esWNQjfSNECJI8kdsEQFwSSvidDn8QB/T0rzF7dta5ltLaBiqI8qu+cMo7HHYA5375r2Xxho9rqVjJCsIJuVYSrn8WMfXIOOleIPaPoerQ8XS6FqlsjQXF6kUHI+c9cLt+LAPw/XrTV1YGoG7oohOzHC1tYPzTEND0u61fWZbtwq+KVSBZQSqKDhV+u+T6k1puiWr2ZZ76YQx20nJ8UmArE/KVOcjYHJ+1calwpLZypqMNqSiEyvleVw2NiADv06YqQGNrWMrIolLFlCIGySP4fL1Oe9Wst/FruWZ1r923WVOMdE1zU4rbjHga8t/wDaTTLdoFgYLItzC2eZBk4YjO23UjG1ffYrxhqVv7LLbR79ZBJpFxPYBJSqFCpz4bDqoAPQ1DeX9zbX00pCoLcq9uYHx8JXGVI38j9BSVqHEMmoaxeWWiQzXF5qc8k5WIZknlOAXIHbbdjsMdaaqt1VukXQMcqDuHu93w8fjEk0tBvbUePT4yXj3ieV5n/dh7mU+DGkYLFyx+FVzknJI29afPZTwTqfD2nNoHu3NrGpyLPqroctBHjKwg9dgSWI2yT5VX9mXst1CPUI9YlaG61mT92l0CHt9N7MYQSBNKBkc4yqnZcnJr03wjwfpOhxRgyoXIzJzHld27s/dj9sDtVtf2gtFf4bTnnxPl7hNrQaTuT+I1A5/wCK/c+UvcH6BFo+kwlGWC3UAIc5Lei9BjzI+5o5qnEX7E08v4YhUZIknjLEkDry4G3kMD7DqO1biGCyJlSe3t1jQg3IBaTlB3KjB5VHr8RPRaz2TXTxhcAQyuIUPMJ71m52VTu/IMgDOMZ6E9Mmuaazu+F5M0a6W1Ld5Z0lo/7T8SsRcXlwlq/xyo8oTKbk5C5JJz3PTyzWg8KabDpqLDP40jpjl+H4jg7DfZQPL88UO0e0FhYpJGZLaKOPxXkaLmklkz8+MbADpkHfoM4o3aRNe3MYurp4YEUSqjHlZ89ByZyfv+gGKiurJB6mXv1IYbBwsdYWi1BS0lrFEhTCSMTIc58xsfzxUlnayW55IJ48qOZ2XHTywO9V7S7s0jCXEs8jKMEREuQfInOOb07VzcaqkN5+y7S5mUOcvBEy84J7MQK0Nqg7jMwMx9lYftY75lDJyNE3R/XvtQ7U+FoL53e5UyZz0G2aNWdhdGFQ+I1A3APf69TV2NZljEPKFX6U4agQAwifelGJUzL5uGGtpm5bfkRTkH0qW/mji09oVYE8pHWnrWbFpYGVvhB8utJV5p8UMbqNwN8mgNSE4WMC03qQ0xHjHTJtRgurYRbMpIPrQD2fXvvHDUlldXWbzTZWidSRnlB2/Q/pTxxZKIrh08UAeQrFml/2N9oQvwXay1wiCRc7B8HB/Pb70HsxBb33Z5//AGDj/wD0On0nN6te6YW/9Tz8D/eIi/2jVs0470zUZ1JcaQEiDEFTJ4/wkjrgK0g8t6YP7OXs/wBFg5uKwhNxgKCHyMZ6YpO/tTXCH2k6LpsYKrY6QjSNn/0khIz+VaX/AGfbq3HDUghcsQRkHtW9rVs0/wDjKVngggH4ZJxFBg6zjy+wm1Xdxi1Y53xSBFIDxRbOCPmI+1Nd3d4tHIONqRYJ1PFFsQQMEjGetcf2cmUf4TQcTY4ZhyqM9q6u7tYLdnJwMVQhnBAOe1CeKNVS2s2UyYJFRp6y7gCeK5ivrF811fFVbOW6VoXCVkLOxU43I/Wsw4cjfUtWGQSoPNj77frWx2UYggSMdhWiP9l2B0EpYMACXgcD712Mmol3xUqDsK1qVxBYnXTvXJya6A7V+IxmtFFkbfKDtUtFubZkYdtqzvwTp2p8oyMmtRdAVI86RuJbMxXJlVehz0p2oeEsB4Q1Bie2GCDt1qjcRDJqbQJS9uqHdgMVYu4cM2Ns1e9Ohl6x4RN4kIS1ZcjJFZZq0fM7Mex7itP4nYMCPvSFf2/isRjOTikCOYyBxiBtB0r3u75zHkCnF7DlTAXoKtcN6QIrcy+Hgtv0onPa9cL9M70lcCxlwcRVnsucHbr6UralYtFKcH16VpElnnOR+VAte0vnj8QJvjrS1RNb7vCCsijaI0yhG7ZztRW3tyyMhHbPSq8EBhlzRq0h5wGPU9qevHepkRQZByIKNqfLevhtDjfajz2RD/Lv1rj3Eb/Dn61i5IMZU5g/iNAVYHpjfasi4kYrI4RcHvjtWw8RDdsnNZHxPyI7kDJwTW32YczBu90pcG3tta6zHJOcKD/FjatO4hniuVgukVWhHVgcisHWd0vlcvyID2O9bRot5p2scM+6wXP7yNOnNk/Wmu2KDXsvHhNfsC8MTV0zJr3Q4dStg9q2Dy7d6SdX4dvYcqYw/wBRvR3S+Mhpdx+z78ZRSRkCjt7cWeoIrwkSKwyO+PyoQsXaGE3lLI2xpkE2i3hm/dohGc1NDoqiUC7Ux5OxRTt9T2FNes2ywMcLjuBQZLe7umxb7MNs5qjXEjJOI2tankCX7LTpJAsMZtJUQ7eG/hMv1z1+tT6jomoRJiE+MG6cjAkfcV9tNNaEE30oCj5iV/0qxJPpMMfhWeoi3mwQCSQP9Kz3tJbiMCsCL8ScR2EnPasUkB5gHPhP/oRRmHWJGZTqfD0lxLJ/eFFDAnucDI/Wq1xNNO3Nc20N6mMB492+xzUEEGmvP/0e81GA9o8MB+lVOH6iW27OI46ZpNzcTJc2+gB4cjleG78J07bo5AH60aPAcLye96lomjozkOEkm8V3HY/MoJ/Ogmg32s2ye7aNp+olsjJS3MjP6jBPL9cUettKlY+Jr4e0dPmjmmLuwPblVwf/AIjj0pNiwPB9fOVOesuWy2dlImn2trHzy7BY5xECR/hiOaLW/CmhXXM2o6XYmQDJws0xQjoMrIcnJ6Ej1rnSvdrbMNjodxZRHdWULuuOpUcpb6seXfqaZoRxTPbibTLc2sYUiOfUYUOfUR8y/mWIoe5vOCZgDwZFo2n6vpspj0W2LQ/IRzXUYCDf4hK/Km9HrGz0ucCXiLhvRElKkSOlxHI7DtkKy4+uTQhJdRSJkbjHTmKkBuVpIpHc9SPAk2I+oqxHd663LLFeam8KgK1y95NDChB3JJR3Y/U96uhzyTBszHn69DGaw0XhW5hMWkS/s2ddkjj1YiOX/CVlLpv3+DrRWLhcyMbiwsZrWd9zJaS2zYx2YwSISPqm++9J0Wrx3Msdn/tFOxRWzBNbxzq++zAyKr4HmrD86Lw6/o0MY8aTUofEXAKePJCxHcBiwX6nNNo6cAj7RZ0tHQn9cmXNa0eYRtJq9nJKwO11EskUm3U5UdfqrD1rEeNPZ1YancyXenxqHOfi3CTEndXVdkbycAb9VFaXqPHkdnzrLpPEHJFs15YQLcxxD+J4g78o+nL54pd1b2m8PRtzT3FneRtgrMyeFIreXLklR92Ge3aqWJk7lHr7xjTG1OkxvSuCrzTeIJbW3lZbvJPhS4UTpjDRk7BiPhIYbggZGMEaZZWNvqOjSK0RZA+ZoCPitpcckhUdviCsR5nyIqjfa3wzxAiXEMq3FuqvNzcyiaDA+LcEZZdj6j9L+j6lFDcS3NtKks8kKtMwJZZznlDEdiRlTjzwQCBUbyTh+sParEZHWc8PwyQWt3YXtuZrS5WYXMIzkFowCynyIwwI3DKrdzSzxlpC3yRxeJzSrboRKT87eISB9QSfsPWn/To7eeEyQAtbqTAGbZlQFsAnODgM6k+npVObh+31FvdcFZYky7dcER8zZPkOYfc1OQBkQAsxYc8TGNftnbVbZowAiIsbfhdl+IhfTlZW++aZ+D+ILj321uoZnDosaXSjBDxr8SHGeocgfUCofaloUdoyXcCnMcjhgoxh1YjA9CzN+dKXDNxdTXF6sEoRGtJEjCsMg4C83pkqDijAAp8IcNuXjxnpnQr+y4jX9rpb83v5ljmCDlLSyR4QgHcEsrKe2Jc9qIWzoNPtZYHcX9vctNChAT3m393DFmHb5myB0JNZnwRfahLaTz2RYTyRWk8Q6eGwZsvjyBMh+grSLG7ntJbAiVZo9PNxKC0YZvikB5MDqu4xv+Nh0xSrICcLBZK+vdHrTLK11nS5NNmuf3NxBm2mjAZ7aPnccyjG/IXXI/wtjrTCbXk06YmCKC7iMT5hl5QAzcrRhj+AnDIfwnKnYilzg2z03UuFbHw57iIpzQCSKMq8alyObA7AKNx5AmnCwhgvbTMNwlzLbz8zpEVAkhJHMyjm5SvNuV28sKRVVrFqdM+v3HWDdjXZ+vr5ytrOj3LXDh0aEyNEfEROYE9yR2UnB8hk+dE+AuIzZ8tlq4KSQEcrD4Tyf5e+DkY7fQirDPaWsQtiJQk0gAMWcoT3IO6Y65HwlSOu9Qz6BCWS6hSXlLvFIrqPhB3yDtlc/cbHzpIltNd3lfURobb6u7s6R21I20li0tvKvLMOeLBB3H5jPmP5dK8le2XTL/UrtLzQIPer7TpZru6tDB4khiRQpkUr8rBm2PzHqK9Az6rGlu0MjcizgcyfKwYjBYjsemfP86Rbm+fSuJbfVYL9rOYxGJwrArKwyUJGN8nlA32z0rRXtGt9QpK/39oOjSNVU49089aNx5oWuwL+2PDDKedrhVw8WwHxRjBfc7kYPfFLnFtrZW8s1noNxJdSlTG0dlE7Agt1bAwAOxNbCLTQNEhvLu1tLZWiRp7iQKnNz55tjnphsYz3+tBtH4gtNVvDbmGeEuWCStF+7YkZILK2B/vYoBtr0rF6umTx16Rheyl1fL5wPXvmTaP7MuOuK0jku7hLK3h2MwXmmVcDbJ2GM9gfKn/hP2RcNcNK4Lvcu7f9KRCPElIJ5fELnmdQcHlJVemBWj2MtrlPGgg5YgVjLqMEnsT2+9cX73wVYw9wiE5ARl3Hpk9PWl7e1rrhtHA93H9xins6jTN7A/U8n18JPp40q0SOG1s4o0ADYGDIfIEdR9BtUuo8cQ6dbzWlhHLdyhSWiiAUZ8mx1PoTgdSDS5rGoambBobaWG3DKR4gfLsPJiOn69KH6TaXFwrRP4i2y45rrky0gBwVihUZ2Yj4nJyQcLtSZO7npGO6Vvac5lzVH1DWpIzrN8lvzlAbaPDvgbqpOct/lHKoG5B6A3wwunaasjWWn3NzcFlQPyrsSSFCA432PxHAG5HnQ630OC0jlmaCWGzlwoxIvjyjpl5TsoJJ2X174pgstQtFRBZ6eBDbsD4caFRIxHygblzj9Ou1QpUNnMs7MybQOPdwJPqusXumaY2qMiLzyjlKH4R3CpnZifPfOOpqtwzxJdpHJfzXCRyuSxL5O38IJ36eQJ8qu3fDHFnF19FcyiG2i5S/PJIqrAp2zznJZvMqNzsMACmnh/2OQLJ415czzxsApeRPDMhHUgtg8voNqPXTda3+scRZrtNRXiwjPu5/SLV5xlqmoyPZaXBK6qAsksahREB/iJ2/OtB9lWgTSAXcoWNhvy/Ox9TjYfejdn7OuHIAokDzSD4mji6DzPwnCj6YPqaedCgsNPiS2tbdCO6qMKv5bVraLs63vBZaZk6ztKrujXSMSreTXRfw4FXAOC30qSOToiqQf4qocQcWw2EjQRG254zuFOcf0FAo+Nonk5ZLiMtjZV3NOX3ojlQYhVQ9i7sRqu3VgfEyxx0xSVxHNFbQyMY8ZBwOpNNNnqCX0QcIM46mg/EsEcsfhrEOZu5qBWLRkSVY1E5mC6vpF/rl+zQRkJnriher+ybUdStFkNqzmFg6465B869AaHw3A7BnRevlTtZaFZBAhjX8qHpuzlW4W7uQciI2nIORnM/nT7YPYvxhxTr2ocVvpzqrWNvbBMEsBG5JP61a9h/Dt7w9pV5ZXUbI/OHZWUjl3IH6Yr+h15wTp17CUaFWU5ztWc8Q+yXTY5JZLW0ROY5PKMZroO0NK+s0TV5zkgxNTXvBxgzz1qF34VnIc7gVn8F+p4ntiCBgkGvUR9ldoyFXt1PN12qhJ7GtFllWVtPi506Ny71g6Dse6pGHGTDW21gdYmQXWYwzHtSNxzq4kk91R/i6da1LizhFdBtHngdl5R8hORXnrijUwb8O7czFgo37k4oOn7Lu0znevTpCVur4KniaZ7NLLmj98cZ5t9/IdK0yJ87UmcErHHpETRgYdR+VNsMucdx6UOjTsp9rrIPtHMIRnNTruKpxuT2q3G29a9VWIMiSgbCvpG1fVH6195c9qdRJGJEy57dKXuJrMuniKu+PKmXk8qoavbCW2ZcbimVGJIEVtAcI3JtRrUsLF4nYigVmvu91y4wM0V1S5BsSo6gUawbkzLAe1xETWz4kjdh0oHBp7XV0qKnU7mj96hdie/Sr3Duk8z+My/Q0gy+cP05k9vYiC3Vcb43qKS1z9Btij0lsANqqyW2dwOnnS7pmSD4QJJab9Pzqje6essLKU3FMb2xBwO1Qvbg9qTeuUPPEy66sDDcMMHbPaiGnwnAycY8qLa9pfhzeIF6/rVW0QjAI7/nR6faXBgCueku+6c8eQK4FmB0WitlECnKe9TNakMF5aR1NG1siFryZnWvEFWOelZJxOAZCWHXOa1PiCUcrkbnf+VZVxQ3OGddx32p7s1SCJztxGIiXiq0pRQfX0p99mSxWszJPcYR1wRzCs51GVkc4bl3q3oeoe7yiQ3DE/XArotZQ1+nKg9Z7QagU3BiPtG/jW1aPUZJLZGMZbIOKF6TxBqGlt8UjsOgGdqbtKEHENm0apzSoOuck0patA9ndNH4AJBwDXL1k0nuWHSd7VYmpUWKesNjiCfUMCSFZObbOOlErCCOaNizCFsZ5Q21K+nRvNhjbsQO+TtRlLUyoea1lYnurb0vc3OJoUqZde1gTmHvM84HzIOmKHPaxvn3CymXB3aVM4+mRioi0S3IVjdQAkA5bBP3zVu41O0tysUOqysM4dVxj7sc1VczxweTP1raXGCkl7HCQduSPB9PPNGNKn0+2cE3t00hOB4rsoz5BQN/yodpl0b9/3F4rRofwxBz+eMmj1u18mY7W6uZmTflVFRQfVmx+poNpBODJXIHEP218dSmNvaWl/ceDhfDSVgCPQJ2+ozRq20sQvHJPpwsV2KW7/DLIx3zg5cD1Kr6ZoLpup3kbqtxxDMHcgGG2YJGfJXkHX6AH0pht9c4f0VxPd3k1xeROWWCzRY1Vu3M53P1Y9s7Ur4wLhh0h6x07UVRbiKyewf5mMao7H/EzzcxUeuAdtsdahvL+1RwjKt0ytgKshAUgdZZpDue+FX6E0IueLb/UrGVtavrbSNNUZ/eSyTzyKd883MqjP1/Os/4t9r2laDb+6aBbW0bw4DThSoU9twAzsfIY9c1dK2sbbWM/CDSvA3WHEfNQ4h1pFU2Oo3EUikt7w07rH13/ABHAx0LlfROlIHEXtp0jSZWaea1v59+Yq6tluxJCKAdzkYrD+NPaTr/EjCK+1Se4LOWSJn+BSe5Ubfbp9etLyWh8MSXLNJIxzk7n7eVbVHY2AG1B6+A/mK29qV1kpQuSPE9PlNUuv7Qt/wAzG2snLEZyb2dlLfxcuQOmw7UqX/td4qupmeLUL+35yciC4ZBv6ZpXjsec87AjG+4FXIrNWGTGjkfEN/mrTXQ6SrkJn4zObtPVueGx8AJePtG4nlBV9V1gqx3zekc36b0Pn4nuJGJujd7nfNwDv96K+xzQ9K4r47tOGeI7yW3024eR3EZHO7LuI1Y/LzdMjcdt69r8O8F8N6Xrur8PLw1po0poLJktXsUaFEMRVgQQc7xZOSSTknvW7pux1cByFUHge/5THu7btXI3MSPCeGrDi68sJRJbajMjDB5ZRjcdDkbfnTpontf1DTJPfJDmTlYMuwjIK4JAG3YZpw/tK8Aey/Stdij9nWlrZXiQudSgtZCbNJeYcoRTnlJXJIUgZxtWIro0kauELEAbgdMd6ytVpNPvNb4yPKaGl7TvKBx0PnPUfBPtFs9b0h2luB4ck6MwO2cEgnHbYtnzBBrV9Mtkvbh5S5MLjll5duY4zkH1+H9K8F6Vrdzp0wjt52XlYZUMRuOn1r1X7KfaTa31nBp6yKJ2Q+IPiLIgVAzH6gYGOhWsHV6M6Y7hys2a711SZX80a/aPpAvuG79IXVbhImnLg7krIpA/Pf1rANOjuNMuJPBixPIbiAgnLEBgyH03BX6CvS+umxl0m8tXdAvKpkCjBwrq3KPMY5s1g3gxPxJeW/MIml5pio3WJXJYkHscjp2zSqPyRG6F/wBfM0Pg25NqxhacyBBJDNNJnAiZ+RVC/XP2XPetQj0dGsG/Z5lUiMNHyt1BOH+pwg+mayThO7SLVoY5oZ/FiCyeAX+FGY5XmPohXz7nrWw2d282k3MCSo0sCyMJElVGZN+ZgWOMZO1A70BsGetrYYIjRwFqV7a3k+nNrdxbiOOBY4Qpl/7MFn5VCsCCBupwBjzrR5+eaaGc2UBuIXDpduwgkJJ3VlLEjO3zdR2rG+GDdQSzXnK93JC+FVYOVkGQCMk/Ec4I7bA+lanoVxHFbJaLMq+PmXxkhUsw/hJXbbc/XagUPyVA9frxIvrxhvX8/OElkcgWdxJDGplPhh3JKD+EMoIx9MdK6STUtPdrW4jyknyvhmDpnIO2wwc4PrUU8/uSQ8lqrCQ4BKoCmwyX68x2PTz9Kln1ARxCS4jMfirmPDY3I7LnA386rcrHOTzLVHjgcStrmjJqh8WF5I3HyuHBOMjb1ORnB6ZrIOIrfWNL1FoNQDyrbsTGwzjDHIJHUbBsj09K1+wvOXxbK4jkaZ3DifGeV8ZA2JHTOdvOqOvadFrljcWqvFHd+EVhfIPNzDJI+v8Az0rKsTLbh1mrp7jV7LciedLqC/uNZuGtOX3O5UNJJ4oeQZIU80ZXD4GRvtgjNV7fhN0kZBapAiKAskEjK2zbYX5cY3x0HSmnWdKvdAuB7wVe5CqGSQEtjoBkdslMef16XNM1G0Fw0AhnsTHtIFlbDjGOZRISPXpSrXN0M2hhV3Vxe0/QpMiObUkijDhR4zKHO/qRv9KZp7OxslWM2/vcrYBdpeWMY81BGcd9znypkjt9L1OJPD1eBJSAJBcScjqQMANhSN/sDQa84f1C2YQxQwXKk8rEtjnXG3L8IB+wb86NXYfAZmba3eN7RxFr3zlvlXwormUnmQLkBCD1wqkk+ijOw3AyaIgMlusVyrCWVT46nl/dL2DkbA4wOXJ64wTk0Uj0fUrK8NxqGmJY8q4jijlYZ26MScjPoCT6VZuWhtxHLL4Vs0jZgCW/NyP35FYgs47sQoFW9o9ZTegICj1+kgtNNu7pRczcyRQgYe6TkBbbpH1GAP1Ge1OXD+jaWJY47i2dxIAVWUnnmzgnmCj5TgYRdio3yKAQRI4SRro+DbOshlnTxJC+TgKD8AOc4LKcbtud6bhdR6ZavaWyFtRnTxTHHG09wUPxfG7/AAx5/jkYHHRdhTWmpDNuPhEtVccYEabVXeVIUtbSFBvNO48SVttgu/mMALyqAOtGg6yxS+7tDEXXEspjWSQdvmOI4+vRQx/nWZWOpail+09xJFcuoIYiNnjh22VScKcdc/Ec5PKOtfuIfaTovDlkl3d3kkkszcluG5mknYD/ALOPv6k8qjb0req1NQTn1690w7dNYzgLzNEWWHTo3jbUYWXIzLM/MgHoAAM/XFV9S4wit7V7PRwt7O23KoxkY6tn5R9aw1OP+L+LLpLeygNlaRnlDzP4s2/foET7ZNaXp2lrplisUcMsskwy55z8TeZJqadW+pJSoYA8Ze7RLpQGt5Pl/MDaraarqJebU9SSFfmKQgKiKOwpet9XWG6930yNpMHDTnfP0px1LhrVtTtzHPFKEYY8GIlFx6nqfzqpLwjLparb2ttGDyjOO39TS2o0pXLL184zp9WGGG6eUbOEtWIt1EhBPU0Q1C6W7uAM9KTbDxdNHLNJjlG9fl4liWVmMoxnzo9LlKgG6xPUANYSs0fTWijQbgUZgvo0GzCshm49t7f4TOB96ks+P0nOElBo1esqq/MeYA6aywZAm1wasiLuw6VQ1PU7d1IIU5rPYuK3kX+82I86rXfETt0fr61pDtRNmBEzoju5jVcapbx/KF6UMl1uNGY+GhA9KTr/AFpkBZpCPvS1d8UFXKiY5+tKp2kwbKy7aFXEN8eX1rfWUqRthiMcp715r17gK4uLz3ogqokL5xtW4NfxXpAlPMTviq2o2Nv4JIA/0pwao2HJgxpxSuBFbg26kS0FrKMeEAg36042zEkHGNqRluYtP1IogwM4A7U2WF0sqBlI375oHdDdme/KIchc5q9CaFwSZA9avwP2J+lNIsqeYQTHl+tShAarxuewqyhzjNMKJTE/Fc7A1HcQ+JEwA7VZVc9TX5kHKc7VfEtiZ/qaizlaQ7EUJi1lLmfwy4IO3WrvH90LSGVlzkAmsi0LiYy6m0OSW5sUdPaHMsB0mlvbeNOIoxnem7TdO91tV23I60M4Rszct7xMBv0+nnTe8IUAKNu1JsvMuW3cQPJbgdAetVngNGJYcZ2qu8GdsUArmezA7W5B6VEYMn5aLPD12qIwelDZAZBMXNW05biHLDcUsR25ik5WG4NaLJbBwVYZBGCKVdSsPAueYL1Pl3oSrtaeIzOLJCME0U8HxEDYP1qhaKSQMfajdmnOvL1xV7q96yFGDMC16bAbGTnPXoazHiOT5/Udq0TiEsckZG5GxrL+I5GZmG/rXuzQDOWZ+Ij6o5LnBqlp8wNwqvzYJq3fKXcjI9aJcK6baS3sRniV/i/KutytdXMUrVnfAmp+zfT28BpoyyDl/hOMUP4kgU30g5FYk55sVqljb2NjwoPdIsHkGNtzWY37mW6Z2jYknvXAau/vdSzAT6R2XpzVpwDBCxTRxbuyjrgYxXQurhF5ku2BXy7VJeakIHxNEzAYHy7UMuNWE8nLyBUPVQKGqFvCa27HGZcae2uV5764Tbc5Usf9KtwDhy4Phx28l0wHNhV5VHp9aHWNlc6jIy2dthAN2cDApjs4rbT4/DkuFeRz8UcYAwfU9Kq5C8AyFBbr0lmy0u2eMFLFoiT8uQfpsKuwJBHDJGkMbMg3jEeM488nP51Wm1i5hj8T3a2RFG2X+Egd/rS3e8ZqwdGZIkXfw4ByIf8AMRu35igCt7DxL5AOBGWTiD3IeJDG0COeVHji3Pnyk9x0zQm/4sFk5XTbB5Lldkur3LmLO/wIcjPrjPpShecbX11KIbSedEb4FSAdv6D6VNa2t3eXEfjycniMPhkYgn6dz9f0ppNNsGXEEW3dJHqF9rOq3xk1C7eW4JzzSS5b8t+Wqk3CF9fwSXMg5goyA22x7jI2rQdA4VuJ5UtLdi7BiXWGLEceP4pj1PXIGSemK0NOERaabJJHZ3N082AOSIBvIjDYKqPoOlHr1PdkbBF7K1cbXnknXOHX02e3vVhPhswRvLJ6USv4TyKY0ZQem2/rWz8U+zy4ureXT7+1aOO4XmX4cEE77fTbfpWWy6DdwO+k6tG8d5AMAN0lUdHUnse/ka1vxItCsT0mPbpDUTjxlKxthzy8uAU2QMM82CAfyzRePSVNnDIkTNlsMWPoTsPt9aDi5ki1MShOVGYc22wPfb9frTIb1TCgdIpIoj8EiKVw52Pw99ulWsGeYquegmba4L/hbXEexupbO5jPjwzQScrL5YYdDtXqbQvbLqPGHDdpdRaYYLuTSYbO4lW4OZZ1Zz4wDZxnn6E+ZzWDcRWNjxKpgkK29win3eY7gkZ2OPOmrgiIWXDdpbeOIZ4IQs5zj95uTjzwO9MajtW0aQVIcHPI/Tr9pnNoQtneMOPXELcXxpBAk0iM3OrACaTmycD4gfLrsPSktY1W1mEkLMuARvyqfr570y69f2lyIo5dTupQg5VDfGFGM9e22+BSpqF7aQ2gildppZSQiKASD22O4H+tI0qe7wRzDAbnGDFG6a1ayvAbeFp3vYXSUt8aKBJzKozupyuTjso7008I6/c6Q6XLOyFRg9sjrvVzTOCLaKL33VIxLNLylEPyJ5f8mqF1pdvLbzGxWdmSUIcAY9OXG5NO3WV21BT0mnpqrdPYXPU+E2/Q/aZFxDpru1xICNyhbCyAnff7H7H8lO31oSa1eX9zFPJLccvMoCgmMAfCfqQc+lZ3p93PpAFphUbxQrKANzuN9+xOfrTdwutwtyZUaNZHlLB23xvy4yfUb1zz6UUMzDpOkSwWoB4+M1fhicXytK9sSt7KY0uNmxhyS+O+QR9eUVq3C+pWSiQKJvDkhUCWZFJiVg0eOUnpy5z1zvtWCw6mLK2a1hSSErHKpXm5QwyAvKB1JGT960fgC5v7W0EkF7HLBBEyNDP8RVm+JQW3z1+nQVmtWwbcIZwGSaal9FZRqvvcNxzOP3kYJXwyQAyDG3TJHXbHatA0C4Sa5kl00iNo5WjT8SkhQSOXp1yR9ayTS2trG5tI7Jz4E5RolJ5kOSQcj8JBI/M0+6HqFtZySTRGTxd5HOccxYDmIA2yMZH3q1NJJ3HiLXNxgc+vKas8NneafJCickzcryDqRsAd+m+TkUH1hbgMiBxJLKFh5unIMZyoA79DU1vIWsRHZRchZGlQFjzF/IZ7Hc1VbUbi8uo7NZiHRQrM2VOBjIxnfbNNaqrjb0iunY5zF7UrpraBb+aPxJeZMFyeUE9cYO2PTerrT+/Wy28jtB8JaOSPLAMPLO4orNImoGWzv4o2hUOYQm6qSQcY7VFb6fKJXcxlUQAYBIAGPXtWDqtKUOVOfXM2Kbwy+0MGAr+1h1Im5vbNI7pFHJJjLNKFAU+WAu4/zUgapw17rcvOjNLcLzLI7AIvzHO5AJ9MHOPrWpuIHna3d05YzzRsy5yCR5bnbA+gqhq+jXUkKyzXsbQAAxotsZJn7HJY8qD0AJ260myB1zGqrjS/EUNCvtRtkIjKtyn4TJHkKD3+IZxt2Y0YvdSjuLc2rzwIwbIEQ5FJP4lxhyfocVTudOsLTwhp1ldhhj92shKSHvlFOxJz6VNCk9lmG3AilkxyiZQrqeuyBiSO3XahBSnEvYUsO7Emfh7UwyPDBDyy4OHuAjMCPnfJYsCO2/0qePSyt1/0026xBgSgdXEm5zzF0ARMAAKFJJ7d6507T7dLiS69wtpJmcI0py7SNk8wJXfy70Yt7a3lk99eysYZQpKRHxE8Mj8T/wAOO2GyfTenKiDyfX0iVuRwPX1kqWlvcRwvOyRQRjKkjEvIu58NcpFAN8s7DJPY9KGnR4by7lSzt7qSHr4CNJLzg7lstjxDjHxNyKB2Owo1a6PrmqXTzTXkc8JBjCxxkAbZAjVgST58vTq2avT2TojLDbOJCoZ7iZWbG2xO45u2B3PatWpDZjAmZZb3WeYr65qNtp1uLDTY7iEyY5kRPFkOCcggDI6EE5A7AdSFma6h13VDaWnDJuZlAjaa7VOUZ6gIme/mx6dKc73R5GgaFZrtELZklunCzMD25V2QdNl39R0qbh7SoNHjU2yBCBjndcu30G+BTA0dmofDdPXSLfjEoXKjLS/wvwlHp0CTXFpAZQeZFW3WNIz5KBR+5vYLLEtwltER3kbLH7VDbNeToqRSMUO7EnlAqnqyaXFjNu09ydlVVLsx+wJrVNFdFWKREO9e+zNphmz1hb08pv2YDYHlwPtVDXHFsjSxF5Cd+Y1TsHu4V5zBFGR0jTt/mb+g/Oh3Ed1NJblpJCoA+VNqGXJq9ocydoD8HiJHFnEb2MUnNJhjnOKzubjVl5lExz9are0fWyJmgSTvg1nlo9zdXDAE4NZpJM2KalxkxsuuLLu7uORHOM+dNnDWszKqtI5x60l6borJ+8dTkedFRexadHgtjypFqwzZjzWIte0CarbcQEgfvBRGHUvF35sn61jtpxOssgRXxv51ofD7vcxK4O9TY5XCiZ/cj8xljXtQdEJ5jSxaWWoalcl91Qb5p3udDW8XL9aN6Fw9BHEByjNP6Ok2NzKW2LUnHWKVroVxEFYlzjzo1FoclwAHUmnE6TbqnLgZq9Y6dEmOYDFNFdlmB0i27emYl23s9iuWEhtgSf8ADRVPZ+Y4sJZ9P8NaRpos4VAZelG4bmwYBQyg+tb2nrV1mBqLnRziYNf8PTaefldcfhYVVhYq3K2xBrctdsbO6gbxIo3BHkKyjiHRUsZWntgTHndfL1+lEek18jpL06gWcEcylE3r6VchI2zQ2BugHSiMGCBtVVh8cy9EoxjvXN26wwMzEZxUkRAXmO3nQLXdQDt4KHI86J4SMZOJnPtDllmtZ2RSSQQKyngjQrl9YMzrkc2elbFxPavcweAqcxfbpXHDvCyWHLI0YDMc9KuvHAhTgDEcuF7ApbJhMDG9HZIh22rjRI1S38MDcbbVeeLqcVRkgw0GPF12qB4cnbPpRN4vTNRNEM+tCKyMwW8G2SN/KozBnfFEmhOcAD8s1yYfShlZG7iDDbnPShOtaaZIy4Xcb00GDfptUU9oJYipWhsmRPbsRAgjKNylf0oxbDkXmPlXy6sTBMTjvUc1x4EJHeiVru4lifETzxxC2RIMjJNZbxGMMw671pfEMikELncedZpr3xeIeu/lS3Zo5E48vnmId7zlyIyQaKcJ2l2uoxubhFyRsTv18qH3sTGTbAzV3QVVLqJ/eGyW3UGupsP+qRpwTYJ6gtIscJKok5zyZ3A8ulZlqRMMzPzZc52NaVo/hScIRFAw/d4wTv09azTXFiS5kDqWJ67182fJvafTtEf9IIi5qLNL8c1wFGNgGoUqLPKBGPhHViR/WptRGXKhjgdjQ9niDjnUkA7g9K0q14jDPnmGhqNppQH71nZzjPPnH07VBd6jEzc4fGSNzsd6CzTpLPzgJydgxqpqVy/hkRhFHQ43oiacMcwbX4En1TXmJ8OGQkDplsj7UJt2uNSnEOWbmOw+VR9WNUAJriTlQDPmBTFoFoVkX3hUUd/EyPyAyTThrWlc+MTW1rW90PcNcGNcyc8t+i8uPhiiaRmIOceWPqRWvaBwjGMRpAlu6rkv4CvNJ6cozgfUgUv8OyTRQq+jac7kLhmIWJBnyLEjPrTZo54gZmuJtQjiRl5XaGMzHy3woXPrvmsTUOzn2ukb37RgR30jS9O01FZJA5hJLTHYA4+WPlIHP6jOO5olNHLPGHsLqO1g5s3Ba3EhaM7kgk7HzY7Z86AaZqWl2pS6M8V00agePqNw9zMe3wRrhFHoD9avnV7+9liS2LzczhhJI9vEFPXYOSowP8JPrQA5UgiBGTyfrCw4R0q5sLgPLN4TOrxxPDGNgMfA7Nkk9frSNxT7NdNucx6npT+EFM0M8cymeLH4xy9Bjz69CO1P8V7rkbr73EWQfGZ7iZS2B+IEYH0xgVJZwx3ry+LbNOzsX5FjLJgjqXOBzeufPFFXVvURx698PWoYHceJ5l1z2IavcGSfh3U7bUUyTySEQykjzB2O46gj6Ul6rwZx3owMWrcN6lFGOkiW7OpA2+ZQRXtW54R4e1WHIjlSYbL4UwZk/wA7A8mPQMaFjgi5RFNhrmoRwITkcvwxgdWZ3KjfAxhT12zua0au1UH5lI+HP8GLWdnVWco2Pjx/M8VppuoOsSwaFqbOTyhEtJSSf/hx9KYrDhzi1po5X4fubKE4SSW8It0j9SzkHz/0r1bPwTf3qrbf7WXs3iEsrxyEHl26YAGOu4P38419kXCKxi61iCbU7skyLFduZhkbLlAR3OcE423J3FebtPTk5Ck/T7mDPZfGHsGPd/4J5qsuBtX12eS10xpdWaIrzSW8TG2TJ25pCBkdflz67U3aX7IppvAFxaoWmCmSWRQhVVAbKqOijOPLv3r0ZDZaJpFssFrokcURcSTeGgBLH8WFABLNk8oAAAG21DNf1ezhhubC2iYzhlErIqgRKMZX6hQM/ljqKU1Xaltg2r7I938x3RaKjTtlFyfMzCOMuF4rOC502ydHcuWMjSAlVxjJI6Ejoo6ZHrSI3DMbaNd3k6SYjIjgESsjMmMjYdQBgk7dj61sF9pFyLy4vprJQqxPcPC/WPPR5PI7g8uepGd+mc3k91dX7adHCYUOVLnBUSH4iz9jgAnHy5wOlC0177eDNW6pLGGZmz6VfXutq17DNKLiQt7wIzh5Bg8qsNi22CD18+9NcWbHTpJUSMM8rvFz9QTKCQft/Wjen6XPo6M7Xht7O9lJjjvboILsL8JJ6cjjORjYc25BxkTxt4sVwtulrIJJHPijIJbAAb77ZPqSe9OG7v2C+ES7kUAkQlFqi3E9tbNbzyeFIC5hOHOcFgPtWi8AapdzQ3GmlUktovhWa4fldPjPKGddi3bp0rIdOurpJ0mikcSxRNMkkTchDAbn69ad/ZvMzX8oE0aGSPkIkOCS3RkxtkEjr1FBsqhVbcs3a0tXupIbi0IW3aVZIkGPhJOTnvjrTtoumXVlNEy3KwzAkqnKSArEjGT3G+1LfBdmVRA1xI0efCLcvyg9Tv03GBT9CJYURnIyJy5YjqoHUj0o2l0ws9tvGKX2FTsWHrWeOGS297mZkPVwx5VBO2fLfau7ZojKwCOJNublP4d9ie9LV7ObRobjxlRIhyhlYnKMfiDDv2qlqPEcNoJlhvHIni2DDcPn9KetpQjLDp/EpTp7H/J4zRYbmyaZvEifMfwn4scy9gf9aYbD3a9jeOOJAW2JB/CRjB9awex4xv53ME0hPYEbU48M8SXEXIZZNyfiOetId7S7AEcGOv2dai9Y8a3oMkNu8sWC6kAEDcr2FQaNNbXdv+zruV4rhl8NRhDjHQ75qccQWt5G1tdTDDQseYHocHG4pG4U96ur3mEZlLEA8o+UDpsNztvWVq6VotBqGQeJCK5Qi04I5hziHRQlw8Elg5ul+IzQKuG8iwB8u/TeqTaStvbFFuIZGcZkJgYDftn5mP5D61pB0eLV7FG1FGtWtgViLHZ1I7kEYobNw7PakvDMkOcFgob49ux7fXNK26Ihs44Pr184JNWCu3PT174kppDw45BKYx23Vd+wQAkk+tWrLTH8U3VxNGVTJSMjCJ5BwB8R/wANda5JrkCOmn2EMc0iKjSOHk+E5B+I7j7daraD/tIZYP2jPFgHlCouCq9iCPl+nXrQVREYAZP6ev2hyzshYkQ/bXs8FwA3LzkBEBldJGOdiYVPTOcc5PXJ86OwaQk0TMr5WNj4p5uZi/XdurHPU9B0APUBNMt4jlFUQSFyFHiM8khzuSDvnfocmn3ReHL/AN0ZJrRrMk5AlIB+uDv065710PZam59uMzD7QbulzmJVzo0DS86oYgD8TPjmb6CprXTBzFbCy8Qj5pD8v3J2H3p5m4f0iyOb9pr1ycBII8Lnyydv51JJbahDbLde6aPolmN0nvn8Z/8AcToT/lXNdVToVHX6TnbNSYq2WjXkzgwWstyVG628ZZfu5+AfbNWG0K/u3Nu8trbkLvBC3iOB/i5c/qQK/X3EGieKffb/AFriKRekbObS2P8AuqeYj7j6UP1DiXia7szaaTo8Wn2Q3EVpFhR9SAB9yam1aEHtHPuHX6Znke5jxx8f7lPWbDStFjLT3skrgfJDyqB9WO35ZrJuNuK0EUsFuVjTyDEk/U96m4w124tpHF5dKZO6mQM36bCsv1a/e+kbDcwrldbqwX2VrgTf0unPDOcxQ11JNTvmf4iM0U0LQo48MQMjFWI7NUkOQN/zq2LuO3BX/npWazYmnuJ4WdX7R2cGQRtWa8T69IzsiNjG21M3EWsBYmXm3IJyTWV6xf8AiSM2Qck0aiveeZBbC5h/QNWkN0vNISM+dbxwbrMYtkDtg7E43ry/p2peA6sCBk7b096BxrJbKqK/kOte1GlZjlRJW3cu0z06mrwBNpFqzb8VQw/AsgxWDWvGs0q4Mmx9ambia7I5hKw/rRKAyRexFPUz0PY8RQzMCZB+dMdjqUbgYYGvM+lcY3EMil52A747VqPDXFSTxpzOCSPOmAfayYFkKjiabearJbwl4gCaU7v2h6vYzlUso5Vz3fFWpdVimt9viyPOlPVD4rM6r371q0ucAAzMtUbskR50r2kQX2Le7ie2kO2GOVb6Gqes6jHO3NzZU+tZ20rRn4zykHP0ohbX1xOmJHyoH3p3vWC7TzABFZsrxC8AUseTpmidt0HQUJtMkDJ8h5UTSRYovEbbFUXyhj75JqF8lrbkDqR50ryTGQmRjnyr9qOom6uDhsgV3pds+oXQjAPIpGaJLLwMmX9J0QXkZu5kB8s+Vfb23EUoCrgCm+2tVt7YQKo6b4FAdWg5WPWiquBBbsnM60eTDBD3FGyncDFLemycki7d6aoxzID5irkZErnBlRou4FRtCenWr7R+lRMnYDaqFZ7MomHO+K48IDarxj865MeNumaoUkZlIxb4x3r8Ye2KueHX7w+1UKSMxZ12yAUyD67Vn3EN/wC7qQXxitQ10qICnesV498RY5OTrUoNhyZdDkTHOIJGYHl3+tIGsrlWyTjNO2ryB2bBJ8qTtVXmBwNqS7PGADOLDZOYk30MjtyopJPlRrgrSY3vVN18GSNwvMaoakzeJyoceuaLcKX6Q3SJk5yAWNbuodjpyBHNAFNwJnoW1VbXh9YrbJATDMcZ6VlPEcjCd2ztnbtWhWOrxtpXhAE/DsSev2rNeJZJJp5HxgAkivnqA98cz6Xpz/rEVdQnLOcjfG+O9UcwPCcq2d8sT/Kp7iZ+c5Gx2ofcl8YVMDtmtitfCSzYle5lDSiO3BCd6rXcHxDxJWHffp+VTyJJCAzHBPTArh44lx4z/Ge7Dm/Sm0OBxE35PM70uzsmkUSzzbnBdcCnfTLCyjdBHd3iuDuFRVH5tn9KXtLhtHTFzqCAdeWRRGCP+fSmC1fT0jMllfWoXG+T4g+nTrS95ZjxmWQhOI12up2NnGI4zG7Njn55PD6eeBlj9SBV5NVu4/DcxycrnIdvhGPIFvm+w70l3MtzHJ4okblC/OCFH6DIr7p+uW0Ya2vbu7JkUqTFCABntzMCx+gFItTnkxoEER+hu58ZhvdSiCAhgbhIebsdhnlHT5mWpBe6hpa+8WGoXckuHkVprvnCEgA8ojU53zvt/Wlqxt9SVhLFJY2tupXlXARs9uY8u3r/ADFTrC2r+JzalbC0wWmco8cSYOCBjLOfRDkn86XKkHGflLLg9BD1txAyGJ9X4lvIjn4lW5S0ib/MZmZ8eixZ9c0w2vtB4YzHZNxPbeOhIMdlHc3jHsAFCnmbG+7fas8e04ahhaOygjMkgHMzxyM7467hG5B5AsT51d03RJ25xb39ypeEkRWtuUfOejybBV9FBJob4I9rP7RkImcnibZomvMxaFotVtYEbDtqE8Vryg9OWPJdf94LRyPUuGJj4cpSVGbI5JBc8pwfifw2YL9XZc1hnC2gafYSc9tpr3d0nNzGVnWON++yhmB7/MrHzFMtpq+oWaxWcWkXbyDmAULywxqc7hFOM75JPM3+IUEgLwokd0rHg8zWrrXOH4GFraT8r8gHvDwuMgdFy2FGOvf618t+IXuoAmlW8d2ZCCsqlQpwCMg5yR2zg7+dZjpLe62sjwW8fiOxiV5okkDN0+FFMnM3f4xjpsKIafe2KtHNeWM91HEQvjaleKFLY6IsYWIbdMdP0qhtI5z8pI0y9OT6/SaFdRXsaQm6lhtrkHmSJQMg9CxDEFiM7EDOT2GKE3tjBZTw6ZaQ+ITEzyzyFcjA2UZICDIyx+xx0I2FrdoPe1J00Xp5o4rbYgKc7ugCnz+KQnoOWvt7qml28MsVtbTXFlOB71yL4jzjfCsdyqZ35C3M2csUUgV4HfweJ4VlOBzA+oWyRWP7Publx7y0e6gfvScvkkjHJj5M7EczkYC5wTX7gNe+8afJcRxXLvPmTPxKX22O+Tjm3OcYJxnbbeKBeR6ZJf6yZLSKZGlMUr5ceIAAGc4yxUjIUYAKLkbhcejtyl7aSWt9HC45lLSTBUVQc8kYxknruOvWmqCF5h68tGHg2Oe90KW3h0vUoluVYO/irMFB2ywkUklhnIXIHY9aQeLLNp9VaO8V4fAQJzSFhlk2GMjPQAYPlWqaNpM93ELoQNfSPEPEuJr1jEwxspAUsT16D70mcU6I4jZltyy8/wARlfnZcbbNnmb6Yq1FmLCw8Z6xQQVgLTfd44obhBIGbOMfCrr0xn+L+eBTJwNKougRCrcpMSxP8wxuWP5Uow6n4NuLCRTJC2eVeUqynG+M9jtRLQb2W28S4VlJc5Ujrkin9vnK0+0wAno+x4zjt4xaqxUsijIOcnPUmjcPFGs6jzL4irFy8nLnHw9xmvP+lcQTFldz8XfO1aXw5xGrxDnfGOxoD6lwdoOBNQdnLWm7bkzS1k97tua5lwpUkldj/wA7Ut3rtKT+9HMMFSD2qR9fj91AVzysNwBuaVl1hlumtyCF/Dmpu1AKBSYfRaVskiMsUphCXBIyrb5NWzxmlhhWnRC3QMwBP2pZ1zU5NO0G41URhjCnwqfxOdlH50h8BcE6zxdrQ1LVrmWQyyZZiSeXPQAdhS6q9nFUcPdVgvd0E9OcGaudanjjmJ8JwQcNgnbselatoltpcEyWtpAsbKOUCSPdzjfJANLPs+0q14fsLeGN4UUAHw2XJJ9V8zWilHnhjm5VyDgMVWEj0+lbGn7NIQFuWnBdp9prfcQnCyaKEwSCRWQDGBHsW26HGObH2qbU9QvfdmUNaqwwFMikkfTmxn86FzajaxI0kkVysiYBJJbI/wAJ70M1GwsdehkbTxdJMw3Ml3Oo+8e6n60PVhkUrX1iNGHYM/T4f3KmvaZdSqz2q2b3SgsI2gkJx/uknr3pd4b0PWBdk6rb+A/Nlo4+ZkdT3OSD57A9eopg07hu70+BI7iXwyuSXQfCV752yPsKl/bWmaMFimaCWRuiQMzux+jdT/KsH8IzsHcbR7//ACav4nYprT2oz6XoBtJlvkb3U8xGEURnB9FHTbz39ab7Z3FsWilECYyZJHCg79Wbf/4Rk9qSNN1PUr1fd4dJuLUybh57qGMjyJXmL/6+VMelcN3kirJqGqNNIm+VJUKvko/DXUaCoU8Ipx8v3nP6xjYMuRDweVLfEDoGYf39yAqn/JGfiP1I+wpe1Dh6zmuDe67q11dSsN84gBHlzSZbH0UUXvPd9LtC6RzPsA3JNyn7kDJ+gpP1biu/tQTo1va2j9A/hc8uf87ZNdGrIEw/ymIVctlYattJsogH0jRYdv8AtfdXuG/+OUqn5Cl7jzwl09jqmp3GAp/d+MFH5JgD86WdT1zibUlZtR1C6kPfMpI/LpWd8Y6klvbuHy7YycnekNZr6q6yqp9o3ptI72As3MzPjzW4H1N4LAcsWT9f5mhVieZPEbqRvQTVbvx9SZw3RquRaisUIXmHN6muHc5YmdbgKoUSxqF74WwYZFL17roVSQwyO1Vtb1dVlIzvSVqWrszOA+R0wDUJWXMIq4Eua7rjSoyq+Tg7Uj3d1I7nqfvUt3fZd8OfKhU0wkOVbb18q1aK9nEBY+cgTo3bI2ST1q9p1/IJR+8I6d6AyzDnHN0yNqsWl9HC4YsObPc09tBWJ5YNzNN0W/c4BbrjG9M0F54hC5Oeu5rL7PXVj5SCAQMbd6OWnEjLh0fGDvkUg6MsdHtCPylucOGx3NNOi68bJViMuMCsvi4mVhjxd+mx2orp2qLOUwcj60M5zzIKHwm22fFcnghVk3+tT/t6Vv7w5z6UiaLMzBSQd8U26XYS30ygAkdacpsA4BiVqeJk11cNcOqgAAn70X0/ZVyCNqsNw0UUSyI23eogogcR+WBT5z1MzlIzxDVo222ap61qojX3eNtzsd6in1FLS3Ls2NqVp9RNxK0rtk9RRU6cywG44hSJnlZUQZdzgVoPDmmrY2ys6/ER3pS4Q0w3L++TptnYEU+xvjAGwoicnMixvAS6hzQ3VoA2SB1q9HJviuL1PEizjO1HEFnEVov3c3XptTbpriWAUqXKeHNkDGaO6HdfFyE1ceUqxwYYKZqNlqwR6VwQMV7E9uErlN64KZ/rVggYx2rnHXNRiRmV+U42zXxlABPlU/Lg1T1CZYYjk4r22ezF/WpfEyqmsz4r05rkNzL+lP17KXkJU996HXGknUCCF270JlzDVEDrPI2qOzFsHv5Ur37BgR2J6dqYNRfZmIyMmlq+YBcDGCO1J6QcCcOhyuTFvVYnycY39a+cN3L2d4hZOffoNq+anM+SeY9MUKt7+SGYN4mN63WrNlJXzjWlsFbhp6D0a7W503PhBMjbPU0k8UMElYAn6elU+GeILuUKoeRsjA2q/r6q6F2XLtn864a/THT34M+k6HUDUUgiJdxMqHpk52qCXDAZySegru7idX5sZwc7mqUviMQzE9flFOoAYRjz0ks9u0mGaRV5TsCcmq8yyLlVhZtvm6VLBhWLSx82K7lvkj+S3RYwd+dzk0cEjiBIB5Mm0y2F0MKkSuvUBOY/mabrWze3tlJYkgdFEeB/Wg2jXAnKmFbcNy4BKk/lTNbJc2oaSa28Rj0YoMD8jSl784MlEA9oSsbKRo/EW3lEbYGUP/E4+1DrbTjJKzR3qQSKxOZJQkm2/XB3opcXksxKvCDgdM8o/Mb1Bdyalaw+JHaGHb4XDgqPuwzQwrEcQofZObrSLshV8aRnILgeNI5Ge7HGB9K70ZNSFwJYb9UeAlgwAJ8sjmK4+u/0oAOI7yJ2W4vrpVU55bdgSx8uvLv9KatI4vSSD3E2CR9CXkxM69jjISNP1+tQ1TY5hVsPQCSalxxxVBI8b6jeTRqwVWjueRVPmAg3P3qnp+t6/fP4mn3d8hRjzTPcsAhPmxK5+7ECj0mlWV/aGQ3rT7q4DILg5OfJuRPz+1EbDh3VIoQkFlBDHjmMs0qoVDdDhsHPfYYHpQMVqMAAGXDjGWgpodeMIXW9et5beF+ZYRclhzt5GJWHnvnPrRzRpILFkjL3li0i83iQ28SBk77yMGkHlg586X9bgjtTJcXt9e3KR7eLFeh41A22OGx06LvQm241e2ijtInWdMkOUWYuy/4mZh1Pp9qEaWtX2YzXYomkanrySgOoLqHCLJPd+K7Jk7lHGEz5DI8gaKQT8STSR6peyCwtlXlhQRWyvyBSBgkgKO5OSNxWWaMZ9RunFjaxPISSI5FwIF7lm2C9hkknyNOLcPajpKxTa1a2FtJNGZYnjIVpMEYCLIXO2xyA3+Wl30+Osu1ygbQI5aBfabB4+uTabqesLG4/fzWczRhttg37tJCMnYOsYUfKaPahxFqctqkl7YQ2Vqsoks7SdVhid+qu0Yy8p/EclEGfuc7h4gt7k20Uc8lzexOW8W9VpeRxkgQwNs7joHkVI03Y9KgvdVjnvZ79J73UNQEXJc3Ac3Mat5LKwCYXvygLnOA3Wq91gcD175QnJyfXwnfEvF9zxTqlxJq2pLKrN4j3TxGRZZFB5VCjI5UwSFXKg4JzjNVOF7W4t1Fxam5uJLuMKAytCJBnbJQMyIT1zu3elWeaBJLi1s9O8Z5W5WlkmLZJ3K4B3z1PQehpx4XnhtYJr+4vZYRE4jaPx/hyAfhPKArnf5c4Gd8UVkYDIhmsVFwBHfw7G20t7y5ligdAsbR2vM7PKdhhWH16ClK70SXUJJmlswgVBH4gaMvnqQSCFUjbIBz260xGJ57SB4biGKK4VwnKh5+Yr8TBUAQeuSfuat2+lXiQiBtNhvZGiDL7tHytEvQsu3KufMn6VSpD/wAYs1wQHJmI8ZcLahAkrG2kXkYKvNszbbbAkHpSja315pMkMWowuI1OM43Feqbfh1rqOH3e1PhRrmRQysyAjo7HYZI7tk74GKpt7HdM1SaZ7mT4ccwUjYHp2HnW5RXZjYVyImdagbfnBEwaXifTrS3NxaO9y5X4YlU7n18qWn9pntFtbrxrU20UQPwxGMEAV6Xm9gFj7qDBjmMmWblweXy3pA4r9jV7pcskscYeFMDYb/Xp0o66VKsl0z8ZpDtJtThFsx8JJ7O/adLxNp7ftKH3W8gPLLGDlTtsy+lNbziS7inXowxtWRaHpcuja08IjKCRQAc7N3rSRNOllHc7/u8bYrE1dQDMqDidRoLAFUseehmmy6NHr/CF1aoQZIwkwA78pyR+VHfZtpFhAyc1tCytj4mYAA/Q7Zpa4R1qNdPdjNhTGep65FMfs0umN7IJxDyhjylgG29VPX7U92W+xQrDmYnbRZK3APHWbpoks+lxeFLYIsRGxWPnyPMEnamC1iilZZbe4tLlmG8VzG2fsR/WlWxuWEcQaa4jJ6SwEPFg+YO4ovG15by8/vkMatsGbmBYehG29bzMMcdB69ZE4DknPjCWvz3FpAk4tJbXAwPdXIwPMEj9KXZ77VY1SYTT3ManaWV8P6AlOU4+tX77TIbqJJGPhuGwrtIHXHkOYg1PY2htCPfJ5YVXo8aZjx5n4jWbqQ9zccD18BG6Sla56n18YFi1vWll5Q2oCBmwzxxtIq/RmUkfnRey02K8UzJqNw/inmKTXPUf5VQbfei/unDxtnaCdI2k+Z7dwu+epGdqHSz3NuRb6dFeT5Ozx+Hgfm5J/KgfgnT2nORCHUq/CDEYdLs5LeGNFnjgABBdjJISp6kDI3+uRRWyv5bq6Ww0/UDI4OWMkeXA6dEBA/Wgel2d7dukl3C0A+Zm8AO4wOvVh17Baa7FrxBym9uZkK4AMTwjGN9hsfyrZ09GFB9fvMu+zJMtXXDur3qEXF/ZogHxPIxx+WM0BuuGtCtsifiWEsDv4Fs8n6nFSaxb6hdKDBpN0VP43flH1AOKEXkd5FA3jGGMAb88yf0Na6hNvKmZ2WzjdKerHgWyhYveXl2++fFjwv8A8KsP1Jrz37W+KrNVkt9OkIiIxypCsY/TJ/WnjjjWorNZF8eMk/wtnevOXHGstd3MgL9/+RXJdq6/e3dKAJ0PZukwe8Y5itcXv7xpecnBPU1Wk1dmXIbOPXvQrULkpzfFuc7UJ95ZDlnYA9PSscV7psZ5kuu6jKxL+JjyFJ93qbkkc23p50X1abnT4Tk0DW08eTlYN9qepQKOZRiegg65upXyRn6dqqtcytt3z5daYJtIzty7mqq6GyyBQOo600rqIPumPMBTeMdwSMHJqGOK4ZgBnenG34bEvKStHNO4PjbGYwR0r34tU4nhp93Jippthdug+BthRN7K7iTk5DjrvWiWHDttDGFCdB1H0rq60NH6KBt+tKnVhj0jArAGJm9t72j8uCd6c+G1unkTIO/60RsuFUd8hN/5058P8KiMofD7+WKWtuLcCNB0QYMO8NWM7xrzL1xW6+zrh+1RFkuIUctgnmFIOgaSkMaqRggU7aRxTHohWOeCXA/FHg/oaZ0BUP8A7Ji68tYhFc03VeFNIuLAtEghcr+HYflWLcR2DaJds0sytDnZgenpitAl49s9Rs3W1n+MD5SCrfka83+3T2kTaNASvOS7YOOmM10dlddigp9Jz9ffVkh4Y1viFZmMUUuQvzYr5w7BNq94sSrlEbf1rz5pftQuNS1GO1t3/vDjfevUXANrDBpUU4IZ3UHPnnvQbEKeyYxVcCDjrH3To47WBIYxjAonFJ3oNBKD1NEIpOmTUiVJhKN871Mf3iEGqUTdKtRuc486KGlCfCBdQhIJO+aj024MUq7nrRPUovgLCgKsUlznHpVy2BmQTmPMT88YbPavpI60O0e7E0HKTkiiBI771YNmUDT4a5PpX3m+lc5qQZOZ8JwCT2pe1u66qDnFHLqURwsc4pL1S5MkrHOQagtxPA5MqkCR/qaYtHsVMJcrnI70CsIDNMo7E4pytoxDCqgY2ry8mELeE/nrfspBJ9d6XNQfALUbunyxGOhpf1Fs82ciktLxicSvIi/f5YEDJxQiO3UTc0oBGemaJXrMCcEdKEO8pk+E/eukQZTAjKYBBMedBuHkC2tvyqM9hj9abrrTZVtudiucdc5rPuF7hop1aZs7961C4nFxpoQOoyK43tio02DE73sPUG9cHwmb6uAkjIDnzoTEC7nDADPWjWtW0nikKNj19aHwWZAwygDuzEACh1EbZsWA7p8aNXBAkzk9v5VUm0+4uZ+WPwyAfxEVeupLaKIosjNj/wBGuR+ZqhbXKCbEen85z80su35DFGrz1EBaRjBjRoNjJbxqTEiSE7O7DNN2nWrwtmK3naWTG7DKetBdCv0s0WR7q1tQ3ZEU/wBM0zRS2t/ID41xOzjZ2PKp+1I3tluZKgyZ7W18Flmmiidhh+TILemd6CXWj2U8ryQX86ZYKefLA+mOhNGZ2t7LCv7tlduVcOc+oGSapyTXDEk+Lvj5oFUEHuM9P0qtZPhJII5MW73RbGOIq0ky7YUtbCIfY7Z+9BJtLtbTlkiu023Abmcg/TYdfWtBs7mBrnwze29ryD94GUb/AHGf51di0qwLPODczrISOeGzVifoXZi32AFF3t1EqLQv5pnljr6WH7ySzlkmYcru94yEj05QeUeWN6MR8fxJM6R6RGyuBzN4XMijHnMSznbvgd8U3z8PwTRzS3s11ZBFAAme3UvtkDlUEk+nQd6T77hK1uJnUOGDNzArEm3nliRgZ8vyqnsk5YfXMMLFfgTrUeNbPWVhH+ydvBOmyPHF4jKuABypzKg9CFz3zRPhzg+5hh9+ghuY7ggu8boyHz3LsB/P+lWNA4QGlzQ3SM7Z+Lne0mC+uW+FCNtsZpm5Uihkm/a2us8wO8IEKOOu7qMkfTyoZwTheBJN23gfzAkckunH3bUL/wAd1JdYoYSzK2Ns77b9xv5UK1GS/vNSkLXErOyEyiQqZZNvlAGWxg98Ad270O4gSKKYPZ3dzEcEcjS88knYg4+I/epNBtrvS4lnnJLurckAYrIOmNgCB9cMfVaqEGMw6Pjkw7dT6jp9jy+P7tFP+792Eixcw/hJYA8o+2T50Ml8SFHRtQM8jSc006TFkjXuAq46dMbb1ajbUbi8N9expJNAv7oPdciW5IwSQSzZI35mbOOmxxXF/o8Ecfiard2rT5BjhgchgMbEEqAO/Qee3eoVVBxPb2Jyeso2+niVFNn4s0SPzPLyqI1XP8KjI36jOfPuaatKuNLuSiTyyCJDli68pXG+wXPMTg7ZG350ipKryskFxEkMYOWkkHKzD+FRkE/y7ntUtlrkKyLa+MbhT8DlnYAE4+FB3Pmd/rvipesuuJG4AD3zW4dTtp7UXUAmRJWWOEzTCIO3cZAblG++Cx7Uc0C7s5LmK1v7+MxXJb9xbs7CaRCcBjs0mD+H88b1mF5faq1rFb6TbwRJaR8kchIbkdu5J6HGcKPqeld+ziyvbrXHe5uvF8OPwwzOXabfJVQOiA9hgMetW02EbJgL6yyHE9GQy206M02ps8URDtAGCIuP4iNuvXc+Q6Ve0u/N1PzW1siQhQ/Kq8pOdgST09O57Ui2d3ZwQM91cu7WxYBS4EcLjHNkZwSNvvkDpTFoutW2oatDYwlPCVsRpEebnkGCWY+g3ydhW6j5YGYjKQI/s8aLGmOYKAdwNz2GT+e1V7zQLbWBcxzRKylvidBsfMn+QqF7aO6m5ZwknhqWjCtkKM7Z/nRqzv4raRIY1/doCA7HY7btjufWm94bh+kECU5XrMW9oHsSuW8PVtGgUGPJKKCGJG+32pDYXMdvLZXULRyICpLjl3r2HYXVi0Y94eNEQNNIWOSVIyM58+tZ3x/wfw/rVgl/YxpHOR4jyhdyXORn0ApLUdnqT3qfKb3Z3bboRVcOPOeb+HOJZhFJYxyZkVvDK9O+K3PgCKHSrAT311HmT5vxYbuDnoawFNKbROPbrT71QRMC8JDfCSpwcgfatv0qZ9Tjt5nuIxNHCpYICodcd/Xbr9qSorCsT4iana9xvUAdDzNY0y/eOPxbK9jaJ+b4Y26ffqp+xFXU1OcBpFupsKoOBKrE/UEbGkyxihktRaMDHFIxBDPjDeQJ6H9KPWTJaxC2aV1f/wBYh5wR3B3Box3dB0nMFVBhi34qmAEEN+UAJBFxDkH0JUEEfamO0u5J7UpA8VsZN+azf4GPfboD9qS5ZbGK5Ep5SzDmI5BjH8XL/UUx2ur6VFb8lusDM+Ph5DH4n3OB+Zr1W7cdx6evWJD42jaPXrzhOytbx5cy38sqISPEilBZfIbb/mtOFlGksEaTz+8lV35+Rj9diD+YpJhvXlH/AEUxQxlSWU/GB9UOfzBq7axzXMym5hZolXBms3yv/wALbj7Gm69qdOYu+W90dGX3RWlhs7ViT+K2YNjH1GTUtktzMrOsrwhhzcqfCNvLeq2nm7W3SPTtWhnjxjErNHID5EY5f1qzMhi3ltjEx7dc+oPQ/lWnWmcEev1iDtjgyjc27szSG4kbzy2aUuKdXWyt5FaRgANviNMms3sdrbsfGPQ9sVhHtA4p5nkhDE7+dLdpawaavAPMLo9Ob390R+POJzPPIAxwDjrmsi1q9MhZ3wTnz6Uza7dtNIzM22TSLq1ygyNun1rijlyWM6tFCDasX9QufiPO23lQe7vlUbMPzrrUrkFywP0pfvpjkgHenaU55kPxLjT+K+5JxRO1RVTmIXzpds5lGxzuaLwXakBM70WxSOk9WRnmMENukqiTYnG5NTLp0fzFMY+2ai02bnUBvtRgeHKB8PTfHpSpYjrDHpmV7a1jDqOUHfv2o1AqxMMDlDYxvVGMIFwMZB2xUkcpIxknBx1oL5PSWzmHIZd/gI6VaRUYfEAewNB7eUxbFtz5VYGoKAAXGOuDtQ9rHpPbgOIcsWijkwANumKbtFnUOMgAenaszXUgJQVY56bUz6PqkoIxjf1q4GIF13HImq2l+sa5OBttir9hImoXQRzkUhLrSogUtimbhS9E19Hv3B61NTkGBasFSZqOm8Ew3EHiNHnI2JH9axn27+zxI9MuJGt8qwO5Ga9T8HRLc2SBlztSf7atDtrnh67V1GPDbauw0i5ryJzdjlbcGfzV0Xg+ex1opG5Z1PMABvXqP2UcQm4sTpl18FxAQpUn02x9ayH2daab/jK8jnIaO0coCejDOT/KnzV424Z4jt9btRywSERzAdMZ2NRcd43iCVQCQOom528oIFEYJPOlnR9QS+tYrlHBDrnY0cglP+tLBscS5MLxPnGe1XI3HWhcMo2yauRyetXDShMtTjxEI60s3kfJMwxvTIrgjGaE6pCc+Iv50QNuGJQNgz5ot6YZghbZjTTz7A5pCEjRSArsRTVpV6tzbgk7iqK+3iUY4OYSLVyWqPnyetcSyiNCxIxiiCyeziDtcvBFEUDYzSfKxeTqOvarut6iJpyAcjNUbSMyuPWoD5MupwMw9oVuCwcjYUxFsYGaHaZD4EA3Aq08nrRFfE9u5n88bvlZSwO/TpS5qDHBJxt1NF57gFSC350FvskFtiPQUHTLgiciuYBvGAyAaEucP170WvRnIxQZjyyHO5zXQ1fljC8w9o6OxDO2OXpT5pF/EYREH5yBjJO1ZpZyzlsAkDypz4ftpZmRy4yMHJOAKxe1aDYpLGb/AGTqRS+EHMs66cHKn8qA+IiozSbbflTzrdrbLp4ZFDuBnYdKzfUWKyHAx2rndOd3sidzYcKGlC8lV2KhyST3qTTY1MyggEk/mPKq6QCRy0pz54onp7tG5S0dIf4mxljWgeFwIgMk5jnplqbeNWSCNWxkFkBxV651K8S1ISblYnLu+FP2x0oRooiOMtLO47u2AKKaqIvdlZbQyMAe+AKzX5eMV9IuX3EN7lueeRyfxK5x98AZ/OhZm1C6IZGKAH4ctjH571+uYRcTkSJCf8IkJP6V9ttJtJXVZVWMNnOGJ/mabRQo8pDnxIzLFpE8EwmvGup8bBEcRoG7dck0wrxNLaJmKEWiEYYNcN8Rx3Ee52/iP2qtpuhx+AEtdPlhjY/PJKTn1x5UXtOF9LYF/e3mfugOB9sVV3XPWB4zyJTh4xWB/eI7QyynotrH4Jb0aRyz4+iivo9pmv2rl7azgtHXIQRrzyD/AH5CxHqcA+lEptKihh+DngA+VBgEjucf8aow2Fuz+ILZ5QNiWJAB+g3NCIU9RCjAg88e8UXV2t6lrJLKrZeaS4lYt9W5lwPyFTPqnEuucrXkl5cLkZHMfAQeWDyqfzemu04U1GeNZb4BIiMqryLCDn0O5FFF0iO2QCOKVlUElogI1Hll2Bb8lFECbuggjcq+EUbbQ7uIGd5okcj5UPxD6kgKo+lHtM0tpITHzzmKQ8zyqfgcfw8xxkfc/er0NvcL8NklrbnJP7uNnJPq7jP5VfsrC9vLtLUpfalfyYWOGFmZj2+VAXP0BH2ob0npKjVHqZWSytNOiXwbWBHDA4SJnZd/mz2Oc75HTGaXtdK30bXE8scgjJMhmcEuTnGy7em+T9q0O60Ow0lVteJtXEEvNyrpelwrc3hb+E4Yoh7fG3N/hqhDa6i942n8NaPp/Dxb4i9xIuoarINzks/7u3GM/LGmPOh9wa/zH+fXxhU1Ibpz69dMzPOH9Mnv5JYpbW5VnChQi8qQoTsQoAMjnbbZRnc5pisvZzBa6hDJNhJW+ZZCfgOO+B1+mQPU7U06ToN7ost3eSXKrLKonkeViZXAO2ZH35fUbeXrHqmsm3hN7GnhyApK91N+9eQY+FI1bYEnPKN/MgbUKwsRxDrYc5WEl4e0WK0FpDaQuI0EbmOAlQoAJRQc/ET8zHJ6DfpUF1xVpHC7m20K3IvZMIDEAfCAGMs3cjJ2HT60N0K4uNQu3utTvZuWBWjFoHOYubJzITspJySzYJxsABUt1a2msuP2HbyNbqxRJkTEbtn5xkZZF65OxJAAxk1dENYBP9wbf7DgnP7SeWK51WxUXUhdmRWh022UgRo5z4sx33PZdzuB1OzdwNBqekyQx+ArG5J5kRCZNt+Useg8+31oRoqWWk2cMKyzqrsC55g0k7jOSWHlvkj6DAFF9J4jimv2SK6fwwDCkKLyrnzZupA8h69aeqZQQVMVtBKlcevX/sfdNvnaaS51a7t44oT8KwxZw+cYJJzI2+PKrN/xXYxzzW8yKZ/D5IrcNl8ZG8hGygDr9aUFjlmgMtnl+bBgycDAJAYD1OT/AOFRWHDFrb3DuGMs7AGaZyTzyE55cZ+Ik+e22aOLmHGIIVKTkmaFJO2o27eDcSLHdtyE/wCDHyj/AF9araldvBpahlUqow6g/MgPl3wBj70JtzdPFLLazk8reBEWORjOWJ7Zz/Squv6rZ2dzBZz5RVTkV8fCGLdCPpg/ejG8kHEmur2gJmftFe0tNWhmdwZVyZPD6kkAgDzB2zvV3hviV7vTEKyESAtFGdjlOY/1B/OljWL03E9vbv8AvGiBVnI+Y5H67/rRK0sVjVRD8KxqAWI2we/61mM4UzowgNQB8JrOh8RSvaxQXoEiSAeE+QcMFB5SO4IOPOmTSeJLdXUSBltjkcqksIz3G/QDb1waxlH1K302S1ErgK8Tq/XlcDZh6bAH60w6ZqOpFTbSxtzkMDn8Q7EE7E7sPVTR1vAxkzJu0oOSJsVzeWhZHRwYw3K6O2wJ6bnb6dDV9r62iiU28yglc+HKvIQB1wcYOO+23faseX9r3dskMd+YrmAIsbk83OgJIRweu22/kKMaIOI0uFjZ2MfwNyjflA6lc+X8qKNQhPA6xJtMVHJ6TaNMlt9Q/dm2WK5UAoWXOR5hgcZ+mMimTTNMkcrK0EqSx5BMbFX27j+Ieh3/AJ0r8M6dNyRSoApU8yHHw47oR5dx/StK0uJWC8ylWAxvufp6+h61rUU95gmZVtm3gS1YKyf3/LJ/jZeV/uw6/evt/KLaFnt5yqns2CCf5H74q64KRmTk58DcdCaROMuJILK3kw4XbdTtmn7HXTVEmKKrXOAInce8UrbxyqSqsM/Lt+leb+KeKDNdP+9Ocmmfj/i8zyyhHBGSBk9qx7VLo3ErOWz5EVwer1B1VhJ6Tq9JpxQnPWfNW1l2VviztjY4xSVqF88jMD1+tEr98qwBB7jel+5Dbk9s9KEq4jggy7lPMebpQu5K5ONsjHnVu/dx+E47iqMmGUDG4x1pyscSjAmRoVTDHPpvV6BwWUgjr+ZoZzgNyk+mK7S5IPLnGO2aOVLdII8R2sJyig9MfnRiK4ViACcEb9qQ7PUZM8pc4/lTFp2oI6hGOBikrKinMMtgbgxhaXkHMpGDtUUdypbJYA/Wqr3arGRgVQ97VZBhtj59aqF3CTu8YyteGKPHNknvmhr38hflL+pqs12pjCg+owapS3XK55j+nSrKvGBB7jmMlpOZCCW3z501aVc8qqN9sb1nljqEZYZYZ7U3aPdhlXPf1pexCIcMDGdrx2ZeXO/6VoHs+Z3uY2J3zWe2wWQg464rSeBY+W4jI8xS4YhgJFmNpnqHgN8WoJ7LSv7b9SgtOGL6SRsKsTHr6UxcHsINMDnuKwz+1lxYNO4OuraNjzXP7lQDjc13GjHd6Uu3lOQu9vUYnnr2SQsffNWYfFNK7D6FjWja7YR6vpMtuy5ypIpJ9nEXufD8Mb4DtT3ZT8ylXx6g+VIUW5JQycf8pD7LtdnMEmiXr/vrVihz1IHQ1p0Eo23NYjf83DfFdvrEDcsNyRHLjz7GtcsL0TwpMrAhwDtVXO0yDwcCMUMu25q3FMNsUFiuOgztVyKbJqu+UIhiOUedfLhFmjOetU45ttj+tTeMCKsLcHMGRAd3GY2O+KsaTqJtplVm2JqTUIwwyO4oHLIYW6kYOc161sjcs9jcMGaCk6uvMD1oNr2qrBEY1YAmgNvxla2cLRTSjmA7mgV7rZ1GZmVjy9vpQe/BHEqoLHEsPKZ5u53o9o9rzMHI6UB0+BpHGx6042USwQgY3oqvgQjHHEvhgihR2rhpB1JqFpD51CZcdDVu+lQOZ/O2aT+XShtw4YkButXJW+I56fyobdEjJ2p3Te+cuoyMQdeAEHI7daDPy+KQ5IANF7lzjPl/Kg9wDzfDvvW9WMLCD3QnZXdtERjLH6036JqwYKiqo7jtikK0Kg4ZT17Cm3QuZnXlQgbZ7k0jrqEZCWj+k1NiONk0PkiutNYsjF8bE9KzPX7FxOx8PAz3rWtD09rq2wxCkr+LuKWeK9IjhYjkzjy3zXEpYtV5UT6NTm3TgvMzSNiQrD4V7dqM6dbk4jggC+pqvcWkiyEpFnfoBRHTve4xlkES/qRWmX3LmLAYMN20ctsokldFC7DbfP0qLUruOZWaUSSAjbxG2H2FWovC5PFlhLAb5Y/yFDdRvWmUi3hVAepxuPvSY6w1YBPMB3SyT/BECi5+Y4UCimiaVZKFa41Jh5pF3Pq1CDFavMFur1nOd0jHMT6elMtlFaQLm1ihtcjGZAWdv9KOSVGJDDJhq0E6stvFe2dmhAYeKDIxA6bA7/ei8AluJRDJrM9w2NvCt1iBz/8AMaFabo7SMLiSRIbfGTLKMc3oBkZ/Oi3jWtrIYdNuoYYiPiEKZeT6v/QYFLswJysHg+MlutHtkjPjyyKwY57s31J2H6n0od7pMic1i8MIP4uctKfuen2Aq/PDcXKiRoTyD5VdsBT5+v5VLo/C2u6zK62tn4iQDxJpHIjhhX+J3YhUHqxHpmvLuc9ZYsqjLSvpPu9pMjXmoozZyzNJlifrn+tN2kWk+tvJHozTXSRb3Bt1AigH8Usz4SMf5mHpQt7Tg3QQrS3EGs3OCeQs1vp6HzJHLNcD0HhJ6sKJXFlq+oWFrqHGuvjSNH+awt3tgiFe3udhGF5v+8IVfOQ07SOcNz68T0H198S1Db+QMevAdYWMPB+mYjvb6fWJiOXwNPcpAD5NcsMv/wD2kPo9XLwalaWLWWrXMPCumTjP7K0uMpdXK9vEBPiEH+Kd8eSmgK8UHTpPA4N0mSxOMPqV7Ksl+48kIHLAD5RgHzY0DleZJXaeReZ2LMWyzsT/ADPqd6OXC8J6/Xr9osKyeW+sMT3ZUNpvDmn2+l2zjlfwpC1zIvfxJtiB5hAq0w6fcaNw3pQiRUjjcmWQhFAdhtzux3YDG3McDypRtbw2/KI+T4tifDCjPmSdzijAkuVmhmtbJr2/lKm2M0bSsx/D4UXds9GI+gGM0nzuyYwMEY9GR69qpms01XUbaDTbGSTxBNcHaZv4sY5pXwBgAYUeVc2GlwnT14jv7K4soZYzcW0k7gX88WDmSNTlbWELk+K2XIJK8xOxe74bj4Y1U6vx3cw8QcdFOe30uU+PZ6FFjmElyB8LzY3EQyBtnmJGRk9rqF/eSTXk0+rX+oSKZTeuWyQeYc4OwAI5mUZ+VV8sRYq1nkc/t8f46/tDVsSMKePXT3e/ofDzgS00yXXriK41O0MeltKUtdPiLRxuvquScNjdmJdurHfFOWp39jZyRW2ockK22Gmithyo6jogHUjYDl6bb5O1Q3N0ml2n7Wu7gzXCEKocDCIMqAoGyk4JPkNztjNG00ue4ZpNUAh1C5Vrsgjeztyo5XYHpKVYci/gUqd3cYDyxhgcjPh4evvGexjj1zTJb97Y2ARHUcxwYYhjHidhgZPIO+M9MUB0nS3vNUACPFZqTyuzbsqnDE+bHcHsAT3po0/TPd9JkknItLOJliRCcsxG4UebZG57tgfhqpGbD3xoWDLzqAyq2whBAEfkAd8n65zmrEgkSqZGQP8AyF5OJIo2As4VlaQEGUqOSNBtlR9gAfLOKvmWaVSlsh57ZeZnB+e4dep/yr/MCqdsluFa8Kq8dzIiI+MfAiliR6eQ8qvLPbafp0c7kKnLJIxJ6nbOfXcmjo7PwZQoqngevXEvTXtrpMc0Em6xzKCpGwwAc/nn7ikDirU5tS1NI7KYlVlivEKjI8Nhy4P+6ebH/Cvuq6vdatrt7FakhIbjkYZzzHm2H025gfI1xo2jXUF3a2XMqgoW3GAuCVC+ucgfRDVzYMbRCVJt9owTpGnM05kmthzSShkLKds/EfsAV/IUww6awxaPEeV5DEMdV7dR1+IjcefpR6y0e3nmZYpPFiUtlEHzIwHKRn0DfnRaO1DraXACmB8hmAAw75wR5DHWgYz1jPfeUFaVobMiBwpLKSqnfcfMB3674wdqZNN4ZsS6yRwCCZxuOc4kH2O/23FSWsRke0DRRsswZHBzs6HBAO2+RkfU46Ypy0i0tXXwiodWw/KT8StjqD3/AONErrVjiKai5lGYN0/hyz3d4vizhyTkj79qa9H4eicoUVW5em2D/wCNSHTxlJkBblIXLADfyz16etMGjJDEwDNjH4G6/nWhRQqtgiZVtzMOsP8AD+kQpGABjYZ/1pjtYTGqxvyhj07ZqpZPCyjkOHHRsdat3V5DFHzzFV2zkjY/8a3aVCiZlhJM41C/hhgcmQqy59CDXm72w8XrG0kavlhnfvWr8a8QQQ2788vMFBIcHBrx17XuLhLeSQpMWBYisDtvV717lTNfsnS7n3kRY1rV5b25ctJkc2etC5PEaPckDHnQW21VZpWZjn61budSURMGPriudSvaJvOxPAlO8mUMyjoBjehLlZGJB7+XSuLq8eaUgH4R5d6jjYkAZGQdye9XIl1OOsp6pbgKWH/hS7LIUkGDtmm68QTQlRv3zSnfxcrk8pxnFHobMhwSOJSnkPPsOu2a+wESE5PSoplIUsM1Elx4QwCD9qeVcjiJuxU8wojCIg5K+dErK9AwA5GOlLE2oSY5QNq+xXzLjDEHsKh6Sw5lUuGcR3bUAyYEmw7VRn1BAxbn/Wl39oyHY59aryvcSklQelCXT46wjOW/LGiPW+X4S21dNqIfbn6bUqJbX2c4OPOrMaXi7lTUmtR0MgBz4RntL4RuMuAe1Nujav8AEqZU79jWZwC758rkedMej+9F1Xfy6UvcFAyYREduAJs2h3vjFVB3PQYrZ/Z1pk00scrD4OuayL2Z8OXmpTRPJEeXI3Ir07oGjDSbBMR45RvtvS+jpGpt46CU11v4VNp6mN0nEEOk6Z8ThFRa8Y/2h/aCOL+IbfQbZ+aKKUM++RmtK9uvtFudE0mW0sJuWRwR81eVNEuptY4iF1PIXIOSSckkmuluu21GsdJyxIX2vEzaNDcWtpDCuxVADimW0usOvUA0lWtzggg+go5a3Z5Rv0rn0t2PmMgZXAhfiW0j1HSpY2+ZVypHXI6UU9nmtveaUIJpcyQfA2/ltQu3uVmhAcjcYNBeHbr9h8UzWnPiG6PMoJ71pOe8XiCmyQXO2xq7Fc79f1pahu9v+NXIbs+dZ3feEk8xjS5H8VTrcjzpfjvBjrVhLsdjUG/EoRDDzBxynfal3WyVjPw7dsVe96yOvWhWuXyQWztIwGQetFp1AztMqRjmYrx1r13pd6JxKQvNggmjfBHFH7RCc8mTsOtKfGcaa1fGMKW+LAHb0o5wZw7JZIgBwBvR7KEVRZVKspJys3fQ40aFZj5UZ8cH0pP4e1QRxi2c7jaj/vA8/wAqRbU7pEutPnpmojNv1qqZ/WuGm6elV/ESwE/n/Odycbn0oZdnPNk9d8UTkywIIz/Khd1lSeXp610+n4M5cDiDLg4ycULmJD82aKXRBUkD70HnJ5yTW7T0lwJZtJeV90JFNeh6jyyhVQnsSaUbcBjjfB60z6DB+8VgT/SgawL3ZLQ+lNhsAWbDwhLNdJy8oGPxVzxdpyBDLJIDtvVrg4IIFAxgDsNqI8QQW11AecnA2Ar5pqbcaklRPp+hQrQA0xe5aCKUsAceQ71wt+Y8sI1x5kdKJ8SWkds7CJQcH70mXjS8xPMfzrZoYWLxB2LtMYBrDnBluFUdcLihV1fSTylY0LLndupNCQ3hkmWR/PA3rn3qZ/hh5lAz96YFQByIDvCOIZSRY4+bCKT26Gr+lySSSbPHAOzPuTS9BdNCQSVAzuWHMauDVjtywkkdsYqGQkYEJ3gPWNkbRF/39693PzbSSH4EHoDsKtWerXkt9DaaRHJe3c7eFBbwRl3lf+FVUEsfoNqBWmnXWsWCaxrV9Ho+iBjGLloi7XEi/NHbxAhriQd8EIv43TuRs9Zvrll4V9n2hXllHqH7hvCBn1LUfNJJEGeT/wBTEFjH4ufHNUdzgZeULDogjy2raVw3huIP/wAqako+LTbG4BigYdri6BI5s9Y4eY9i6HarUd/xZx3p/vt9PYaPw5YzY52Y22n2r+QwD4kv+FQ8p7560ow6fovCMnJr8sfEOsIQq6RZzf8AQrU9hdXEZ/eMO8MBx2aQbrXWuXfEXEdxb3GtSEiBfCtYVRYoLRP4IYUASNfRRv3yd68QE4PHuH3MoFDcj5+H6D1+sdbPUOH9DIueE7EXV3Gc/tvVbdSyN521sxKx+jyc7+QSq9/f+/ySXeo381xdSsHluJHLO57lnOWNLejaBeyyKryOzEkhQDn0pni0GO1OZ/3kjDlEaktv/iNUZy5x4eQlSip06yvb3SG3LWBcKMhpTtzeeCdzUsVncOPGfPO3youc+n9KL6Posl7fQ2FuXnnkPJDbwplifIfbqTsBuaddC0cW14tjw+3verPIIJdQhTxUtnYbQ2o2Ek2A37zIAAYgqoL0xWhfiLWOE+MA6Vwvc2s62t1ZpdasQpFm4LR2YbAD3JAJ5idlhGWY7YJ+GnmaaH2axT2mkzC84wuFJvL+cqTpqnqMDKrJvgRrkJtks3y/td1/TPZdaNw9w5JFNxKQxubuN/FTTWYYYI+P3tywJDSn5QcKFGxze1nluWaSYth388s7HsPMn+ZJPlRLmGmBVPzft/f7fHoOtTf7T/l/f+v3+HWfT4Ql1JeO5ZI3MryStzPLJzZB36/H8bMepX0GKuq8RyadYMNOlKSyMw8TI+BD1Zm/i2GT2ozfafFbA2MnKPCAWUj5UYZzGPp0J8yakl0G300Qs9hHcXpKe6WcicwV2OVklU/MxLZWM9SQW2AU5R3DgTRTaxDGBNLWWysItc12L99BEsllZSAEQpy595lUjALAxiKMjLFw7gKVUtmi2jmNItWHiSsxvbtmbmM8pJIUsdyASCc7liKg1HSI0vFs5Zvev2fzXOoXBbma6ut2Ylu45y35fSiem20kk6xTLlH/AH0rdPhT5APqd/tVzYA20+jPEAjIlfiDUZ7dLGzuAsk904jjVTgI8gJZsdsJjH+Y+dWxwvBa3V8HDE28hj6fNyDlI+pfOf8AKKjsbJtY4i4ctZAA15qUUj+YDuEUZ8sBDTXxDLFbS3GoAYS6mneMDufHbOPvmh7e8UufXH9iXL92VQdf7/owfDChEFs5H7mNyeU4A5l3oLxDM81o1vG3wIwaRfONshh9vhP0NXPf447+K2ibeSFRkA4PNGoH/wAxoSOa6kLgZEhVznfCgnI/KjqcCUHXM+6HZKRLIwBkmYHK9SeXGR5bA7/ejMqCCCWZnBfkOAuwEKg//UdvuK50OzJbmRdy5C5HoBn9KuXZjZJWj+IHCKT0wOp/PFVZxLDlpd0C3NpiNDmQrChY9AQAf6Uxafpsa3Xu8S8sNzHzcg6cyjH23UUL0kYmMjqcnmk/ViP6UctiyRxL8QZHXkbuB1oyYIGYCxjk4kVmIowWKkwy4aUZ2R+hb03BP/hTpo8EU2BMc7Eg43B7/wBD5eVJCk+KkwA5ZGYMOuzYP8xTbw/O4twjgkqdiPIdqLpWG7BgdSDtyI8waesiYf5sYLDckdfv9KgaOS0lMRzNH25CSR9Aev061d0V43jWJ3w2Mgf1B7ihnEl6bOUcyyHP4lPz48v8X/O9bFgVU3zMTJbbC9tq5sYlmDs9uT8TKCeU/wCJeqmrl7r0E9oWScEPsQxBFIEfER5155C/MPhnUbsvkw71LPMvhNNEypkZ+A7fkaAdcApCwv4c55EWfajr8VnpsoEiggE7bCvG/GOovf3kjkk5Y7mtu9s/FIjWSzD5J64NeddUvmmJIGBnpXO22HUWlvKb+lr7msDzlKK5aFiObcetWWlkkXuD0oVAyeKMtROGeNhhdyKsy4ELwTzODCTjLb96jPwuAvTvVgN8XMdh9KpythiegzQwMy3STg5UjfHSgWoQDDk469aOQOCCCOhz0qrfQKw3x9M1KHa0v1EUGid2KAdTXS6VI+Sq5+1GobGPxSx2+tFYbSNExyA04b9o4i5qBPMUotElkPKVzV+34ZJ/CTkU3WlkgYFl361dW2hQggb7EfSgPq2PAhK9Mo5xFi24RaYqvLv6CmbSPZyZCvNGDnvimHR7aOR1OBgkHpWiaDawDlYrjH86z7dVY3AhyErGQIg2vssSRQngHf0qw3slABIgwO21bdp9lbsg2XcbbUUFlblPlU/avIlp5ZoBtWM4E82Xfsya3I5Yjg9cLRzhX2dF7iMyREjNbRNoEN0/92vXyo/oXC0ULhzHg/SvANb7BMsdV3awh7N+C4LCCPEWMDyp84gia1091jIU8uM180CAWyqAMY9Kj41vYE02RmlA5Vz1rf0GnWhPZnN625rny08Q/wBojUbpdUa1abIJJIzSFwFaYL3mM5/KrPtj4ij1jiy6WEkrG5TJ774olwjZiDSYyB8/XtVdSdtOPOIkf7MRmt5mODnGCKNWUxGMd+tBoYzgE0TtFJIAzjH5VksOIwoxDdpdGMsrAYxkVV11BIINRtx++gcE/SpRExTIGScA19jPMTbTIcNkU7pbcgAwDjacxt0bUBdWUUytnK+dFop+2aTuGue1drJwcDJXI7UzqDSuqr7p/cZYZhVJ+nepo7jcb4oUsjdqkSYg4zikGfE9C6XJPelbi/VCsZiUg0TmvPChZ2OwFZrxFq8l7ee7xsdz59qqrmQ05s7Nbq794Zd89KebW1ENupxgAYpc4ctOe4Ub/DuacpyvgiNegGKLXrzSNhg9uORKSXZt5VeNtwabdP1H3mBW5s7Ugzycj8rEjNEdE1EQTchbCtS2pbYd69DIY85jwJx/pXLTCqKzgqGU5zXxps9DSK6oy/SeFpmwSRt5mqNww36/lViWT4T/ADofPLjKnP2r6Vp1yeZyyDEpXPT+npQe4zzY2z6UWuHBHQ49aFTgs+ACc7VuVfllhO7diCBn0xTbw/byuyuzcqnH3pXs40jIkkAPlmmCxvnZwsfNjzoGsBasgRnSHbYCZsvDt7awW4RWHNgZH+tErq5SYY3IxjOKSuFlZ41Lu2evWmy5dY4QV2z51811tQW4gT6fonNlKkjETuJ7QfGyLg5JJFIt1aJklkOfrWi6nykMWbrvik7UoXLkhcDPendIxAxL2qGgH3FZM4GAB3qFtPl5uWJAAfKiwjKkrnrtgVe02wuL+9isLGB7m6mJWOGIDJxud+gAAJLEgAAkkAZrQDnPESIA/NAdvpLA/HDknb6k9P12xTP+wdP4aAPENml9qg/u9FBISE9mvWUgg/8A8uhDH/tGQfCxe0kt9HuI7DhWY32uysI/2jbKZBExyPDshjLP2M+M9fDCj42u22k6FwYS2qRW+sayhJNlz89naN/69lP7+Tv4ankB+dm3Wrgkc+P0EEX8B/Z/ge+ULThPWOJ3TizjHVBZac6iGO6kiGZETpBZ26coZV6BUCRJ3Ydy9xdtY2UmkcNWn7D0+4TwrmRpufUL9D2mmXHKh/8AQxhU8+c71QvNXvtWv31TU76S6uXAQyvj4VGwVQAAijoFUAAdBVqExcjTPEcY2LdWoD3Nn2fn4/1LogIG7p5eH9yKy0iCC3WOygWMLvzEdMd80QkutKsIEa4mkuLgnr5nyHlQO91S4RGijVghOyk9RVGGDUdRuFEQbmBznHSqLWTy0s7eUdtP11Iwo5Pd1P4c/Ef9aI6dNq/EN+ul6Pa+JPcMVjjzyjAGSzE7AAZJYnAAJNBOH+E9Q1e9hsLdJJ7iY8oVDu3cksdgoGST0ABJrRtH0lJnfgrg64t3E0Ly6zrMz+HD7vHvIS7Y8O0j6ljgyHBO3KKYrTcePXuEVd9njz65lnhzTLi5lk4X4Qm8cOvLqutqoXx13LRQc2OWHY7kjnwXfCDFNnEHEWm+zKyfhrhmVf260Rhur5QT7gjY5oYQRnxG2LuQG2BbGFjjj1viWw4B0eHh7hLxEvJo1kE0sfJOiMAwuZVIykj7NFEd0Xlkcc/hpHll3HaYMl1OecnmPxEknvlj1Jp53/DrtX837e4fzE1Tv+X/AC/v7z/E4VBOxDRPgtzYLZLb7kn17nrTdodvDo2mtxTdgeO7vBpUbDYyLtJOR/DHnA83I/hNL/D1vDrN60TXJs9PtImu7+7Iz7tapjnfHdiSqIvVnZR3qzrHEGpajqBu7S0XT3RVgsrXPMul2yj92h7NNg8x8mZmOWI5U+g3GNH2jtHr1+36QvCy6XIks7c9+uHjjYcwth2dwer7/Ch6E8zb4FX9KMqRycQXEp54pGit2Y8zPdOCWfPfw0Oc/wAbL5Ur6dAscgRpi7tl5ZD8R9T6nfYdSSB3o1qGvWkd5HpVmo8LTP8Ao+FOV8XOZN+/xDlz35M96XyMZHQQ3d4IB6w9OtlbWvu6jHivhwDk8qAMfzwFH1J719ubl7O2ikcZMsKS7HqWLgAegCAUAj1RLgoQ5cxruR05mOTj/wCUfaj2rmOO00hnKgPpFo2Ce/NLQWKkFvKWCFcA+Ms+ztHl4w0J5UUk6laqBj/0eZXP0+BRUgaTW+DjcOc3GjXiXJHc2t0Ap/8AhmVP/wDJRj2YW0DcaaCpIykVzdY8i1vK2f8A4QlDuFLi0066ifUv+r7u3NnfgDf3eRQGb6qeVx6oKYQKtahuASw+i4+uIJss7EeAB+rfuIGltpozp92qEsLWDt1KOwP/ANFXhp62zyQKCQHKLjyyDt9sUZ1HSZdLC6feY8eynntHZd1bdXDA+TK/MPQ1y8aERTnGGXB8yy/D/LH50ByQSD1h1IIGOnrE+WNt7vbkgAE5Ofr1NfZ7QACMqRyKAwx3O5/pVtp4oFVpAORMEjHzN2X+p9PrXActErtu0hLfUmgk54l1GOZNYZQ+I22QUH3G/wClGxI3w8rdY2GfJuoNBRNHyrGDkgbY9DVw6iiLCwO5JJBPUY3/AJ5pqt+MGLWKSeBCsECy/Ay4J3wPXf8A5+lGLO49xUoHAMnwqWOAG7fTfI9M0tPqASGGSMjnQYO/zAf+NXdQ1KO4sYbtMfvAVcA9+oJ/1o6MqZYdYFkZsA9I22XFds5EEoeGaLBIxl4W/iA/EvmK71LVDdA+K6spAIZfiQ+vp/zmkNg946XsLHxEVckdc0a05mkwrOVJ3HkaJ+MdxtaU/DKORDFra21zluVRjfboTQzi7WLfRNLkIdQcHbNE55YtLtWkJHQn6Vg/tX4ud45Ykm8x1rO1N21cKOY1pqu8cZPEy72h8SPq2pyOJAyg4H51m2p3mTyrk98/6V1r+sye9vzOTn1oO92JV5s5+te09ZVBmPWEZ4kkckrMeUjJ3PpRXT42YAEDA60CguVjfbuQBTHaSqsIZOh9aK+QMTy4PWTTlgCB1+naqXNIcAgjOc/SrLTo7lc4BOME/pXzkUgcx69QKByOstjMrRXXJIQdt+lSXEoI5jg52obdOUJPQioDfmQNzHf0q/dZOZAbBhCPBffbBohEDynfoe3nQiznaTlwc5NFoWfY9qhgRxJHWE7V1BAI6irXMCRjciqEbiNiSOg/Ku2uVU+Y9TS2MmMbsQ5p9yYWXB6U46Nrgj5eY4BPn0rMkvCGBydj2NEbTVgCMP12xmoNWeYB3BGJt+n8RDlBEg/OjVrrbSuBzjpWK2PEQAGZNgabtD1vndOZxg+vWhvvxiLhQBmbJo5WZlZsZO1PmkwRGMbA1lXD2qx/Dlh6Vo+h6iJAoBp/SIqxDUs0YWcWiF+bGKyD2vcXyWek3TQSfEFON/StL1vVI0hMRkVWYELnbJxXkf27cbR2sk1hz/vVYpICCOUgkEf0rpdJpRYNp4zMnUWkLkdZgF3M+qcQO53Z5izfnWwaVaiC0hi5flQZHlWfcGyWd5rjXEkSLErjNalaxhzzIOYHcEGs7tOhqWCGK02i1iZPBAWA+H60VtYMEYG9R2sBI6Y2z1orb22OijFZYXMdU8y1a2wZSD5eVVrq0e2n8cHYn7UVtkAwPyqzc2K3MJXHbaj117TKPzIrWITJHdRqA6bmj8CiWJZAOo8qWdOn92mNrI/Q4/40zWAKnkwcNvTdtIvq94g1O3rPzRcvYZqIjcelEJItqpTDkDNnYb1jWac4hgYB4q1VbCxYeJylh51nmmFrq7e6f8J2q5xxrYuL73RCCAcECvvD9jmSKAKTnBag9yUXJlRgmPPDdv4MHjMNz0oq75OwqGBFghWJdgoAr6WBGM1gagndukMOIL1VDkup+m+KqWtwQ436HrRS7j8SMrjNASPBuCvbOKLVYbEKGLtxHrTLzxoAOYZAqy0nrS9otxh8Z2NG2ORt3rLuzW3Esh45nhp5Cc7jP0qlOd8jv0qXxMA4ONx3zVeYgjY/WvslC4M5xVwMSnMSevT+dUXYCTJq5OSBv0odMdzitavO2T0MtREM25oxp7AMBG29LsTktgk0b01yrAjNB1Iyhh9OfbGJp3DjiGAOWy31zRe4vHdcs+KUNFvuUKM5x6elHmk8ZAQo8t6+fatCtpLT6VoLF7oBZHdSo/MOfm+/QUDumjyyncZ6D/Wr90rRqRnGe5FULO1N5cSyvMsVvbKJLq6kBKQITgEgblidlQbsdh3ItSuTxCs4UZaR2ek3GrXLWtlCicqGWaaV+SKCIdZJG/CoyPMkkAAkgEvY6bLfwXmj8K4tdKjVTrGs32YVlTO3incxw5GUt1y7kAsGOAtxUs30yC41YXWk8OM3jWtrHy/tDWJFyPG3+FV6gSN+7jBIjDtzEjtX1661qOOzWCGx060Ym0062yIISRu5J+KSQ/ikfLH0GANFR3Y9r1685nszWNgdPXzPu8JK3EOlaJDJp3Ccc6eKpjudUnXku7sHqqAE+7wn+BTzMPnY/KB0aXN5gLJHDGBjAGMCqvgxZ588zenSo55XX8e3kKoxLdIRVCjPjDttp6RYma4Uld8YzVoSpzeJPcKsXkdz9qVhfXky+DFzKg7jarFuXlcCRyxwdjvVSpB6ywGekZIIbO8mWQMTGfPv9KN2Mc8t9Do+haY011ct4ccKY53b1z0Hck4AAJJwDS/pcF5Lcw2WmW0tzeXTrFDHGuXdz0VR5/oBuaZluZbCccDcHt+09c1Tmt9Rv4ZByuACz20EhwEgQKWlnJAYKxJEa73RM8n1/cFYxPA59dYz2SXd5MOAuCDHqGo36tHqOoRSBYnVfieONzgR20YHM8pwH5ST8IALD+1NM4K4dgg050vjfyLc2Qli21iaNiE1CdG3FjC4Pu0Df30gMrghcUHS90LgnhW5tI2S70zxPdtUnUtE3Ed6gD/s6I7PHYxZR522ZgUU4eQLHmGqcY6nr2sXGr6pePPd3b5llVQi9AFRFGyIqgKqjZVUAbCmS3cAf9v29fX4fmAtXenHh+/rw8vj+VuvNckeaee5uZLu+uWaSaRzztJIxyzMx6knJJ86GGd7kL7xkEsFCoOYknooHck7ADuRQR9Za2j8NSG5+3Uk0y8K3rcOaVd+0C7I9/tZ20/QEYAquolQ0k+Oje7Rsr+QlkhHUNhdTvPJwPOMGvYvI58BGvU72x4TshwRZvG2oRTJca5cghgl2oPJbKfxeACc9hKXPVVIWTqkCIVgyEQklj3ali2kMKeGec82SSzczEnuT3J3JJq9DJPF/wBNlBVYdreMDJaT+LH+HqP8WPWg26jeeOnhGKtLsHPWNMF9+yop9RZghsuQAdS963N4KfSIBpWH8SKD2ofpYubhUgRBHCq4GepH18/WuNaRdLW30dsNLYK3jAHJe7kwZST35cJFn/1Z86pR308ERijkC83znHSlXtzwIylIxn17o3jUbDToUUEEr0z3PpUnE2p3mvarwjplvIVF3w/pzEqfhjV3mDN+QP5Vm9/fTySx21sDJNL8IJ/CPOtSg0wWen8PXOf3lrwfZQBx1Mjy3Ea/cKzn7VdcLWSYNkwwj97Grpr32grfyAoJIbxoVz8sfhFVHphSBS+b1mSK3B3OA2PIUW9jNyG9oum2kQwvgXSE+Z8Bjj9KXcKskjd1YqB570O1ydMhP/Zv2WVrrA1DD3L+7R/9/HEHCbcgL6noIjeXHWexAKCT1MPMqt/g5D+E0GsbwSRStLljAfFVQcZ7Nv5D4fyqHhe71Gw1uGfTrjwLiSKSGJ8BgJGXKAg7MpYKpU7EEg9av3Om2t3arxPw7b+Dp8h5b6xBJOnSSDBTfcwNk+G3b5G3AJl2N6i0dRwf5/bPz8TiAi0sUPQ8j+Pd7vlxxmlLey3sy83ypsqgYA7/APHzopPKYCqk/wB0ir98b/qTVOytFg5pXHww5Y+pHT8zXU5Z0DE5LKh/Sh1KSCxlrCucCdXFy0U648ga+zzSie2KZKBt/QEYqq48a6DnJXGPrUvh5j8OTOIzgEdR/qKJzKHEL80vMsbkKdgM0U061le2ltcgggMAD5VQtxNNEhkCyHGxbo33pj0pIWkSMwNFKV6MaarQExOxiBKmnWs1rcht8dwB2pmiWyhjNwGwOpHrVN41t5f368vL0PnSxxbxhBYQukbDlYHpQLbRT7MlK2uIIkfHnFkMML+DLtjzrzfxlrwvJZC0hJz+VGeNeMveXdEmPxds1lerXdxcMxzsfzNKVg3NuaaKVilMRX4juH8YuucZ61UtLrxUwWBPlmrOqpJNEwxvQOwlaGUxt2NbVSgpxFnbD5hZiysCM/SjelXnNF4ZO9BWxIMqR619s7lrefJUivFdwxPA45jIX5XHMfyqx43MvOD3oW1wJF51b5q7huGIVCMAnelynGYQNg8TrUYmKFx070CQsLgqc5pmdfHhKsf0pdvEaO4LbbVek8Yg7PZ5MK2A5B2HrReCdQCM+opetLocgyRnHarcNwSR8RwD+lUdMk5kCzPSHI7jm3HQ/wA6hkmHLkNv61FDNhDnJ71BPMG5sfbegqnJxCd4ccT7JfMNi+T1z6VHHqzxt8R+2e1UbhixJ/LNUX5s/EelMqgxFmsJEaLfWyDs3xDpTjw1rLyyqBJnfoayeKRw4U05cG+93F2kUCMzZBAFAvqAXMtXYTxPR3CZluEQjPb7VsHDllLFb+K/l0rOfZzod1Fbxy3qcuRnFaVfaxZ6VYGd5FCRjDb9KY7N0rWsMTP1t2wFZnXt11jUIuFdQTR5mW9SF5I+UkHAG+CO+OleN+MOIrz2h6evEk9wguriV1vEXqJ1Ay2DvhgQ31LDtW4+0TjSbVdZmtoXjkhWTlCvEHG3TY/WvMNzrGnRcQzT6MJYkkuHjngZQOb4mAI+wH0Nb+nfcTX4DB+ExC+/BHh9cxj4H0i9aMSI0hyc7DqK3LTYAkaIBgKoApI4R09NIhtbj3iKdHUboCCrHqrDsR0269ehFaJaRcj8qrtnYnypXtitlu9qA0bh8/GErSL4RhSAOoonBH06ZG1VbVQAB0xsTRW3jBXOAT13rLRPGaAMkt4wfL/SikMQKYqvBGM4x+dEYV26Y27UYLJi1rlibSZb5F2U4bFGtJukmjXEnxAbf0q5e2iXNu0bKPiFKlncSaZftZyKQASVOOo7/lTlXBGZUjxjvzB03O42xS/xRqSabp8kjNhsHFFreZXjD5A8/wDWsn9p3EL3F0um202DncCh3afBJxxJDZEXbLn1fVHvJASmS2++9P8Aw1ZhCbh+o6UscPaX4FsiYPM5yc09QILaFYl2OMn61lapNiEecuPdCImyBXBl7bYqoJ8HrXzxst1P5VzGoTwnmPjLeQTnfHlQrU4OVvEGwJojEQ22a5v4/Et+2R5UnS22wRazPWV9Om5CDk7EGmeFxLEGBBFJlpKqPjp5edM+mTiSIqSMio11fGZVW5nhsnY469TUbsemfSuwT/iHcVG474FfYKxMACVphzdvWh8ynmyPvV99gcflVOc8uc1orwMS2MjmcwqM77UVtHCkAAk0Kikx1A9au2snlQb1LCFpIQxv0dyxUb/lTR4pWEYIyBtSVpM7Iy4ODTpomjahr0rrZmJIrdBLd3lw3JbWcROPElf8IydgMsx2UEmuM7QobvZ3XZl6mnOekgs9Mu9XuTCkjBAQZH8Nn8ME4ACr8Tux2VF+Jm2Hci3q9zo/DYSwnsob28tnLW+luyy29rLjBnvWX4bi4P8A6JT4cY+Ek4KmXiHjGx0u1OgcCieO1TmWbVJk8O7vGIwzqB/cKw2Cg83L8JIBIKIcR9+XHQDpipqArHmfpGiGtO48D6y/e6pe6ndzalrF3JcXc55pJZGyzY2H0AGwAwANgMVQe7JYANhOuBXDMZTlsfSopSY8scUVBk5Mqwx06CX7e4Eg5VYqPPvV2GOFgA+DigNtdKWClsD6URivVlkWCEd+vl61LJ5Sqv4wgVMjeHFgDGwAxVm3snSVIUiknnlYRxxRqWaRycKqgbkkkYAqSytPiDHJ5iAM7k/Ybn6U233JwBDLFGw/2lmiZZZT/wDwqJl3RT2uGU/E3/ZqeUfESRVUyYNr9pxIJY7nhpX4Z0NXveJNSYWV9LaDxGh8QhfcLYr8zsSFkdfmP7tTyhiWbQNHsuGdPvrSPUYbdLeLm4j1yBVnEcauB7nafhlUShY17XFyB/2Fu5apwtw1qmlXkHDmnRsvFurQlbhwQjaFYOmXTmO0dzJGfjY/3MTYJDO/JU4w1exvvduGOGxGug6W3NHIgKpeXCrye8FevIq5SFT8qZY/HK+TqO7HeN6938/LrBly/wDrXx6n7/x8/eVfibXbzirURcyWwsrG1QW2nafHIZEs7YMWEfOd3cszPJIfikkd3PXAFi3aMh16/hHlRg2HKfFZgqgY371OlsQonUAMB8Ofw+tIuXY7jNCsovAEraHoGo6xrNnoulqJdW1GdbeAucJCW/ET2wAWZuiqrHr0O8T3WmapeW2ncPM50LQoP2bpTMOUyxhi0lyw/jnlLyn0ZF6KKJ6Bpw4e4Vu9f5iNQ4hE2lae3Qw2YwL2cer5W3U+Rn8qXr2PwUCQ9AN9tqhgwUJ58/p4fz8p5HUvu8Bx+v8AXT5yCS4itB4cI537uR027Uc4ef3YvxDeohTTESVFfcSTk4gTHf48uf8ADG9ALW2SaQzOf3aZOCMZ9aYNUiktbW00uRSvIBf3i/8ArZFHhIf8kJX/AHpZKCQFjOS3HnKhkUr73cyEs5J5nOSxJ3J8yT3qjPdNOcRjCDJA/wBalMMsoNxMmFJwoPaoUUXMwtYU2ZhzNjc+lBAAPEP4cwhw9p3vN17y3xBcHPn6CtW1xPdtG4bgRh40uiWcr4/CqmZUH/zSH7ik7RrMoI7O2j+Jiqg+bE4H609a7ZoLvTXjz4UGh6dGgPfEWc/fOfvVSxZHx7hBORvXd7zL/saPge0vhx3GFa/W3Ynb+8Vo/wD9cUPkt2j1Oa3dT+4nlB+ocj+lWNCuv2Lqun6kp5ZbW7guM9N1kVv6Uw8QaI1lxrrenyKOaPUrg/7jSFl+3KwoqUtZpwnkx+oH/wAYu9wS8t5gfQn/AOUFwWs6hJYiUl5g6H+EjcH7GmGO4m0TVm1PTCsXvCGVUZA0bxS7vE6nZk5uZSp/h88VDFBzvkfKoAFS/Ddxy2gOZbQNPER1aPGZUHqMc4+j+dMVU7OV6+EWstDHn9YQOlWmtWjvw5EY52+OXTC5Z1x18BjvKnX4fnH+Ib0Fe1fwApDc6xgMCNwRkbjtVywCyKrLgZwy47Y6Yow+qvdMkWuWSahsU8cuYrlR2/egfF/vhqaFSWDPQ/T+vh0+EBvdDjqPr/f7/GLFrbMyeISBg96M2OkrOA3iYDbE46eRorZ6Vo10HFvqbR46rdwEMh8i0eVYfYf0ozo2ioEMMs9oebdXiuMgjPkQKldKQeRn17pVtRxmD9M0VYuaENGwZsPC4IGfQ9vrRmW193to5EU5iGDzdQM7dOuM9asyaT4EizyXEYXHI5GTgjpkY22pc4s4ot9GieB5W8RRgHsape6aes54g6w1zDHMFce8VDTtLMviqSg2/iBrz5xLxvLqKyOzEKO2aIe0bjb3xGQMABts2dvtWNX+t8+QHz9qw60bUWF26ToK61pr98s6prHiyknOTtjzoVLeyHHh5xVW8nL7hSAR96hinGeXIJXYVppVtHEWd8mfZTytiT8R3FBdStvBkE0WQD1x2o3IonBVyAeg33qpJF4iGJtx09aYQ7DmDYZEp2c3MAG7mrlxETGHQgHtVaG3MMmMbGicLJInIVGcbGrswByJVV4wZWtLghfDcmr0Moyu58tqr+68jcyHqfKrUcICjBPTYiqMwPSSExCEFwnhnffpQXVObmOAN+h61e+TJI2AqtKqysSf171FZCnMFYCeILhd0+EE7d/KiloxIxn8jUJtVGcDGKsWqBScADPpRLHBEoilTzLyTMq45vvXMsy8mebBOahlYRAso6dKFXF8Q2Mn6UJU3HiS/s9ZdnlUts1Q86uQoznpsKHG5kdgAOpxTjwPwtPruowIsZIdgKm1loXc5nqazc21Jb4J9nuucXXccVjaPyEjmcjYV6m4B9hcXDtrFPdRgvy5ZiO9P3sf9m9lo+lwn3eMEKPw7miPtf4ysuB9AaaUOEPw5QZx9aFoq/xrhrOngILV3fhx3df6mJV9rNtoLzQJIuI/4W6fase4u9pVxc6jc6feTFLd0YwherOo5sY75xVfXfaLa3+mSz2wEtzOxIPQkVk3EGpXk1xb6nPFhbaUOwGc4Ox/Q10uiYaPUrnpOZ1NhvDID1E0Pjq1WDUbW7VOSPULSK5QgYB5hn88EVgfHfD19a8Q3erWMJMNxiZ2TA8NwAG/M7575NegtYuZuJeA9I1VLPCaPO9pPKB1VwPDP02xWYcYRqqSqUBVkOQT2xUaus6LXsi9PD4HmC0p7yvJ9GNHAtxea5wzBb3V1LNeLbx30CyuWZbd2dAMntzxP023Hen7RJ2vLUNIPjiIQnHUds1lnsw1e5Ww05pwWj0PVrXQjMF+GO0vIpiUY9h7zDA656NM2PnxWie8fsHiBLcH9xeNzEHbY9R9qa7TqFy785yAYLTNsYjHT+Y52iDbG+aLQRjzwAao2sZBGF+tErdWyMiueVZqCXYIx+dXokOPr61VhH4s5FXoem9GVcCWBnap2Pel7inSDJF77BhZIviyKZkA7jNUddgebTZQjEMFJ8s0VBziQTM6uuO4NL09lkcCXHylsgHypF00rxNrJvi6tzMTgHO1IHtR1q5stUljWX4WJUqDTh7EbW7voBNOxwSGBH8q1Ni2U8xM5rsJmt6bpscWJgvQDbyq1PJg753/AFqZTyoV7L+pqncMckZztXMa8DJEeQ+cjaQ8xyfy6V9STJIyarO/pXcRHUHrXL6keM83MK2x23NTTnmiYdjVWBgBuR9asOwaP6jzrLK+3mBcZEAF2jkzt1xR7Q5+ZioOR60v3hIdiNgDt60Q0ObllUFu3nT96d5VmAXrPG3Pk9c718Z/h75rj8Rr6v4q+sV8cTEzkyGUZNUJ+tEZOp+lDbj5qbQy5Wcod8HpVuGUJg7bVRTv9auWX9/H/wB4v86tjIlTwY98NcNmZLPUNeee0trzeytYsC81D1iDbRxbHM8nwgAlQ+Dhh13i06lZQ8N6PHBaaJZSeKsFtzCO4nxjxWLfFJgHCs+ScltubAg4v/8AzicU/wDu6b/9AtLlt8o+orA7SrAPHE6PsZyevhn+JYucsMBfrgVRljbHMWIzRLy+tVLzofrWEvBwJ1WSesoB/DB5AOlVp2lkPX9KsSdD9qi/7FvrTKmCK+EooJGlMcJ3HzMelXYLqK1Usp2xks3Q4/pVeP8AuH+rVZsf/L7L/wBoi/8ArFMDmKtxmPtjqz8DWUOpXYH+0l5GJbKBxk6ZCw+G4kB6TsDmND8innO5XF/h2+j4b023441d4n1C8LyaBbXADh2ViH1GYN1ijcMIwdpJVLHKRNzJftH/APP7iD/3lP8A/VRzjr/zk0f/APp/Q/8A7OKiBR8vWYHoAfP1iPtxeTcFcNSaVLNIeIeLY1vNWklYmaCwc88cDk/F4s5JmlzvyGNTuzilYahGrjI53OenRase0v8A/OVxN/70u/8A9I1AbH+8X70OxBnHlxJr5AfxMO2VlNe3GWTKAZO+1GtM4ZvNf1az0HTmSNrqURCR/kQHdpG8lRQzE+SmudE/uP8AdNNPBP8A1hqP/ufUP/t3odSCxwD0l7GKDIgrjDWrG91QJpUbrptlClhpkR6raxZCEj+JyWkb/FI1KzwzXE5Dt8P4sfyq/J/5efof5VxB87f896E/tEmFQbABCGj2Vl70jX0PPZWytczp/HHGASv++3LH9Xr4FvNX1CS4vDzyTyNNO2Ni7Hmbf6np5YqxZf8AkV//ANzD/wDp0q5o/wA4+ppWxABiNK5MGa5CEwiqFAGBtXGg6S/Nzcm56k9hVriD+/H+Y0Z0f+8/3KC1YAxDCwlSYZ0mxWzzdg/FDHzg/wCM7L+pz/u0ya2sS3drAo2ttK06Pc9MWkR/rQa2/wCrJfqn8molxF/5XP8A+zWv/wBtFTFNSis/p94B3Lvn14QTFMLm4kkZiUhPXO2RWvcZQrd6vNxAD8UrvZzHylixyn/eiaM/Y1jGif8AVU/+c/zrYtZ/6q1T/wB5Q/8A29N0KO7cfA/v/MVvOXVvj9oFe4hghHLKoB7k4qo8rWY978QxMGDxyg9GByCD060IvP8Aqxfr/WrVx/5rXn/d/wBa8y+XhLLwYek1HT7eCK+gCRRMypLGo2hkboMdkbfl7dV7b2LW8t72c3CHMSY5gDujf6GkzTv+pp//AHM//wBxFV/hLref+z//AKwq5XDSCvX3HEeIWXT9SjvFIaOT4WOdiPI0ws8Omuk0ak2l0c5XB8N/5Z9O4pa03/yU/wCQf/VRkf8AUcn+ZKG7mtSw8IMIHIBlviTXo9L0551nhd+TALE7ivNXH3tGnvZZVkUIucNg4zWs8c/9WH7f1rzhxl/et/mrE1DG6z2jxNXRVKi9OYrcQ6oZoXlSUsp3xikmeVzEZMYNMurf3H2pWuPkf6U9plCrxL2k5nyO8mli+P8AD1+lfUlR3DAjPeoovlb71An96ftTqqImxIMIXEzNupG/866tp1BPiHJNVp/w/SuU/vhUBQRiWzgwoYfFIwM+or8ieG4yTyg1btf7pPpVV/mb/N/WlwctiHxwDLgjVhkE9M7dKh5niYqAcdasQ/KKjn+aqg84niPGffEMi8hxkDNRNDJnIXr51+i6n6/0qwen5fyqc7ekoRk4lcNgnmU5/PFfF2OVzjrUsnX7ioj1+9WBzKEZODIrgsyYzQmaJi+SM70Yk+Y/eqj9qJW2II156ybRdHe7nVQpOTnavVHsF9msk88N21sSqkdutYFwb/5dH9v6V7k9hn/VkP0FZWoc6i9am6R/aNNQXTrNg0DRFsrNIhFj4cb1g/8Aa80iSX2eaqY4y7RwlwM43Br0lbfIKwn+1N/5iav/ANw1bWnqFdyKvmJz17F6nLeRnkD2W8GLLpK3t/K3MFyVJ6UR4l0XT5bSey5ABIpHMB37UX4C/wCoZP8AKKEcQ/j/AM1Oaok3sSZm7EVBgSL2W3lzq2m6nwZcPyi5iMTek0blo2+4GPvSbxhZvyMsifGFKMue+4Ipn9kn/nnN/wC0R/zNDvab/wBZ33/tD/zrY7T/ANtNGob8xGD9IlpkFdroOnWKXs9u7ez4q0vTrqeWPT+JJVtdSiDHlmSNGOD6grGwPUMqsOlbLxVYy3mke/uhF1Z/vG2wQw+cGsI4c/8AODhT/wB4zf8A6M16S1v5tV/7yT+VeJL6VGPgWH6dZCgLqCB5A/XEscE6qus6LFKZQ8kY5H339D+VNttH8O/Ssx9k3y3H2/nWpwfh+1YbDa5AjlZ4lqBBsD+tX40+AE9aqQf0q7H0+9WAl8yRQMZ/nQ3iOZbfSpnY4+A53xRROn3pe42/6kn/AMp/kauBIPAzPJnHOhy61qUt3GC55yGAFat7HNOWz0wI2RkbH0NKUP8Afzf5/wChp/8AZ/8A3X2FN1sSoEFYPGOkhC5UHJ60OupcE71dl+Y/U0Ouu1YvaACsYwvIxKryEE71LFISd8j0xVY/MPqf5VLB0+9c1qFAlgMnEJQvnGM471cDEpvvQ+DoKvx/3YrKskMOIF1HCynlzvviv2ly8kiEnvvXWof3o+n9KrWP98f8wp1BvqwYoODif//Z"
+    },
+    "type": "object",
+    "properties": {
+      "filename": {
+        "description": "",
+        "example": "cat",
+        "type": "string"
+      },
+      "image": {
+        "description": "",
+        "example": "/9j/4AAQSkZJRgABAQEBLAEsAAD/4QDiRXhpZgAATU0AKgAAAAgABAEPAAIAAAASAAAAPgEQAAIAAAAMAAAAUIKaAAUAAAABAAAAXIdpAAQAAAABAAAAZAAAAABOSUtPTiBDT1JQT1JBVElPTgBOSUtPTiBEMzIwMAAAAAAKAAAfQAAGgpoABQAAAAEAAACugp0ABQAAAAEAAAC2iCcAAwAAAAIBkAAAkAMAAgAAABQAAAC+kgkAAwAAAAIAEAAAkgoABQAAAAEAAADSAAAACgAAH0AAAAAmAAAACjIwMTU6MTE6MTUgMTE6NTQ6MzcAAAADUgAAAAr/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAGpAoADASIAAhEBAxEB/8QAHQAAAgMBAQEBAQAAAAAAAAAABQYDBAcCCAEACf/EAFYQAAIBAwIEAwYDBQUEBQoBDQECAwAEEQUhBhIxQRNRYQcUIjJxgUKRoRUjUrHBCDNictEWguHwJDVDc/E0NlNjdHWSorK0FyU3s8ImREVkdoOTo9L/xAAbAQACAwEBAQAAAAAAAAAAAAADBAECBQYAB//EADkRAAICAQMBBQYGAgMAAQUBAAECAAMRBBIhMQUTQVHwImFxkaHBFDKBsdHhBiNCUvHSFSQzQ2Jy/9oADAMBAAIRAxEAPwDyHfw/EzHJxk70qaxj4snO9PWrQiNGGxPcedI+r9SN9+9KaI5MY1gwIqTr8X1rhB5CppwQxx1FRID16VrY5mU3EmjHxZ38qvwABftVGMHG9XoTgYxt9KIvETt5k6dcYzjar1uB1O5qimdv+f1q/bg9hnO9X5ziJ2cCFbMZOMfemCwUEigVnjmB86YNP2wcdNq9Mu08ZjLppCYOd6NWp5yM9f0pftnAAUDbqfrTBpzcxz16AUjqeOYpQCXxC1pCxIBOcf8AO1MVjbqeUgHJwfKhNmFBXG2cHGOn+tMNiMgYGP61y+sJJnZdnoBiEraBQOma+XbLGu1WogBHnA32odqEgLkDpWI6EmdRQfZlYHnbI2qZSBgnzqCJh9Tn86lQ57iqNXiO189ZbQBsZH1xV+3yBjoMd6p2ihsHHQ4q2rhDnPSqBPCNgGQ3L/vcVXmPMvzA57etc3EvNIWByetRtJzKMAen1ond+UsvBn6IlcY3+1WUG+wH3qqpOcAmrlspO/YVOzMZUeM5e6mtZ1mt5eR1OVIGfqCDsR6HY1O8UOoW8l5p0IjljBee0GTyr3kj7lPNeq+o3FKfPOR96+QyS28qTwSvFLG3Ojo2CrDuDRBXgbTJPPIlaVvjBB29K7t5GLdaJm1t9fPNZRpb6oc89qoCx3J84uyyecfQ/h3+Gh0EbKxDKQwJUgjBBHUEdj6UwKyolQwYyC7mIbGeu1D7tQwBA2O/1q9dDmP3qnKg8P6URR0kEQJyF5Sd/vROy+Fc4PWq3hHxc4Iz5USjhAgx023o88BK16BIec/bFDZIjy82djRB258qfw9qhkhyMDqaLWBBPnMrWwLBlxt51ZFm9xLBaQL8bsF/XrXNrEVVmYYPNtTJodqscvvswHMwxGD/ADpTW6gaZCR1Mb09PedeghBNLEECWCMCkRy7D8R9aYrLmghRYUCnG5I6CqVlEj4ZjklizZphsFEi8zJ16LisOgGxi7dTG3O1cSzp8cwCygAnu7HYfQUXSK55chvFPkp2qG3V0T4VVcdNs1agS6l+ExFx2IbFala+Ez3OTPqe8KMPZnY9MZx+VWLaSNTmNGI8jGRXx9O1s4a1m5R1+FgCPrX2ObiSwk5LjT5JQe4IYGruSg5B+UmtQ/Qj5yzKtvKnOsMZPfBww/1r6LYhOdEZlPk+cfnViGbT74ATWbJL3DLXL2GnwEsJJ7cn8SHmX7is6+vvOVx+00Km2eyc5gDU7QM6yKT16E012+nJqPCFzAVXJiZd9+opa1VAilkmEnqBimHhN5p9Lnhd8jlo/Yrd3fgyO1kNukzPGmpeLba7f2EijMUrAY9DXVu2MH/hTTx/DY23GN9aJajn8Rg7KNs5paWLkdl2yD1862NfVsfJ8Zz+jt3JAHtBYx6C0g25DnPnTDwLrknEHBOn3cq5kgXw2IPbp/QUue0ZC3DcoQYzt9KGf2fNUubjTtR0GZt4mMiqT5+X5UxpEF2htr8Rg/KB1L7NWjeYx95qPiHGFBzWCf2hOGOJb/iHT9bg1e4vLS6jMcVrMzeFYmCNSSNyCCCSBy5zkb5Fb+ID2xikf2kTNpuu8C6hHOivDxAhSNlJSQ4QrzenOseaW7GJGtStTgMcH18ZbtHb+HY4zjkSh7GNY1O94fv9M1PRLWxuNJv/AHad4rFbV3uDEplhkUDPNCy8m/cnpnFPlzzvbSBVDHlJCnv6UQm0mHTJ5rK2aN0jnlPPGgUSuzlmk27sxLE9SSa493+EjHzDv5UtrdQb9S1jcHP7cfaF0yrXp1XrxLnBmkSycMXlvHJzSeDzlebPnkY9KW9UcW9lNK2RyoTTf7OmFndTWbOS7u7OCflJ6Y26bUo8bgafp18JlwVZlx5Vr9rhbBReP+S4+UT0VhrNtZPQ/vMV0oftXjMEY/vcn862F0yN1xsMbVlPsttHvOJ57rlBC5PTpWxmBgckYwPzrN1jAMB5R3TtjJgt0z1AFBNQtgbsFhtynf8AlTU1v2GT26UJ1K1Pjr8O+Pz2qmlsHerDW2ZWXhCsuluCQBynB8sb1mWrBbvViudo8DI/OtTQvHokxcYAT8tqydZOaSads/ETWlqlAsz7orp7PZIkun2Jub0Y3GenpTesQjQIMYG1UOGbMEGds53NGmiwM9/Ss66wM2I/R7IlFkyc527V9jgLSqPMb471YMWOvbvmpEjAZTynfpQa2w4jFrZrIgmaBY7gsmBnvTJHEDEhOMctCrq2w4ZATjrtRyxX/ocfN9SftTWrya8iJ0NhsThYdtu/TNDtXYonhqPvijRAVObuKXtWkJkIJ8+9ZyElsRtzxzF+7CqDk/Nt9K/afaGV1OO9dyKJnwDRnSbIcwYjYetNs+xeYEc8y5DbCOEAAH1qxHCSdqlYZBwO2MeVSwoeYbd6AGMswA5n1LcbA/SuBByzMoBIbYURjjHYZ+lfpoOV1k64IPpRq7drgmK2rkQDcQe73AbcA/yotymSBTndNutR6pBmJXRejE/arOm/v4uVh1Falw31mIqdrSo6NjYEVwVZTnYd6uSRkHlJ74x1r54O/mc461iMQBGwcmZhrceebGxOw2pC1lSCwO5PTG9aHrRHxZ6b49Kz7W1GWB23/Suq0B6Cc7rfy8xVuvnOd8+lRKvTapbgnnIGNqiAwc5rZMxzwJLHkHFW4ziq0Qyc/wBKsx4xgjeiCLPzLkYJ3FXYN2xiqduSQAOtX7YHmBqwHjEbTCtnvjIO9MFlsB2yN6BWYOwPSjURwoGN6mZduScQ3ZnmYbE0x6cDsSN+lLOm5YjApq09eUjAORSOq4EHp1BeMlkuFXOObp0pgsFJ6g77/egWnDmUEHbAP/IpjsY+UDbt9a5m9cnBnY6FMgYhDn5Yjt2oVdPkmrc8hUcuNhQ+XOcEnH0pE15nR6dMT7D06ZzUiD4sHtn71CmU2Odv1qxCAWGT3ob1ZmjUuDL9rgAd8V1ePyD4SB518jAUAj61FcNzg4AzQRVzmN4lTmLZJ69dq/RvzY8qjyQCuf8AjX2MfFjc/wA6MKxiWAlkL3Aq/AoSEt6VWiUHl7+lWHcRpgHpXlryIbmU5mw9cK3cdMYr9K2fvUJz065o4rzKzsBXJz9qPRzR67CsWoypHqQAEV3IeVbjySY9ObsJD9G8wChXmZcdKtzryxcvmMGr4xxPbM8yheQTwTy29zC0UsTFHjcYZWHUEdqoyjGQtMUU667CmnXjhb6JRHaXDnHiAbLBIf0Rj0PwnYjAGeNklaKRWV1YoysMFWGxBHYg9qsK8dJ5OTgyosWTzY2q9yYgJK9v1qOGPJCnG/r3qzcqEi5N96uEzCbcQLJHiXJBNSBSqr3IBzX6RM+WPOrNpC0sioULMSOnff8A4V6xhSpLSFq7w4n7TNPe+kZDsi/FIf6UaWIF4+TcfKoB6CoGVNMRo48lpCecD+VWdJiPNk52OT9+1cpqdQb33HpNeuoVr7MZNOtyeUnHkBTDbRyKBy4H2oRZBgAFTHqaLxy8pBa4Cgdd9qPUwURS0EmErVLlhhQQD5rV62hvI3w8iEYzgrgUHbUrSJQZr1EUeZODX1Nbs3UFLkt/uNg08lkVNTHoIzwpMuOWfkxuQDmiVnqKRjkn1CD6bb0nwXtpMCqqST35sfoTV5IrWQhmtFbH8LAkUytzKMiD/DgnDRziuVnA/c20mPwl9z96/SJpM4KtB7u56Enal23S1VQkFvMmO6kgCrPvdug8OYkqO/MSa93gsHtASwq2H2SYL161mszvZxyxk7OpJGKOcIWzNbyFUCc69B0oZNesJfDjUOjfXpTNw+T4b8oC/BS2nVU1K7Y1qmY6Ugzy37Y9IfSeMry6EyYmcN0/OlE24kZZUGzAE0/e3TTJH4vmuzIHTlHw56Gk7RIPerUofmhbGPStrtAmyrI6icnpm7s7Yoe0KELw3KCAfQ9RST7OIZeHeJdP1UE+BqLeC+PX/jWke06yKaAU5fmPc0unRprf2fxavBD4ktnKsoOOgByf5UDszUCplV+jNtPwIxLaw7gWHgM/Kay1qFkK+R27VmPt3vP2NacKaonK0lrrLzRwhyryMsDYAPYZIBPbIxWqaZP+09LsdTC7XNuj5Hc4FYx/anuzZ6Twqvgx5/aVxMsnWRGWEAADPQlt/UCltADp+1EQ/wDFpa9xbpz4gibXeWVlFcsmnQGK0CoYY8Y5VKKcY+pNVzbb9Om4rrh24Oo8I8MagZBP7xoVgWnBz4zrEEdz6l0bPqDV4wnOSOtJ9pf6tZdWPBm/eXoszUpz4CArO7utF18SwJ8E3K7HyIIH5bmgHt9vYbJJBspvh4i+RJ7inDWLNLe2XVprmOBIcliwzt9Kx3X+IIPbBqVrokVzFC9lN4bFBnIz1AJ+ldHo0bXdmL/2RuPgZn23d3qvcRz7sdJY9jmhGOwl1Fo/7w4B/wBK0V7TrjO350Q0nhEcL2MWlrhiiA8wXqKsNaY2wa5jU6gvaZpK/GQYDe0J3Yd8/eqN1Y80ycq7ZyKZ3tCcnl3qCWyPOsrKAE3Joen1GLVnns45i3qVs0GjNCoAZ1wAemO9ZW1n/wBJ8JAfnIx960fV9ejF8bZ0BUEp1/X60vaPpfvmsy/BlRJsa6ntMitFtHlEtHc2WJEK6Rp5t7JF5cZHYVYe2AGw3o2bPkQR42G1V5bcgk43Ncv+IyczWSyBWgKkEfau44cMpwAAc4q9Jb77qd658IKw7cpzRK7ssIzvDqRK11ZkjIBGN+mau2cJS0zjOD+RogbUSKGU8pIz0rtbYx2rYAGDvitrUJmkmJVW4sAge+lMUbbdQdqUNRuvjYjfHrvTHrk/KpGfTekyZ2nmIGcc24rPqXJyY6zZMuWERkcEqCScU12tv4EIUDc7nNCdGtgzKT2/nTAwCr9BiqWvkyymVsjPfGNqmgI5hg9/KoHZc7etdxMFYHJ8sUIGQ7ZhaHmBGRsOlSTAsmAPzqGBsjbv1yKnzgY26dv1qwJEAeesruiz27IeqjequlOUZou6nzq0OaKTlO4Y+VDnJtb/ADy4Vz2862dO+5OYjYu0wncxnxObfc9qjHKqsxxvvV2KP3iAMNiNx3qG8gWOJsY361l6isq5WMK+RMm1hwS5zjOcelIessSG696dNWckkjY0j6u5y2DkV1OimBrSMRWudpPLtXCb9OvSurn5+tcIcdP51siY7HykqEj4e3lVqLruc1VXJPT/AMatwDfGc1cQD9JehBBzsM0Stx0ND4BuBjftRO0GdiNxRF64mbeeYUtAFAJotAxY8pIOOgoXb5UYzjuMURtW5mG/oak++ZrZ6w7pyHmGd803acucDPXelawX5T16bHypu0tchQRkdqTvyRBUHNsZNKT5VYD+tMlunJHjyzQTS0w6nl2zjyo65Kx4x18q569eTO57MUFeJUmfLffpmomwVORjFSSDJ6CozkHAxvSjIB0nT6dATIiD1BwfKrNuCe2agTJO4zVmE8m+NzVSuRNEV4loPhCSKg5uYYz+lcTylF5cmoEkHN9aH3cKFn11+PfO9TRxjIONqgLEPnHpU0MnMME+vSrbfGWCkwhbqAM1DeSgNgnGBUsLYUdT22qjeSFmJ5sAHy71UJC7eJy79/SoGYMxVSfPavwbKYJzg1yNm5jTCriSExyZdtwOYDO+M1PeyfAF2O3WoLbPKCSAB51xcy+JmNWHlUbfOW2cSm0vNzIdwdvtV25mGsW7XTEnULRA0573EQ25/wDOvRvMYPUGh0nw74696ktZJLe5juLZuWSNuZSdx9/Q9CPWiDA6yoTxEntV58NnPepruIsiqBnOOlFbPRXmYXFpCRBOOeNf4PNPsf0xRyz4UeQpJOuB6ilrtVXpxljChN3SIw01pDyhDg9NqM2OmrYKlzIvTp6+tF9YS007lgiALnY4obqdw6QxRnfG7bdK53U9pNrCVH5RG00/cgHxMF6hBI17I6sGy22OlFdLtjEi8x+o9aGQy+NI0gA5c77d6N2BU4Oc0jnJjRUhcQ7awZGARnG9Xo9MeYAs5UDpgdap2sjKPhHQZwKuw3UnKPGmVQ3YHemksUeESZW8JJHoOl5zLeuWzkgb0Qg0jRAOVpCceZHWhUl+wk8C3Gw/ExNfHv7yCETOyRN+At/9X08qartA8JQ12NxujGtjYWQUCLHfdtxXwX9tBkQHwuX+FAT+ppTW6iuGAk1aSZz2QttXydbOEE++uDtkCQ4x61J1JPTiGTR4/OST8IwXetw+IA91cTt3B+DFdwamjLzx6c+R3b4qXYNR0sOI7efxZQewL4oxBc6jMR4EaNt0xiiV8nJP3l2rC8Y+0P6fq1zdTLC0EIXyA3py06MCKTBIylKfDdpeSv4l1Zxqc+VPOmQpzMj4GVO1Er3nULzEdYUFZCzzX7TrNrjiG+LHm5HyoP0pL4Zg8DXGilziVenatj9pOmwx8QTtGn96oYn9KzG8tJ7K7S7SIt4L52/hrXU5sek+M5BjtAYeEV/a5EkdtDZqoyzj+flRjTOGhd+z57LABmtz26HGaX+M9Qh4m1yzitFVlVsMQ2cGtb0rTxFpMNqVwPC5Dj6VmXK1RCjqDmHzlj8pnvsdupdW4IjgmlV5NMnktWx1AViB/Kse/thQG3veEZlgkB8O8Afmypw0Z5ceY659cVrvsbsk0viTjDh0y/u470zwqxHNhxnp9c1nn9q/Tje8eeznTBA6G8nMAmJyp57mNSvL6Zz961b0C9rLcOjDd81zEqW/+12nw4+Rx9poHsLvI9V9kHDRjbLWMc9i8fXw2WUyde+fF5vQkjtTyLb/AA0j/wBmnSBp3Ams8O3EExvND1ya0upHmBRbjncOiJj5eVEbOdy5rVvcQegrK/yCrZrncdGCsP1AP8wumf8A17fLP7zMvafoc+o8LXkcF89u5jK7bDGK8p+zrROJrDjOK+sOd1hl/vBkd/MV6r9vuppoPBNzMTglCo3wcnbalv8As76faXmiQvfWY8WRTICy9ab7Guup0drg9OkrcRwSPGahZC7uLG3kvSTN4YByc1I9pncr0ox7n2xj7V8a18hXIXXtY5c9TCBtowPCA3tM9qC8TTiy09z0+HPlmnI2u/y9KW+L7CC5sWgkXd1Ir1DlrQsh7Mjmea9Y4kmbXPd1kxzPsc1rvBGmI1oLllHORnNZ6PZ4bjiAyiInfIIHbNbLwjojWNoImJwg2Ga6ztrUCvTpXnwg6hgjE/TWmMgLVKa1O4VcUzz2g8qpS2xJ6etcmt2Y+rxaktSTjGfoKhktyFJHnk5o9La/4elVpbbmUjB37UZbscwytmcWhjeJC+xI2qxJCGtZAuebl2+1CreQxzrA+dtt/LNW9X1GOyZeQ7NtnPbvXYaewaikDzidrd0czPNdlkeVowNwcfehVtZvz+O/Y0yX1tDfXLXEPQsc4rmHS/HvIrWHBXP6Uu9RoXa3WO13bukv6Pp7Lb+Jy9atSROOwyM5o5HppihSLGCBuAKil0+QjoMGk2rYnkQvexbkDqd+g3rhHIYAg47UZm0l2PynJ/SoxocrEZB/LrXhUc5xPG4dTP1u4IB8x1FW13OM9Tv9a7i0eRACWNWhpbA/1zUip5XvB4GUpE5uV8Daq2q2JeJZ0PT0o7HprsMEZI2ruXTWktTGynan9ICvsmLWnPSVOHmWaEISMDapdXteVWUDfG1UtMjaxuREWIGds+VMF3bG6hUrjPQkd6ZtoNg3eUEtm04nnHVJOYtlsUm6sd29KZtRlyWJ6DO1K+oDnDZ61r6QbRMnVcxbuB8RJ89qhB3/AJVPefCarg43FaucTKYZ4llBkbAVag67Ej61UhOTjH0q1CQrVfHHEBZxCMAAG2+KJ2gAfr12NC7c9OmKKW+AOYfzoq4mVfCanYDbIPaiNl8w2xn1oXCxJGeporZAB68c4iLrxmNGlrnHTfrTZpiZHKNx2pV0obj4fKm/Sxhthn7UrbFaD/sjXpyZRSO2OlFJWypGKG6eQFwRtjcgdNqsGYEelYWoXJ4nedlvgTmTKk7feo3I5+uxrovnO+49apySkdT09aVwek7LSL5S3Ge/c1cUARgnf+lDIpAxI89queKFj5SwyPzr22aeyR3L5IwetVg4ICnz339ailmJzk53qLxR3/8AGvbMDMlU5l9mBAOd67hbBx64qkkxIwTnOwqS3m+ME4wO9e2QoQCGixEZwRiqLtzBt96/PcgRkDoexqt4wwd8kdKptMttwJ1GxViu24r8rAnHc7586rSTcrHfoa68Yk82TjtV9vjLAZhGNk8Pr8386rzZU8/3r48nLBzk+g2r5AWI+LcE7VU8CWInc1nLJFzKM8u236V3ptnLNIv7skZANMOgWfiusT45XHemvT+GYLfmm5Ad81hW9rCljWYYUcZEKcOR2EGnqkgUNjmAx3xQXiLiNLOJxCQNjjBr9qSXEEReAleXoR2pYuonvrwwunOsyk48vP8AWucvvfUtGKqlT2j0kNs8uo3bXswPhgfDv1NR3QErSu2d9sE+VTypJZJHaQ746jvVC8lC/AWwTgEHsTualf8AWuwSwHevuH6SFIhGEhTZc8xOdzR+0Aj2UdBjNA7H95OAw9Bmjkau8ykHbOOUV4+1xDWDHWE7cN8xY7j1rv8A6ZkfPy5+HB/pUMXheMAjZJ2I3o1bJC7KqLyMBnmPRQOpNFTYDiKN7PM5gt5FUytA8ijblJzzHy9B51ZTSfHk94urRA79idhUg1OEsEV15FXCDfJ/413Hdyq/7kIpPYg5pkWJ+VYIbx7Um/YzmLl5Uiz05RvUD6BpSkRzQC4kPzF/9O9Q397cqfhueUgdW6Chja00ALS6xliegP8ApR6+T0ngLD0MZrdNE0oYtLeBcDcFQN6rXWvSxuIbRFRGO5RcCgMutPcKGWXlHZipJNT2CatcyK3iYh/xjc0wbMcAy6afHtWfWPvDlxM6B5JSc05aShnnxv0pP0WIwooC4OKa9BuWF0fICraNWbUKW6RDWsvdtsiL7TtLMeoCXlG6gVjvtAtr1dFnlsWKOIzgg9TW3e0q9ae9Eajt5Vnuq20b2Eolj5hjoac11wq1BZPCcinPBnmf2KarJqnEdzp93FiWGb94WODnO21epY7cKqrjsK8vW9uNB9rTSWcfhC7+ZV6H1/OvUmkye+WME3cqBTfaTi9UuAxkCBoygKE9DEXRuGI9M9sF1f8AIqrrFkOXBwGeMnOfXDfoay7+0fZtP7bPZRp0UCLO98v7wyZwBcxnBT7Eg98+lb5xbo3iwW2swc63WlzLPGydSB1U+hGaxb2op+2v7W/s1to0WRbax98YqnxD52yx7jYY+9Oov4rS16odawVb4YOD9cQAPdu9X/Y5H6/2DD3C0R4U/tL8UcIW2fcuLdMbiJYmfA94wqtyD8R5kc/Q1sS2w7gVjP8AaU00aBxP7O/ajbWc5k0zV/2ZeTQk5S2k/eLnywyPg/4sVu6JFOq3EDh45AJEYbBlIyD+RpDXV9/pKL/EZQ/pyPofpC1ttdl/X7faebf7ULHUH0jhSJyGv7gAjGfhUZNNPs04bk4cn0yydQSLRVIHmd6BavZ/7cf2jINMliZrbRrPnbfKh3P+grR71jpvEtt4agqX5FGOnaq6FtgFR6HJk3r088Z+caWtAN+X0qI2vp1o0Yeb4sbsM1E0GO1c5ZpwpIkE5gdrTbYYzWfe0C+WwRgc5xgGtTkhCoSR0FefPbTrxtrtbZXySRt51bSaYG9cSp6gQ9wPbWupO1w8XxDYU8izjgXCKMUp+yqJm0mKV48FxzfnT/NBgbVPbTFnA8pCfmOYDmgHkKoSwjfpR2eAZORQ+aAntWGMiNI/EDTRA9qqyRddu9FZovixVZ4c52oy5jKNF3V9O54TPEeV13GO9IHE2rXksPhgt4kOds9R3rVdUVVtSDsSKyfXLSVryQINySB3Fdb2G2TtbpK2DcJBoOtwzWEr3Lcsw/CO9O3AOlSSRPqE6ks5yM4z6Vm2kaLdRXrtI/OC3NgjYVsnBkEnunMdlG2K0dc4aziVqJXiFWt/TcdxUZtu53JogU3yAa6EWT0260uo84wxg4WIbqv1rpdPUYJWisUOeoqc24Izy/8AGibYPd4QP7oOnLXSWh5sY2ombfG+KlSAeVeAzJzKcFkDg4BqSWzCLnl26HFEoIcYBFWHgDoVOMGj1Lg8SjGZdxPG9ldpLE5UHbFFeGtUS8cRzONuufSpOKbNTIYmTOO6n9azuLXJNP1VUAI3I61rphELRYjLYEx/UXIkb1/Sl+5fBbINH9at5YZd0JDfIw3DfSly+OAw3BHap0rBolqkPWAr44cj171VVqtTxNPkxnLA7L5/SqGSjEMCCD0NaQIJxM3HEuwNv3q9Cc9KGRtuKvQSZIJ29KIDFrBCdscY3x5bURhk6b9aEwyAEHfrV2KTcbmiiZtq5hm1YDb9KN2WSRjIx1pdt3zj02o9YNkjvVjzELRgRs0lgCMjypz01sqDjIA/OknSmAKj7dacdMfCjJyAM7UtcQBE9PnfgRmS4CKoAz2+1SeNzJkYHcY/lQkXIz5jOD6CpDeKYzliO+3esm1QZ2fZrHcJca65R82POqU1yBLjzqpPeYBPNuOvrVGa9DYIxkHzpXbg5nf6H2hD9rOMbE58qnkugq7Z3FAIL0cuM9a6mv8AsG6V4rnpNULiXpJyD12IPrURn3xkdaGy3oK8wbpUPvw2+LrUqPCQRg5hqK5AIyasx3A5jv13pcF4OYNk1cju8quGOTtVNuDCgZGYWmvd+XNQ++Z7/rVa4s7xEE/hsUJxnFTafp11eXkcCxn46g4HJkbhJHkZyuBjJxVmNZCoXB22p20/2W3V3GJCSF7UXi4AFtMhmUHkOD6ik7NZUnAMkHPSJdhpFzfQhVRsEYO3eimm6DdLGY7iA/CcAkVplnpunWMKqI02HlVPU54GDpbKvNjIx1rH1fagGVEMiM55i3bwHT41k7xnP2oonE6JFzMwKEbgVFJau9ms8wPI5KNt0oENDZ1aGIsyK2x7b1yGotNrkmaddakYMn1/itYbVxGuQwyD50P4Cvf2ktxfsd0kYLt8uR0rq54Wee28N2YI3wk826kGiXDWippdvc2gULIfjyBgMRvn71fTWqpyZ7UKndFVgybM+pPLgnqdq5n04Nes0ikocOc+YFFWshDfMpPwyAMp+tdmBZ0SRQTjZjjPoatZd1Mog24xA/uKwyGdF+UZq/BMqhSyYx8Rx22q+NPRxylt2AxtXEFgFguGYb8+PtQ1sLHAlywI5kVrcLGDPMQibkE9ftVy81ePTbfNwMtKgllBGCq9VT69z9vKuY9N8SSOaZMx26h+XszE/Cv3O59AarXejvqUgeXLeI/xlvxep+9OVlKwCep/aAbDtg9BObfXjKVkFqADsuTnbzqHVuJri2QrZlpJmBARRgk0Yi0UpMfDhVEUbd67sNAtRM91LF4jnp6CjLaCBiSDWDkiZ9PHxlrUijwpYUc7Bjgfl1o/pfCElqqtd3w8TYEH4m/0FODWwVliiiVR1P8ApXQ08FSQFWRzjIHSjCzAlm1RI2qMCV7O3tLdVxb/AC7c7/z3o/aiE8ojwSe9ApLKN5OQtIxXfbYZonZA2/72X4UHQUzRaMe1FLRu6GPGjWpkQDB3ohGW0u7VQuz0M4W1VZZVGAFz0NOV7pKahEk8IGV3rWGLqc1fmEyW/wBduLehmc8cAy3McvL82RmkjXR4emSnzUitR4x0xxahmT4k3rNOIrHUJrApa2M8nMcZEZC/mdv1rMvZ3fBHJmDqqhVacdJiF9w6t7xLa6kFOY+ZeYfpW0cEuz2LQFs+G21AeH+F5JvGNzNZxsvxqHuo2YfZCx/Sj/C0NnYam9q2qI3Pn4I4JCPzYKK0q99qPUfDkTPJAKnznz2oW+uSezziBOGw37SNhN7vynB5+U4wfOvGP9mD2i3L+2m21z2g6hfalINPfTbdnjM00bEjlVd9uhHev6CvbadJC0MhuZA4KkciKMH7mvInE3s99l/sX/tD8HXuhWOrgapcSySwvfp4UTu3LzAGMsRl+nMMVo9g3qLW0tg3B/DzIB4MBqvy94DjH8zZf7RujjXPY1q00d01uLB7fUSxyC0ccg51OPNGYU4cN3MY4G0y9WN4QunRnklzlCFxg59AKM8TaRba7w7qejPbB47y0kh5HPNzEqcfrisbteP30n+zjqfF99qbTz2qXCP48PK0cw28PlG+zDFRQDf2bdWvVGVsfHKn7SzD/avv4+eMfeA/7NH/AO1HHPG/G8igrLqD20JB5lKR/CCDWgcbxG21WKdPhKSg/bIoP/ZM4Vn4e9klhdXkbR3GqFruUFcYLkt/Wm32iWoP70r5EEVnhtt6hfA4h3bfaT+ny4jVaL4tnFIDnKCvrx4qDhiZbjRbdxk4QA/XFEXjxk4pXVJi1h74uDxgwNqmILKRzt8JryP7VWm1Xi+G3jJKGQD9a9U8a3gs9KlyRuK89z6E1/xTb3TKWUuG6VOjISzeZI49qavwDpos9LtYeXGIx/Km6aHPf9KGcOQhBHGOiqB0phmh26fpS2tr7w5lRgGApoe2CcelUJ4d8Y3o/NB12qjPb1lmj3QyGL88J7CqjR8p5umKNTw5oZqIEMBJ22q1enJbEZVjiKWv3ZDMiHpttSvd6eTaSalykFNxmmK8i95m5e5O9fNRtDcJDo8KgtL83pmt2snSoGHWFBgTg7Qxq1nPezqQxJK+op24YRYUe1KjmXPfc11p+lrolsloi4Veu1fHAsb9ZwSI5NjWtt3AN5wY4OYSdOUkEb19jCnscGrDxrKiyrg5G9QiMrsB/wCFCA28RjORJogPLIqyoDDONxVaPIqwpIO3eiAEyhnfhKdwK6VB1xUibjzrrkq209ZGZ9RcYOa6lYFGy3KMZrgsEU5oZqd/4UBVSMtsKMkqeYA1cLJLJ8WVGSP9KyPVLKefiDmjTmAc/DjrWu6lEP2dlY/3jmqWi8M293LHeSRYZOp9aaRifYlWwvMZ5f7JvBs5kl0TjF4pX3Mc37yMHywd6z/i3+xNxtePI2jXWmX0J3jnt5OSVR5FG2cffNaTot3qF7HjSuI1laMASc0R/dnzL/KcUy6PrPFdjOrRcQwTxLuTE2ACPPO35Vy636mpw6FvoZv2aaplKOB+08FccewT2ocAXjR8TcL30NozELdxwtJEy9jzLnl+hxSLd6ddRTNY6lAyTKAY58bMD0z6etf1lt/aNcS2pi1nTY7hVGGeIBlcHzG9BNY9nvsS9omnNpuqcM2duznP7pBE6Me4I3Faa9vXIwFoB+HB9efgZlN2LSQdhI+PI+H8eIn8pjHLBKUmjKlTircZ5GAHfcV7t4u/sC6Tq0Er8H8VKGIJhiugCV8l5h1Hr1rzbxn/AGePab7NnmsuKeErySyRyEvLdPFjx55XpW1pu29PcOfZPkePl4fpMPV9i3Vk7eR5j7/zMwjc8obtVyFiMHcA9PWrA4du4WMUscoRt45CuBnyPka5hhMMgs7xSEc5jkx8prYXUI59k5mDdpLU/MMS7av03o9YyDbG3nS3GktvKYZRhlOCKPWOTF8IJKbnHlRwwxmZF1ZBIIjfpUu4GfvTRZ3XINzvSXpUh/TvTDbTM+FRSSfLzoNx4iFSHvOIwG9BHMew8+9cG9PKW5z8Q3yKEh5QpXJx2zULzyRZL5286zHIHSdj2bWcgmEmundiBnGMGqkkkqsVfof5VxDdPaSpcSLmFjyt5AUYvtFuzaS3EY5lgAdCN+ZDWdbqFQjPjPoHZ1bbc4gmK+OOvTauJNQbrkYPrVO5SazJlYE28+CG8j5VWWGWVZYhklPjXA6iih1IzNF2OYSN4dirfCRneohdHmAznPSrNjoNxNbxScpbnk5QB6im7h/2UapfTLJMpVFfI+lDbUInJM91islpfSoJYoXKnqcdKa+EeFNQ1uZR4RCA55sVtOkezbT49KSOSNedRg+tSm303hi3ZYI1Vxkbbb1mWdqqFO3rCqGPAhDSeDdJbSktruFT8GDkDrX5eEtG0qX3mNEGO9AtP4lvrx2VX5R1A9KnvtUnmiZJHPKFxnyrCs1thzgw6acDho6Wmo24iCxBSPSqepvM3xBSQw2YDvSfoOrtAJLeSQuVwR51BqnHv7OcpcHAU5ANKPZk8mFWls4UQvrBv7XTpL3flAyMVnNlxi/7VQysQnPgnPStPj1my1zQ2liIdJkJGCMA46V5z4xmXTtWeOGRovjJBI2A7g0EqHOBGtKN+VcT0Kyz31k0NtIgjlXxEPqKH2N09tcJzJyt8vKejeY/Kkng/jqMWFsktwcxAdNyp8/pTpa3mj67MpS8ASfBABwx37HsQaWNO45lCWqyrDiS6hqIs52tW5HiY8yt0OD/AKVVubwRvHNDk4XLY7r3qG88drhdMuYkuJbaRvCnG3Ov8J+o2+tcFUiRL22fxbWQFCCcmNx8ynyOKVarDErCLtxzJo7lJ5YkcklGwrf4e35VYtZo4U8HAzHkP+dVbe2S3vBZqGkjuAZreQdAuMMp/nUsEJllWGMKGMbCVenMuKqynPM8ADwJdvSsFzAUf4XwR32rgXSKjkZyXIwe1C724mjt1ifIe0AIPmudjVzh1YrjUJLib4olBuGyNsAZx9zgfevKpztXxk93tQs3hDFyViW3tiBzR/FMP8bD+gwPzr7Gojt4uX4SxJ6UMs2upL24tbv4peZmJPc5z/Wr6FmXLZ5o3AIz2NestJOR08PhBirZxCEMGYZCZOZj69akizGzKAAQN6+oEjQxq2DtgVWCymeVycJkYPnV1sKYMHszmXGtoXlMznZVyNuhr7M0dpEJuX59l+tfI1Dx85z8W2Ks+AvhI0+AEY4JO2f60yljMcQLDHWVbuQwonhj94wy2RuKozzMLY3U3MFXfHQD6k7D70WaLxQUCczO3MWkGwHbb/Wkfj6aeWHklnPhp8KIOhNOoQq88mWoU2OF6Rr0LiC2xzR3KkjtH8Q/Pp+Wa0zhfiwyFbYkkeprz/wjb3PhB2Y8qgH6mtd4MtwZFlentG9otBTiT2jTSqnPM07XLOO+0xpYzhgvUda86e0GN438GZmc5Pzkt/OvREt2I9NYBtuWsK9olg9zMZ1XON/tmne1XRbUHj1nHvp3srNg8IG4FtQI3fHwnbFVtSP7J1qOXpl+XNHuELcRWOemaq8bWIaMXAXcYIPqKS0l+zUgnoeJj3DC/DmN9qwmhjlXcMOteRf7a2o/sTjbgjVoIwksEkrmTGxClGwfyr1ZwvcePpEJJBZRg151/tb8KjjLjDgbh25/dQXtzcQideqOYvh+xx+lPaCz8J2kjH/iSfkDB24dCp6HH1InovgzXbfifhbSuIrZlMd/axzgg7bivEHt5460iC/4g9lnCPEUl9b61xMs1zDETyxl2XxYsnY/Ge30869L/wBnLXNQi0jUPZpqsAM/Bvh2LSr0cb4/MYP3rx3/AGlOBL72c+3a/wBb0jQL2w0u7uYtRtLhoi8JmY5cq3yj48/CfOt/TIml7RspB9mweyf/AOWIYfSUpYugc5JXB/UcH6z+iXDmifsDh3S9JEPhC3tI0CZBxt6fSgfHdsHtSxHVapew3WdW4k9mukcQa1qHvd1exF3bwgnLv0AFHOMbbx7HA7gj9KxL0SjVMlZJUHgnrPVlsAv1kHAziTRUTO6HBpgZRj7UpezxitnNas393IevXem+Y8sTH0qNWM2kyTwSJmPtLvGIS1XfnYAigFjogSSK68MYwDVvjCZrrX44VOQGNMx08Q6TG4XfApcAqVAl24RR5z5w9/eqMYHemmSLIz2pX0MkTr23pxKfAPPFFuTPWUPWCpoObOKoywgdh6Uaki36VTmjFLGjxll4gGeEk9KVuIJgMRggYp1vVEUbufKs/wBYfxZWyTk7UzRQB7RjNfMGW0Y/eTOM8gzRLhfTDc3kmqzIMZ+EYqCO2Myx2sWeZj8QFOVlZJZ2qQoMADf61babXz4CF8YO1e3HJ4ijGetBpk8W3ZCAWTemq8jEkJBpaZeSUhj12rVoG5dplj0zJ9JufGg5HAyNqulATjY+VA7OT3S+aPm+Fv1pgTJAPn0xUsvMushVOVgSOtTLjrXYjHavqrirAT0ljHapcDuKjQDrX2WVY0ZyelTgESMSjfThW5Ac49aWbu694vggA5U361f1K75Y5JCT0OKXoZmZi2N2NeU7RmSFOIcs4jfyFQvwrt9aZNOsVs42hIG+/SqXDdkEVWZfvR67jCqHQAYo1Jx7Uo3PEy7k4lvrWO81LV9QhtmXnAnkEcS+QCjGT6D86JQ6m8UHPbTC7jtwFkmlZxGCRsoHc/SkloNU1O8hgv70z3MuORGfIiB/E/8ACMb4/M9q0P8AauicKSWui2nialdwKFgs7XA5Xb5priRvhQt15RkgYHpXOjTls4OJ19loQAYz7hLNhY6/Oh1O7itNLtgoZZbx2T4exCDBxTFomq6NdviTX1uvC6yWNrIFX6ux3oLfX4uljuL7SPeJGPMgNzyR+peSQZPoFFTnRbm6hjm1XiOPS7TYrEkXhod+isd2+wFebTbTgc+v0i/fixfb4+Hon9o+6frpjnHuutahN4ZyFMZO3ptTHae1FDcHTNXhS6iIAdHTfB81YVlkHDGoEBdCv9QKNuHt5ssw8yGxgfapJNL1azEaXvFNzDInwqtwnO2fLON6XdLFGFGPXvlVWlj+b+fpNE4n9lPsV9oMLe86LbWssyjEkA8Ng3ntWF8df2JJWglfhLVo723ALKkh5ZAd8FT51oCa80McUE+uK7g7GMhOfHnzUZ0zje7gm93AY4GcKTz49MZBqBfZS2aiVPu6fLpKvpQ6bXAYe8TxvqvsO4v0iF4OIdHlivLJsLJ4ZxNF6+ZHmKEabwjc2ty3iRP4LqVIx0/1r+h1jxhomsKtjrOni5yNvFiGR+dC9S9lPs4166d9PUW0xJbwyByk/etOrtjWqpGAwPlxj9PrMW7sHRWMDypHn4+un9zxVa8D3Lwq1uxLDyHWmvRvZxqs6xTQwtlfmBHzDzFenj7E7Wyw9pE0q82eZUVh+QNW4tAg0sCMW6Bl2wRyMfs2P0od3+RapF2suICn/EdGXDq2Zhl57IJbjTfeIFKyhRtik6b2bao5eCaAh91BxtntXqYT28JMEsRQjYhhg/kapy2WnPzMEXmNYw7cuGRmdMnY2nQhtv8Ac876D7Pbi4t5NL1O2wAeXmI/WnfhX2fvFay6bekvyoYeY9x2z9tq0xbXTxHI/IocDPTyqgNVtrWY4APMMnekNT2q9nU9ZpU6YIMIOkyX/wDC03SXGkSwfBztyHGB6Va0f2LNG6+8qcR8yEkfhPStctNTsbj4QqKxzv3zRi3urd7dWJViNmHnTNXalhX80iyrB5Ez+z9mujWKxL4S5Ug4x3Hejl3bDT+VbWNcbDamK505ZZR4R/vBlcn0pY1ma40ySMyk8r7fcCq2ayxvzGerrVjx1l2zmvZoU5VIG4IoZrWmQXAHjDd85zV3TOILOCOOdyApIU58zVrVoLa/5nt7hQoORvtmvCzIzIIKNg8RS/2fFtaNdWTh3Q4x6VUeBrUc9wQ6z7FemMiurtr+zWSCCZmLczcvcEDpS5FxD+0rUC5Z4yxbnB6jlONqG1pI4jaIeueJdja3F61ikgWTk5gc52AoZxbw5LqoMHMFklh/dn/EBnFU+DLa71biFr6OYMis0LAjbB+U006nLHPr9tbKrMVUSEN2YbH9aCSwbMZ4rYKsVfZ3d6joYj0i/jm8KZ2RyRnkcDJFJvtd0u6sLs6hAviJyF3B3V164+uK2u3Nrb6m9peRFJ7qPxYSy4HiJ1GD3KmqXEPBw4l4emKQ+PMjKsQGMOpBAG9XSzawsPjBhx3pPTM81WHEcOn3sU0UrG2ZeflU83hg439V7HyrXrG6057a21HTrtYbe62SQnKxynof8uds1ko4Fu+HtX5bppYLET+FNk5eykzs234cfpW0cKcDQ32n3Ol3VtHBOsbsvhsVhlznEiDouTsw6DINM6gV8MktYTjLQxw1ezalK0GoxKt1C5SU82RzKdiD59P086bbixtbqIo6yILqPMsa/AVderg9j39aA8D8MTQSiK8jeS45FhuEOztyD4ZB5OowD5jHam4QNBNGom54pUZJVx8RBPXB/nSbYycRN29rjwgXStPHNZQCUORM4jdRnn26jy6bj60VXTgXUSxcklsTGSO6EjIP0NWJtLl0i+V7Zle2uLiOZGDAeG4IVvzBGR60a1C3h1Ex36ry++RlZ/D6FlGM/XYVHdZXPlKG7DZ8ItzaD78rocAvIYQ3bI7ffriotA0JrNLq2duVr1jHEWHURjmP5sVH+7TTe2/u1vpeqWj88Uq4lQDbIx8XoRXzUYVnmtHgPNc2ZVMY2Yn4/ts2/wBKgUBck9enz/rMn8QzAKOn8f3iCH04yXFteyKqOIgsmO5XFfJ7AwS3Ky7tyiVSBTE6JdRJCiktDK+eUfDtjf8AOoWhSYFpd2kXw1AOfi7j6UFqsDiWW4nrALZeS3mRfhxjI6H61Ys1NwpXGTzkAY3NEP2eYtOY8uDDjc7DB864tLYoUeIYVoyxY9Sf9KDsK+00uXBGFkaKsPhxtgt5dQD/AFqa6ieSNU5sn5iT2HlX6GNZZssu6oWGe5qbJbAI+YYBoitn4QLDmcqqxRFsks64xSXrmkjULhuZeYJuB6mnabkRHdTkgbelURZ45GdSNuZs9803U+OTPIShyICs7A2MCxhR8WCcdqedAukgVFGB2pav8/CYk6nYAVJZXcsBLOD8IpxNYKTmRZWblmk3mpc9mIUbtSZxAkLwN44zgHrVE8R3TOIwpxnFWtXgur3TuZB8RHTuTS1upbW3hhF7NN3GnYYg7QgggYRjbNfuI4BLpzNjJSvui2c9nAYp1wwq3fRiW0ljx1U152ats+U4W1CGwYE4Au2ktJbY9Y3OR96zT+0eYrXifgDU+c+JDrsaBM9Q6MDT5wazW2tXNux2fcUg/wBqFVY8ISRriePXrUo/8O5z+lbdjZ11Tjo2PqImT/qPu+xhG6mX2ef2gtMu7WXwdO4+sua+DnEYmt0C831Ksn5U3f2h9MXU/YrxhbNbrK66XNIoZc4dF5gR6ggYod7beHbnW/ZiNX06CN9T0DwtSt3bYiNCPGUHtmLmFNvv2mcd+zf9oW4E1jrekMQA2cq8ZU79/rTvejUdm1XjlqW2H4dUP7r+khT3WoKnoTn68/Xn9Yp/2Z9RGp+xnQJPDK+DF4R32bB6jFaBrsRexbAyRv0rE/7FN5eTeyA2VxJzxWF/Lb2753ZBjOfvn863i9j8S2kXHVdq92qQuvsI8Tn58yFUqNp8IkcFyNDrNzbMcc2Djp0z/wAKcdRbwrR2yBtSVpoFpxOhIxz5Gf8An6U18TTrb6dIzH8JqdUCdre6EYZbHnModBf8TZJyA+K0nULTk0eMKOi0i8LW3vWs+MFOGfP61qN9biSyMeDstLgHefdCW/mAHhETS5PDuuUgbGnqL44lI7is+YNbX5XtzbZp70yYT2aEGnGTMhl5zOnTrVOaPfeiEgx36+VVZRt9PtUCvzlgMRZ4im8KAxrjcdKQ7hBNcAEbd6a+IrkPMyhunr3oBaW5mlJ68xxRWXasZVdq5lzQ7DMhuXXoNtqPH0PWura0EFuoA3IzX51I3JqFr28SVHjIJMbg9cdKXtTh5GblHU5FMMuTjOPOhWqQgx+Iucij1+wQ0IBniLl7GGjWdPmjxnFGdJvEuYVKsDgb0KkYJzIw2cVW0i590v2t3GzE4px1B5HjLgY6xyUA+oNSeEDv5VHAQwBHQ1aAFBXpLESIJ1xQ3VrgInhA4Jos55cnOKVdUui9yzc2y71VjiSBmB9an2WBGY+eKj0i1Mky9Sg657GqlzO1xcFubvj7UxaDbBVXPU71B5wJLDjEa9LjEMIwMHtV6TlkiK4+lVIGCoBUvinGAcdqKrQW2eftCNxaMdb1a68IMPGigT5m/hcj6/KD5Z8qZuHQxBniWLT1nJW2e4Y82D80gAHNIx8wO/zd6UWvJrSOOXkWW6kkAjjK5CbDBI7ncURskvmDzTXkhupxh7gseZVHUA9h16eprHWzHWdbbUWBM0ePUNJ4fRpLHTZNa1eVCI57whVB6EknZUB/kfLNS2Wo3KoNf1rU7QXDYEcyR83OT+GEEFuXO3MB26ilPT3V5I4p7YfEvjtzL0hUfAgU9PPJ2GR3NF7z3lreC7u+eTUNRPiJBGpZ5VGyjzCL2GwJ7Yo//wCTpM9k2nBkur683K1pHqd/c3Dnn5pZeSJM9MICWbPYsWzRHh+LUNWdLW+uLy9tV2aG4t1MLH+EeJk/UjFftH0Rbd0sFs/edbu/3kuACsIPUu3oPz7bU2xRppUDQ+9JE3LytK+OZiew8h38z9KqaT4mUa9VG1RIrCw4X0mOVJNB93WMZaS2YLHgfwh8/pjPlVrSo9FvpTJojWcTYyqy5SXPqd0J+jflQo6dpMTIrq17eTfE7TNzHHYsM4VfIbn0qeSO+jBFxf21uqL4fvDAKkKnoFTz+pz6DpS71hDkgSVsLeJhnVbzUtNjiguYbhzI2I2kVVz9D3oeOL5bW5C363QWPvHIrcp88A1U0yw0jSnlVdb1e/muVzIsuGix/wByRyAepGaFnTvZvrF46Q8NXCSxHElxZzlYlb/ui2PrgrS7ozng49ef/kZqdF/MMjzmgaZ7VGtJAy3rPbscBs7j6inbTuO9P1U+HdQQzxOm3ONjWGi1srGSaTRNH0zVRApE3upLvEuOskR+MfXlI9apQ+0L9nWQMlmi2yE5aEhuX6YO2PKlmssqO1+fjDfh0tGap6CubHR72E+5TC3Un+5l+NPsD0+2KBajwXdypJJplyqELnlZ8oT5Buq/fI9aQeFuO11SMxe/xXMIwUkQ4dPRhTCvGt1o92sJlBhlPn+dI3V0WNllxCKdRScA5ibr+ra5oE5t9Vs57Zn2+IHBHmD0I9RS1FxFdXE04UHnjAJUnqp7it0u9U0LiuzfTdRtophjKqezY6qeqk+Y28wazK84EhstRmvLHEtpGDkEYkjU9VkHl0IYbH0O1Zup0gq9pTkTU0mvRwVdcN9JX0W/uZpEkBJQkHbyP/Gmy1nMUa2zyENIpIJ7n/WlnT0W1iyMjwjyOezqTkGic94nxKzkujKyN6d/0pBMq3ELa/eHAjnZ6iXWO3ckyJGCp8waF8QeBdB45m2wqqc9GJ3oDpWqXDXQkdnYJF8OD1Aq1qNxDNcwgEuOrJnrncGnms3piJrXssirq8UsMkEMTsqSk4H+Ne1BtL46FnrLaFdy5Z+Z4+Y9x1FNut24flZWPigs8W2zPg/DWGcSySRa+mruUR7ZmPr1AOfzo2nGTjM0kAvQgibnFqNrq1uWacRtzqM4w2cbH6E5pW4usF/2hU6fFm3XTJp2UDA8bBYA4oVwxr082lrfvb4gEqWrFtzzqOcH9CPvTJqeoxnTRcxrzGZn+IDBMTrsR6Y/lTe3EzcNXZgTngJl0+9lto0xF4S8zlf+1CKSfTcmj8KWWqcRXF6luSFIh3GFVS2SM+e29VdEsHHDUVzHEA11aGdnO7cxO39fyoToV3q1teX14WKWzXy2z7Z2BU//AKx/Kl7cbiIWsGwlgYy8QQnWLqyNqvh3BiZ4ip+JW5SAd+vn9M0T4FuH1Dhy6eZD4kDbqUwykHckeYOenlS3puoyx8Ranp12ymWwuY57Zuzwsd8eex6U4cGeAmrTzwBhazSeBPGg3UqDhgO3Mo6eanzqqMScGVvTYnHh/wCzPvaNp1mJP2k1oq3aQCK4VVGXjfcEjuQdwf8AjQHhTUb+NWiiu3QQKMkdIvKQD+HpzDyJp79sOnRQ38slwHXmspTFLGpAeJCGT6kfGMfSs34YWW4nh1K1lSX3cNHeRhs+LEQdwo6nGdvI+lWOVyDHKMWUbprejwzz3aXkkTQXdsQkka5BAGDkHoVGdvQ0cnFpqFxEGURy+I3L4fTnG+QP8Xl51WW0McUd5YyRsq28c8EhY4khbA5c/iBDDB9M1LrMduosb21ByhheYt869id+/n61DK6L7UztyO2Vkz3YS1u7W5HjEj3q3YoCCYwGwR57Gr10s8E0rW3wwTyHEabgPgOGH+dT+ZpW1C9ZoWCZd4hIM8uObAww+4bP50Z07U1urGPxHPiPCjRk9CBuvTyyB9qhLsqc+vWJD04wYQVZZfdbOMYilkdWQjHKHw4PpvkYqOB1jvLm7bm+OWOUHGPhbIH2AxVqOWT3szSFQ/hSXGf4eWMnP5jNV4VnmsgA3M7QBQSuF+EfCTRt2a8+OT9P/YADDevXhJtOX3ezaRubmZWcgH8bSD4f5GuLoLcMJLZgqRkzjbAGRvvXaR5t5gCQiRgIMdXA6/r+oqCzmeOyitnTmbwPjA8z0WhH2hg8CFUYJI6y5b2wuNNELluWTDOfTtgH7V8FrJGCkoHUBfUZ6V2L4K0viPkhQBj8I6E/nsPoasRxiX4C5XIGe5yOgAqrbW6T3IlGW08G7lLH4sFVz51C8UoUMF+EjbHlRO8VpZOaJMMRynO5HqT0FfikCx+FzDPIFz/CP6UPuwekncQILCsYmdxhcgflXJ57uJp2wkS7ZzucdhVu4jGAAP3a5xnufOqFxzzYhQnlUYCjYn7dqkNt4MsBunLGCXlETqCo75OP0qqyxt8HioN9yQ25/Kroto7cgSuFAGTio7gKcGKLHl50N8sOZdMA4E7tNMgVOeSWFj/vf/8ANFrN1U/E8TL23P8ApQ5JAkYRuuKnimfwwAux6V5GCHInnBbrDLWNrcoSoHN1yKB31o9uxVl2ozYF1wWJ+lTanaieDnC4+1Os/fLk9ZznaehDLvTrMqiQ6bxAJ3PKhbGKzj+1NczrZcNeBgodZtST5DmzmtY4r0prqMtBlZF7jqKwT246zNd3XDmh3WTMNSt3Hryk5P5VvdlivtChDn/ZSeR5rOQvU1hl8CPuJ6W06CHVOH47K6XniurUwSg9CrqVI/I1mf8AZk1MTcJapwXHLLLBwnqcukQrcAeIsauygMB2yDWk6I//AOS7VRt+6FZzwJpUXD3t747tjexwftu3tdUt7dX5RIjrh25e7eKjb+vrVexHF6arTH/khYfFCD+xP6Qeo4YOPPHz9CIf9i6/iWTjzh+1ikitrDW5vBR3zygyyKFx6BRXpqReeJl7EGvMH9mKS5Pth9qMgijtoLjWbstAMKQ63Ljp9AT9TXqMYx169Ka7XYrqUZv+SIfoPnCnBd/iZmeqO2ncRQuo+EuMj9KL8camV0pPDI+MAdaEcewSQ3QvYgFMJ5s5xtSvf8QfttYYIXLmM5YfXpR7QTUth6QqjNi/CN3s9s/Ek8f8P0rQJF5kZTjcUvcFWAtNOD8uC3nTExpSlgef1kZ3MWiBxHa+BeiYDG9GuGbvmi8FjUvElgLiItjpvS9o92bS6UOx2OMGtQcrmXIyI7SD/hQ3U5xBAzedEQ/iRh17jNLPE93yp4StgnarqkuozFLUJGnlbIO5zV7RLHnlBZcBdjVFFMkoXG/b0pv0mxFva82PiYVYjc3whm8p9lTAx5VTmXBxiiEwwCapTjO5qdskSjJtkg1UnUSKVPcVamAHeqkrAeua8B5QoWK9+hiLr2BzjHagl9IySLdLuVO5zTHrcXx+KuSDsaV7hmAeBj16HP5UWtsrtMIR4x60K8W7tUYHtRlW5R9aQ+E9ReJjbucgHam6W7Crtt3qrkDme254nzUbpYIHOcZ2BpI1S85Y3YDLSHberXEmuIX8FZdgeoNLazm7m52YmMbDJpcvuMMiEDMu6fB4jhnHenLSUUKDjYUu2KDChep6YpkgYwxAdDioLY4EjGYS8YKNjXwXJHXah5usbjpVd7wHo1eD4ntmZjWmxh3tzI/xvI2SewJ6/XbFMdqxm8eeGFSFHhWwY/CWJ5edv8I6/b1pOtLlrd3kIPwghTnqx2otba015JHayStBZxNzzcm2UQE4/kKy6xmdXfk9I9WNpHHLHFGyO8zIZp5RlmA+XI7IPnIPptRlNVGp3q/7MN4HvLG1j1K6HxuE2Zo0/hG4HYk5JrM9N127vA12yvFbDcKd3k5mAA+p/QUWtpNXmuV0LTnX32+ULd3sj4W1th8yoOwxsOm+TWlW/QLMi6rByx5jlNxLNDqD8LcAxGaeXL6pq9xIBHGg/CD+I9zjbz7CiIuE0/wWjafU9TuR4dvnPKB3kbO0aAfiO52xk7UDkuNC4b09YppEED5ZFzs6ocAkdSgPRfxMeneiv+0VtpdpFJqK+G9w4a1thvLI38UgHQZ2A9O9GCRNm/6iMSRWeiWxu7y4hkupCHY7hQe22SfoPuarxC2Wb3rUJv2hdg+NHbuvLDar/GwHf6nJ9KDxrFJE1/qErOLc8wSQ8qGUndm88HYDf71+Iu9Wj+IeHbu2IreNOVnP8UjfXoKVuGOBJQZ6mMU08OpwSLqZEFqRvyyCPxT9Bv8AzoebnSdGtmFlbQ4x+EZC56fD6+dfILC3kmjt7aNXuEATqDy47k9BjrXFxFpsE8qWV0re77TT4yiN+LB/G/8Az6VnWnPQRqvAOCYB1G5WGcTuDHd/OotY8zIex5xsh+9VJtXXWnNvr+irqS4Ie7S6WDUI/wDM4Xw5evSQE+TCqOtx61xIDa6BdNbQtk+GwxHP6lx8lUV4YbSohacQTPqJxsjDCR7fKpUfF9Tk0obAgwD+nWadag4z193hDI4B4ms2Gr8BXQ1q2VQZLY/ur+3H+KHJ5wP4o2YUQTUbnV4YFmZ4bkHeNzy/F3ANB+HL+bSrxJopGuIoieRY2IngH55bH5itDfXtJ1+ILxJZtOJAAt7EFW6Q9mYn4Zh/nw3+IUjdZXZx+U/T+v1+cZzYpy3tfv8A39JFol3d6fMlteSsebLROT8w/hPrRC61u5stRhfxss2RFKCN+zKR326g7GqGowyWWni7iuV1LTIwEF/B/wBi4+UTIfihY9Pi2PZjSZrPFCrJChJKBiwb+Fx1H32rPsSxTtbg+uRLIBadw6Rtvp4LyaS50cqsiK4uLJTnmA38SEdSB+JOqjcZXoHfXklAwWHMmRlth2P1pH/2glS7W+tLqWKVg9xE6vhopB3HkQRmivv41zTzrWm26e/2Lh9StoxyrJC/zXUSdhvl0Hy7svwkhbfh94yBz69f1GgO6xu6Rs0bVJmhke0mBe0Krj6vg/bGKKWGpxT3tzdzRjEXOFGdub5SPtSpbRyaXdGXxFEV2Y+Uj+Dm+b7ZNMUcTTWkJgiCtb300d3GNudhJjP3G/rXhUSIOxlU/GEbyG5uNPRjIRIjM2V3+EdceXbesZ4u01vf7tJZhlgIWB2wxkVSc+g3+9bVBGy6K0LZjk8EgyH+AuD+YBpL4z4afU4LiaCNo7hlkklCnoUlXxB91DMPpV0/1sDC6a0DIPSZroutppPDtxYzSO80V+skak9XTmVznvkHH3FarwFFBxDptlNduzT6UP3kYOzwyF0DEHsOYf8AIrKuJeFpbfStZu1LZ0/VIYQqZI5XmjyR9sD704+zLjCLQtX0y01F43zc3GlXW3/YF2IP1GWb/drQXFuGPiYPVJ7B7rr1m3w6X4unWEMQ8P3eSISqjbsrSOjflg0maVFJbxfsu5eTmuL65ZcAEuYpSrH6jbb60+6bdyRCWGaP99bz+A6g8ueQEE/fnVvXNJ+qWFzCkN/HE5m0fULt2UdVi543O/4iXLg/5/pS11aoYlpLGbIPrr94sapqkNrxAl6shM1p0LHKmM/hPmQozj0pw4F4jtryeLVLVy1t+0v2ffoDvGZF54nXsMnOPUEd6zeLVYdR1HiDSdRKo2l3yWgfmDeIhU+Dv54518zyAUp+zPi5OFPaBfcL3ryfs/XfEsmUk+GHQq0TAnuHIAPqahNOTnzHMfsAdMePr0J6R9q+kT6joTcjMJYwwDA5ENwnXb+Fxg15p4Q1G60niiGbT7j3ZXnF1biY7RNuHjbbdQ4YH03r1bo15FxVookkl5J5gYJSY/lmj3JI7kHOR5fWvOntA4dtOHOKL23vIWghgn8YSRkN4SyYZXzjBHMrDyPQ4ySIydxHnLdnuNjVHqJ6j4I/Zep6JZywQmKNGkEESnKwAkmSAg5A5WLAeQfbbFS3PDb+5zFyrSRMwBK5JjOeU+uQv5jNZ37LOIZIdKkspbgNNbTBXxlRNgMkcuNjzbNEwO4ZFzWy2mo203isvK5JAKAY+AjIP/8As/Wn6imor2v4fxMLVK+muJWYvxRZXukIpBYN/eSbk/GV5vyK/wBKF8PazM1rZRnYh1UAnflxj+la1xdoEdwJYrmMeHcxwc2X33Rht6fBg/UViq6dPolwYGDHw5WYty4C7tJt5jlK1iais0FkPnNvR2rqUGes0/TryOWyunz8Udq5B7hSVUD/AOb9KsaPycgRsswnDbnYAAj+p/KlLRtZ8O3ukK83OqRDJ2GCCf5D86ZNBuFYSeGA3LhQR0JHzH6Z2+1ErsztHrrF7qNgaGoZ1GnvMImIKgKCfIkZ+p3P2oT4JhuppEB5G+PONmP4QPqc/qaOM0c6eFCzIMgB/Id29Nts+VUbyONpFWIgQRIVQdC52HMB/wA5p2+slBjoP38fX8xOlhk++UIUW6kWKHlysgEjDBDyDfH+VQfzo5pvOwkneRVgViObG7bfmfU0FgBmC28KFYVYcxUY8Q9eX6dc+govayNchrK1MLCIkTTfgRv4R/E36D16Vn1jJjdkml93Q8yoxifdE5TzOfP6VwljcznEkAjkbcL/AADzY9B/Or9vELZgsUhmuW+EuQGbPkB0z+WKse4TcjQ3U7xK2T4SMcsT15m6k/kPrTArJ5xF94EC3K2sOBJKz422/oP6mq72dsm8EEjyMMgYwAPOj50x7cqngooPRTscds1Hcv7qGV5IouY7nqzfQda8a/FuJIf/AK8wH+ynkXxXwue53xVN7ZhJhVZiO56UdLSzIPCDIB3cb/8AjXM2nOwAcfEwyIwcBR5n1qpQN0lhZg8wJPaiI45wXPWpIIOTDk5ANEJtG5SZGUZxgCuBDHAg5yWPYY2FUNRBhO8yOJLaSKr5dxt0Ao5EI57cgYzil+KEbyhcD1FEdPmPOBz7eVGqJU8+MBaocYgLW9OaJnfkyN+vevDv9qHjG90bjrSTFYEG0kEwkxswz0+te/8AXYGkgLAZ2zXmb2xcF6Tr/EOmLqFkknLdAjK+YrU7EsGj7RU4yCD+047tXTbFYiaH7M+Jm4m4UsNTKlTJAhwevTNBOJZLfQfb3wDxExghi1exv9I1GWZMqbeJo5QAT8r4kfB/0pl4V0y10fRoLO1QKqrjHQfSl32ypcJw7o2t2+oQ2P7F4i069nnlTnAt/E5ZUwN/iDKtB7E1y/8A12t2GFZipHufK/eYt6E1EA84z8uZjX9nnWXuP7RPH63V9G9xPq+pZeM5SbluXGVxtgDH5V668QhSQelfz5/sz8SQj233uuWUDRafqWoXPhxyOHkj8ZpJI1J2yQoAJxjNe/VlBQHm2Izmtn/KAKPw5B/44+X9S+P9rCYP/aS4sm4b4dmuoJiknyjY75P+lAfYXqcfFEMEyM0gGPEY9zVz+1SLW64VurchWbGQMZ3qj/ZY0ybTtFjhZNnIIPnRKNZW3ZWLPPiFtXYoYcGem7OFLa3SFOgFTbHrUKtgAdcV0G64NZNOoGZ4LgTi7hE0LKR2pH1aye3nMiKdvKn3OetAtfsS0TSRjtW1pbgw2k9YRYN0jia3W3NtcvyuBtmg2q3S3szujBl7b1nPtI1q80GFruGTkKHJ8xQbgr2lDV51gdmJYgHNaKoyr7Xzl1Gw8zX9E05pp+dkOAc03FQkYVewqnw9FHJYrOCOYirsox1FeXiWB3cylOPKqM4ODkiiMozmh84xkedXHuhVg+bBHr5UPnzuBtRGcHfAxQ6frv2qjcQywXqUYmhYYGRuKTNS5owXIzy7Hzp2n64pW1a3Hisrr8D/AMqEH2nMMBniDbG5aGaOdCQO4zTHf62ItPMiNlsY60nSXJ04vHMMjfYmgDcRyvctDLLyxdOufoKl0LjaJAIDZMJXeoPNOZHYkE7CvsGoYYIPrQ1pYpctE4znYVNYxSPKB0JPSk2zWOesb4fpHHR7x2Ic5wPOjTalkEdqBWi+DCB026VK829Lm4sZPdiEJL/IOM/Sq/vhzs1UzN1PN6Vwzb9T+dWFh8ZYIJml6HQMowM7n0/0qhLqEtlYSxRgFpCVyT1HUk/kBiiF2/ibqBj1O1B7myWZgoHMcjrVkXibrcdYZ0i4unsrJrmXL3EpaKJTnJTpnyUbk+Zpms9ctrCe6e4uOTxY8OkRy7E9Sx7bDAA7nJpBGsvah0sVbMMDQRN36b8o7DJr9w9Z3Wr2/wCzI5PChV+WWZmwCDvIxbsNsff1ppAQciJWrnrH/hjVLrWb9uINRtB4VqBMEbdQi/3Nug6LuQzHr96btCsbvWtUk4gvGklZHPNIEGWONxFnZRnbm3+vahemW1pHYrKyk2iFUgjI5TOF+Y47A+Z7Udn4hgs9NFzfpFbRk4jgXbKjpkeQ8sfXyoxOFmbYdxwsN3N5DDNbclvBPKmWgtw2Yk2+Yt3x3b8qmiuIZue61HUiyuSXmzyoAPwRDoF9eprNjr1rqniXsa3TQBsLGr8glx5t2X6da4stJ17ibUop9euJI9MQg21jDnkOO7HuB19aSsPOWhFqA6Rxl12TXZJtJ0KcWemWxze3MWQWH/ow/c464zVWe8W/YafdaeP2TCo8OHcSPjoxI6D0P3qXVNRl0GyTTdH0t3QkAER/FKx/EcfKKgZLq4tjFc26XMsg5mjcGM/Zh09M1m2WA/ljtaY6w4hDoW0zUII4UQh0fAOfIMOw8qpxwWk0RgfxGkHx+IN1/wCH6UmapEZJImW31DRUhOFWRS8TeeOXf7nrRWDiS5lsoktHhvnjXlSWJwGI9RsdvKs+4blyPX6xqtCDxGH9m2ZtluzGlyYSHEikJIp77jcj60NvtQ/cM0dzkRnl+o8jQ8cSiPEyoEbdZlPQHG4INAZNajjll2ISRSJEYE4XOxHnWeUZjH61J6w1qHF2saHeQ6voV9LbSleUSRH5k7qykEOvYqwIIO4r9cPw77Q4RHbXVjwxrwQmSCRvC0u8JPLzRuc+5yZIOGzCfOOlOTU42aTTZkR5BIHR1YfGNunrjp51d022jtuKrSF51a2vbUrG+AVaQggAjybOCKe057te7cZHl/HkfRBlrUAXvF4bz/nzHoQZZaRxHpmo6nomraTeWuq6Q7NcWcyFXCnZwR5EbgjIIIIzT5oml/s7SLW+0u6zLPZyR212rcrRzRMXjJPZsEKR0I9CRTvwld2upXiaDxPZteQ2lqptpCQbyyt5DyNHGxOZIg43hY4GQUKnrUThbUOFhPpeout1pkkrvZalEQ0MinZZPMMhblkQgMAQSOhJbaOO8Tp+x9/2PT9gk2t3nu34P7/D+P36yfVra11vRdI1ywgjgEMlsb+zUY93S4Xcrj8HMSMdiCPLPxrvNsJy/JLGIWZSNzIrgM2MbEBv61Q4R1aexsrmzSIXF3o6PJJZPu1zZO+Hh9QCMqeoOAO1fOLfedG0Ky4ztdQOpabO6KzMFDXESPhHfHSTw28KQd2UN0NBdQx3LK1khhWf0/iFNV1OKydZgpaC2nkt5+boGDjl+xB/MGmaDQV1WBtTsHDtLlvDByHdQQyEdiw29ayPiPXJdOn1xXInilaOdMr/AHiqQGYY/wABQ7+daN7NeIRLPfWsBIhE5urblbIeKRQxI/xKxbbuCfKgVIGYBvGGuDLVvWI3E+kfsvhi8miVzBcraygv2y0a5b1BjA37k1ieja9fadxqIAiNKbhfDEzYV5lIZASegYqyZ/8AWGvYWt8N22r6dqfDaIhHhvLbqGxk8rGSPfqFkAcD1PlXl72xcET6de32sWVsqfs42886hDiTnRWIB7hUD5HoaZ067G2P0MYo1S3IR4/aek+BNX/bdvcRT8iXd1bzQj3gFXSSF+X4h1BCRrzd+9EeLkS54WuHtmW3l3Lj8Xhycjnf+IAj+fasT9gPGrawtrHfSZ1PTrpbV3Y5FyifAjsTvzNA4ic9ysRPU1s+vanYPpIkeEhZGiQgDm5GEhDEn/Izr/uCq6n2GIJ9dYilZWwYExTTITo/th440jU4FOnzyxqwOByYkDxTqe2wbBH8JHekviXSpdM1sahqUNx4Mmqm3IjUc8HOhZWX1JUEdjgjO9alb6fd617R+I7S6iEAg0OMDIyvNFciRAT9JJBk91pM173q+tJuDtQv8ara3i20My/LMvM6RlsbbeLGc9jv3q1bAsG9w+U0MnBHjNW9mnE95pbiK9kBE0sQuCjEBZ3HLHLjO6yE8pPYsme9W/anptjqWlz6lDGZLg2CSwsYx8aJIpMbj+IczDHXrWbcGadccR6DFeeK1tcJG1lfxOSTHHKDyORtkR3CcrZ7MKZI+Kr65s7rQdVldrlYGjjlU5OWVHXcfxBW3z8wNBtQAYHUQVQIu3qfjBvs64hfS9YW0u5CLSaFRFK5+J4ZYwU+L0KsP9zzr0xDIGht7iORlZoIbecA55JVPw7+vLjNeW9CjhvbzSLS9xbSFfc+byRmaW2f7N46Z/8AVnzrefZ3r3vNrELxy8c9uIGRtsSodjnsfhP3zQabCLCh8ekt2pUHAtTqOvr9M/KaneWA1SztrjlC+BEWcKOq55wfsQRj1rLuKNEElyPDOIpHdPl6qAg279OYema1jTJVit4AZvEQwgkdjGc7/wDPnQTWdJhvbOWFi6+Gyw8yjDMAQWH3Cr+dP6vTC9Qw6zF0epND+6efra9lja8hUYMUoiGT1IbDYPptTVol/gpp8bEeGAZmBznvy59e/oD50sa1BLZOUEPL4qNcMcYwvOWOPopX7sPKqOh67MJxEox4j5cnuSd8nsvTP0xXPVsVbM662oW1kibfYSeJComdAjKC2/bGcH/Sh+qXi+CZfE5U5CzyfiK9gPr5j7ZNCtG1GHU0cMS9rC4Vw55fHcjYHG+OmQOwxRTULc3koRecxxDmVgBjYfMB5noPTfyrZLm2rCznwnd2+1A1jfvq9w9pAZYYwP3zBsMN/lH8P8xsOvR204IkMccCxwxrhAY+uPJewPm25oXpuixaVbgO/L4jhyEGGYbnGT5+f1+tXXuwMhFSNEHKCSR9RnGw69PX1oVWnaoZfrLXXrYcJ0hmE2tqhEcI8iQdwfJew+u/3qz74tovNFbxRMRkkuXc/bv9TtSuvEMUJPJIkZycSEgBRjr5/wBaoXXF1tbkhcRo7D95IR4sxxtgHoPU4owdUHXEX7p3OAI3SyXd6zNNeS+G2yoh3P2XA/WqrR2sKk80a5B+IuOY/TG9LJ4jaWIMk8SxONuQkgnuS34v5VXl18DZLscx+bK5P3NK23pnnkxmvTWHgRkE7wuGihbl7F/h++9ULni/T7Cc2sVwtxcE/GwIwn3rOOJeJdZnR7eyui0b7cwwMD+ZpStLHWbg8lnbu7OCWc/KPXP9aWXUEnCTSr7OG3dacT0Pa8Q6TPH4HvEUkjDMhD5xXy6FuwD2wUY8z0HrWI6bPqGjOIoy7uT8UrfiPmB2Ap/0nUH1BPCV9+UZGepp8WbxgiKW6XuuVPEYvf1lLKm5GxIqzarJs4OKDwYthgBVx+tEbfUoyPDBqfjAEY6QlPdGSExk7gYrEva5HJY3VlqBU8qXEefoTj+ta2Zcy4zisn/tF+NBwnLdwZ5oWVy3kAQaa0Q3aqtj4H9+Jjdq6fvKWx5Rj06TmtIXzkFcih/HmnjV+Cdcsz4fOLGW4iZ1yqSwjxUYjfIDICRjcVDwbqMepcM6feggmSJSd/QUD9s/CnEnG3s81LSOEuKb/RNSiR7qJ7PPNdhI3zbNghgHzjY9cZyM1g7Rpu0wlrFAr9fLB6/pOXVdwBE8kf2drGNtNvuK7Ys82l8S6WJmRSVEEkU2AGwB85J89hXvmXUEh0v3nOAE/pX80vYxqs1rqllo1zb3NlY3Vx4iyJ4kXvEq/CFdR8EgjJ3zuufM4r3vxfr8NpwjbFJMGeFOnmQM/pX0L/LdEPwddqnJ3/IFQMe/lc+HWK0EvcFI65/fP3mWe0O3u+N9QWyjyYi55/LG2BT/AOzDToNFvU0y3TCQIqgeuKrcG6MX0d9XuI/3jAsCe3YfpRTgvbiCYfQ/euSTUbtMax0BjV3tEnwHAmoq5rsOKrBq7V8jFKVW8iW2yyrb18mRZYmBAO3eow2d6g1G7W2t2cntW1pLCSJ7Exj2r8Nx60Xto03OR9DWfcAez+bR79zIpKhjgkHOM9c1tV43vkzsyhiW770waVwrbva+OIwGIz9a6OnWZ9hukIeFAMGcPX8unKlvMCFOwBpmkkWRBIhyCO1LWoWrW8jRlTkDY1Po2qEH3Scjfp60fG048JXoYVkYDbNU59tx+dW5cZqjcNt1ryNzzCLKNx3Oenehk/nRCdqHXDKcjPWvOYdYNuTjOOtCNQg8ZScHIFFrg43xQq6kABGNyMEHtSdjYjCxF4kURr43MST1Hes41S6czfujjG5ycZp84ynYZiRjlduvWs4u7ocxSQEEnYg7U7pHD9espcpHSHdG1EyhYiN870/6RbBkWYgYIzWb6DZuXEnKQvnWnaROrWwRSOYDHSl9cvBIhKCehl/nx5fSuDIT39a4O2/X0r4G23z1rKGOsd4E65j1ziuWbbANclgMjIrkvjYt1qd/lPcTPL20nsZGWRSF+nWhzzM/NGowzDAJIGBWja/paXLSKycrDIG1Zxq2g3Vs7MzNy56Cm9Oyt7LdZrFw4DzmK2hSTkWWNmKlFwTgZ6nA3Jp10mCy03SVkmnW1jIzgqFLL6jruaQbCSK2l+NSigEnB+JvTNT3Ooalq8vheGVTICgLgAfenNuIlZlziM8/tBmjLw6F8MxyDcSLzci9MLVKB9S1a6HvDy3MwACrIdz6t/CPr+VVki07TIVe4lUzHBIYgBR9uv0oxpS3epwNJa2ssdgch3RcNIPLmOFX6k0FmI5kBUHSXrexis7gvqGpQ3ksYDeEPht4j2Lnvjy6elXrvim8tLWT9ll724Y8gcKeUnyAHRR5d6Bz6jw8ka2Gsahp1rFG21pp4a8lT1cp8HMfV6YNCh4VgiS40Kwu7qaQHme5vFtPsVjDN+TikrfN+nvl0A/4jn15wfo2r8UafcSapqGoSm6YhFgLZGfUdBjypz03jqWeMjUI4Sg2Y28oV+Yeamqkd7bXi+AuicOW9yTyp71bSXZz580rsPzFUbib2iaRN41hfW9rFG6gDTbKzjGM7/LECfpmkbWRzknHwH/kMBxtx8z/AADDMvFtjqAazhuoiB8LrJjnQdid/wBaEXUcNyfB06W0llB5SGZdu4JIOR9TRGX2jce27BLnim+AQbASmIsPquMH0oZbe1Tj+11RoX4u1Oe1mO7SSLKR6FXU/wA6UapCchj8h/MPVvHskD5n+JVF9w9dlrbU7wXGpWw5ZILNgOdfIyHr9QPvUMGr+APfNM0DTUtxh5BNEblxjZ8mTIB3B2A2zRPinibjiGWK+tLrSNQfH7yG80SwlJ+7wc2/TGfvRPh/VdO1WSKW54F4caSWLMkSW1xp8gbGHQrDKEP3Q+deCVkZVvmP4zDlmrGWGfgf/BAXDfF2rTavPoMupCxMDlrWaCFEjdOoQhVyNjsRnBHrT5qzavJo0kst7FOYP+kRTSWcM/hd1kAK5Kk9cb/MOuKW34c9nfELSRabLruganbDmUJcQ3otyD2SQQuQOm0hODvTrodjqMt34Gl61pGtXfg/vNPRjY3z7fPHDPy5Y43VGdW2NXOnZ1BQ5Pu/jrFbLk3Zxj9Pv0+sFy6qlw2m8WajottbX9g6CW5tJmiilWTlAkQjKFGIGQQCGAO2KdkvPGefWeH7KS+tZybXXdDkHK8oAPLOi5OJE5tnTOVbG6jFBtM0+0trybRbiw5BOrRTabe2zQv4bfMBBJsR6DbuOlGZOHpvd4TpTRm9tEaK2mnlws8GQRH4g3V15flkGdvhYjNEqZwMj5fuMfbxi12wkD1698VOPbC44Y1Kw450l3uNMdhaXF6BySW4woAlA+U7AMp2Iwyny709tFu9Om4U1C7hSy1sme3mIPhwXXxL4mDsgO6Sr9GHSrUPHE8NzdaPr2myTJPGIry0njDeNEdirD/tB1ww3U4IJzylP4ys04cu/etOnF5wtrsvvWl3rHmFrcLgS20hHQ7ZI2O+fPA7ApXvKuniPj9vLyPHkSxSGYiuzr4Hzx9x9RFPiie799jtL6EQanpsklhcxyNygE/uzGx7AjGG6fLvuDTT7KtSk0+9s0gibxYh4FxA5IPJg8pbfPLkMh8jg0rcXr+3kSeANJquk2xju4mOHvdPUcqyAfikiACnGSUVT+E1J7I9asdbvrzhy51RrXiHTz4mj3F2AI7uIsCbR5wcAsWUxs4XDHlLENsNaTYMrzjn1/E0bXC1Yb4H15faennsNVfUraaOdnR45bKUvnMqOPEt7pG6cwVnRvPHSkD2laOur6LqFwtuLmfVLJniCjlC3Mdu6Oh9MyN552HY1qXDfi3WiPZ3EMyGLkvIIzGVe3PMTLAyn4lIwxBXcZYdhkHrWn3V43gyqJIIiJSYmHxrzN4UqN0OchW7564zR9TWe5Dr16/z9/jMTS37LsHwnj3geCTQeLUsnUpBqDYjIzzBzG8edu+cH6qtehZNels+HodY1GF5Lp7+3EsYf4XLgkOuB0cSAj6is8u+Hrey4pS+v7cGCzeO4mYZXkty8Rdx5FfGikx5Bx2NaU2gRDhC40a5m5Al1cWbTeIMwR+I0tpcg5/7NnaMjyx2UVms/wCIAZus6PU92jhh0Pr1+kJ3mgXOn8Xajf2MytDqOgu5UD42kDRsmM/h+Bz6ZPnWTcacMft28kvrCSKG5gax585Bd2hLIVbO+Ao6jfJ8q3fRLv8AaE37UvQIZQIyrSAYiWSJ4ZV8+UP4gxvuFNImpQ5n0uRraYu1uLKfChRHd2jR+HnfqfjBP8OakHuznMSptbJB68evkInTyPpmu3HFOmRCaHVLdLqWOM4DLNyiRCvmJQxHng9xTB+z4BrGm68i4TULF9OuIcgqZ4izRuPIGN8gjuopdi0/VrKDTgLUCOJZXW4cnLOk5b5f4SVY7k7SNV3TjNJDDbXMk7SWEvghBnEfIeZCGAGSYTy5z1FMBgesGysOhk0trJZXtnHdQx+DBL7t7wAQQpk8WEkf4ZRMpPTE3rTnpXENpapYX3MBbySEMvdBJMwVvXlfP5iqWp2ok0hpoJQ5gu5LVgy4LhZwoOPNlVM+rVSms4le7W2ZRHDcXEELOxCjllEykjy5AcetKXIc5xLpYLBhumefv+83XhbidZrOa1ldidPPIebtzFT+Wc0zi6SWRg5UBXMh38u/5AbVh3CWrS2uo3DNGVhvrRmyBzKORDv6bqw/KtC/a5zNMHJCx5bfIbA6/fc03VcRXk+vXEzLqAtmB4+v3zET2o6QtvF7wypGs0axc+fkVgXkBH15Bt5+lZQbi5s702sZUSyqGzn4huMDHmAyj6kmvQXFsEXEVjp2nSRK4meGSbmOByjnJG/UZUViunaLearxTfX95HurpyIx5QAytjPbGQ7fYCsm7TkW4XoZ0nZ+rXuCH8PQmlcI20kGlwQwxhiEJA5sgM2OZmP0xv5CnUBDGj27K6ZPxuOuOrH08h9aUrbUrW0i9yhnjjRmxJIT0jTAJ9M4/XHU0L1/2jaFpNtNc3GopFBEmxZgOVAepHr2HVmO2y1saZVrUD16/qYlosvfIHWNera7BAeaab9ypJPMcGVh+JvJRg7d++w3z3jP2w6PoAZb28HvIbEcK5YljjquMsx8sbCsW439vGoXMck2kNJZWskjCO6kQmViPwQp1ZsY36DGf8VZnp2m8b8c3vh2Nrf2VpdMFluDmSebJ/FIPkBzkhcepNMjSW6k56L5+J+AjIXT6IZv5byH3PhNT4s/tGCxf3O61iz0xmKs0ZBmmBA2Zo1BA+jdKFaH7TrXiK6jXSuIm1e5uHGEdOUx/wATd+XApp4P/sXWeqWkE9wJR4twiyyk5JiJ3ZQNgR6k+tZ5x77NJf7N/t7sdFmmFxpOqIngXJHKJYZPlbl7MHBUitG3/HRVR3jo3xOOf0gtL/kFdl4pq2/AA5+f79J6y4M4L990lLqK7Lu6fG3MWLegHYfrRyXgHULt/CPJCgbcKhzjyJNKnAt3JFE9mk00EXNz4hZkYggZ+LOR36Vreg6jaarZxSW0qva8o8LlcupA26/i3HXzrntXoamI2jEMdZdWSSYA0/2Y2CqQ5LjPxnqD6Udj4FsoLRovgRGXGMg5/wCH6UzQyWsS8qydF5vWrUIsXjL3ADOVIIz09P8AhR9Po6q/DmZ9uuusOSZjnEHAy25eS0j5UYczvzDJH9aXtLtZtLmaVCXRfxZ/ma3e/wBA0+TIkjDPgFUclgoPcjpSpqXCloFIZHUZOXxhfsB0odmmZW3L0jdOuBXY0X9PddRXnljQAbdatx6XK0nPC6KnWqEc9pp10bK3Yksd8nJpjsRacoZZWJPXeqkZ6yzEjkdJSjiEdyok7Uh+3OCDUOFL62MZf90cb4Faq2nLITNGnwikXjzSv2hA8HKORgVOe9EUmpd48OZn6s+zMp9i2otccFwW0jfvLVjGe3Q/6Vo9jIXuIkDEczqoI7ZOM1k3s+hl0PinWdALqYiVnRfqMH+QrTbK58O4ik68kit+RFZf+Rjfq+/UcWAN8xORpXC7fIkfKeR/Y5wrw/rljc6xfq02p6ImoRaU/jkRi354Eebwu7mZ5/iPcg7kDGt8a3zyxaPw6jFg6pGCDuDsP0xWceyPTNPstU4y0ATOZuH9U1nTk2APu/ixSrnuRzr0O3cdTlo4WupeKPaDZRMh5LCP4lP12P619K/yBlfs224HxrP6bP5548YlpAReD5b/ALTdY7JbDhiKBBjCeX5UucHsBxFKAdxim/WTyaa0a/hXA/KkHhG7C8WSxE/FgV8z0rFqHAj5TCTWQ31qVCc7VAretSKcd6FSTmWxLK48+1LnE9/yJ4Knr1xRuWYRxlz5GkTWdQ94u3JbbOBW9ouAWkAZOJNo9s11eonUZya0SCNYYVjAxgUp8HWeFNw602c5rV0zZO7znjyYF1+xE0RlQYIFJE/PFLzA4ZT5VpM4Dgqeh2NJXEOnmCQzIuxrXqYONhkDmX9OvlvLcAt8a9d6jue4INL+mXxt7gYyAdqYJyJEDrvkVZh5yyDHEF3D9Rn0oZcycuRmidyvUmhF0OtDLRlIMvLgqD03oDqF4I43dtuXfFFr4ncYpP4muzBblQd2FK2EmNIIqazdm7ndiTtSte2ivMpKjlB3GKK3UwDFT0znrXOn25uZNwD60Spu6G6WwHJBhHQbYpHyjIwP0o/pt0IbgRscA9Qf51SgUWaBAMGoZJzHIJR069aK7d6MwZ9kRu8QfN2rkybHB2G9D7W7Elsrbbdal8c775I9ayHUoxBjIbIzLDv1wpG9cGQ5+mx9PSoPHGxY965aUcuS2+ajMnI6Q9FcR69CY3RUnhXbb5h5Ut6rarMWSWMhlyCp2qeOWSC+S5iuCnhtnr2700yWFtrdqb62iCygZZAN/v5U+aO9XvE6iJdndo9ye4uPs+Ex/U9OdAfCVIyN9lyaEiF1QtPdMoJwSuCx/XH6046/bPEzxuuPQdDSe9sTKWdS57DsPrTFdhYYYTbK+IMljm0+xlWddOhdkGUe5Pjux7Hl2UfkaG6pxLql7ODfTXlzynEcOPgUdgqj4V+wqW5gvJQSgK46bVGmm6xdoIjNHGo3GSQT9TVm2jqZVFJ6eEsaVxLbWTCXVNAg8KLfk5cM31Pc046V7QvZ5qUYN/pFzpjL8KyKQw+oxSM/CE90ytdX64I2BGVz5Y619ThKGO4w92rSdQmWT9CP60lalLc85/WFXeZtdvq/D3gRCz1j3mBjnEsecA+uail1Cxw81pqUeSTsNs1mKQzWEaQAzIrdWROZR/rV+zliupPDvWz15Z4QcbfxL/pWRdQM5EbRMdYz6xJdTxiO4sxIXTPNjmDfcfKaTNWnZXFnK0kTAZhm8j/CaNftS94dlgOphrvTpPjjdD8SDzU9D9K71yzsLuP9oWMiT28wzzx74P08+2KEilOsMrKDtl3hfUW4k0d9L1FjJcQqVAx8e3Q+v1Gav8KanLb3X7C1d/e7XmZVMspWa3kB25WzzcpGdhuPWkOyuDZ6pHDZTBJrggxqflc/4D1Vv8J2p6m4e4j1stc67wxcW2FDe930kdnG4H8ZmZD/ALy7/wA6Ia8NwOsizABUnEYOIIYJtUgfSb2JNYQCQ2GoqVF8qjZo5Vx8eBgkDfbINXbyztNesozc6HKVgfxXtjOqXllN2e3nHwlcE5G3qM0J05rG3todJ1r2g8MCCN/3dvf3pvAgxtyywIwBHb4gfWmHSJW04rcW3G3DF3bOBCjEXbo3+EzCAhs+UgY+tVCEf3FTnjjn15Rk4a4m4ttFh0LUtR07XuH5FCQQ34Et/bEnb4XP71fVCr7dQa07S2lm0/le1ltZLc8ySCaSeIjy5iPeISP4ZVkA/jxvWS23B+gXyytYz6C8krfvrbxnjRmbspKDwyfMcoPfNHdL4L1y1uYpbFtXsVaMIgmiWflx1CXEDEMmB+MN/u9a0KLn6OufXn698QvqTqpx69eEbtf0nTLq1b33R4ZJIBzcvglgEb8aFc/Ac4LJlR5Cse1vTLHh69uBaX0s3D946jUbCdw6xSHZJc9Y2Un4ZSCpBKscErWq23EvFWkN+ytSv7HWYAC/u96jrKgzswPz77DmGR03HSk/jmaz1RTcWczxTQjmW2mcNLCfxKp2LqRnbJ27GlNYqp7dfyx6B9cQ2hZt2x+nn69e+Yhxbot9o2oqujXpX3WRJNOuypJhfqscmeiuCR3VxsCey5oEsp1p+I9Ht47a+s4RcXNmSP3S7LKvKdnhYMd9xy8pztsy65etp9y1vD4U9hKTGbU5DQ5OSqg7YPXlBCnY4VgGrPRcXNhxFDqejXh8SItJD4hKucDMiA48shgeuQSOuRUNuUgTedCFBPP3nt3gTjttQ0nT9R1G2kjMxMPPzcxEoGAVY778hBU9HQjyJtaxDHpuq2V7ZMZdN1ZXPhxNlJH5TzoAB8J5Qwx/lH4VrLPYjxVb3dleaHqr8jqiTIqqBHPaSgeHKuNuZHUo2Nxyqe2+j3s8nhTaZzgWN8wZCf8A91vlYNHIP4fiwD2IYUZrC1Y3fP8Amc41QquIHof1KuuaXZ2+r2t5cpa3EF1JJYySgYY+JC2AwI+VimP9/HaqlvZLqWntZQzo9ssi2k/iAAxyIIwC2P8A0kTxPnpkvRbUZ7C9hhkaFohdOA8SkFreVXEiY/yuCPMh8b7ig+g30eo2l5pV4kUc4jZEmXYM8PMAh8xyMeU9gzDfAxnCvBwOI8tpKZPhLFjL7hZWUkiuC87WVzzrk+KgIbP+8it2ySfOutasbayePVI357Ce9kuEDDOGkjZvh9cNtntnuKn0+4a+067+BHV74zuhIDiVN8gDzDSrk+Y8q610XH7KeJDG8KiwvIJlA+I8xGcHqCCo9BIPI15qsAkzy2bmxmKU9odVXS7Jo5I5oVgAiU/CoZjC4Bz8QzHkelVuH7eF9QtooZZFt1RopEmOzgIcDH+EOQOnyEVJd+8aHa2MkihZtN1Wa0knB3e2KrPA4HcKOaM56co9antkgs9Mlht3kNyZHtpGUnDcrh1cfc/kx7VI4OTCtyMD9P5+8KXMDyaZLG8cUU1mwuWySBIG8ORTnzBjC/SqGpaFcPeXdtE8BBWeZRITnxS6NEPuh5Cem+aYjy3gtNQR43jlkSaNDkho+WRWU+YIGR/lrnUtLi07WUMjvKt1pjrbBgCQypkxn/EFwQf8JqHIbgylJKnj3ylaW4tJEsHyiva8glDZKtIrbHz6rn1ps0OSR9FFteKXRVZUlBYleXnVfrhkIP8Axpfhube/hs5onBEuQHCjDPEevXbKlM/5T503cP6fDaWclnIhHjS3HKSfh+NwSQex2Jx6tRaV3uAOhxA3sVX2uuYR0+2PuNvLJhnijYc2PlACtg9zu3as/wBWsY9Fe9u5VQRJIqDA+YhckD6szD6A1pNvzWluWln5kaNW3P4jlD+eFNZD7Wtag07TTIZ+WJXGOUZLyE7ADy3yTR9XWqVrt69J7QFrbdvgZmPtB9oo0BTahg87DmIB6fNgbd8kn7VjGvcS3P7qfXVN7qdxiSz01WIULjaSX+FcDYDcjYY3NVuMOJTJfzatNi4nmZobGJkyq4O8rDuq9Bn5ifIGueFOGp7vUjeXzu11MFkZ5UPO7HqSTkdPyxgbU1p6E0lYtsGT4TR1esFX+mng+JnHss9w9o2vW13f3slxdM/LJCYx/wBHRTuqqNlTodu3XeveXAvs/wBB4f08fu45AIy3OOVUQ4PyDbA265NeFPZ9pf8A+G2q8SWdjHGdWjimZ2clXubZxzRoF7Lseg6geVe2OCfaHpUnBFjxHMyXPv8Ap8U9uqJzF/EjBGe22d/oa7urR1dnqmssIZLF3KfAcdPX2nzi7X2a8tSPZdTg+/3+vvNx4cu7G2t44rVFzIytkNkev6E14B/ty8V6Rxn7YI34TmintdM1D9nWs8ZLBnj8MuVJG48ViB2yDWi+0v298Q2Okto2neHp9+4Pi6lbjkkkiIxyIo2Gd8sa8wcHafNxd7RNOskDSafohN3MXOxAbnOfMluRf/CidodrU67TbKvif4h+yezbNNqRY568D9fH19p6+4HjupFFiZ2jiP7qSUkGQseoUdzj7DvW16Daw28a2tiP3afACTnP/Pn+VYf7NLS31SR7icOwWTmIXaMt0UZHzHbOPStsjvVjhW2jlYkj5guwA7ADvXzWx0zjwE7jVA7seMYbaZ/eAFVfDj+J3bYVYbWtMS6ZLYqZVPxzFs8ufIdPsKTr7UI4bcrJPh+X+72L7dWbBP5b+WaC6brMN/dosMr+5g/G+MeI+dx9PPH0pazUFDtlKtLvUt5TUbbUZbxmleXliOCrSbc/ry/6mvl45uwInukA8hglj50Du1laJLiaZ7aHkPIObPMB1AXuf+c1Nw9dx3EqxQqGbP8ACOb79hTKWktsMXNPs7x4RZ4o01dOk/aMFmilT8T8u+KraVr1tOBkAM3fGK0zX9JbVLUQyxxEEZPxDY1ifE+g6lot48qXAKZJVVHT7UHU1mp8jpG9JYty7W6zS7XUUCYaRceVBuJo4pbVpV3PbbYUh6NqupXEwV3cjP0p9uEZ9KLSHHw/U14P3lZEDraO7U4nnaeKTTfavHcSuyxXsDRjtkjf/WntXKuVzuCRST7Uo57a6tdcslHi2M4br1Gf9KaI71J4obtWBWdA+QeuaT7RT8T2dTeOqZQ/uJx6psvZfPn1+omD6bf2PB3tx9q2nNp3iftC3k1e3n5d4ZXSOSRM5xyusjde6LRP+zIbjXtU1TiiZTyyOFQ42CgbUjf2gdYveF/aNq1xpqMkuuaZa5Y4xITHJGRn6RYH0rv+ydxzLFcPw3K0qGQAphth55Fdpfpjr+wUYPj/AFoTx1KZH1+0VH+q5lxyW+hAP26T11qjc1i49DWaaFJ4PGQ7Myj+daJey5s2Gd8Y+tZvZjl4thkGBnI69a4HQLmp/hNBlxNljYkAmplYVQilJQeoqcS4XmJFVrGTI2yrr9/7tZtytuRikOJ3vbtYwCSzf1ojxdqZL8gbIHUCo+DrVrq5Fw42HStkHu6wo6meA2jcZoOkwC1s0TGDjer3iZFVVcKOVegGK+l81qUYCgQOJI7evSh2pW63VuyHGcVdJ2qJ9x0rRrJE8BMy1NJLC7KsPhzTBpF0tzbBCd8VHxdpvOhmQfFvQjh68CzmEnONqfXD8y5GRkQ3cruR5UJulzmj10gYc46GhU8ec0CxSDiGTmLl3GN8is64um5pygOy1p2pARwSSHsNvrWU8QkvI+Op6UqwywEMDE66Yuxyd+m4o5w7adHI9M0Me2M1yqBc4OMU5abp/gWqgJ8Xehah9q4hk4GZS1FCGwADnv5UOc84Krvijd/AWTP8jQNgVfbpU6O3KlTBWnHSW9LnMZMbHp+VXmYhyF6ZwKFQqyS84OcedEWBZVfsR286rq8D2xK1Xc4zOjOQMkmuWlwM83SoiCWHnnyr5g9MbdOlJBxDh5Y1geBzTDYk7HyqjoHFd/od2c3bzW8h+Nc5JorxLHiFl9Cay7VLye3dhExBz0FbHZtngZzF5wwImocRXFrq1u19ajLAZIyM1mp1PF34Y5uuCPTNWOCuIZhfNZ3Kc6SjB2yaKcQaF7nqKXUCYD9jtVtQe5u2kdek6rsy86ijk9JCtwhtfEXqe+KDXWoDmI8fw8dzRO/cR25RUKv+IY2pQ1aXkU8y4J71BAYzSqYqIWtrqUTBxrR5j8uRsPX0pgtH1u45TDdWsq9SeUEsPvWSXN/JEcwE5Bzmrencc6pY4BVlVcZJUnaq2aR3GVnu/RD7U1lri5kQxchjMYIY7g/XuKpyLqltIt3B4nOhHLLCwJ+46Gl/TOKrnWB4ccvJIN89Vx6k9KP6dxDYWzOk8EUk2MFkz4P5dT/L61k2VPWTkRyuxWEN2Oo2+vWMlrd2RMZyZZA4SJGH4vi2B9F39KqaX+ydEE0djdy8Rgnm8FJDbxRj/Ev97JjzHJUcqNqRXUBLJNGg6xYLRfROmPoKpPZ2U863CXVpM0O6868sg+xGf1pcEQuMnrC1zxNxDJbleHLi30WFxnk04LbP6gygGRvUOxr9onEaXbC31jVrWW6I/c3QuEknGPwtk5YfcUU0rX9OtrZ1Md5BI4y8tvK6kHoTkqQfuamukvbvTx/s1xjZTsmSq6lB4m3Ug9MfUVUtuG1xx68gZQnacqIRgvVkCxXVhYTlgoEllciM56Z5WOD9MjFEY7WC0maVNMmtppAFWUgBebOwbALHP8QP2pb0/WuMDIqSRaGZo8E+B7vySL6JJzN/Km+x4j1z3dYr/RXXxQQ3i21usa77HA5QR9D5UHBB4IniQeMTu0udLin91u/GspuYSCa31ONHXfcgNEjKc9961vgniJwkllccQ6veW5ARnnhtLsMD0JlhaNh9dzWUaxfaPHbxzahZiAhctNbo2xB65duUD86p6dfcBXssaXGiwzKxyZ2ljDLnof3RVz9iaJTqXobgcfE4+ki7SrqE5+x/eemYW0nUbWOxu5475lDmIXgZwM9omlJI9VD49KVuM+C7aaxa3hNxJDGhBWQEmLfZQfmIHlvjzpE0XVOALGf3TSeKksLkqEktru8uAAx6fBK24PpmmmObiaBDe2s1rLCrcwlhuo5RsP4TyHp2y3TamrrV1KYZflzMxaH01mVOPjxPO/HWhe5SFo7lnYEqCvzMPItuGGexwayjU9QeIyRrK7XELLIhmUrKHXo38LHsT+IdR3r0h7T+H7K6WfVb7TTHPOoaRra3KnmAPxNj5e3Y1541mwkWQA2UcrpKWhbxjzSEbkA5wcj9TSejIDFW8J0m/vaQwmqex/iy0n8BbuM2avA8AwcoGfGcEjKgNgZ3wQofYhhsOoa89nbzTzlriLKW9yF7AEczFfQNn1U98bebvZ/puhywS6lpepeBeQyJL7vIzYI3BjyvwsrdASqspDK2+M6lacRCW4IvllKzwNF8Q/dzxlcHcbBgcffnwcNRrQASq8TKsry27rNJ126u9O12a+tpFNtfwePb4XmDTIpLKR3PKGOOp5cdRS9bcYafeaxFAwMJ1Eq0Ds+0Ejg5QkdV5lb1BGe+KqtqUd5wfEouFW4t5EMEoc4YhlGd91fIH+/jsSKynWNVvtBvGWAbrPb3dueXEYLZYrt5lCP/ABoG3efZk0oGGG6jibHo/EUtvPczxhld4veYgi5/6RGDHcW7fXwwV33L/wCKnVPdFtLnSHMMtvLao0RO5MAJcqhH8Pi86+mf4a8/W/GTLq117vJNFdQXTXEcBchZA6Bih+pQEf4ga1Ph3X5L8QW1vexD3aVbW2Zmx4clxGxhLEduZFTP+IZ+aibPBoOxSvI9eUNWFs2qQyLNyLdPJbTw5ccrs6lZAP8ACXRsf95v1r9apBY6dpFrDbB4733uD96TzgomShJ35uXYZ/h9KCx64Ybu3ujarEYZL0NE/wA0TLAJQnquM48jEwpqvrgeEZUiR2tAroyuCwmSQqJAvcMmx8wp86VKbDDFiwAPrw/uX9DWM2cWlvI8rpA7QOF3KZ50ZcbZzLjpjDkdqYNUs/gjuhyeLaSRtGAccwADjr02Ykdug9KU4WOlNa3txBKn7KljWVl3YwvEEEg6ZxybjvyetP1xHY6gzrb3MbySc0MlvGeXJK86lcj/ABbZ23G5BrzpuQt5Qedrg+cWbDR7OG5W0s71Y4be595tnZSVjUqOZD/h5WQd9gD2p30HT7gusbwqyvIHCZ5uSXl5HQ+hyMEbUnOEsr9w6h4Ut0XcchKAlV79eXK47cuK0vhi3PuNskLkgIgVmJLLy+eeuxwT3GPKi9lsrWFSIPtFWVQ+esWNQjfSNECJI8kdsEQFwSSvidDn8QB/T0rzF7dta5ltLaBiqI8qu+cMo7HHYA5375r2Xxho9rqVjJCsIJuVYSrn8WMfXIOOleIPaPoerQ8XS6FqlsjQXF6kUHI+c9cLt+LAPw/XrTV1YGoG7oohOzHC1tYPzTEND0u61fWZbtwq+KVSBZQSqKDhV+u+T6k1puiWr2ZZ76YQx20nJ8UmArE/KVOcjYHJ+1calwpLZypqMNqSiEyvleVw2NiADv06YqQGNrWMrIolLFlCIGySP4fL1Oe9Wst/FruWZ1r923WVOMdE1zU4rbjHga8t/wDaTTLdoFgYLItzC2eZBk4YjO23UjG1ffYrxhqVv7LLbR79ZBJpFxPYBJSqFCpz4bDqoAPQ1DeX9zbX00pCoLcq9uYHx8JXGVI38j9BSVqHEMmoaxeWWiQzXF5qc8k5WIZknlOAXIHbbdjsMdaaqt1VukXQMcqDuHu93w8fjEk0tBvbUePT4yXj3ieV5n/dh7mU+DGkYLFyx+FVzknJI29afPZTwTqfD2nNoHu3NrGpyLPqroctBHjKwg9dgSWI2yT5VX9mXst1CPUI9YlaG61mT92l0CHt9N7MYQSBNKBkc4yqnZcnJr03wjwfpOhxRgyoXIzJzHld27s/dj9sDtVtf2gtFf4bTnnxPl7hNrQaTuT+I1A5/wCK/c+UvcH6BFo+kwlGWC3UAIc5Lei9BjzI+5o5qnEX7E08v4YhUZIknjLEkDry4G3kMD7DqO1biGCyJlSe3t1jQg3IBaTlB3KjB5VHr8RPRaz2TXTxhcAQyuIUPMJ71m52VTu/IMgDOMZ6E9Mmuaazu+F5M0a6W1Ld5Z0lo/7T8SsRcXlwlq/xyo8oTKbk5C5JJz3PTyzWg8KabDpqLDP40jpjl+H4jg7DfZQPL88UO0e0FhYpJGZLaKOPxXkaLmklkz8+MbADpkHfoM4o3aRNe3MYurp4YEUSqjHlZ89ByZyfv+gGKiurJB6mXv1IYbBwsdYWi1BS0lrFEhTCSMTIc58xsfzxUlnayW55IJ48qOZ2XHTywO9V7S7s0jCXEs8jKMEREuQfInOOb07VzcaqkN5+y7S5mUOcvBEy84J7MQK0Nqg7jMwMx9lYftY75lDJyNE3R/XvtQ7U+FoL53e5UyZz0G2aNWdhdGFQ+I1A3APf69TV2NZljEPKFX6U4agQAwifelGJUzL5uGGtpm5bfkRTkH0qW/mji09oVYE8pHWnrWbFpYGVvhB8utJV5p8UMbqNwN8mgNSE4WMC03qQ0xHjHTJtRgurYRbMpIPrQD2fXvvHDUlldXWbzTZWidSRnlB2/Q/pTxxZKIrh08UAeQrFml/2N9oQvwXay1wiCRc7B8HB/Pb70HsxBb33Z5//AGDj/wD0On0nN6te6YW/9Tz8D/eIi/2jVs0470zUZ1JcaQEiDEFTJ4/wkjrgK0g8t6YP7OXs/wBFg5uKwhNxgKCHyMZ6YpO/tTXCH2k6LpsYKrY6QjSNn/0khIz+VaX/AGfbq3HDUghcsQRkHtW9rVs0/wDjKVngggH4ZJxFBg6zjy+wm1Xdxi1Y53xSBFIDxRbOCPmI+1Nd3d4tHIONqRYJ1PFFsQQMEjGetcf2cmUf4TQcTY4ZhyqM9q6u7tYLdnJwMVQhnBAOe1CeKNVS2s2UyYJFRp6y7gCeK5ivrF811fFVbOW6VoXCVkLOxU43I/Wsw4cjfUtWGQSoPNj77frWx2UYggSMdhWiP9l2B0EpYMACXgcD712Mmol3xUqDsK1qVxBYnXTvXJya6A7V+IxmtFFkbfKDtUtFubZkYdtqzvwTp2p8oyMmtRdAVI86RuJbMxXJlVehz0p2oeEsB4Q1Bie2GCDt1qjcRDJqbQJS9uqHdgMVYu4cM2Ns1e9Ohl6x4RN4kIS1ZcjJFZZq0fM7Mex7itP4nYMCPvSFf2/isRjOTikCOYyBxiBtB0r3u75zHkCnF7DlTAXoKtcN6QIrcy+Hgtv0onPa9cL9M70lcCxlwcRVnsucHbr6UralYtFKcH16VpElnnOR+VAte0vnj8QJvjrS1RNb7vCCsijaI0yhG7ZztRW3tyyMhHbPSq8EBhlzRq0h5wGPU9qevHepkRQZByIKNqfLevhtDjfajz2RD/Lv1rj3Eb/Dn61i5IMZU5g/iNAVYHpjfasi4kYrI4RcHvjtWw8RDdsnNZHxPyI7kDJwTW32YczBu90pcG3tta6zHJOcKD/FjatO4hniuVgukVWhHVgcisHWd0vlcvyID2O9bRot5p2scM+6wXP7yNOnNk/Wmu2KDXsvHhNfsC8MTV0zJr3Q4dStg9q2Dy7d6SdX4dvYcqYw/wBRvR3S+Mhpdx+z78ZRSRkCjt7cWeoIrwkSKwyO+PyoQsXaGE3lLI2xpkE2i3hm/dohGc1NDoqiUC7Ux5OxRTt9T2FNes2ywMcLjuBQZLe7umxb7MNs5qjXEjJOI2tankCX7LTpJAsMZtJUQ7eG/hMv1z1+tT6jomoRJiE+MG6cjAkfcV9tNNaEE30oCj5iV/0qxJPpMMfhWeoi3mwQCSQP9Kz3tJbiMCsCL8ScR2EnPasUkB5gHPhP/oRRmHWJGZTqfD0lxLJ/eFFDAnucDI/Wq1xNNO3Nc20N6mMB492+xzUEEGmvP/0e81GA9o8MB+lVOH6iW27OI46ZpNzcTJc2+gB4cjleG78J07bo5AH60aPAcLye96lomjozkOEkm8V3HY/MoJ/Ogmg32s2ye7aNp+olsjJS3MjP6jBPL9cUettKlY+Jr4e0dPmjmmLuwPblVwf/AIjj0pNiwPB9fOVOesuWy2dlImn2trHzy7BY5xECR/hiOaLW/CmhXXM2o6XYmQDJws0xQjoMrIcnJ6Ej1rnSvdrbMNjodxZRHdWULuuOpUcpb6seXfqaZoRxTPbibTLc2sYUiOfUYUOfUR8y/mWIoe5vOCZgDwZFo2n6vpspj0W2LQ/IRzXUYCDf4hK/Km9HrGz0ucCXiLhvRElKkSOlxHI7DtkKy4+uTQhJdRSJkbjHTmKkBuVpIpHc9SPAk2I+oqxHd663LLFeam8KgK1y95NDChB3JJR3Y/U96uhzyTBszHn69DGaw0XhW5hMWkS/s2ddkjj1YiOX/CVlLpv3+DrRWLhcyMbiwsZrWd9zJaS2zYx2YwSISPqm++9J0Wrx3Msdn/tFOxRWzBNbxzq++zAyKr4HmrD86Lw6/o0MY8aTUofEXAKePJCxHcBiwX6nNNo6cAj7RZ0tHQn9cmXNa0eYRtJq9nJKwO11EskUm3U5UdfqrD1rEeNPZ1YancyXenxqHOfi3CTEndXVdkbycAb9VFaXqPHkdnzrLpPEHJFs15YQLcxxD+J4g78o+nL54pd1b2m8PRtzT3FneRtgrMyeFIreXLklR92Ge3aqWJk7lHr7xjTG1OkxvSuCrzTeIJbW3lZbvJPhS4UTpjDRk7BiPhIYbggZGMEaZZWNvqOjSK0RZA+ZoCPitpcckhUdviCsR5nyIqjfa3wzxAiXEMq3FuqvNzcyiaDA+LcEZZdj6j9L+j6lFDcS3NtKks8kKtMwJZZznlDEdiRlTjzwQCBUbyTh+sParEZHWc8PwyQWt3YXtuZrS5WYXMIzkFowCynyIwwI3DKrdzSzxlpC3yRxeJzSrboRKT87eISB9QSfsPWn/To7eeEyQAtbqTAGbZlQFsAnODgM6k+npVObh+31FvdcFZYky7dcER8zZPkOYfc1OQBkQAsxYc8TGNftnbVbZowAiIsbfhdl+IhfTlZW++aZ+D+ILj321uoZnDosaXSjBDxr8SHGeocgfUCofaloUdoyXcCnMcjhgoxh1YjA9CzN+dKXDNxdTXF6sEoRGtJEjCsMg4C83pkqDijAAp8IcNuXjxnpnQr+y4jX9rpb83v5ljmCDlLSyR4QgHcEsrKe2Jc9qIWzoNPtZYHcX9vctNChAT3m393DFmHb5myB0JNZnwRfahLaTz2RYTyRWk8Q6eGwZsvjyBMh+grSLG7ntJbAiVZo9PNxKC0YZvikB5MDqu4xv+Nh0xSrICcLBZK+vdHrTLK11nS5NNmuf3NxBm2mjAZ7aPnccyjG/IXXI/wtjrTCbXk06YmCKC7iMT5hl5QAzcrRhj+AnDIfwnKnYilzg2z03UuFbHw57iIpzQCSKMq8alyObA7AKNx5AmnCwhgvbTMNwlzLbz8zpEVAkhJHMyjm5SvNuV28sKRVVrFqdM+v3HWDdjXZ+vr5ytrOj3LXDh0aEyNEfEROYE9yR2UnB8hk+dE+AuIzZ8tlq4KSQEcrD4Tyf5e+DkY7fQirDPaWsQtiJQk0gAMWcoT3IO6Y65HwlSOu9Qz6BCWS6hSXlLvFIrqPhB3yDtlc/cbHzpIltNd3lfURobb6u7s6R21I20li0tvKvLMOeLBB3H5jPmP5dK8le2XTL/UrtLzQIPer7TpZru6tDB4khiRQpkUr8rBm2PzHqK9Az6rGlu0MjcizgcyfKwYjBYjsemfP86Rbm+fSuJbfVYL9rOYxGJwrArKwyUJGN8nlA32z0rRXtGt9QpK/39oOjSNVU49089aNx5oWuwL+2PDDKedrhVw8WwHxRjBfc7kYPfFLnFtrZW8s1noNxJdSlTG0dlE7Agt1bAwAOxNbCLTQNEhvLu1tLZWiRp7iQKnNz55tjnphsYz3+tBtH4gtNVvDbmGeEuWCStF+7YkZILK2B/vYoBtr0rF6umTx16Rheyl1fL5wPXvmTaP7MuOuK0jku7hLK3h2MwXmmVcDbJ2GM9gfKn/hP2RcNcNK4Lvcu7f9KRCPElIJ5fELnmdQcHlJVemBWj2MtrlPGgg5YgVjLqMEnsT2+9cX73wVYw9wiE5ARl3Hpk9PWl7e1rrhtHA93H9xins6jTN7A/U8n18JPp40q0SOG1s4o0ADYGDIfIEdR9BtUuo8cQ6dbzWlhHLdyhSWiiAUZ8mx1PoTgdSDS5rGoambBobaWG3DKR4gfLsPJiOn69KH6TaXFwrRP4i2y45rrky0gBwVihUZ2Yj4nJyQcLtSZO7npGO6Vvac5lzVH1DWpIzrN8lvzlAbaPDvgbqpOct/lHKoG5B6A3wwunaasjWWn3NzcFlQPyrsSSFCA432PxHAG5HnQ630OC0jlmaCWGzlwoxIvjyjpl5TsoJJ2X174pgstQtFRBZ6eBDbsD4caFRIxHygblzj9Ou1QpUNnMs7MybQOPdwJPqusXumaY2qMiLzyjlKH4R3CpnZifPfOOpqtwzxJdpHJfzXCRyuSxL5O38IJ36eQJ8qu3fDHFnF19FcyiG2i5S/PJIqrAp2zznJZvMqNzsMACmnh/2OQLJ415czzxsApeRPDMhHUgtg8voNqPXTda3+scRZrtNRXiwjPu5/SLV5xlqmoyPZaXBK6qAsksahREB/iJ2/OtB9lWgTSAXcoWNhvy/Ox9TjYfejdn7OuHIAokDzSD4mji6DzPwnCj6YPqaedCgsNPiS2tbdCO6qMKv5bVraLs63vBZaZk6ztKrujXSMSreTXRfw4FXAOC30qSOToiqQf4qocQcWw2EjQRG254zuFOcf0FAo+Nonk5ZLiMtjZV3NOX3ojlQYhVQ9i7sRqu3VgfEyxx0xSVxHNFbQyMY8ZBwOpNNNnqCX0QcIM46mg/EsEcsfhrEOZu5qBWLRkSVY1E5mC6vpF/rl+zQRkJnriher+ybUdStFkNqzmFg6465B869AaHw3A7BnRevlTtZaFZBAhjX8qHpuzlW4W7uQciI2nIORnM/nT7YPYvxhxTr2ocVvpzqrWNvbBMEsBG5JP61a9h/Dt7w9pV5ZXUbI/OHZWUjl3IH6Yr+h15wTp17CUaFWU5ztWc8Q+yXTY5JZLW0ROY5PKMZroO0NK+s0TV5zkgxNTXvBxgzz1qF34VnIc7gVn8F+p4ntiCBgkGvUR9ldoyFXt1PN12qhJ7GtFllWVtPi506Ny71g6Dse6pGHGTDW21gdYmQXWYwzHtSNxzq4kk91R/i6da1LizhFdBtHngdl5R8hORXnrijUwb8O7czFgo37k4oOn7Lu0znevTpCVur4KniaZ7NLLmj98cZ5t9/IdK0yJ87UmcErHHpETRgYdR+VNsMucdx6UOjTsp9rrIPtHMIRnNTruKpxuT2q3G29a9VWIMiSgbCvpG1fVH6195c9qdRJGJEy57dKXuJrMuniKu+PKmXk8qoavbCW2ZcbimVGJIEVtAcI3JtRrUsLF4nYigVmvu91y4wM0V1S5BsSo6gUawbkzLAe1xETWz4kjdh0oHBp7XV0qKnU7mj96hdie/Sr3Duk8z+My/Q0gy+cP05k9vYiC3Vcb43qKS1z9Btij0lsANqqyW2dwOnnS7pmSD4QJJab9Pzqje6essLKU3FMb2xBwO1Qvbg9qTeuUPPEy66sDDcMMHbPaiGnwnAycY8qLa9pfhzeIF6/rVW0QjAI7/nR6faXBgCueku+6c8eQK4FmB0WitlECnKe9TNakMF5aR1NG1siFryZnWvEFWOelZJxOAZCWHXOa1PiCUcrkbnf+VZVxQ3OGddx32p7s1SCJztxGIiXiq0pRQfX0p99mSxWszJPcYR1wRzCs51GVkc4bl3q3oeoe7yiQ3DE/XArotZQ1+nKg9Z7QagU3BiPtG/jW1aPUZJLZGMZbIOKF6TxBqGlt8UjsOgGdqbtKEHENm0apzSoOuck0patA9ndNH4AJBwDXL1k0nuWHSd7VYmpUWKesNjiCfUMCSFZObbOOlErCCOaNizCFsZ5Q21K+nRvNhjbsQO+TtRlLUyoea1lYnurb0vc3OJoUqZde1gTmHvM84HzIOmKHPaxvn3CymXB3aVM4+mRioi0S3IVjdQAkA5bBP3zVu41O0tysUOqysM4dVxj7sc1VczxweTP1raXGCkl7HCQduSPB9PPNGNKn0+2cE3t00hOB4rsoz5BQN/yodpl0b9/3F4rRofwxBz+eMmj1u18mY7W6uZmTflVFRQfVmx+poNpBODJXIHEP218dSmNvaWl/ceDhfDSVgCPQJ2+ozRq20sQvHJPpwsV2KW7/DLIx3zg5cD1Kr6ZoLpup3kbqtxxDMHcgGG2YJGfJXkHX6AH0pht9c4f0VxPd3k1xeROWWCzRY1Vu3M53P1Y9s7Ur4wLhh0h6x07UVRbiKyewf5mMao7H/EzzcxUeuAdtsdahvL+1RwjKt0ytgKshAUgdZZpDue+FX6E0IueLb/UrGVtavrbSNNUZ/eSyTzyKd883MqjP1/Os/4t9r2laDb+6aBbW0bw4DThSoU9twAzsfIY9c1dK2sbbWM/CDSvA3WHEfNQ4h1pFU2Oo3EUikt7w07rH13/ABHAx0LlfROlIHEXtp0jSZWaea1v59+Yq6tluxJCKAdzkYrD+NPaTr/EjCK+1Se4LOWSJn+BSe5Ubfbp9etLyWh8MSXLNJIxzk7n7eVbVHY2AG1B6+A/mK29qV1kpQuSPE9PlNUuv7Qt/wAzG2snLEZyb2dlLfxcuQOmw7UqX/td4qupmeLUL+35yciC4ZBv6ZpXjsec87AjG+4FXIrNWGTGjkfEN/mrTXQ6SrkJn4zObtPVueGx8AJePtG4nlBV9V1gqx3zekc36b0Pn4nuJGJujd7nfNwDv96K+xzQ9K4r47tOGeI7yW3024eR3EZHO7LuI1Y/LzdMjcdt69r8O8F8N6Xrur8PLw1po0poLJktXsUaFEMRVgQQc7xZOSSTknvW7pux1cByFUHge/5THu7btXI3MSPCeGrDi68sJRJbajMjDB5ZRjcdDkbfnTpontf1DTJPfJDmTlYMuwjIK4JAG3YZpw/tK8Aey/Stdij9nWlrZXiQudSgtZCbNJeYcoRTnlJXJIUgZxtWIro0kauELEAbgdMd6ytVpNPvNb4yPKaGl7TvKBx0PnPUfBPtFs9b0h2luB4ck6MwO2cEgnHbYtnzBBrV9Mtkvbh5S5MLjll5duY4zkH1+H9K8F6Vrdzp0wjt52XlYZUMRuOn1r1X7KfaTa31nBp6yKJ2Q+IPiLIgVAzH6gYGOhWsHV6M6Y7hys2a711SZX80a/aPpAvuG79IXVbhImnLg7krIpA/Pf1rANOjuNMuJPBixPIbiAgnLEBgyH03BX6CvS+umxl0m8tXdAvKpkCjBwrq3KPMY5s1g3gxPxJeW/MIml5pio3WJXJYkHscjp2zSqPyRG6F/wBfM0Pg25NqxhacyBBJDNNJnAiZ+RVC/XP2XPetQj0dGsG/Z5lUiMNHyt1BOH+pwg+mayThO7SLVoY5oZ/FiCyeAX+FGY5XmPohXz7nrWw2d282k3MCSo0sCyMJElVGZN+ZgWOMZO1A70BsGetrYYIjRwFqV7a3k+nNrdxbiOOBY4Qpl/7MFn5VCsCCBupwBjzrR5+eaaGc2UBuIXDpduwgkJJ3VlLEjO3zdR2rG+GDdQSzXnK93JC+FVYOVkGQCMk/Ec4I7bA+lanoVxHFbJaLMq+PmXxkhUsw/hJXbbc/XagUPyVA9frxIvrxhvX8/OElkcgWdxJDGplPhh3JKD+EMoIx9MdK6STUtPdrW4jyknyvhmDpnIO2wwc4PrUU8/uSQ8lqrCQ4BKoCmwyX68x2PTz9Kln1ARxCS4jMfirmPDY3I7LnA386rcrHOTzLVHjgcStrmjJqh8WF5I3HyuHBOMjb1ORnB6ZrIOIrfWNL1FoNQDyrbsTGwzjDHIJHUbBsj09K1+wvOXxbK4jkaZ3DifGeV8ZA2JHTOdvOqOvadFrljcWqvFHd+EVhfIPNzDJI+v8Az0rKsTLbh1mrp7jV7LciedLqC/uNZuGtOX3O5UNJJ4oeQZIU80ZXD4GRvtgjNV7fhN0kZBapAiKAskEjK2zbYX5cY3x0HSmnWdKvdAuB7wVe5CqGSQEtjoBkdslMef16XNM1G0Fw0AhnsTHtIFlbDjGOZRISPXpSrXN0M2hhV3Vxe0/QpMiObUkijDhR4zKHO/qRv9KZp7OxslWM2/vcrYBdpeWMY81BGcd9znypkjt9L1OJPD1eBJSAJBcScjqQMANhSN/sDQa84f1C2YQxQwXKk8rEtjnXG3L8IB+wb86NXYfAZmba3eN7RxFr3zlvlXwormUnmQLkBCD1wqkk+ijOw3AyaIgMlusVyrCWVT46nl/dL2DkbA4wOXJ64wTk0Uj0fUrK8NxqGmJY8q4jijlYZ26MScjPoCT6VZuWhtxHLL4Vs0jZgCW/NyP35FYgs47sQoFW9o9ZTegICj1+kgtNNu7pRczcyRQgYe6TkBbbpH1GAP1Ge1OXD+jaWJY47i2dxIAVWUnnmzgnmCj5TgYRdio3yKAQRI4SRro+DbOshlnTxJC+TgKD8AOc4LKcbtud6bhdR6ZavaWyFtRnTxTHHG09wUPxfG7/AAx5/jkYHHRdhTWmpDNuPhEtVccYEabVXeVIUtbSFBvNO48SVttgu/mMALyqAOtGg6yxS+7tDEXXEspjWSQdvmOI4+vRQx/nWZWOpail+09xJFcuoIYiNnjh22VScKcdc/Ec5PKOtfuIfaTovDlkl3d3kkkszcluG5mknYD/ALOPv6k8qjb0req1NQTn1690w7dNYzgLzNEWWHTo3jbUYWXIzLM/MgHoAAM/XFV9S4wit7V7PRwt7O23KoxkY6tn5R9aw1OP+L+LLpLeygNlaRnlDzP4s2/foET7ZNaXp2lrplisUcMsskwy55z8TeZJqadW+pJSoYA8Ze7RLpQGt5Pl/MDaraarqJebU9SSFfmKQgKiKOwpet9XWG6930yNpMHDTnfP0px1LhrVtTtzHPFKEYY8GIlFx6nqfzqpLwjLparb2ttGDyjOO39TS2o0pXLL184zp9WGGG6eUbOEtWIt1EhBPU0Q1C6W7uAM9KTbDxdNHLNJjlG9fl4liWVmMoxnzo9LlKgG6xPUANYSs0fTWijQbgUZgvo0GzCshm49t7f4TOB96ks+P0nOElBo1esqq/MeYA6aywZAm1wasiLuw6VQ1PU7d1IIU5rPYuK3kX+82I86rXfETt0fr61pDtRNmBEzoju5jVcapbx/KF6UMl1uNGY+GhA9KTr/AFpkBZpCPvS1d8UFXKiY5+tKp2kwbKy7aFXEN8eX1rfWUqRthiMcp715r17gK4uLz3ogqokL5xtW4NfxXpAlPMTviq2o2Nv4JIA/0pwao2HJgxpxSuBFbg26kS0FrKMeEAg36042zEkHGNqRluYtP1IogwM4A7U2WF0sqBlI375oHdDdme/KIchc5q9CaFwSZA9avwP2J+lNIsqeYQTHl+tShAarxuewqyhzjNMKJTE/Fc7A1HcQ+JEwA7VZVc9TX5kHKc7VfEtiZ/qaizlaQ7EUJi1lLmfwy4IO3WrvH90LSGVlzkAmsi0LiYy6m0OSW5sUdPaHMsB0mlvbeNOIoxnem7TdO91tV23I60M4Rszct7xMBv0+nnTe8IUAKNu1JsvMuW3cQPJbgdAetVngNGJYcZ2qu8GdsUArmezA7W5B6VEYMn5aLPD12qIwelDZAZBMXNW05biHLDcUsR25ik5WG4NaLJbBwVYZBGCKVdSsPAueYL1Pl3oSrtaeIzOLJCME0U8HxEDYP1qhaKSQMfajdmnOvL1xV7q96yFGDMC16bAbGTnPXoazHiOT5/Udq0TiEsckZG5GxrL+I5GZmG/rXuzQDOWZ+Ij6o5LnBqlp8wNwqvzYJq3fKXcjI9aJcK6baS3sRniV/i/KutytdXMUrVnfAmp+zfT28BpoyyDl/hOMUP4kgU30g5FYk55sVqljb2NjwoPdIsHkGNtzWY37mW6Z2jYknvXAau/vdSzAT6R2XpzVpwDBCxTRxbuyjrgYxXQurhF5ku2BXy7VJeakIHxNEzAYHy7UMuNWE8nLyBUPVQKGqFvCa27HGZcae2uV5764Tbc5Usf9KtwDhy4Phx28l0wHNhV5VHp9aHWNlc6jIy2dthAN2cDApjs4rbT4/DkuFeRz8UcYAwfU9Kq5C8AyFBbr0lmy0u2eMFLFoiT8uQfpsKuwJBHDJGkMbMg3jEeM488nP51Wm1i5hj8T3a2RFG2X+Egd/rS3e8ZqwdGZIkXfw4ByIf8AMRu35igCt7DxL5AOBGWTiD3IeJDG0COeVHji3Pnyk9x0zQm/4sFk5XTbB5Lldkur3LmLO/wIcjPrjPpShecbX11KIbSedEb4FSAdv6D6VNa2t3eXEfjycniMPhkYgn6dz9f0ppNNsGXEEW3dJHqF9rOq3xk1C7eW4JzzSS5b8t+Wqk3CF9fwSXMg5goyA22x7jI2rQdA4VuJ5UtLdi7BiXWGLEceP4pj1PXIGSemK0NOERaabJJHZ3N082AOSIBvIjDYKqPoOlHr1PdkbBF7K1cbXnknXOHX02e3vVhPhswRvLJ6USv4TyKY0ZQem2/rWz8U+zy4ureXT7+1aOO4XmX4cEE77fTbfpWWy6DdwO+k6tG8d5AMAN0lUdHUnse/ka1vxItCsT0mPbpDUTjxlKxthzy8uAU2QMM82CAfyzRePSVNnDIkTNlsMWPoTsPt9aDi5ki1MShOVGYc22wPfb9frTIb1TCgdIpIoj8EiKVw52Pw99ulWsGeYquegmba4L/hbXEexupbO5jPjwzQScrL5YYdDtXqbQvbLqPGHDdpdRaYYLuTSYbO4lW4OZZ1Zz4wDZxnn6E+ZzWDcRWNjxKpgkK29win3eY7gkZ2OPOmrgiIWXDdpbeOIZ4IQs5zj95uTjzwO9MajtW0aQVIcHPI/Tr9pnNoQtneMOPXELcXxpBAk0iM3OrACaTmycD4gfLrsPSktY1W1mEkLMuARvyqfr570y69f2lyIo5dTupQg5VDfGFGM9e22+BSpqF7aQ2gildppZSQiKASD22O4H+tI0qe7wRzDAbnGDFG6a1ayvAbeFp3vYXSUt8aKBJzKozupyuTjso7008I6/c6Q6XLOyFRg9sjrvVzTOCLaKL33VIxLNLylEPyJ5f8mqF1pdvLbzGxWdmSUIcAY9OXG5NO3WV21BT0mnpqrdPYXPU+E2/Q/aZFxDpru1xICNyhbCyAnff7H7H8lO31oSa1eX9zFPJLccvMoCgmMAfCfqQc+lZ3p93PpAFphUbxQrKANzuN9+xOfrTdwutwtyZUaNZHlLB23xvy4yfUb1zz6UUMzDpOkSwWoB4+M1fhicXytK9sSt7KY0uNmxhyS+O+QR9eUVq3C+pWSiQKJvDkhUCWZFJiVg0eOUnpy5z1zvtWCw6mLK2a1hSSErHKpXm5QwyAvKB1JGT960fgC5v7W0EkF7HLBBEyNDP8RVm+JQW3z1+nQVmtWwbcIZwGSaal9FZRqvvcNxzOP3kYJXwyQAyDG3TJHXbHatA0C4Sa5kl00iNo5WjT8SkhQSOXp1yR9ayTS2trG5tI7Jz4E5RolJ5kOSQcj8JBI/M0+6HqFtZySTRGTxd5HOccxYDmIA2yMZH3q1NJJ3HiLXNxgc+vKas8NneafJCickzcryDqRsAd+m+TkUH1hbgMiBxJLKFh5unIMZyoA79DU1vIWsRHZRchZGlQFjzF/IZ7Hc1VbUbi8uo7NZiHRQrM2VOBjIxnfbNNaqrjb0iunY5zF7UrpraBb+aPxJeZMFyeUE9cYO2PTerrT+/Wy28jtB8JaOSPLAMPLO4orNImoGWzv4o2hUOYQm6qSQcY7VFb6fKJXcxlUQAYBIAGPXtWDqtKUOVOfXM2Kbwy+0MGAr+1h1Im5vbNI7pFHJJjLNKFAU+WAu4/zUgapw17rcvOjNLcLzLI7AIvzHO5AJ9MHOPrWpuIHna3d05YzzRsy5yCR5bnbA+gqhq+jXUkKyzXsbQAAxotsZJn7HJY8qD0AJ260myB1zGqrjS/EUNCvtRtkIjKtyn4TJHkKD3+IZxt2Y0YvdSjuLc2rzwIwbIEQ5FJP4lxhyfocVTudOsLTwhp1ldhhj92shKSHvlFOxJz6VNCk9lmG3AilkxyiZQrqeuyBiSO3XahBSnEvYUsO7Emfh7UwyPDBDyy4OHuAjMCPnfJYsCO2/0qePSyt1/0026xBgSgdXEm5zzF0ARMAAKFJJ7d6507T7dLiS69wtpJmcI0py7SNk8wJXfy70Yt7a3lk99eysYZQpKRHxE8Mj8T/wAOO2GyfTenKiDyfX0iVuRwPX1kqWlvcRwvOyRQRjKkjEvIu58NcpFAN8s7DJPY9KGnR4by7lSzt7qSHr4CNJLzg7lstjxDjHxNyKB2Owo1a6PrmqXTzTXkc8JBjCxxkAbZAjVgST58vTq2avT2TojLDbOJCoZ7iZWbG2xO45u2B3PatWpDZjAmZZb3WeYr65qNtp1uLDTY7iEyY5kRPFkOCcggDI6EE5A7AdSFma6h13VDaWnDJuZlAjaa7VOUZ6gIme/mx6dKc73R5GgaFZrtELZklunCzMD25V2QdNl39R0qbh7SoNHjU2yBCBjndcu30G+BTA0dmofDdPXSLfjEoXKjLS/wvwlHp0CTXFpAZQeZFW3WNIz5KBR+5vYLLEtwltER3kbLH7VDbNeToqRSMUO7EnlAqnqyaXFjNu09ydlVVLsx+wJrVNFdFWKREO9e+zNphmz1hb08pv2YDYHlwPtVDXHFsjSxF5Cd+Y1TsHu4V5zBFGR0jTt/mb+g/Oh3Ed1NJblpJCoA+VNqGXJq9ocydoD8HiJHFnEb2MUnNJhjnOKzubjVl5lExz9are0fWyJmgSTvg1nlo9zdXDAE4NZpJM2KalxkxsuuLLu7uORHOM+dNnDWszKqtI5x60l6borJ+8dTkedFRexadHgtjypFqwzZjzWIte0CarbcQEgfvBRGHUvF35sn61jtpxOssgRXxv51ofD7vcxK4O9TY5XCiZ/cj8xljXtQdEJ5jSxaWWoalcl91Qb5p3udDW8XL9aN6Fw9BHEByjNP6Ok2NzKW2LUnHWKVroVxEFYlzjzo1FoclwAHUmnE6TbqnLgZq9Y6dEmOYDFNFdlmB0i27emYl23s9iuWEhtgSf8ADRVPZ+Y4sJZ9P8NaRpos4VAZelG4bmwYBQyg+tb2nrV1mBqLnRziYNf8PTaefldcfhYVVhYq3K2xBrctdsbO6gbxIo3BHkKyjiHRUsZWntgTHndfL1+lEek18jpL06gWcEcylE3r6VchI2zQ2BugHSiMGCBtVVh8cy9EoxjvXN26wwMzEZxUkRAXmO3nQLXdQDt4KHI86J4SMZOJnPtDllmtZ2RSSQQKyngjQrl9YMzrkc2elbFxPavcweAqcxfbpXHDvCyWHLI0YDMc9KuvHAhTgDEcuF7ApbJhMDG9HZIh22rjRI1S38MDcbbVeeLqcVRkgw0GPF12qB4cnbPpRN4vTNRNEM+tCKyMwW8G2SN/KozBnfFEmhOcAD8s1yYfShlZG7iDDbnPShOtaaZIy4Xcb00GDfptUU9oJYipWhsmRPbsRAgjKNylf0oxbDkXmPlXy6sTBMTjvUc1x4EJHeiVru4lifETzxxC2RIMjJNZbxGMMw671pfEMikELncedZpr3xeIeu/lS3Zo5E48vnmId7zlyIyQaKcJ2l2uoxubhFyRsTv18qH3sTGTbAzV3QVVLqJ/eGyW3UGupsP+qRpwTYJ6gtIscJKok5zyZ3A8ulZlqRMMzPzZc52NaVo/hScIRFAw/d4wTv09azTXFiS5kDqWJ67182fJvafTtEf9IIi5qLNL8c1wFGNgGoUqLPKBGPhHViR/WptRGXKhjgdjQ9niDjnUkA7g9K0q14jDPnmGhqNppQH71nZzjPPnH07VBd6jEzc4fGSNzsd6CzTpLPzgJydgxqpqVy/hkRhFHQ43oiacMcwbX4En1TXmJ8OGQkDplsj7UJt2uNSnEOWbmOw+VR9WNUAJriTlQDPmBTFoFoVkX3hUUd/EyPyAyTThrWlc+MTW1rW90PcNcGNcyc8t+i8uPhiiaRmIOceWPqRWvaBwjGMRpAlu6rkv4CvNJ6cozgfUgUv8OyTRQq+jac7kLhmIWJBnyLEjPrTZo54gZmuJtQjiRl5XaGMzHy3woXPrvmsTUOzn2ukb37RgR30jS9O01FZJA5hJLTHYA4+WPlIHP6jOO5olNHLPGHsLqO1g5s3Ba3EhaM7kgk7HzY7Z86AaZqWl2pS6M8V00agePqNw9zMe3wRrhFHoD9avnV7+9liS2LzczhhJI9vEFPXYOSowP8JPrQA5UgiBGTyfrCw4R0q5sLgPLN4TOrxxPDGNgMfA7Nkk9frSNxT7NdNucx6npT+EFM0M8cymeLH4xy9Bjz69CO1P8V7rkbr73EWQfGZ7iZS2B+IEYH0xgVJZwx3ry+LbNOzsX5FjLJgjqXOBzeufPFFXVvURx698PWoYHceJ5l1z2IavcGSfh3U7bUUyTySEQykjzB2O46gj6Ul6rwZx3owMWrcN6lFGOkiW7OpA2+ZQRXtW54R4e1WHIjlSYbL4UwZk/wA7A8mPQMaFjgi5RFNhrmoRwITkcvwxgdWZ3KjfAxhT12zua0au1UH5lI+HP8GLWdnVWco2Pjx/M8VppuoOsSwaFqbOTyhEtJSSf/hx9KYrDhzi1po5X4fubKE4SSW8It0j9SzkHz/0r1bPwTf3qrbf7WXs3iEsrxyEHl26YAGOu4P38419kXCKxi61iCbU7skyLFduZhkbLlAR3OcE423J3FebtPTk5Ck/T7mDPZfGHsGPd/4J5qsuBtX12eS10xpdWaIrzSW8TG2TJ25pCBkdflz67U3aX7IppvAFxaoWmCmSWRQhVVAbKqOijOPLv3r0ZDZaJpFssFrokcURcSTeGgBLH8WFABLNk8oAAAG21DNf1ezhhubC2iYzhlErIqgRKMZX6hQM/ljqKU1Xaltg2r7I938x3RaKjTtlFyfMzCOMuF4rOC502ydHcuWMjSAlVxjJI6Ejoo6ZHrSI3DMbaNd3k6SYjIjgESsjMmMjYdQBgk7dj61sF9pFyLy4vprJQqxPcPC/WPPR5PI7g8uepGd+mc3k91dX7adHCYUOVLnBUSH4iz9jgAnHy5wOlC0177eDNW6pLGGZmz6VfXutq17DNKLiQt7wIzh5Bg8qsNi22CD18+9NcWbHTpJUSMM8rvFz9QTKCQft/Wjen6XPo6M7Xht7O9lJjjvboILsL8JJ6cjjORjYc25BxkTxt4sVwtulrIJJHPijIJbAAb77ZPqSe9OG7v2C+ES7kUAkQlFqi3E9tbNbzyeFIC5hOHOcFgPtWi8AapdzQ3GmlUktovhWa4fldPjPKGddi3bp0rIdOurpJ0mikcSxRNMkkTchDAbn69ad/ZvMzX8oE0aGSPkIkOCS3RkxtkEjr1FBsqhVbcs3a0tXupIbi0IW3aVZIkGPhJOTnvjrTtoumXVlNEy3KwzAkqnKSArEjGT3G+1LfBdmVRA1xI0efCLcvyg9Tv03GBT9CJYURnIyJy5YjqoHUj0o2l0ws9tvGKX2FTsWHrWeOGS297mZkPVwx5VBO2fLfau7ZojKwCOJNublP4d9ie9LV7ObRobjxlRIhyhlYnKMfiDDv2qlqPEcNoJlhvHIni2DDcPn9KetpQjLDp/EpTp7H/J4zRYbmyaZvEifMfwn4scy9gf9aYbD3a9jeOOJAW2JB/CRjB9awex4xv53ME0hPYEbU48M8SXEXIZZNyfiOetId7S7AEcGOv2dai9Y8a3oMkNu8sWC6kAEDcr2FQaNNbXdv+zruV4rhl8NRhDjHQ75qccQWt5G1tdTDDQseYHocHG4pG4U96ur3mEZlLEA8o+UDpsNztvWVq6VotBqGQeJCK5Qi04I5hziHRQlw8Elg5ul+IzQKuG8iwB8u/TeqTaStvbFFuIZGcZkJgYDftn5mP5D61pB0eLV7FG1FGtWtgViLHZ1I7kEYobNw7PakvDMkOcFgob49ux7fXNK26Ihs44Pr184JNWCu3PT174kppDw45BKYx23Vd+wQAkk+tWrLTH8U3VxNGVTJSMjCJ5BwB8R/wANda5JrkCOmn2EMc0iKjSOHk+E5B+I7j7daraD/tIZYP2jPFgHlCouCq9iCPl+nXrQVREYAZP6ev2hyzshYkQ/bXs8FwA3LzkBEBldJGOdiYVPTOcc5PXJ86OwaQk0TMr5WNj4p5uZi/XdurHPU9B0APUBNMt4jlFUQSFyFHiM8khzuSDvnfocmn3ReHL/AN0ZJrRrMk5AlIB+uDv065710PZam59uMzD7QbulzmJVzo0DS86oYgD8TPjmb6CprXTBzFbCy8Qj5pD8v3J2H3p5m4f0iyOb9pr1ycBII8Lnyydv51JJbahDbLde6aPolmN0nvn8Z/8AcToT/lXNdVToVHX6TnbNSYq2WjXkzgwWstyVG628ZZfu5+AfbNWG0K/u3Nu8trbkLvBC3iOB/i5c/qQK/X3EGieKffb/AFriKRekbObS2P8AuqeYj7j6UP1DiXia7szaaTo8Wn2Q3EVpFhR9SAB9yam1aEHtHPuHX6Znke5jxx8f7lPWbDStFjLT3skrgfJDyqB9WO35ZrJuNuK0EUsFuVjTyDEk/U96m4w124tpHF5dKZO6mQM36bCsv1a/e+kbDcwrldbqwX2VrgTf0unPDOcxQ11JNTvmf4iM0U0LQo48MQMjFWI7NUkOQN/zq2LuO3BX/npWazYmnuJ4WdX7R2cGQRtWa8T69IzsiNjG21M3EWsBYmXm3IJyTWV6xf8AiSM2Qck0aiveeZBbC5h/QNWkN0vNISM+dbxwbrMYtkDtg7E43ry/p2peA6sCBk7b096BxrJbKqK/kOte1GlZjlRJW3cu0z06mrwBNpFqzb8VQw/AsgxWDWvGs0q4Mmx9ambia7I5hKw/rRKAyRexFPUz0PY8RQzMCZB+dMdjqUbgYYGvM+lcY3EMil52A747VqPDXFSTxpzOCSPOmAfayYFkKjiabearJbwl4gCaU7v2h6vYzlUso5Vz3fFWpdVimt9viyPOlPVD4rM6r371q0ucAAzMtUbskR50r2kQX2Le7ie2kO2GOVb6Gqes6jHO3NzZU+tZ20rRn4zykHP0ohbX1xOmJHyoH3p3vWC7TzABFZsrxC8AUseTpmidt0HQUJtMkDJ8h5UTSRYovEbbFUXyhj75JqF8lrbkDqR50ryTGQmRjnyr9qOom6uDhsgV3pds+oXQjAPIpGaJLLwMmX9J0QXkZu5kB8s+Vfb23EUoCrgCm+2tVt7YQKo6b4FAdWg5WPWiquBBbsnM60eTDBD3FGyncDFLemycki7d6aoxzID5irkZErnBlRou4FRtCenWr7R+lRMnYDaqFZ7MomHO+K48IDarxj865MeNumaoUkZlIxb4x3r8Ye2KueHX7w+1UKSMxZ12yAUyD67Vn3EN/wC7qQXxitQ10qICnesV498RY5OTrUoNhyZdDkTHOIJGYHl3+tIGsrlWyTjNO2ryB2bBJ8qTtVXmBwNqS7PGADOLDZOYk30MjtyopJPlRrgrSY3vVN18GSNwvMaoakzeJyoceuaLcKX6Q3SJk5yAWNbuodjpyBHNAFNwJnoW1VbXh9YrbJATDMcZ6VlPEcjCd2ztnbtWhWOrxtpXhAE/DsSev2rNeJZJJp5HxgAkivnqA98cz6Xpz/rEVdQnLOcjfG+O9UcwPCcq2d8sT/Kp7iZ+c5Gx2ofcl8YVMDtmtitfCSzYle5lDSiO3BCd6rXcHxDxJWHffp+VTyJJCAzHBPTArh44lx4z/Ge7Dm/Sm0OBxE35PM70uzsmkUSzzbnBdcCnfTLCyjdBHd3iuDuFRVH5tn9KXtLhtHTFzqCAdeWRRGCP+fSmC1fT0jMllfWoXG+T4g+nTrS95ZjxmWQhOI12up2NnGI4zG7Njn55PD6eeBlj9SBV5NVu4/DcxycrnIdvhGPIFvm+w70l3MtzHJ4okblC/OCFH6DIr7p+uW0Ya2vbu7JkUqTFCABntzMCx+gFItTnkxoEER+hu58ZhvdSiCAhgbhIebsdhnlHT5mWpBe6hpa+8WGoXckuHkVprvnCEgA8ojU53zvt/Wlqxt9SVhLFJY2tupXlXARs9uY8u3r/ADFTrC2r+JzalbC0wWmco8cSYOCBjLOfRDkn86XKkHGflLLg9BD1txAyGJ9X4lvIjn4lW5S0ib/MZmZ8eixZ9c0w2vtB4YzHZNxPbeOhIMdlHc3jHsAFCnmbG+7fas8e04ahhaOygjMkgHMzxyM7467hG5B5AsT51d03RJ25xb39ypeEkRWtuUfOejybBV9FBJob4I9rP7RkImcnibZomvMxaFotVtYEbDtqE8Vryg9OWPJdf94LRyPUuGJj4cpSVGbI5JBc8pwfifw2YL9XZc1hnC2gafYSc9tpr3d0nNzGVnWON++yhmB7/MrHzFMtpq+oWaxWcWkXbyDmAULywxqc7hFOM75JPM3+IUEgLwokd0rHg8zWrrXOH4GFraT8r8gHvDwuMgdFy2FGOvf618t+IXuoAmlW8d2ZCCsqlQpwCMg5yR2zg7+dZjpLe62sjwW8fiOxiV5okkDN0+FFMnM3f4xjpsKIafe2KtHNeWM91HEQvjaleKFLY6IsYWIbdMdP0qhtI5z8pI0y9OT6/SaFdRXsaQm6lhtrkHmSJQMg9CxDEFiM7EDOT2GKE3tjBZTw6ZaQ+ITEzyzyFcjA2UZICDIyx+xx0I2FrdoPe1J00Xp5o4rbYgKc7ugCnz+KQnoOWvt7qml28MsVtbTXFlOB71yL4jzjfCsdyqZ35C3M2csUUgV4HfweJ4VlOBzA+oWyRWP7Publx7y0e6gfvScvkkjHJj5M7EczkYC5wTX7gNe+8afJcRxXLvPmTPxKX22O+Tjm3OcYJxnbbeKBeR6ZJf6yZLSKZGlMUr5ceIAAGc4yxUjIUYAKLkbhcejtyl7aSWt9HC45lLSTBUVQc8kYxknruOvWmqCF5h68tGHg2Oe90KW3h0vUoluVYO/irMFB2ywkUklhnIXIHY9aQeLLNp9VaO8V4fAQJzSFhlk2GMjPQAYPlWqaNpM93ELoQNfSPEPEuJr1jEwxspAUsT16D70mcU6I4jZltyy8/wARlfnZcbbNnmb6Yq1FmLCw8Z6xQQVgLTfd44obhBIGbOMfCrr0xn+L+eBTJwNKougRCrcpMSxP8wxuWP5Uow6n4NuLCRTJC2eVeUqynG+M9jtRLQb2W28S4VlJc5Ujrkin9vnK0+0wAno+x4zjt4xaqxUsijIOcnPUmjcPFGs6jzL4irFy8nLnHw9xmvP+lcQTFldz8XfO1aXw5xGrxDnfGOxoD6lwdoOBNQdnLWm7bkzS1k97tua5lwpUkldj/wA7Ut3rtKT+9HMMFSD2qR9fj91AVzysNwBuaVl1hlumtyCF/Dmpu1AKBSYfRaVskiMsUphCXBIyrb5NWzxmlhhWnRC3QMwBP2pZ1zU5NO0G41URhjCnwqfxOdlH50h8BcE6zxdrQ1LVrmWQyyZZiSeXPQAdhS6q9nFUcPdVgvd0E9OcGaudanjjmJ8JwQcNgnbselatoltpcEyWtpAsbKOUCSPdzjfJANLPs+0q14fsLeGN4UUAHw2XJJ9V8zWilHnhjm5VyDgMVWEj0+lbGn7NIQFuWnBdp9prfcQnCyaKEwSCRWQDGBHsW26HGObH2qbU9QvfdmUNaqwwFMikkfTmxn86FzajaxI0kkVysiYBJJbI/wAJ70M1GwsdehkbTxdJMw3Ml3Oo+8e6n60PVhkUrX1iNGHYM/T4f3KmvaZdSqz2q2b3SgsI2gkJx/uknr3pd4b0PWBdk6rb+A/Nlo4+ZkdT3OSD57A9eopg07hu70+BI7iXwyuSXQfCV752yPsKl/bWmaMFimaCWRuiQMzux+jdT/KsH8IzsHcbR7//ACav4nYprT2oz6XoBtJlvkb3U8xGEURnB9FHTbz39ab7Z3FsWilECYyZJHCg79Wbf/4Rk9qSNN1PUr1fd4dJuLUybh57qGMjyJXmL/6+VMelcN3kirJqGqNNIm+VJUKvko/DXUaCoU8Ipx8v3nP6xjYMuRDweVLfEDoGYf39yAqn/JGfiP1I+wpe1Dh6zmuDe67q11dSsN84gBHlzSZbH0UUXvPd9LtC6RzPsA3JNyn7kDJ+gpP1biu/tQTo1va2j9A/hc8uf87ZNdGrIEw/ymIVctlYattJsogH0jRYdv8AtfdXuG/+OUqn5Cl7jzwl09jqmp3GAp/d+MFH5JgD86WdT1zibUlZtR1C6kPfMpI/LpWd8Y6klvbuHy7YycnekNZr6q6yqp9o3ptI72As3MzPjzW4H1N4LAcsWT9f5mhVieZPEbqRvQTVbvx9SZw3RquRaisUIXmHN6muHc5YmdbgKoUSxqF74WwYZFL17roVSQwyO1Vtb1dVlIzvSVqWrszOA+R0wDUJWXMIq4Eua7rjSoyq+Tg7Uj3d1I7nqfvUt3fZd8OfKhU0wkOVbb18q1aK9nEBY+cgTo3bI2ST1q9p1/IJR+8I6d6AyzDnHN0yNqsWl9HC4YsObPc09tBWJ5YNzNN0W/c4BbrjG9M0F54hC5Oeu5rL7PXVj5SCAQMbd6OWnEjLh0fGDvkUg6MsdHtCPylucOGx3NNOi68bJViMuMCsvi4mVhjxd+mx2orp2qLOUwcj60M5zzIKHwm22fFcnghVk3+tT/t6Vv7w5z6UiaLMzBSQd8U26XYS30ygAkdacpsA4BiVqeJk11cNcOqgAAn70X0/ZVyCNqsNw0UUSyI23eogogcR+WBT5z1MzlIzxDVo222ap61qojX3eNtzsd6in1FLS3Ls2NqVp9RNxK0rtk9RRU6cywG44hSJnlZUQZdzgVoPDmmrY2ys6/ER3pS4Q0w3L++TptnYEU+xvjAGwoicnMixvAS6hzQ3VoA2SB1q9HJviuL1PEizjO1HEFnEVov3c3XptTbpriWAUqXKeHNkDGaO6HdfFyE1ceUqxwYYKZqNlqwR6VwQMV7E9uErlN64KZ/rVggYx2rnHXNRiRmV+U42zXxlABPlU/Lg1T1CZYYjk4r22ezF/WpfEyqmsz4r05rkNzL+lP17KXkJU996HXGknUCCF270JlzDVEDrPI2qOzFsHv5Ur37BgR2J6dqYNRfZmIyMmlq+YBcDGCO1J6QcCcOhyuTFvVYnycY39a+cN3L2d4hZOffoNq+anM+SeY9MUKt7+SGYN4mN63WrNlJXzjWlsFbhp6D0a7W503PhBMjbPU0k8UMElYAn6elU+GeILuUKoeRsjA2q/r6q6F2XLtn864a/THT34M+k6HUDUUgiJdxMqHpk52qCXDAZySegru7idX5sZwc7mqUviMQzE9flFOoAYRjz0ks9u0mGaRV5TsCcmq8yyLlVhZtvm6VLBhWLSx82K7lvkj+S3RYwd+dzk0cEjiBIB5Mm0y2F0MKkSuvUBOY/mabrWze3tlJYkgdFEeB/Wg2jXAnKmFbcNy4BKk/lTNbJc2oaSa28Rj0YoMD8jSl784MlEA9oSsbKRo/EW3lEbYGUP/E4+1DrbTjJKzR3qQSKxOZJQkm2/XB3opcXksxKvCDgdM8o/Mb1Bdyalaw+JHaGHb4XDgqPuwzQwrEcQofZObrSLshV8aRnILgeNI5Ge7HGB9K70ZNSFwJYb9UeAlgwAJ8sjmK4+u/0oAOI7yJ2W4vrpVU55bdgSx8uvLv9KatI4vSSD3E2CR9CXkxM69jjISNP1+tQ1TY5hVsPQCSalxxxVBI8b6jeTRqwVWjueRVPmAg3P3qnp+t6/fP4mn3d8hRjzTPcsAhPmxK5+7ECj0mlWV/aGQ3rT7q4DILg5OfJuRPz+1EbDh3VIoQkFlBDHjmMs0qoVDdDhsHPfYYHpQMVqMAAGXDjGWgpodeMIXW9et5beF+ZYRclhzt5GJWHnvnPrRzRpILFkjL3li0i83iQ28SBk77yMGkHlg586X9bgjtTJcXt9e3KR7eLFeh41A22OGx06LvQm241e2ijtInWdMkOUWYuy/4mZh1Pp9qEaWtX2YzXYomkanrySgOoLqHCLJPd+K7Jk7lHGEz5DI8gaKQT8STSR6peyCwtlXlhQRWyvyBSBgkgKO5OSNxWWaMZ9RunFjaxPISSI5FwIF7lm2C9hkknyNOLcPajpKxTa1a2FtJNGZYnjIVpMEYCLIXO2xyA3+Wl30+Osu1ygbQI5aBfabB4+uTabqesLG4/fzWczRhttg37tJCMnYOsYUfKaPahxFqctqkl7YQ2Vqsoks7SdVhid+qu0Yy8p/EclEGfuc7h4gt7k20Uc8lzexOW8W9VpeRxkgQwNs7joHkVI03Y9KgvdVjnvZ79J73UNQEXJc3Ac3Mat5LKwCYXvygLnOA3Wq91gcD175QnJyfXwnfEvF9zxTqlxJq2pLKrN4j3TxGRZZFB5VCjI5UwSFXKg4JzjNVOF7W4t1Fxam5uJLuMKAytCJBnbJQMyIT1zu3elWeaBJLi1s9O8Z5W5WlkmLZJ3K4B3z1PQehpx4XnhtYJr+4vZYRE4jaPx/hyAfhPKArnf5c4Gd8UVkYDIhmsVFwBHfw7G20t7y5ligdAsbR2vM7PKdhhWH16ClK70SXUJJmlswgVBH4gaMvnqQSCFUjbIBz260xGJ57SB4biGKK4VwnKh5+Yr8TBUAQeuSfuat2+lXiQiBtNhvZGiDL7tHytEvQsu3KufMn6VSpD/wAYs1wQHJmI8ZcLahAkrG2kXkYKvNszbbbAkHpSja315pMkMWowuI1OM43Feqbfh1rqOH3e1PhRrmRQysyAjo7HYZI7tk74GKpt7HdM1SaZ7mT4ccwUjYHp2HnW5RXZjYVyImdagbfnBEwaXifTrS3NxaO9y5X4YlU7n18qWn9pntFtbrxrU20UQPwxGMEAV6Xm9gFj7qDBjmMmWblweXy3pA4r9jV7pcskscYeFMDYb/Xp0o66VKsl0z8ZpDtJtThFsx8JJ7O/adLxNp7ftKH3W8gPLLGDlTtsy+lNbziS7inXowxtWRaHpcuja08IjKCRQAc7N3rSRNOllHc7/u8bYrE1dQDMqDidRoLAFUseehmmy6NHr/CF1aoQZIwkwA78pyR+VHfZtpFhAyc1tCytj4mYAA/Q7Zpa4R1qNdPdjNhTGep65FMfs0umN7IJxDyhjylgG29VPX7U92W+xQrDmYnbRZK3APHWbpoks+lxeFLYIsRGxWPnyPMEnamC1iilZZbe4tLlmG8VzG2fsR/WlWxuWEcQaa4jJ6SwEPFg+YO4ovG15by8/vkMatsGbmBYehG29bzMMcdB69ZE4DknPjCWvz3FpAk4tJbXAwPdXIwPMEj9KXZ77VY1SYTT3ManaWV8P6AlOU4+tX77TIbqJJGPhuGwrtIHXHkOYg1PY2htCPfJ5YVXo8aZjx5n4jWbqQ9zccD18BG6Sla56n18YFi1vWll5Q2oCBmwzxxtIq/RmUkfnRey02K8UzJqNw/inmKTXPUf5VQbfei/unDxtnaCdI2k+Z7dwu+epGdqHSz3NuRb6dFeT5Ozx+Hgfm5J/KgfgnT2nORCHUq/CDEYdLs5LeGNFnjgABBdjJISp6kDI3+uRRWyv5bq6Ww0/UDI4OWMkeXA6dEBA/Wgel2d7dukl3C0A+Zm8AO4wOvVh17Baa7FrxBym9uZkK4AMTwjGN9hsfyrZ09GFB9fvMu+zJMtXXDur3qEXF/ZogHxPIxx+WM0BuuGtCtsifiWEsDv4Fs8n6nFSaxb6hdKDBpN0VP43flH1AOKEXkd5FA3jGGMAb88yf0Na6hNvKmZ2WzjdKerHgWyhYveXl2++fFjwv8A8KsP1Jrz37W+KrNVkt9OkIiIxypCsY/TJ/WnjjjWorNZF8eMk/wtnevOXHGstd3MgL9/+RXJdq6/e3dKAJ0PZukwe8Y5itcXv7xpecnBPU1Wk1dmXIbOPXvQrULkpzfFuc7UJ95ZDlnYA9PSscV7psZ5kuu6jKxL+JjyFJ93qbkkc23p50X1abnT4Tk0DW08eTlYN9qepQKOZRiegg65upXyRn6dqqtcytt3z5daYJtIzty7mqq6GyyBQOo600rqIPumPMBTeMdwSMHJqGOK4ZgBnenG34bEvKStHNO4PjbGYwR0r34tU4nhp93Jippthdug+BthRN7K7iTk5DjrvWiWHDttDGFCdB1H0rq60NH6KBt+tKnVhj0jArAGJm9t72j8uCd6c+G1unkTIO/60RsuFUd8hN/5058P8KiMofD7+WKWtuLcCNB0QYMO8NWM7xrzL1xW6+zrh+1RFkuIUctgnmFIOgaSkMaqRggU7aRxTHohWOeCXA/FHg/oaZ0BUP8A7Ji68tYhFc03VeFNIuLAtEghcr+HYflWLcR2DaJds0sytDnZgenpitAl49s9Rs3W1n+MD5SCrfka83+3T2kTaNASvOS7YOOmM10dlddigp9Jz9ffVkh4Y1viFZmMUUuQvzYr5w7BNq94sSrlEbf1rz5pftQuNS1GO1t3/vDjfevUXANrDBpUU4IZ3UHPnnvQbEKeyYxVcCDjrH3To47WBIYxjAonFJ3oNBKD1NEIpOmTUiVJhKN871Mf3iEGqUTdKtRuc486KGlCfCBdQhIJO+aj024MUq7nrRPUovgLCgKsUlznHpVy2BmQTmPMT88YbPavpI60O0e7E0HKTkiiBI771YNmUDT4a5PpX3m+lc5qQZOZ8JwCT2pe1u66qDnFHLqURwsc4pL1S5MkrHOQagtxPA5MqkCR/qaYtHsVMJcrnI70CsIDNMo7E4pytoxDCqgY2ry8mELeE/nrfspBJ9d6XNQfALUbunyxGOhpf1Fs82ciktLxicSvIi/f5YEDJxQiO3UTc0oBGemaJXrMCcEdKEO8pk+E/eukQZTAjKYBBMedBuHkC2tvyqM9hj9abrrTZVtudiucdc5rPuF7hop1aZs7961C4nFxpoQOoyK43tio02DE73sPUG9cHwmb6uAkjIDnzoTEC7nDADPWjWtW0nikKNj19aHwWZAwygDuzEACh1EbZsWA7p8aNXBAkzk9v5VUm0+4uZ+WPwyAfxEVeupLaKIosjNj/wBGuR+ZqhbXKCbEen85z80su35DFGrz1EBaRjBjRoNjJbxqTEiSE7O7DNN2nWrwtmK3naWTG7DKetBdCv0s0WR7q1tQ3ZEU/wBM0zRS2t/ID41xOzjZ2PKp+1I3tluZKgyZ7W18Flmmiidhh+TILemd6CXWj2U8ryQX86ZYKefLA+mOhNGZ2t7LCv7tlduVcOc+oGSapyTXDEk+Lvj5oFUEHuM9P0qtZPhJII5MW73RbGOIq0ky7YUtbCIfY7Z+9BJtLtbTlkiu023Abmcg/TYdfWtBs7mBrnwze29ryD94GUb/AHGf51di0qwLPODczrISOeGzVifoXZi32AFF3t1EqLQv5pnljr6WH7ySzlkmYcru94yEj05QeUeWN6MR8fxJM6R6RGyuBzN4XMijHnMSznbvgd8U3z8PwTRzS3s11ZBFAAme3UvtkDlUEk+nQd6T77hK1uJnUOGDNzArEm3nliRgZ8vyqnsk5YfXMMLFfgTrUeNbPWVhH+ydvBOmyPHF4jKuABypzKg9CFz3zRPhzg+5hh9+ghuY7ggu8boyHz3LsB/P+lWNA4QGlzQ3SM7Z+Lne0mC+uW+FCNtsZpm5Uihkm/a2us8wO8IEKOOu7qMkfTyoZwTheBJN23gfzAkckunH3bUL/wAd1JdYoYSzK2Ns77b9xv5UK1GS/vNSkLXErOyEyiQqZZNvlAGWxg98Ad270O4gSKKYPZ3dzEcEcjS88knYg4+I/epNBtrvS4lnnJLurckAYrIOmNgCB9cMfVaqEGMw6Pjkw7dT6jp9jy+P7tFP+792Eixcw/hJYA8o+2T50Ml8SFHRtQM8jSc006TFkjXuAq46dMbb1ajbUbi8N9expJNAv7oPdciW5IwSQSzZI35mbOOmxxXF/o8Ecfiard2rT5BjhgchgMbEEqAO/Qee3eoVVBxPb2Jyeso2+niVFNn4s0SPzPLyqI1XP8KjI36jOfPuaatKuNLuSiTyyCJDli68pXG+wXPMTg7ZG350ipKryskFxEkMYOWkkHKzD+FRkE/y7ntUtlrkKyLa+MbhT8DlnYAE4+FB3Pmd/rvipesuuJG4AD3zW4dTtp7UXUAmRJWWOEzTCIO3cZAblG++Cx7Uc0C7s5LmK1v7+MxXJb9xbs7CaRCcBjs0mD+H88b1mF5faq1rFb6TbwRJaR8kchIbkdu5J6HGcKPqeld+ziyvbrXHe5uvF8OPwwzOXabfJVQOiA9hgMetW02EbJgL6yyHE9GQy206M02ps8URDtAGCIuP4iNuvXc+Q6Ve0u/N1PzW1siQhQ/Kq8pOdgST09O57Ui2d3ZwQM91cu7WxYBS4EcLjHNkZwSNvvkDpTFoutW2oatDYwlPCVsRpEebnkGCWY+g3ydhW6j5YGYjKQI/s8aLGmOYKAdwNz2GT+e1V7zQLbWBcxzRKylvidBsfMn+QqF7aO6m5ZwknhqWjCtkKM7Z/nRqzv4raRIY1/doCA7HY7btjufWm94bh+kECU5XrMW9oHsSuW8PVtGgUGPJKKCGJG+32pDYXMdvLZXULRyICpLjl3r2HYXVi0Y94eNEQNNIWOSVIyM58+tZ3x/wfw/rVgl/YxpHOR4jyhdyXORn0ApLUdnqT3qfKb3Z3bboRVcOPOeb+HOJZhFJYxyZkVvDK9O+K3PgCKHSrAT311HmT5vxYbuDnoawFNKbROPbrT71QRMC8JDfCSpwcgfatv0qZ9Tjt5nuIxNHCpYICodcd/Xbr9qSorCsT4iana9xvUAdDzNY0y/eOPxbK9jaJ+b4Y26ffqp+xFXU1OcBpFupsKoOBKrE/UEbGkyxihktRaMDHFIxBDPjDeQJ6H9KPWTJaxC2aV1f/wBYh5wR3B3Box3dB0nMFVBhi34qmAEEN+UAJBFxDkH0JUEEfamO0u5J7UpA8VsZN+azf4GPfboD9qS5ZbGK5Ep5SzDmI5BjH8XL/UUx2ur6VFb8lusDM+Ph5DH4n3OB+Zr1W7cdx6evWJD42jaPXrzhOytbx5cy38sqISPEilBZfIbb/mtOFlGksEaTz+8lV35+Rj9diD+YpJhvXlH/AEUxQxlSWU/GB9UOfzBq7axzXMym5hZolXBms3yv/wALbj7Gm69qdOYu+W90dGX3RWlhs7ViT+K2YNjH1GTUtktzMrOsrwhhzcqfCNvLeq2nm7W3SPTtWhnjxjErNHID5EY5f1qzMhi3ltjEx7dc+oPQ/lWnWmcEev1iDtjgyjc27szSG4kbzy2aUuKdXWyt5FaRgANviNMms3sdrbsfGPQ9sVhHtA4p5nkhDE7+dLdpawaavAPMLo9Ob390R+POJzPPIAxwDjrmsi1q9MhZ3wTnz6Uza7dtNIzM22TSLq1ygyNun1rijlyWM6tFCDasX9QufiPO23lQe7vlUbMPzrrUrkFywP0pfvpjkgHenaU55kPxLjT+K+5JxRO1RVTmIXzpds5lGxzuaLwXakBM70WxSOk9WRnmMENukqiTYnG5NTLp0fzFMY+2ai02bnUBvtRgeHKB8PTfHpSpYjrDHpmV7a1jDqOUHfv2o1AqxMMDlDYxvVGMIFwMZB2xUkcpIxknBx1oL5PSWzmHIZd/gI6VaRUYfEAewNB7eUxbFtz5VYGoKAAXGOuDtQ9rHpPbgOIcsWijkwANumKbtFnUOMgAenaszXUgJQVY56bUz6PqkoIxjf1q4GIF13HImq2l+sa5OBttir9hImoXQRzkUhLrSogUtimbhS9E19Hv3B61NTkGBasFSZqOm8Ew3EHiNHnI2JH9axn27+zxI9MuJGt8qwO5Ga9T8HRLc2SBlztSf7atDtrnh67V1GPDbauw0i5ryJzdjlbcGfzV0Xg+ex1opG5Z1PMABvXqP2UcQm4sTpl18FxAQpUn02x9ayH2daab/jK8jnIaO0coCejDOT/KnzV424Z4jt9btRywSERzAdMZ2NRcd43iCVQCQOom528oIFEYJPOlnR9QS+tYrlHBDrnY0cglP+tLBscS5MLxPnGe1XI3HWhcMo2yauRyetXDShMtTjxEI60s3kfJMwxvTIrgjGaE6pCc+Iv50QNuGJQNgz5ot6YZghbZjTTz7A5pCEjRSArsRTVpV6tzbgk7iqK+3iUY4OYSLVyWqPnyetcSyiNCxIxiiCyeziDtcvBFEUDYzSfKxeTqOvarut6iJpyAcjNUbSMyuPWoD5MupwMw9oVuCwcjYUxFsYGaHaZD4EA3Aq08nrRFfE9u5n88bvlZSwO/TpS5qDHBJxt1NF57gFSC350FvskFtiPQUHTLgiciuYBvGAyAaEucP170WvRnIxQZjyyHO5zXQ1fljC8w9o6OxDO2OXpT5pF/EYREH5yBjJO1ZpZyzlsAkDypz4ftpZmRy4yMHJOAKxe1aDYpLGb/AGTqRS+EHMs66cHKn8qA+IiozSbbflTzrdrbLp4ZFDuBnYdKzfUWKyHAx2rndOd3sidzYcKGlC8lV2KhyST3qTTY1MyggEk/mPKq6QCRy0pz54onp7tG5S0dIf4mxljWgeFwIgMk5jnplqbeNWSCNWxkFkBxV651K8S1ISblYnLu+FP2x0oRooiOMtLO47u2AKKaqIvdlZbQyMAe+AKzX5eMV9IuX3EN7lueeRyfxK5x98AZ/OhZm1C6IZGKAH4ctjH571+uYRcTkSJCf8IkJP6V9ttJtJXVZVWMNnOGJ/mabRQo8pDnxIzLFpE8EwmvGup8bBEcRoG7dck0wrxNLaJmKEWiEYYNcN8Rx3Ee52/iP2qtpuhx+AEtdPlhjY/PJKTn1x5UXtOF9LYF/e3mfugOB9sVV3XPWB4zyJTh4xWB/eI7QyynotrH4Jb0aRyz4+iivo9pmv2rl7azgtHXIQRrzyD/AH5CxHqcA+lEptKihh+DngA+VBgEjucf8aow2Fuz+ILZ5QNiWJAB+g3NCIU9RCjAg88e8UXV2t6lrJLKrZeaS4lYt9W5lwPyFTPqnEuucrXkl5cLkZHMfAQeWDyqfzemu04U1GeNZb4BIiMqryLCDn0O5FFF0iO2QCOKVlUElogI1Hll2Bb8lFECbuggjcq+EUbbQ7uIGd5okcj5UPxD6kgKo+lHtM0tpITHzzmKQ8zyqfgcfw8xxkfc/er0NvcL8NklrbnJP7uNnJPq7jP5VfsrC9vLtLUpfalfyYWOGFmZj2+VAXP0BH2ob0npKjVHqZWSytNOiXwbWBHDA4SJnZd/mz2Oc75HTGaXtdK30bXE8scgjJMhmcEuTnGy7em+T9q0O60Ow0lVteJtXEEvNyrpelwrc3hb+E4Yoh7fG3N/hqhDa6i942n8NaPp/Dxb4i9xIuoarINzks/7u3GM/LGmPOh9wa/zH+fXxhU1Ibpz69dMzPOH9Mnv5JYpbW5VnChQi8qQoTsQoAMjnbbZRnc5pisvZzBa6hDJNhJW+ZZCfgOO+B1+mQPU7U06ToN7ost3eSXKrLKonkeViZXAO2ZH35fUbeXrHqmsm3hN7GnhyApK91N+9eQY+FI1bYEnPKN/MgbUKwsRxDrYc5WEl4e0WK0FpDaQuI0EbmOAlQoAJRQc/ET8zHJ6DfpUF1xVpHC7m20K3IvZMIDEAfCAGMs3cjJ2HT60N0K4uNQu3utTvZuWBWjFoHOYubJzITspJySzYJxsABUt1a2msuP2HbyNbqxRJkTEbtn5xkZZF65OxJAAxk1dENYBP9wbf7DgnP7SeWK51WxUXUhdmRWh022UgRo5z4sx33PZdzuB1OzdwNBqekyQx+ArG5J5kRCZNt+Useg8+31oRoqWWk2cMKyzqrsC55g0k7jOSWHlvkj6DAFF9J4jimv2SK6fwwDCkKLyrnzZupA8h69aeqZQQVMVtBKlcevX/sfdNvnaaS51a7t44oT8KwxZw+cYJJzI2+PKrN/xXYxzzW8yKZ/D5IrcNl8ZG8hGygDr9aUFjlmgMtnl+bBgycDAJAYD1OT/AOFRWHDFrb3DuGMs7AGaZyTzyE55cZ+Ik+e22aOLmHGIIVKTkmaFJO2o27eDcSLHdtyE/wCDHyj/AF9araldvBpahlUqow6g/MgPl3wBj70JtzdPFLLazk8reBEWORjOWJ7Zz/Squv6rZ2dzBZz5RVTkV8fCGLdCPpg/ejG8kHEmur2gJmftFe0tNWhmdwZVyZPD6kkAgDzB2zvV3hviV7vTEKyESAtFGdjlOY/1B/OljWL03E9vbv8AvGiBVnI+Y5H67/rRK0sVjVRD8KxqAWI2we/61mM4UzowgNQB8JrOh8RSvaxQXoEiSAeE+QcMFB5SO4IOPOmTSeJLdXUSBltjkcqksIz3G/QDb1waxlH1K302S1ErgK8Tq/XlcDZh6bAH60w6ZqOpFTbSxtzkMDn8Q7EE7E7sPVTR1vAxkzJu0oOSJsVzeWhZHRwYw3K6O2wJ6bnb6dDV9r62iiU28yglc+HKvIQB1wcYOO+23faseX9r3dskMd+YrmAIsbk83OgJIRweu22/kKMaIOI0uFjZ2MfwNyjflA6lc+X8qKNQhPA6xJtMVHJ6TaNMlt9Q/dm2WK5UAoWXOR5hgcZ+mMimTTNMkcrK0EqSx5BMbFX27j+Ieh3/AJ0r8M6dNyRSoApU8yHHw47oR5dx/StK0uJWC8ylWAxvufp6+h61rUU95gmZVtm3gS1YKyf3/LJ/jZeV/uw6/evt/KLaFnt5yqns2CCf5H74q64KRmTk58DcdCaROMuJILK3kw4XbdTtmn7HXTVEmKKrXOAInce8UrbxyqSqsM/Lt+leb+KeKDNdP+9Ocmmfj/i8zyyhHBGSBk9qx7VLo3ErOWz5EVwer1B1VhJ6Tq9JpxQnPWfNW1l2VviztjY4xSVqF88jMD1+tEr98qwBB7jel+5Dbk9s9KEq4jggy7lPMebpQu5K5ONsjHnVu/dx+E47iqMmGUDG4x1pyscSjAmRoVTDHPpvV6BwWUgjr+ZoZzgNyk+mK7S5IPLnGO2aOVLdII8R2sJyig9MfnRiK4ViACcEb9qQ7PUZM8pc4/lTFp2oI6hGOBikrKinMMtgbgxhaXkHMpGDtUUdypbJYA/Wqr3arGRgVQ97VZBhtj59aqF3CTu8YyteGKPHNknvmhr38hflL+pqs12pjCg+owapS3XK55j+nSrKvGBB7jmMlpOZCCW3z501aVc8qqN9sb1nljqEZYZYZ7U3aPdhlXPf1pexCIcMDGdrx2ZeXO/6VoHs+Z3uY2J3zWe2wWQg464rSeBY+W4jI8xS4YhgJFmNpnqHgN8WoJ7LSv7b9SgtOGL6SRsKsTHr6UxcHsINMDnuKwz+1lxYNO4OuraNjzXP7lQDjc13GjHd6Uu3lOQu9vUYnnr2SQsffNWYfFNK7D6FjWja7YR6vpMtuy5ypIpJ9nEXufD8Mb4DtT3ZT8ylXx6g+VIUW5JQycf8pD7LtdnMEmiXr/vrVihz1IHQ1p0Eo23NYjf83DfFdvrEDcsNyRHLjz7GtcsL0TwpMrAhwDtVXO0yDwcCMUMu25q3FMNsUFiuOgztVyKbJqu+UIhiOUedfLhFmjOetU45ttj+tTeMCKsLcHMGRAd3GY2O+KsaTqJtplVm2JqTUIwwyO4oHLIYW6kYOc161sjcs9jcMGaCk6uvMD1oNr2qrBEY1YAmgNvxla2cLRTSjmA7mgV7rZ1GZmVjy9vpQe/BHEqoLHEsPKZ5u53o9o9rzMHI6UB0+BpHGx6042USwQgY3oqvgQjHHEvhgihR2rhpB1JqFpD51CZcdDVu+lQOZ/O2aT+XShtw4YkButXJW+I56fyobdEjJ2p3Te+cuoyMQdeAEHI7daDPy+KQ5IANF7lzjPl/Kg9wDzfDvvW9WMLCD3QnZXdtERjLH6036JqwYKiqo7jtikK0Kg4ZT17Cm3QuZnXlQgbZ7k0jrqEZCWj+k1NiONk0PkiutNYsjF8bE9KzPX7FxOx8PAz3rWtD09rq2wxCkr+LuKWeK9IjhYjkzjy3zXEpYtV5UT6NTm3TgvMzSNiQrD4V7dqM6dbk4jggC+pqvcWkiyEpFnfoBRHTve4xlkES/qRWmX3LmLAYMN20ctsokldFC7DbfP0qLUruOZWaUSSAjbxG2H2FWovC5PFlhLAb5Y/yFDdRvWmUi3hVAepxuPvSY6w1YBPMB3SyT/BECi5+Y4UCimiaVZKFa41Jh5pF3Pq1CDFavMFur1nOd0jHMT6elMtlFaQLm1ihtcjGZAWdv9KOSVGJDDJhq0E6stvFe2dmhAYeKDIxA6bA7/ei8AluJRDJrM9w2NvCt1iBz/8AMaFabo7SMLiSRIbfGTLKMc3oBkZ/Oi3jWtrIYdNuoYYiPiEKZeT6v/QYFLswJysHg+MlutHtkjPjyyKwY57s31J2H6n0od7pMic1i8MIP4uctKfuen2Aq/PDcXKiRoTyD5VdsBT5+v5VLo/C2u6zK62tn4iQDxJpHIjhhX+J3YhUHqxHpmvLuc9ZYsqjLSvpPu9pMjXmoozZyzNJlifrn+tN2kWk+tvJHozTXSRb3Bt1AigH8Usz4SMf5mHpQt7Tg3QQrS3EGs3OCeQs1vp6HzJHLNcD0HhJ6sKJXFlq+oWFrqHGuvjSNH+awt3tgiFe3udhGF5v+8IVfOQ07SOcNz68T0H198S1Db+QMevAdYWMPB+mYjvb6fWJiOXwNPcpAD5NcsMv/wD2kPo9XLwalaWLWWrXMPCumTjP7K0uMpdXK9vEBPiEH+Kd8eSmgK8UHTpPA4N0mSxOMPqV7Ksl+48kIHLAD5RgHzY0DleZJXaeReZ2LMWyzsT/ADPqd6OXC8J6/Xr9osKyeW+sMT3ZUNpvDmn2+l2zjlfwpC1zIvfxJtiB5hAq0w6fcaNw3pQiRUjjcmWQhFAdhtzux3YDG3McDypRtbw2/KI+T4tifDCjPmSdzijAkuVmhmtbJr2/lKm2M0bSsx/D4UXds9GI+gGM0nzuyYwMEY9GR69qpms01XUbaDTbGSTxBNcHaZv4sY5pXwBgAYUeVc2GlwnT14jv7K4soZYzcW0k7gX88WDmSNTlbWELk+K2XIJK8xOxe74bj4Y1U6vx3cw8QcdFOe30uU+PZ6FFjmElyB8LzY3EQyBtnmJGRk9rqF/eSTXk0+rX+oSKZTeuWyQeYc4OwAI5mUZ+VV8sRYq1nkc/t8f46/tDVsSMKePXT3e/ofDzgS00yXXriK41O0MeltKUtdPiLRxuvquScNjdmJdurHfFOWp39jZyRW2ockK22Gmithyo6jogHUjYDl6bb5O1Q3N0ml2n7Wu7gzXCEKocDCIMqAoGyk4JPkNztjNG00ue4ZpNUAh1C5Vrsgjeztyo5XYHpKVYci/gUqd3cYDyxhgcjPh4evvGexjj1zTJb97Y2ARHUcxwYYhjHidhgZPIO+M9MUB0nS3vNUACPFZqTyuzbsqnDE+bHcHsAT3po0/TPd9JkknItLOJliRCcsxG4UebZG57tgfhqpGbD3xoWDLzqAyq2whBAEfkAd8n65zmrEgkSqZGQP8AyF5OJIo2As4VlaQEGUqOSNBtlR9gAfLOKvmWaVSlsh57ZeZnB+e4dep/yr/MCqdsluFa8Kq8dzIiI+MfAiliR6eQ8qvLPbafp0c7kKnLJIxJ6nbOfXcmjo7PwZQoqngevXEvTXtrpMc0Em6xzKCpGwwAc/nn7ikDirU5tS1NI7KYlVlivEKjI8Nhy4P+6ebH/Cvuq6vdatrt7FakhIbjkYZzzHm2H025gfI1xo2jXUF3a2XMqgoW3GAuCVC+ucgfRDVzYMbRCVJt9owTpGnM05kmthzSShkLKds/EfsAV/IUww6awxaPEeV5DEMdV7dR1+IjcefpR6y0e3nmZYpPFiUtlEHzIwHKRn0DfnRaO1DraXACmB8hmAAw75wR5DHWgYz1jPfeUFaVobMiBwpLKSqnfcfMB3674wdqZNN4ZsS6yRwCCZxuOc4kH2O/23FSWsRke0DRRsswZHBzs6HBAO2+RkfU46Ypy0i0tXXwiodWw/KT8StjqD3/AONErrVjiKai5lGYN0/hyz3d4vizhyTkj79qa9H4eicoUVW5em2D/wCNSHTxlJkBblIXLADfyz16etMGjJDEwDNjH4G6/nWhRQqtgiZVtzMOsP8AD+kQpGABjYZ/1pjtYTGqxvyhj07ZqpZPCyjkOHHRsdat3V5DFHzzFV2zkjY/8a3aVCiZlhJM41C/hhgcmQqy59CDXm72w8XrG0kavlhnfvWr8a8QQQ2788vMFBIcHBrx17XuLhLeSQpMWBYisDtvV717lTNfsnS7n3kRY1rV5b25ctJkc2etC5PEaPckDHnQW21VZpWZjn61budSURMGPriudSvaJvOxPAlO8mUMyjoBjehLlZGJB7+XSuLq8eaUgH4R5d6jjYkAZGQdye9XIl1OOsp6pbgKWH/hS7LIUkGDtmm68QTQlRv3zSnfxcrk8pxnFHobMhwSOJSnkPPsOu2a+wESE5PSoplIUsM1Elx4QwCD9qeVcjiJuxU8wojCIg5K+dErK9AwA5GOlLE2oSY5QNq+xXzLjDEHsKh6Sw5lUuGcR3bUAyYEmw7VRn1BAxbn/Wl39oyHY59aryvcSklQelCXT46wjOW/LGiPW+X4S21dNqIfbn6bUqJbX2c4OPOrMaXi7lTUmtR0MgBz4RntL4RuMuAe1Nujav8AEqZU79jWZwC758rkedMej+9F1Xfy6UvcFAyYREduAJs2h3vjFVB3PQYrZ/Z1pk00scrD4OuayL2Z8OXmpTRPJEeXI3Ir07oGjDSbBMR45RvtvS+jpGpt46CU11v4VNp6mN0nEEOk6Z8ThFRa8Y/2h/aCOL+IbfQbZ+aKKUM++RmtK9uvtFudE0mW0sJuWRwR81eVNEuptY4iF1PIXIOSSckkmuluu21GsdJyxIX2vEzaNDcWtpDCuxVADimW0usOvUA0lWtzggg+go5a3Z5Rv0rn0t2PmMgZXAhfiW0j1HSpY2+ZVypHXI6UU9nmtveaUIJpcyQfA2/ltQu3uVmhAcjcYNBeHbr9h8UzWnPiG6PMoJ71pOe8XiCmyQXO2xq7Fc79f1pahu9v+NXIbs+dZ3feEk8xjS5H8VTrcjzpfjvBjrVhLsdjUG/EoRDDzBxynfal3WyVjPw7dsVe96yOvWhWuXyQWztIwGQetFp1AztMqRjmYrx1r13pd6JxKQvNggmjfBHFH7RCc8mTsOtKfGcaa1fGMKW+LAHb0o5wZw7JZIgBwBvR7KEVRZVKspJys3fQ40aFZj5UZ8cH0pP4e1QRxi2c7jaj/vA8/wAqRbU7pEutPnpmojNv1qqZ/WuGm6elV/ESwE/n/Odycbn0oZdnPNk9d8UTkywIIz/Khd1lSeXp610+n4M5cDiDLg4ycULmJD82aKXRBUkD70HnJ5yTW7T0lwJZtJeV90JFNeh6jyyhVQnsSaUbcBjjfB60z6DB+8VgT/SgawL3ZLQ+lNhsAWbDwhLNdJy8oGPxVzxdpyBDLJIDtvVrg4IIFAxgDsNqI8QQW11AecnA2Ar5pqbcaklRPp+hQrQA0xe5aCKUsAceQ71wt+Y8sI1x5kdKJ8SWkds7CJQcH70mXjS8xPMfzrZoYWLxB2LtMYBrDnBluFUdcLihV1fSTylY0LLndupNCQ3hkmWR/PA3rn3qZ/hh5lAz96YFQByIDvCOIZSRY4+bCKT26Gr+lySSSbPHAOzPuTS9BdNCQSVAzuWHMauDVjtywkkdsYqGQkYEJ3gPWNkbRF/39693PzbSSH4EHoDsKtWerXkt9DaaRHJe3c7eFBbwRl3lf+FVUEsfoNqBWmnXWsWCaxrV9Ho+iBjGLloi7XEi/NHbxAhriQd8EIv43TuRs9Zvrll4V9n2hXllHqH7hvCBn1LUfNJJEGeT/wBTEFjH4ufHNUdzgZeULDogjy2raVw3huIP/wAqako+LTbG4BigYdri6BI5s9Y4eY9i6HarUd/xZx3p/vt9PYaPw5YzY52Y22n2r+QwD4kv+FQ8p7560ow6fovCMnJr8sfEOsIQq6RZzf8AQrU9hdXEZ/eMO8MBx2aQbrXWuXfEXEdxb3GtSEiBfCtYVRYoLRP4IYUASNfRRv3yd68QE4PHuH3MoFDcj5+H6D1+sdbPUOH9DIueE7EXV3Gc/tvVbdSyN521sxKx+jyc7+QSq9/f+/ySXeo381xdSsHluJHLO57lnOWNLejaBeyyKryOzEkhQDn0pni0GO1OZ/3kjDlEaktv/iNUZy5x4eQlSip06yvb3SG3LWBcKMhpTtzeeCdzUsVncOPGfPO3youc+n9KL6Posl7fQ2FuXnnkPJDbwplifIfbqTsBuaddC0cW14tjw+3verPIIJdQhTxUtnYbQ2o2Ek2A37zIAAYgqoL0xWhfiLWOE+MA6Vwvc2s62t1ZpdasQpFm4LR2YbAD3JAJ5idlhGWY7YJ+GnmaaH2axT2mkzC84wuFJvL+cqTpqnqMDKrJvgRrkJtks3y/td1/TPZdaNw9w5JFNxKQxubuN/FTTWYYYI+P3tywJDSn5QcKFGxze1nluWaSYth388s7HsPMn+ZJPlRLmGmBVPzft/f7fHoOtTf7T/l/f+v3+HWfT4Ql1JeO5ZI3MryStzPLJzZB36/H8bMepX0GKuq8RyadYMNOlKSyMw8TI+BD1Zm/i2GT2ozfafFbA2MnKPCAWUj5UYZzGPp0J8yakl0G300Qs9hHcXpKe6WcicwV2OVklU/MxLZWM9SQW2AU5R3DgTRTaxDGBNLWWysItc12L99BEsllZSAEQpy595lUjALAxiKMjLFw7gKVUtmi2jmNItWHiSsxvbtmbmM8pJIUsdyASCc7liKg1HSI0vFs5Zvev2fzXOoXBbma6ut2Ylu45y35fSiem20kk6xTLlH/AH0rdPhT5APqd/tVzYA20+jPEAjIlfiDUZ7dLGzuAsk904jjVTgI8gJZsdsJjH+Y+dWxwvBa3V8HDE28hj6fNyDlI+pfOf8AKKjsbJtY4i4ctZAA15qUUj+YDuEUZ8sBDTXxDLFbS3GoAYS6mneMDufHbOPvmh7e8UufXH9iXL92VQdf7/owfDChEFs5H7mNyeU4A5l3oLxDM81o1vG3wIwaRfONshh9vhP0NXPf447+K2ibeSFRkA4PNGoH/wAxoSOa6kLgZEhVznfCgnI/KjqcCUHXM+6HZKRLIwBkmYHK9SeXGR5bA7/ejMqCCCWZnBfkOAuwEKg//UdvuK50OzJbmRdy5C5HoBn9KuXZjZJWj+IHCKT0wOp/PFVZxLDlpd0C3NpiNDmQrChY9AQAf6Uxafpsa3Xu8S8sNzHzcg6cyjH23UUL0kYmMjqcnmk/ViP6UctiyRxL8QZHXkbuB1oyYIGYCxjk4kVmIowWKkwy4aUZ2R+hb03BP/hTpo8EU2BMc7Eg43B7/wBD5eVJCk+KkwA5ZGYMOuzYP8xTbw/O4twjgkqdiPIdqLpWG7BgdSDtyI8waesiYf5sYLDckdfv9KgaOS0lMRzNH25CSR9Aev061d0V43jWJ3w2Mgf1B7ihnEl6bOUcyyHP4lPz48v8X/O9bFgVU3zMTJbbC9tq5sYlmDs9uT8TKCeU/wCJeqmrl7r0E9oWScEPsQxBFIEfER5155C/MPhnUbsvkw71LPMvhNNEypkZ+A7fkaAdcApCwv4c55EWfajr8VnpsoEiggE7bCvG/GOovf3kjkk5Y7mtu9s/FIjWSzD5J64NeddUvmmJIGBnpXO22HUWlvKb+lr7msDzlKK5aFiObcetWWlkkXuD0oVAyeKMtROGeNhhdyKsy4ELwTzODCTjLb96jPwuAvTvVgN8XMdh9KpythiegzQwMy3STg5UjfHSgWoQDDk469aOQOCCCOhz0qrfQKw3x9M1KHa0v1EUGid2KAdTXS6VI+Sq5+1GobGPxSx2+tFYbSNExyA04b9o4i5qBPMUotElkPKVzV+34ZJ/CTkU3WlkgYFl361dW2hQggb7EfSgPq2PAhK9Mo5xFi24RaYqvLv6CmbSPZyZCvNGDnvimHR7aOR1OBgkHpWiaDawDlYrjH86z7dVY3AhyErGQIg2vssSRQngHf0qw3slABIgwO21bdp9lbsg2XcbbUUFlblPlU/avIlp5ZoBtWM4E82Xfsya3I5Yjg9cLRzhX2dF7iMyREjNbRNoEN0/92vXyo/oXC0ULhzHg/SvANb7BMsdV3awh7N+C4LCCPEWMDyp84gia1091jIU8uM180CAWyqAMY9Kj41vYE02RmlA5Vz1rf0GnWhPZnN625rny08Q/wBojUbpdUa1abIJJIzSFwFaYL3mM5/KrPtj4ij1jiy6WEkrG5TJ774olwjZiDSYyB8/XtVdSdtOPOIkf7MRmt5mODnGCKNWUxGMd+tBoYzgE0TtFJIAzjH5VksOIwoxDdpdGMsrAYxkVV11BIINRtx++gcE/SpRExTIGScA19jPMTbTIcNkU7pbcgAwDjacxt0bUBdWUUytnK+dFop+2aTuGue1drJwcDJXI7UzqDSuqr7p/cZYZhVJ+nepo7jcb4oUsjdqkSYg4zikGfE9C6XJPelbi/VCsZiUg0TmvPChZ2OwFZrxFq8l7ee7xsdz59qqrmQ05s7Nbq794Zd89KebW1ENupxgAYpc4ctOe4Ub/DuacpyvgiNegGKLXrzSNhg9uORKSXZt5VeNtwabdP1H3mBW5s7Ugzycj8rEjNEdE1EQTchbCtS2pbYd69DIY85jwJx/pXLTCqKzgqGU5zXxps9DSK6oy/SeFpmwSRt5mqNww36/lViWT4T/ADofPLjKnP2r6Vp1yeZyyDEpXPT+npQe4zzY2z6UWuHBHQ49aFTgs+ACc7VuVfllhO7diCBn0xTbw/byuyuzcqnH3pXs40jIkkAPlmmCxvnZwsfNjzoGsBasgRnSHbYCZsvDt7awW4RWHNgZH+tErq5SYY3IxjOKSuFlZ41Lu2evWmy5dY4QV2z51811tQW4gT6fonNlKkjETuJ7QfGyLg5JJFIt1aJklkOfrWi6nykMWbrvik7UoXLkhcDPendIxAxL2qGgH3FZM4GAB3qFtPl5uWJAAfKiwjKkrnrtgVe02wuL+9isLGB7m6mJWOGIDJxud+gAAJLEgAAkkAZrQDnPESIA/NAdvpLA/HDknb6k9P12xTP+wdP4aAPENml9qg/u9FBISE9mvWUgg/8A8uhDH/tGQfCxe0kt9HuI7DhWY32uysI/2jbKZBExyPDshjLP2M+M9fDCj42u22k6FwYS2qRW+sayhJNlz89naN/69lP7+Tv4ankB+dm3Wrgkc+P0EEX8B/Z/ge+ULThPWOJ3TizjHVBZac6iGO6kiGZETpBZ26coZV6BUCRJ3Ydy9xdtY2UmkcNWn7D0+4TwrmRpufUL9D2mmXHKh/8AQxhU8+c71QvNXvtWv31TU76S6uXAQyvj4VGwVQAAijoFUAAdBVqExcjTPEcY2LdWoD3Nn2fn4/1LogIG7p5eH9yKy0iCC3WOygWMLvzEdMd80QkutKsIEa4mkuLgnr5nyHlQO91S4RGijVghOyk9RVGGDUdRuFEQbmBznHSqLWTy0s7eUdtP11Iwo5Pd1P4c/Ef9aI6dNq/EN+ul6Pa+JPcMVjjzyjAGSzE7AAZJYnAAJNBOH+E9Q1e9hsLdJJ7iY8oVDu3cksdgoGST0ABJrRtH0lJnfgrg64t3E0Ly6zrMz+HD7vHvIS7Y8O0j6ljgyHBO3KKYrTcePXuEVd9njz65lnhzTLi5lk4X4Qm8cOvLqutqoXx13LRQc2OWHY7kjnwXfCDFNnEHEWm+zKyfhrhmVf260Rhur5QT7gjY5oYQRnxG2LuQG2BbGFjjj1viWw4B0eHh7hLxEvJo1kE0sfJOiMAwuZVIykj7NFEd0Xlkcc/hpHll3HaYMl1OecnmPxEknvlj1Jp53/DrtX837e4fzE1Tv+X/AC/v7z/E4VBOxDRPgtzYLZLb7kn17nrTdodvDo2mtxTdgeO7vBpUbDYyLtJOR/DHnA83I/hNL/D1vDrN60TXJs9PtImu7+7Iz7tapjnfHdiSqIvVnZR3qzrHEGpajqBu7S0XT3RVgsrXPMul2yj92h7NNg8x8mZmOWI5U+g3GNH2jtHr1+36QvCy6XIks7c9+uHjjYcwth2dwer7/Ch6E8zb4FX9KMqRycQXEp54pGit2Y8zPdOCWfPfw0Oc/wAbL5Ur6dAscgRpi7tl5ZD8R9T6nfYdSSB3o1qGvWkd5HpVmo8LTP8Ao+FOV8XOZN+/xDlz35M96XyMZHQQ3d4IB6w9OtlbWvu6jHivhwDk8qAMfzwFH1J719ubl7O2ikcZMsKS7HqWLgAegCAUAj1RLgoQ5cxruR05mOTj/wCUfaj2rmOO00hnKgPpFo2Ce/NLQWKkFvKWCFcA+Ms+ztHl4w0J5UUk6laqBj/0eZXP0+BRUgaTW+DjcOc3GjXiXJHc2t0Ap/8AhmVP/wDJRj2YW0DcaaCpIykVzdY8i1vK2f8A4QlDuFLi0066ifUv+r7u3NnfgDf3eRQGb6qeVx6oKYQKtahuASw+i4+uIJss7EeAB+rfuIGltpozp92qEsLWDt1KOwP/ANFXhp62zyQKCQHKLjyyDt9sUZ1HSZdLC6feY8eynntHZd1bdXDA+TK/MPQ1y8aERTnGGXB8yy/D/LH50ByQSD1h1IIGOnrE+WNt7vbkgAE5Ofr1NfZ7QACMqRyKAwx3O5/pVtp4oFVpAORMEjHzN2X+p9PrXActErtu0hLfUmgk54l1GOZNYZQ+I22QUH3G/wClGxI3w8rdY2GfJuoNBRNHyrGDkgbY9DVw6iiLCwO5JJBPUY3/AJ5pqt+MGLWKSeBCsECy/Ay4J3wPXf8A5+lGLO49xUoHAMnwqWOAG7fTfI9M0tPqASGGSMjnQYO/zAf+NXdQ1KO4sYbtMfvAVcA9+oJ/1o6MqZYdYFkZsA9I22XFds5EEoeGaLBIxl4W/iA/EvmK71LVDdA+K6spAIZfiQ+vp/zmkNg946XsLHxEVckdc0a05mkwrOVJ3HkaJ+MdxtaU/DKORDFra21zluVRjfboTQzi7WLfRNLkIdQcHbNE55YtLtWkJHQn6Vg/tX4ud45Ykm8x1rO1N21cKOY1pqu8cZPEy72h8SPq2pyOJAyg4H51m2p3mTyrk98/6V1r+sye9vzOTn1oO92JV5s5+te09ZVBmPWEZ4kkckrMeUjJ3PpRXT42YAEDA60CguVjfbuQBTHaSqsIZOh9aK+QMTy4PWTTlgCB1+naqXNIcAgjOc/SrLTo7lc4BOME/pXzkUgcx69QKByOstjMrRXXJIQdt+lSXEoI5jg52obdOUJPQioDfmQNzHf0q/dZOZAbBhCPBffbBohEDynfoe3nQiznaTlwc5NFoWfY9qhgRxJHWE7V1BAI6irXMCRjciqEbiNiSOg/Ku2uVU+Y9TS2MmMbsQ5p9yYWXB6U46Nrgj5eY4BPn0rMkvCGBydj2NEbTVgCMP12xmoNWeYB3BGJt+n8RDlBEg/OjVrrbSuBzjpWK2PEQAGZNgabtD1vndOZxg+vWhvvxiLhQBmbJo5WZlZsZO1PmkwRGMbA1lXD2qx/Dlh6Vo+h6iJAoBp/SIqxDUs0YWcWiF+bGKyD2vcXyWek3TQSfEFON/StL1vVI0hMRkVWYELnbJxXkf27cbR2sk1hz/vVYpICCOUgkEf0rpdJpRYNp4zMnUWkLkdZgF3M+qcQO53Z5izfnWwaVaiC0hi5flQZHlWfcGyWd5rjXEkSLErjNalaxhzzIOYHcEGs7tOhqWCGK02i1iZPBAWA+H60VtYMEYG9R2sBI6Y2z1orb22OijFZYXMdU8y1a2wZSD5eVVrq0e2n8cHYn7UVtkAwPyqzc2K3MJXHbaj117TKPzIrWITJHdRqA6bmj8CiWJZAOo8qWdOn92mNrI/Q4/40zWAKnkwcNvTdtIvq94g1O3rPzRcvYZqIjcelEJItqpTDkDNnYb1jWac4hgYB4q1VbCxYeJylh51nmmFrq7e6f8J2q5xxrYuL73RCCAcECvvD9jmSKAKTnBag9yUXJlRgmPPDdv4MHjMNz0oq75OwqGBFghWJdgoAr6WBGM1gagndukMOIL1VDkup+m+KqWtwQ436HrRS7j8SMrjNASPBuCvbOKLVYbEKGLtxHrTLzxoAOYZAqy0nrS9otxh8Z2NG2ORt3rLuzW3Esh45nhp5Cc7jP0qlOd8jv0qXxMA4ONx3zVeYgjY/WvslC4M5xVwMSnMSevT+dUXYCTJq5OSBv0odMdzitavO2T0MtREM25oxp7AMBG29LsTktgk0b01yrAjNB1Iyhh9OfbGJp3DjiGAOWy31zRe4vHdcs+KUNFvuUKM5x6elHmk8ZAQo8t6+fatCtpLT6VoLF7oBZHdSo/MOfm+/QUDumjyyncZ6D/Wr90rRqRnGe5FULO1N5cSyvMsVvbKJLq6kBKQITgEgblidlQbsdh3ItSuTxCs4UZaR2ek3GrXLWtlCicqGWaaV+SKCIdZJG/CoyPMkkAAkgEvY6bLfwXmj8K4tdKjVTrGs32YVlTO3incxw5GUt1y7kAsGOAtxUs30yC41YXWk8OM3jWtrHy/tDWJFyPG3+FV6gSN+7jBIjDtzEjtX1661qOOzWCGx060Ym0062yIISRu5J+KSQ/ikfLH0GANFR3Y9r1685nszWNgdPXzPu8JK3EOlaJDJp3Ccc6eKpjudUnXku7sHqqAE+7wn+BTzMPnY/KB0aXN5gLJHDGBjAGMCqvgxZ588zenSo55XX8e3kKoxLdIRVCjPjDttp6RYma4Uld8YzVoSpzeJPcKsXkdz9qVhfXky+DFzKg7jarFuXlcCRyxwdjvVSpB6ywGekZIIbO8mWQMTGfPv9KN2Mc8t9Do+haY011ct4ccKY53b1z0Hck4AAJJwDS/pcF5Lcw2WmW0tzeXTrFDHGuXdz0VR5/oBuaZluZbCccDcHt+09c1Tmt9Rv4ZByuACz20EhwEgQKWlnJAYKxJEa73RM8n1/cFYxPA59dYz2SXd5MOAuCDHqGo36tHqOoRSBYnVfieONzgR20YHM8pwH5ST8IALD+1NM4K4dgg050vjfyLc2Qli21iaNiE1CdG3FjC4Pu0Df30gMrghcUHS90LgnhW5tI2S70zxPdtUnUtE3Ed6gD/s6I7PHYxZR522ZgUU4eQLHmGqcY6nr2sXGr6pePPd3b5llVQi9AFRFGyIqgKqjZVUAbCmS3cAf9v29fX4fmAtXenHh+/rw8vj+VuvNckeaee5uZLu+uWaSaRzztJIxyzMx6knJJ86GGd7kL7xkEsFCoOYknooHck7ADuRQR9Za2j8NSG5+3Uk0y8K3rcOaVd+0C7I9/tZ20/QEYAquolQ0k+Oje7Rsr+QlkhHUNhdTvPJwPOMGvYvI58BGvU72x4TshwRZvG2oRTJca5cghgl2oPJbKfxeACc9hKXPVVIWTqkCIVgyEQklj3ali2kMKeGec82SSzczEnuT3J3JJq9DJPF/wBNlBVYdreMDJaT+LH+HqP8WPWg26jeeOnhGKtLsHPWNMF9+yop9RZghsuQAdS963N4KfSIBpWH8SKD2ofpYubhUgRBHCq4GepH18/WuNaRdLW30dsNLYK3jAHJe7kwZST35cJFn/1Z86pR308ERijkC83znHSlXtzwIylIxn17o3jUbDToUUEEr0z3PpUnE2p3mvarwjplvIVF3w/pzEqfhjV3mDN+QP5Vm9/fTySx21sDJNL8IJ/CPOtSg0wWen8PXOf3lrwfZQBx1Mjy3Ea/cKzn7VdcLWSYNkwwj97Grpr32grfyAoJIbxoVz8sfhFVHphSBS+b1mSK3B3OA2PIUW9jNyG9oum2kQwvgXSE+Z8Bjj9KXcKskjd1YqB570O1ydMhP/Zv2WVrrA1DD3L+7R/9/HEHCbcgL6noIjeXHWexAKCT1MPMqt/g5D+E0GsbwSRStLljAfFVQcZ7Nv5D4fyqHhe71Gw1uGfTrjwLiSKSGJ8BgJGXKAg7MpYKpU7EEg9av3Om2t3arxPw7b+Dp8h5b6xBJOnSSDBTfcwNk+G3b5G3AJl2N6i0dRwf5/bPz8TiAi0sUPQ8j+Pd7vlxxmlLey3sy83ypsqgYA7/APHzopPKYCqk/wB0ir98b/qTVOytFg5pXHww5Y+pHT8zXU5Z0DE5LKh/Sh1KSCxlrCucCdXFy0U648ga+zzSie2KZKBt/QEYqq48a6DnJXGPrUvh5j8OTOIzgEdR/qKJzKHEL80vMsbkKdgM0U061le2ltcgggMAD5VQtxNNEhkCyHGxbo33pj0pIWkSMwNFKV6MaarQExOxiBKmnWs1rcht8dwB2pmiWyhjNwGwOpHrVN41t5f368vL0PnSxxbxhBYQukbDlYHpQLbRT7MlK2uIIkfHnFkMML+DLtjzrzfxlrwvJZC0hJz+VGeNeMveXdEmPxds1lerXdxcMxzsfzNKVg3NuaaKVilMRX4juH8YuucZ61UtLrxUwWBPlmrOqpJNEwxvQOwlaGUxt2NbVSgpxFnbD5hZiysCM/SjelXnNF4ZO9BWxIMqR619s7lrefJUivFdwxPA45jIX5XHMfyqx43MvOD3oW1wJF51b5q7huGIVCMAnelynGYQNg8TrUYmKFx070CQsLgqc5pmdfHhKsf0pdvEaO4LbbVek8Yg7PZ5MK2A5B2HrReCdQCM+opetLocgyRnHarcNwSR8RwD+lUdMk5kCzPSHI7jm3HQ/wA6hkmHLkNv61FDNhDnJ71BPMG5sfbegqnJxCd4ccT7JfMNi+T1z6VHHqzxt8R+2e1UbhixJ/LNUX5s/EelMqgxFmsJEaLfWyDs3xDpTjw1rLyyqBJnfoayeKRw4U05cG+93F2kUCMzZBAFAvqAXMtXYTxPR3CZluEQjPb7VsHDllLFb+K/l0rOfZzod1Fbxy3qcuRnFaVfaxZ6VYGd5FCRjDb9KY7N0rWsMTP1t2wFZnXt11jUIuFdQTR5mW9SF5I+UkHAG+CO+OleN+MOIrz2h6evEk9wguriV1vEXqJ1Ay2DvhgQ31LDtW4+0TjSbVdZmtoXjkhWTlCvEHG3TY/WvMNzrGnRcQzT6MJYkkuHjngZQOb4mAI+wH0Nb+nfcTX4DB+ExC+/BHh9cxj4H0i9aMSI0hyc7DqK3LTYAkaIBgKoApI4R09NIhtbj3iKdHUboCCrHqrDsR0269ehFaJaRcj8qrtnYnypXtitlu9qA0bh8/GErSL4RhSAOoonBH06ZG1VbVQAB0xsTRW3jBXOAT13rLRPGaAMkt4wfL/SikMQKYqvBGM4x+dEYV26Y27UYLJi1rlibSZb5F2U4bFGtJukmjXEnxAbf0q5e2iXNu0bKPiFKlncSaZftZyKQASVOOo7/lTlXBGZUjxjvzB03O42xS/xRqSabp8kjNhsHFFreZXjD5A8/wDWsn9p3EL3F0um202DncCh3afBJxxJDZEXbLn1fVHvJASmS2++9P8Aw1ZhCbh+o6UscPaX4FsiYPM5yc09QILaFYl2OMn61lapNiEecuPdCImyBXBl7bYqoJ8HrXzxst1P5VzGoTwnmPjLeQTnfHlQrU4OVvEGwJojEQ22a5v4/Et+2R5UnS22wRazPWV9Om5CDk7EGmeFxLEGBBFJlpKqPjp5edM+mTiSIqSMio11fGZVW5nhsnY469TUbsemfSuwT/iHcVG474FfYKxMACVphzdvWh8ynmyPvV99gcflVOc8uc1orwMS2MjmcwqM77UVtHCkAAk0Kikx1A9au2snlQb1LCFpIQxv0dyxUb/lTR4pWEYIyBtSVpM7Iy4ODTpomjahr0rrZmJIrdBLd3lw3JbWcROPElf8IydgMsx2UEmuM7QobvZ3XZl6mnOekgs9Mu9XuTCkjBAQZH8Nn8ME4ACr8Tux2VF+Jm2Hci3q9zo/DYSwnsob28tnLW+luyy29rLjBnvWX4bi4P8A6JT4cY+Ek4KmXiHjGx0u1OgcCieO1TmWbVJk8O7vGIwzqB/cKw2Cg83L8JIBIKIcR9+XHQDpipqArHmfpGiGtO48D6y/e6pe6ndzalrF3JcXc55pJZGyzY2H0AGwAwANgMVQe7JYANhOuBXDMZTlsfSopSY8scUVBk5Mqwx06CX7e4Eg5VYqPPvV2GOFgA+DigNtdKWClsD6URivVlkWCEd+vl61LJ5Sqv4wgVMjeHFgDGwAxVm3snSVIUiknnlYRxxRqWaRycKqgbkkkYAqSytPiDHJ5iAM7k/Ybn6U233JwBDLFGw/2lmiZZZT/wDwqJl3RT2uGU/E3/ZqeUfESRVUyYNr9pxIJY7nhpX4Z0NXveJNSYWV9LaDxGh8QhfcLYr8zsSFkdfmP7tTyhiWbQNHsuGdPvrSPUYbdLeLm4j1yBVnEcauB7nafhlUShY17XFyB/2Fu5apwtw1qmlXkHDmnRsvFurQlbhwQjaFYOmXTmO0dzJGfjY/3MTYJDO/JU4w1exvvduGOGxGug6W3NHIgKpeXCrye8FevIq5SFT8qZY/HK+TqO7HeN6938/LrBly/wDrXx6n7/x8/eVfibXbzirURcyWwsrG1QW2nafHIZEs7YMWEfOd3cszPJIfikkd3PXAFi3aMh16/hHlRg2HKfFZgqgY371OlsQonUAMB8Ofw+tIuXY7jNCsovAEraHoGo6xrNnoulqJdW1GdbeAucJCW/ET2wAWZuiqrHr0O8T3WmapeW2ncPM50LQoP2bpTMOUyxhi0lyw/jnlLyn0ZF6KKJ6Bpw4e4Vu9f5iNQ4hE2lae3Qw2YwL2cer5W3U+Rn8qXr2PwUCQ9AN9tqhgwUJ58/p4fz8p5HUvu8Bx+v8AXT5yCS4itB4cI537uR027Uc4ef3YvxDeohTTESVFfcSTk4gTHf48uf8ADG9ALW2SaQzOf3aZOCMZ9aYNUiktbW00uRSvIBf3i/8ArZFHhIf8kJX/AHpZKCQFjOS3HnKhkUr73cyEs5J5nOSxJ3J8yT3qjPdNOcRjCDJA/wBalMMsoNxMmFJwoPaoUUXMwtYU2ZhzNjc+lBAAPEP4cwhw9p3vN17y3xBcHPn6CtW1xPdtG4bgRh40uiWcr4/CqmZUH/zSH7ik7RrMoI7O2j+Jiqg+bE4H609a7ZoLvTXjz4UGh6dGgPfEWc/fOfvVSxZHx7hBORvXd7zL/saPge0vhx3GFa/W3Ynb+8Vo/wD9cUPkt2j1Oa3dT+4nlB+ocj+lWNCuv2Lqun6kp5ZbW7guM9N1kVv6Uw8QaI1lxrrenyKOaPUrg/7jSFl+3KwoqUtZpwnkx+oH/wAYu9wS8t5gfQn/AOUFwWs6hJYiUl5g6H+EjcH7GmGO4m0TVm1PTCsXvCGVUZA0bxS7vE6nZk5uZSp/h88VDFBzvkfKoAFS/Ddxy2gOZbQNPER1aPGZUHqMc4+j+dMVU7OV6+EWstDHn9YQOlWmtWjvw5EY52+OXTC5Z1x18BjvKnX4fnH+Ib0Fe1fwApDc6xgMCNwRkbjtVywCyKrLgZwy47Y6Yow+qvdMkWuWSahsU8cuYrlR2/egfF/vhqaFSWDPQ/T+vh0+EBvdDjqPr/f7/GLFrbMyeISBg96M2OkrOA3iYDbE46eRorZ6Vo10HFvqbR46rdwEMh8i0eVYfYf0ozo2ioEMMs9oebdXiuMgjPkQKldKQeRn17pVtRxmD9M0VYuaENGwZsPC4IGfQ9vrRmW193to5EU5iGDzdQM7dOuM9asyaT4EizyXEYXHI5GTgjpkY22pc4s4ot9GieB5W8RRgHsape6aes54g6w1zDHMFce8VDTtLMviqSg2/iBrz5xLxvLqKyOzEKO2aIe0bjb3xGQMABts2dvtWNX+t8+QHz9qw60bUWF26ToK61pr98s6prHiyknOTtjzoVLeyHHh5xVW8nL7hSAR96hinGeXIJXYVppVtHEWd8mfZTytiT8R3FBdStvBkE0WQD1x2o3IonBVyAeg33qpJF4iGJtx09aYQ7DmDYZEp2c3MAG7mrlxETGHQgHtVaG3MMmMbGicLJInIVGcbGrswByJVV4wZWtLghfDcmr0Moyu58tqr+68jcyHqfKrUcICjBPTYiqMwPSSExCEFwnhnffpQXVObmOAN+h61e+TJI2AqtKqysSf171FZCnMFYCeILhd0+EE7d/KiloxIxn8jUJtVGcDGKsWqBScADPpRLHBEoilTzLyTMq45vvXMsy8mebBOahlYRAso6dKFXF8Q2Mn6UJU3HiS/s9ZdnlUts1Q86uQoznpsKHG5kdgAOpxTjwPwtPruowIsZIdgKm1loXc5nqazc21Jb4J9nuucXXccVjaPyEjmcjYV6m4B9hcXDtrFPdRgvy5ZiO9P3sf9m9lo+lwn3eMEKPw7miPtf4ysuB9AaaUOEPw5QZx9aFoq/xrhrOngILV3fhx3df6mJV9rNtoLzQJIuI/4W6fase4u9pVxc6jc6feTFLd0YwherOo5sY75xVfXfaLa3+mSz2wEtzOxIPQkVk3EGpXk1xb6nPFhbaUOwGc4Ox/Q10uiYaPUrnpOZ1NhvDID1E0Pjq1WDUbW7VOSPULSK5QgYB5hn88EVgfHfD19a8Q3erWMJMNxiZ2TA8NwAG/M7575NegtYuZuJeA9I1VLPCaPO9pPKB1VwPDP02xWYcYRqqSqUBVkOQT2xUaus6LXsi9PD4HmC0p7yvJ9GNHAtxea5wzBb3V1LNeLbx30CyuWZbd2dAMntzxP023Hen7RJ2vLUNIPjiIQnHUds1lnsw1e5Ww05pwWj0PVrXQjMF+GO0vIpiUY9h7zDA656NM2PnxWie8fsHiBLcH9xeNzEHbY9R9qa7TqFy785yAYLTNsYjHT+Y52iDbG+aLQRjzwAao2sZBGF+tErdWyMiueVZqCXYIx+dXokOPr61VhH4s5FXoem9GVcCWBnap2Pel7inSDJF77BhZIviyKZkA7jNUddgebTZQjEMFJ8s0VBziQTM6uuO4NL09lkcCXHylsgHypF00rxNrJvi6tzMTgHO1IHtR1q5stUljWX4WJUqDTh7EbW7voBNOxwSGBH8q1Ni2U8xM5rsJmt6bpscWJgvQDbyq1PJg753/AFqZTyoV7L+pqncMckZztXMa8DJEeQ+cjaQ8xyfy6V9STJIyarO/pXcRHUHrXL6keM83MK2x23NTTnmiYdjVWBgBuR9asOwaP6jzrLK+3mBcZEAF2jkzt1xR7Q5+ZioOR60v3hIdiNgDt60Q0ObllUFu3nT96d5VmAXrPG3Pk9c718Z/h75rj8Rr6v4q+sV8cTEzkyGUZNUJ+tEZOp+lDbj5qbQy5Wcod8HpVuGUJg7bVRTv9auWX9/H/wB4v86tjIlTwY98NcNmZLPUNeee0trzeytYsC81D1iDbRxbHM8nwgAlQ+Dhh13i06lZQ8N6PHBaaJZSeKsFtzCO4nxjxWLfFJgHCs+ScltubAg4v/8AzicU/wDu6b/9AtLlt8o+orA7SrAPHE6PsZyevhn+JYucsMBfrgVRljbHMWIzRLy+tVLzofrWEvBwJ1WSesoB/DB5AOlVp2lkPX9KsSdD9qi/7FvrTKmCK+EooJGlMcJ3HzMelXYLqK1Usp2xks3Q4/pVeP8AuH+rVZsf/L7L/wBoi/8ArFMDmKtxmPtjqz8DWUOpXYH+0l5GJbKBxk6ZCw+G4kB6TsDmND8innO5XF/h2+j4b023441d4n1C8LyaBbXADh2ViH1GYN1ijcMIwdpJVLHKRNzJftH/APP7iD/3lP8A/VRzjr/zk0f/APp/Q/8A7OKiBR8vWYHoAfP1iPtxeTcFcNSaVLNIeIeLY1vNWklYmaCwc88cDk/F4s5JmlzvyGNTuzilYahGrjI53OenRase0v8A/OVxN/70u/8A9I1AbH+8X70OxBnHlxJr5AfxMO2VlNe3GWTKAZO+1GtM4ZvNf1az0HTmSNrqURCR/kQHdpG8lRQzE+SmudE/uP8AdNNPBP8A1hqP/ufUP/t3odSCxwD0l7GKDIgrjDWrG91QJpUbrptlClhpkR6raxZCEj+JyWkb/FI1KzwzXE5Dt8P4sfyq/J/5efof5VxB87f896E/tEmFQbABCGj2Vl70jX0PPZWytczp/HHGASv++3LH9Xr4FvNX1CS4vDzyTyNNO2Ni7Hmbf6np5YqxZf8AkV//ANzD/wDp0q5o/wA4+ppWxABiNK5MGa5CEwiqFAGBtXGg6S/Nzcm56k9hVriD+/H+Y0Z0f+8/3KC1YAxDCwlSYZ0mxWzzdg/FDHzg/wCM7L+pz/u0ya2sS3drAo2ttK06Pc9MWkR/rQa2/wCrJfqn8molxF/5XP8A+zWv/wBtFTFNSis/p94B3Lvn14QTFMLm4kkZiUhPXO2RWvcZQrd6vNxAD8UrvZzHylixyn/eiaM/Y1jGif8AVU/+c/zrYtZ/6q1T/wB5Q/8A29N0KO7cfA/v/MVvOXVvj9oFe4hghHLKoB7k4qo8rWY978QxMGDxyg9GByCD060IvP8Aqxfr/WrVx/5rXn/d/wBa8y+XhLLwYek1HT7eCK+gCRRMypLGo2hkboMdkbfl7dV7b2LW8t72c3CHMSY5gDujf6GkzTv+pp//AHM//wBxFV/hLref+z//AKwq5XDSCvX3HEeIWXT9SjvFIaOT4WOdiPI0ws8Omuk0ak2l0c5XB8N/5Z9O4pa03/yU/wCQf/VRkf8AUcn+ZKG7mtSw8IMIHIBlviTXo9L0551nhd+TALE7ivNXH3tGnvZZVkUIucNg4zWs8c/9WH7f1rzhxl/et/mrE1DG6z2jxNXRVKi9OYrcQ6oZoXlSUsp3xikmeVzEZMYNMurf3H2pWuPkf6U9plCrxL2k5nyO8mli+P8AD1+lfUlR3DAjPeoovlb71An96ftTqqImxIMIXEzNupG/866tp1BPiHJNVp/w/SuU/vhUBQRiWzgwoYfFIwM+or8ieG4yTyg1btf7pPpVV/mb/N/WlwctiHxwDLgjVhkE9M7dKh5niYqAcdasQ/KKjn+aqg84niPGffEMi8hxkDNRNDJnIXr51+i6n6/0qwen5fyqc7ekoRk4lcNgnmU5/PFfF2OVzjrUsnX7ioj1+9WBzKEZODIrgsyYzQmaJi+SM70Yk+Y/eqj9qJW2II156ybRdHe7nVQpOTnavVHsF9msk88N21sSqkdutYFwb/5dH9v6V7k9hn/VkP0FZWoc6i9am6R/aNNQXTrNg0DRFsrNIhFj4cb1g/8Aa80iSX2eaqY4y7RwlwM43Br0lbfIKwn+1N/5iav/ANw1bWnqFdyKvmJz17F6nLeRnkD2W8GLLpK3t/K3MFyVJ6UR4l0XT5bSey5ABIpHMB37UX4C/wCoZP8AKKEcQ/j/AM1Oaok3sSZm7EVBgSL2W3lzq2m6nwZcPyi5iMTek0blo2+4GPvSbxhZvyMsifGFKMue+4Ipn9kn/nnN/wC0R/zNDvab/wBZ33/tD/zrY7T/ANtNGob8xGD9IlpkFdroOnWKXs9u7ez4q0vTrqeWPT+JJVtdSiDHlmSNGOD6grGwPUMqsOlbLxVYy3mke/uhF1Z/vG2wQw+cGsI4c/8AODhT/wB4zf8A6M16S1v5tV/7yT+VeJL6VGPgWH6dZCgLqCB5A/XEscE6qus6LFKZQ8kY5H339D+VNttH8O/Ssx9k3y3H2/nWpwfh+1YbDa5AjlZ4lqBBsD+tX40+AE9aqQf0q7H0+9WAl8yRQMZ/nQ3iOZbfSpnY4+A53xRROn3pe42/6kn/AMp/kauBIPAzPJnHOhy61qUt3GC55yGAFat7HNOWz0wI2RkbH0NKUP8Afzf5/wChp/8AZ/8A3X2FN1sSoEFYPGOkhC5UHJ60OupcE71dl+Y/U0Ouu1YvaACsYwvIxKryEE71LFISd8j0xVY/MPqf5VLB0+9c1qFAlgMnEJQvnGM471cDEpvvQ+DoKvx/3YrKskMOIF1HCynlzvviv2ly8kiEnvvXWof3o+n9KrWP98f8wp1BvqwYoODif//Z",
+        "type": "string"
+      }
+    },
+    "required": [
+      "filename",
+      "image"
+    ]
+  },
+  "YoDawg": {
+    "title": "Yo Dawg",
+    "example": {
+      "filename": "loop",
+      "hashes": {
+        "tiny": "Qmdx5aD4Yum54qtvygNkgczQinYsS4vu1gYZh5e5sXTfWV",
+        "small": "QmadM28DfUubFECPzzpfq74M3EHM6VXWzipJ93vH4S5hJh",
+        "medium": "Qmf6QcfKt3xtaV7bgbqffB6BGWF5jd2BcuwtoyRtENvziX",
+        "large": "QmcPNQrFCxCYgffU816bjnynFb2TEKCSG5KhjEdSc8DQAf",
+        "original": "QmRob2P9Cpyg4d8TkWXt5a1DmgKEViZh3N3Scho4DWPJiX"
+      }
+    },
+    "type": "object",
+    "properties": {
+      "filename": {
+        "description": "",
+        "example": "loop",
+        "type": "string"
+      },
+      "hashes": {
+        "$ref": "#/definitions/Hashes"
+      }
+    },
+    "required": [
+      "filename",
+      "hashes"
+    ]
+  },
+  "Hashes": {
+    "title": "Hashes",
+    "example": {
+      "tiny": "Qmdx5aD4Yum54qtvygNkgczQinYsS4vu1gYZh5e5sXTfWV",
+      "small": "QmadM28DfUubFECPzzpfq74M3EHM6VXWzipJ93vH4S5hJh",
+      "medium": "Qmf6QcfKt3xtaV7bgbqffB6BGWF5jd2BcuwtoyRtENvziX",
+      "large": "QmcPNQrFCxCYgffU816bjnynFb2TEKCSG5KhjEdSc8DQAf",
+      "original": "QmRob2P9Cpyg4d8TkWXt5a1DmgKEViZh3N3Scho4DWPJiX"
+    },
+    "type": "object",
+    "properties": {
+      "tiny": {
+        "description": "",
+        "example": "Qmdx5aD4Yum54qtvygNkgczQinYsS4vu1gYZh5e5sXTfWV",
+        "type": "string"
+      },
+      "small": {
+        "description": "",
+        "example": "QmadM28DfUubFECPzzpfq74M3EHM6VXWzipJ93vH4S5hJh",
+        "type": "string"
+      },
+      "medium": {
+        "description": "",
+        "example": "Qmf6QcfKt3xtaV7bgbqffB6BGWF5jd2BcuwtoyRtENvziX",
+        "type": "string"
+      },
+      "large": {
+        "description": "",
+        "example": "QmcPNQrFCxCYgffU816bjnynFb2TEKCSG5KhjEdSc8DQAf",
+        "type": "string"
+      },
+      "original": {
+        "description": "",
+        "example": "QmRob2P9Cpyg4d8TkWXt5a1DmgKEViZh3N3Scho4DWPJiX",
+        "type": "string"
+      }
+    },
+    "required": [
+      "tiny",
+      "small",
+      "medium",
+      "large",
+      "original"
+    ]
+  },
+  "UploadImages(e.g.LoopImage)request": {
+    "title": "Upload images (e.g. loop image)Request",
+    "example": {
+      "filename": "cat",
+      "image": "/9j/4AAQSkZJRgABAQEBLAEsAAD/4QDiRXhpZgAATU0AKgAAAAgABAEPAAIAAAASAAAAPgEQAAIAAAAMAAAAUIKaAAUAAAABAAAAXIdpAAQAAAABAAAAZAAAAABOSUtPTiBDT1JQT1JBVElPTgBOSUtPTiBEMzIwMAAAAAAKAAAfQAAGgpoABQAAAAEAAACugp0ABQAAAAEAAAC2iCcAAwAAAAIBkAAAkAMAAgAAABQAAAC+kgkAAwAAAAIAEAAAkgoABQAAAAEAAADSAAAACgAAH0AAAAAmAAAACjIwMTU6MTE6MTUgMTE6NTQ6MzcAAAADUgAAAAr/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAGpAoADASIAAhEBAxEB/8QAHQAAAgMBAQEBAQAAAAAAAAAABQYDBAcCCAEACf/EAFYQAAIBAwIEAwYDBQUEBQoBDQECAwAEEQUhBhIxQRNRYQcUIjJxgUKRoRUjUrHBCDNictEWguHwJDVDc/E0NlNjdHWSorK0FyU3s8ImREVkdoOTo9L/xAAbAQACAwEBAQAAAAAAAAAAAAADBAECBQYAB//EADkRAAICAQMBBQYGAgMAAQUBAAECAAMRBBIhMQUTQVHwImFxkaHBFDKBsdHhBiNCUvHSFSQzQ2Jy/9oADAMBAAIRAxEAPwDyHfw/EzHJxk70qaxj4snO9PWrQiNGGxPcedI+r9SN9+9KaI5MY1gwIqTr8X1rhB5CppwQxx1FRID16VrY5mU3EmjHxZ38qvwABftVGMHG9XoTgYxt9KIvETt5k6dcYzjar1uB1O5qimdv+f1q/bg9hnO9X5ziJ2cCFbMZOMfemCwUEigVnjmB86YNP2wcdNq9Mu08ZjLppCYOd6NWp5yM9f0pftnAAUDbqfrTBpzcxz16AUjqeOYpQCXxC1pCxIBOcf8AO1MVjbqeUgHJwfKhNmFBXG2cHGOn+tMNiMgYGP61y+sJJnZdnoBiEraBQOma+XbLGu1WogBHnA32odqEgLkDpWI6EmdRQfZlYHnbI2qZSBgnzqCJh9Tn86lQ57iqNXiO189ZbQBsZH1xV+3yBjoMd6p2ihsHHQ4q2rhDnPSqBPCNgGQ3L/vcVXmPMvzA57etc3EvNIWByetRtJzKMAen1ond+UsvBn6IlcY3+1WUG+wH3qqpOcAmrlspO/YVOzMZUeM5e6mtZ1mt5eR1OVIGfqCDsR6HY1O8UOoW8l5p0IjljBee0GTyr3kj7lPNeq+o3FKfPOR96+QyS28qTwSvFLG3Ojo2CrDuDRBXgbTJPPIlaVvjBB29K7t5GLdaJm1t9fPNZRpb6oc89qoCx3J84uyyecfQ/h3+Gh0EbKxDKQwJUgjBBHUEdj6UwKyolQwYyC7mIbGeu1D7tQwBA2O/1q9dDmP3qnKg8P6URR0kEQJyF5Sd/vROy+Fc4PWq3hHxc4Iz5USjhAgx023o88BK16BIec/bFDZIjy82djRB258qfw9qhkhyMDqaLWBBPnMrWwLBlxt51ZFm9xLBaQL8bsF/XrXNrEVVmYYPNtTJodqscvvswHMwxGD/ADpTW6gaZCR1Mb09PedeghBNLEECWCMCkRy7D8R9aYrLmghRYUCnG5I6CqVlEj4ZjklizZphsFEi8zJ16LisOgGxi7dTG3O1cSzp8cwCygAnu7HYfQUXSK55chvFPkp2qG3V0T4VVcdNs1agS6l+ExFx2IbFala+Ez3OTPqe8KMPZnY9MZx+VWLaSNTmNGI8jGRXx9O1s4a1m5R1+FgCPrX2ObiSwk5LjT5JQe4IYGruSg5B+UmtQ/Qj5yzKtvKnOsMZPfBww/1r6LYhOdEZlPk+cfnViGbT74ATWbJL3DLXL2GnwEsJJ7cn8SHmX7is6+vvOVx+00Km2eyc5gDU7QM6yKT16E012+nJqPCFzAVXJiZd9+opa1VAilkmEnqBimHhN5p9Lnhd8jlo/Yrd3fgyO1kNukzPGmpeLba7f2EijMUrAY9DXVu2MH/hTTx/DY23GN9aJajn8Rg7KNs5paWLkdl2yD1862NfVsfJ8Zz+jt3JAHtBYx6C0g25DnPnTDwLrknEHBOn3cq5kgXw2IPbp/QUue0ZC3DcoQYzt9KGf2fNUubjTtR0GZt4mMiqT5+X5UxpEF2htr8Rg/KB1L7NWjeYx95qPiHGFBzWCf2hOGOJb/iHT9bg1e4vLS6jMcVrMzeFYmCNSSNyCCCSBy5zkb5Fb+ID2xikf2kTNpuu8C6hHOivDxAhSNlJSQ4QrzenOseaW7GJGtStTgMcH18ZbtHb+HY4zjkSh7GNY1O94fv9M1PRLWxuNJv/AHad4rFbV3uDEplhkUDPNCy8m/cnpnFPlzzvbSBVDHlJCnv6UQm0mHTJ5rK2aN0jnlPPGgUSuzlmk27sxLE9SSa493+EjHzDv5UtrdQb9S1jcHP7cfaF0yrXp1XrxLnBmkSycMXlvHJzSeDzlebPnkY9KW9UcW9lNK2RyoTTf7OmFndTWbOS7u7OCflJ6Y26bUo8bgafp18JlwVZlx5Vr9rhbBReP+S4+UT0VhrNtZPQ/vMV0oftXjMEY/vcn862F0yN1xsMbVlPsttHvOJ57rlBC5PTpWxmBgckYwPzrN1jAMB5R3TtjJgt0z1AFBNQtgbsFhtynf8AlTU1v2GT26UJ1K1Pjr8O+Pz2qmlsHerDW2ZWXhCsuluCQBynB8sb1mWrBbvViudo8DI/OtTQvHokxcYAT8tqydZOaSads/ETWlqlAsz7orp7PZIkun2Jub0Y3GenpTesQjQIMYG1UOGbMEGds53NGmiwM9/Ss66wM2I/R7IlFkyc527V9jgLSqPMb471YMWOvbvmpEjAZTynfpQa2w4jFrZrIgmaBY7gsmBnvTJHEDEhOMctCrq2w4ZATjrtRyxX/ocfN9SftTWrya8iJ0NhsThYdtu/TNDtXYonhqPvijRAVObuKXtWkJkIJ8+9ZyElsRtzxzF+7CqDk/Nt9K/afaGV1OO9dyKJnwDRnSbIcwYjYetNs+xeYEc8y5DbCOEAAH1qxHCSdqlYZBwO2MeVSwoeYbd6AGMswA5n1LcbA/SuBByzMoBIbYURjjHYZ+lfpoOV1k64IPpRq7drgmK2rkQDcQe73AbcA/yotymSBTndNutR6pBmJXRejE/arOm/v4uVh1Falw31mIqdrSo6NjYEVwVZTnYd6uSRkHlJ74x1r54O/mc461iMQBGwcmZhrceebGxOw2pC1lSCwO5PTG9aHrRHxZ6b49Kz7W1GWB23/Suq0B6Cc7rfy8xVuvnOd8+lRKvTapbgnnIGNqiAwc5rZMxzwJLHkHFW4ziq0Qyc/wBKsx4xgjeiCLPzLkYJ3FXYN2xiqduSQAOtX7YHmBqwHjEbTCtnvjIO9MFlsB2yN6BWYOwPSjURwoGN6mZduScQ3ZnmYbE0x6cDsSN+lLOm5YjApq09eUjAORSOq4EHp1BeMlkuFXOObp0pgsFJ6g77/egWnDmUEHbAP/IpjsY+UDbt9a5m9cnBnY6FMgYhDn5Yjt2oVdPkmrc8hUcuNhQ+XOcEnH0pE15nR6dMT7D06ZzUiD4sHtn71CmU2Odv1qxCAWGT3ob1ZmjUuDL9rgAd8V1ePyD4SB518jAUAj61FcNzg4AzQRVzmN4lTmLZJ69dq/RvzY8qjyQCuf8AjX2MfFjc/wA6MKxiWAlkL3Aq/AoSEt6VWiUHl7+lWHcRpgHpXlryIbmU5mw9cK3cdMYr9K2fvUJz065o4rzKzsBXJz9qPRzR67CsWoypHqQAEV3IeVbjySY9ObsJD9G8wChXmZcdKtzryxcvmMGr4xxPbM8yheQTwTy29zC0UsTFHjcYZWHUEdqoyjGQtMUU667CmnXjhb6JRHaXDnHiAbLBIf0Rj0PwnYjAGeNklaKRWV1YoysMFWGxBHYg9qsK8dJ5OTgyosWTzY2q9yYgJK9v1qOGPJCnG/r3qzcqEi5N96uEzCbcQLJHiXJBNSBSqr3IBzX6RM+WPOrNpC0sioULMSOnff8A4V6xhSpLSFq7w4n7TNPe+kZDsi/FIf6UaWIF4+TcfKoB6CoGVNMRo48lpCecD+VWdJiPNk52OT9+1cpqdQb33HpNeuoVr7MZNOtyeUnHkBTDbRyKBy4H2oRZBgAFTHqaLxy8pBa4Cgdd9qPUwURS0EmErVLlhhQQD5rV62hvI3w8iEYzgrgUHbUrSJQZr1EUeZODX1Nbs3UFLkt/uNg08lkVNTHoIzwpMuOWfkxuQDmiVnqKRjkn1CD6bb0nwXtpMCqqST35sfoTV5IrWQhmtFbH8LAkUytzKMiD/DgnDRziuVnA/c20mPwl9z96/SJpM4KtB7u56Enal23S1VQkFvMmO6kgCrPvdug8OYkqO/MSa93gsHtASwq2H2SYL161mszvZxyxk7OpJGKOcIWzNbyFUCc69B0oZNesJfDjUOjfXpTNw+T4b8oC/BS2nVU1K7Y1qmY6Ugzy37Y9IfSeMry6EyYmcN0/OlE24kZZUGzAE0/e3TTJH4vmuzIHTlHw56Gk7RIPerUofmhbGPStrtAmyrI6icnpm7s7Yoe0KELw3KCAfQ9RST7OIZeHeJdP1UE+BqLeC+PX/jWke06yKaAU5fmPc0unRprf2fxavBD4ktnKsoOOgByf5UDszUCplV+jNtPwIxLaw7gWHgM/Kay1qFkK+R27VmPt3vP2NacKaonK0lrrLzRwhyryMsDYAPYZIBPbIxWqaZP+09LsdTC7XNuj5Hc4FYx/anuzZ6Twqvgx5/aVxMsnWRGWEAADPQlt/UCltADp+1EQ/wDFpa9xbpz4gibXeWVlFcsmnQGK0CoYY8Y5VKKcY+pNVzbb9Om4rrh24Oo8I8MagZBP7xoVgWnBz4zrEEdz6l0bPqDV4wnOSOtJ9pf6tZdWPBm/eXoszUpz4CArO7utF18SwJ8E3K7HyIIH5bmgHt9vYbJJBspvh4i+RJ7inDWLNLe2XVprmOBIcliwzt9Kx3X+IIPbBqVrokVzFC9lN4bFBnIz1AJ+ldHo0bXdmL/2RuPgZn23d3qvcRz7sdJY9jmhGOwl1Fo/7w4B/wBK0V7TrjO350Q0nhEcL2MWlrhiiA8wXqKsNaY2wa5jU6gvaZpK/GQYDe0J3Yd8/eqN1Y80ycq7ZyKZ3tCcnl3qCWyPOsrKAE3Joen1GLVnns45i3qVs0GjNCoAZ1wAemO9ZW1n/wBJ8JAfnIx960fV9ejF8bZ0BUEp1/X60vaPpfvmsy/BlRJsa6ntMitFtHlEtHc2WJEK6Rp5t7JF5cZHYVYe2AGw3o2bPkQR42G1V5bcgk43Ncv+IyczWSyBWgKkEfau44cMpwAAc4q9Jb77qd658IKw7cpzRK7ssIzvDqRK11ZkjIBGN+mau2cJS0zjOD+RogbUSKGU8pIz0rtbYx2rYAGDvitrUJmkmJVW4sAge+lMUbbdQdqUNRuvjYjfHrvTHrk/KpGfTekyZ2nmIGcc24rPqXJyY6zZMuWERkcEqCScU12tv4EIUDc7nNCdGtgzKT2/nTAwCr9BiqWvkyymVsjPfGNqmgI5hg9/KoHZc7etdxMFYHJ8sUIGQ7ZhaHmBGRsOlSTAsmAPzqGBsjbv1yKnzgY26dv1qwJEAeesruiz27IeqjequlOUZou6nzq0OaKTlO4Y+VDnJtb/ADy4Vz2862dO+5OYjYu0wncxnxObfc9qjHKqsxxvvV2KP3iAMNiNx3qG8gWOJsY361l6isq5WMK+RMm1hwS5zjOcelIessSG696dNWckkjY0j6u5y2DkV1OimBrSMRWudpPLtXCb9OvSurn5+tcIcdP51siY7HykqEj4e3lVqLruc1VXJPT/AMatwDfGc1cQD9JehBBzsM0Stx0ND4BuBjftRO0GdiNxRF64mbeeYUtAFAJotAxY8pIOOgoXb5UYzjuMURtW5mG/oak++ZrZ6w7pyHmGd803acucDPXelawX5T16bHypu0tchQRkdqTvyRBUHNsZNKT5VYD+tMlunJHjyzQTS0w6nl2zjyo65Kx4x18q569eTO57MUFeJUmfLffpmomwVORjFSSDJ6CozkHAxvSjIB0nT6dATIiD1BwfKrNuCe2agTJO4zVmE8m+NzVSuRNEV4loPhCSKg5uYYz+lcTylF5cmoEkHN9aH3cKFn11+PfO9TRxjIONqgLEPnHpU0MnMME+vSrbfGWCkwhbqAM1DeSgNgnGBUsLYUdT22qjeSFmJ5sAHy71UJC7eJy79/SoGYMxVSfPavwbKYJzg1yNm5jTCriSExyZdtwOYDO+M1PeyfAF2O3WoLbPKCSAB51xcy+JmNWHlUbfOW2cSm0vNzIdwdvtV25mGsW7XTEnULRA0573EQ25/wDOvRvMYPUGh0nw74696ktZJLe5juLZuWSNuZSdx9/Q9CPWiDA6yoTxEntV58NnPepruIsiqBnOOlFbPRXmYXFpCRBOOeNf4PNPsf0xRyz4UeQpJOuB6ilrtVXpxljChN3SIw01pDyhDg9NqM2OmrYKlzIvTp6+tF9YS007lgiALnY4obqdw6QxRnfG7bdK53U9pNrCVH5RG00/cgHxMF6hBI17I6sGy22OlFdLtjEi8x+o9aGQy+NI0gA5c77d6N2BU4Oc0jnJjRUhcQ7awZGARnG9Xo9MeYAs5UDpgdap2sjKPhHQZwKuw3UnKPGmVQ3YHemksUeESZW8JJHoOl5zLeuWzkgb0Qg0jRAOVpCceZHWhUl+wk8C3Gw/ExNfHv7yCETOyRN+At/9X08qartA8JQ12NxujGtjYWQUCLHfdtxXwX9tBkQHwuX+FAT+ppTW6iuGAk1aSZz2QttXydbOEE++uDtkCQ4x61J1JPTiGTR4/OST8IwXetw+IA91cTt3B+DFdwamjLzx6c+R3b4qXYNR0sOI7efxZQewL4oxBc6jMR4EaNt0xiiV8nJP3l2rC8Y+0P6fq1zdTLC0EIXyA3py06MCKTBIylKfDdpeSv4l1Zxqc+VPOmQpzMj4GVO1Er3nULzEdYUFZCzzX7TrNrjiG+LHm5HyoP0pL4Zg8DXGilziVenatj9pOmwx8QTtGn96oYn9KzG8tJ7K7S7SIt4L52/hrXU5sek+M5BjtAYeEV/a5EkdtDZqoyzj+flRjTOGhd+z57LABmtz26HGaX+M9Qh4m1yzitFVlVsMQ2cGtb0rTxFpMNqVwPC5Dj6VmXK1RCjqDmHzlj8pnvsdupdW4IjgmlV5NMnktWx1AViB/Kse/thQG3veEZlgkB8O8Afmypw0Z5ceY659cVrvsbsk0viTjDh0y/u470zwqxHNhxnp9c1nn9q/Tje8eeznTBA6G8nMAmJyp57mNSvL6Zz961b0C9rLcOjDd81zEqW/+12nw4+Rx9poHsLvI9V9kHDRjbLWMc9i8fXw2WUyde+fF5vQkjtTyLb/AA0j/wBmnSBp3Ams8O3EExvND1ya0upHmBRbjncOiJj5eVEbOdy5rVvcQegrK/yCrZrncdGCsP1AP8wumf8A17fLP7zMvafoc+o8LXkcF89u5jK7bDGK8p+zrROJrDjOK+sOd1hl/vBkd/MV6r9vuppoPBNzMTglCo3wcnbalv8As76faXmiQvfWY8WRTICy9ab7Guup0drg9OkrcRwSPGahZC7uLG3kvSTN4YByc1I9pncr0ox7n2xj7V8a18hXIXXtY5c9TCBtowPCA3tM9qC8TTiy09z0+HPlmnI2u/y9KW+L7CC5sWgkXd1Ir1DlrQsh7Mjmea9Y4kmbXPd1kxzPsc1rvBGmI1oLllHORnNZ6PZ4bjiAyiInfIIHbNbLwjojWNoImJwg2Ga6ztrUCvTpXnwg6hgjE/TWmMgLVKa1O4VcUzz2g8qpS2xJ6etcmt2Y+rxaktSTjGfoKhktyFJHnk5o9La/4elVpbbmUjB37UZbscwytmcWhjeJC+xI2qxJCGtZAuebl2+1CreQxzrA+dtt/LNW9X1GOyZeQ7NtnPbvXYaewaikDzidrd0czPNdlkeVowNwcfehVtZvz+O/Y0yX1tDfXLXEPQsc4rmHS/HvIrWHBXP6Uu9RoXa3WO13bukv6Pp7Lb+Jy9atSROOwyM5o5HppihSLGCBuAKil0+QjoMGk2rYnkQvexbkDqd+g3rhHIYAg47UZm0l2PynJ/SoxocrEZB/LrXhUc5xPG4dTP1u4IB8x1FW13OM9Tv9a7i0eRACWNWhpbA/1zUip5XvB4GUpE5uV8Daq2q2JeJZ0PT0o7HprsMEZI2ruXTWktTGynan9ICvsmLWnPSVOHmWaEISMDapdXteVWUDfG1UtMjaxuREWIGds+VMF3bG6hUrjPQkd6ZtoNg3eUEtm04nnHVJOYtlsUm6sd29KZtRlyWJ6DO1K+oDnDZ61r6QbRMnVcxbuB8RJ89qhB3/AJVPefCarg43FaucTKYZ4llBkbAVag67Ej61UhOTjH0q1CQrVfHHEBZxCMAAG2+KJ2gAfr12NC7c9OmKKW+AOYfzoq4mVfCanYDbIPaiNl8w2xn1oXCxJGeporZAB68c4iLrxmNGlrnHTfrTZpiZHKNx2pV0obj4fKm/Sxhthn7UrbFaD/sjXpyZRSO2OlFJWypGKG6eQFwRtjcgdNqsGYEelYWoXJ4nedlvgTmTKk7feo3I5+uxrovnO+49apySkdT09aVwek7LSL5S3Ge/c1cUARgnf+lDIpAxI89queKFj5SwyPzr22aeyR3L5IwetVg4ICnz339ailmJzk53qLxR3/8AGvbMDMlU5l9mBAOd67hbBx64qkkxIwTnOwqS3m+ME4wO9e2QoQCGixEZwRiqLtzBt96/PcgRkDoexqt4wwd8kdKptMttwJ1GxViu24r8rAnHc7586rSTcrHfoa68Yk82TjtV9vjLAZhGNk8Pr8386rzZU8/3r48nLBzk+g2r5AWI+LcE7VU8CWInc1nLJFzKM8u236V3ptnLNIv7skZANMOgWfiusT45XHemvT+GYLfmm5Ad81hW9rCljWYYUcZEKcOR2EGnqkgUNjmAx3xQXiLiNLOJxCQNjjBr9qSXEEReAleXoR2pYuonvrwwunOsyk48vP8AWucvvfUtGKqlT2j0kNs8uo3bXswPhgfDv1NR3QErSu2d9sE+VTypJZJHaQ746jvVC8lC/AWwTgEHsTualf8AWuwSwHevuH6SFIhGEhTZc8xOdzR+0Aj2UdBjNA7H95OAw9Bmjkau8ykHbOOUV4+1xDWDHWE7cN8xY7j1rv8A6ZkfPy5+HB/pUMXheMAjZJ2I3o1bJC7KqLyMBnmPRQOpNFTYDiKN7PM5gt5FUytA8ijblJzzHy9B51ZTSfHk94urRA79idhUg1OEsEV15FXCDfJ/413Hdyq/7kIpPYg5pkWJ+VYIbx7Um/YzmLl5Uiz05RvUD6BpSkRzQC4kPzF/9O9Q397cqfhueUgdW6Chja00ALS6xliegP8ApR6+T0ngLD0MZrdNE0oYtLeBcDcFQN6rXWvSxuIbRFRGO5RcCgMutPcKGWXlHZipJNT2CatcyK3iYh/xjc0wbMcAy6afHtWfWPvDlxM6B5JSc05aShnnxv0pP0WIwooC4OKa9BuWF0fICraNWbUKW6RDWsvdtsiL7TtLMeoCXlG6gVjvtAtr1dFnlsWKOIzgg9TW3e0q9ae9Eajt5Vnuq20b2Eolj5hjoac11wq1BZPCcinPBnmf2KarJqnEdzp93FiWGb94WODnO21epY7cKqrjsK8vW9uNB9rTSWcfhC7+ZV6H1/OvUmkye+WME3cqBTfaTi9UuAxkCBoygKE9DEXRuGI9M9sF1f8AIqrrFkOXBwGeMnOfXDfoay7+0fZtP7bPZRp0UCLO98v7wyZwBcxnBT7Eg98+lb5xbo3iwW2swc63WlzLPGydSB1U+hGaxb2op+2v7W/s1to0WRbax98YqnxD52yx7jYY+9Oov4rS16odawVb4YOD9cQAPdu9X/Y5H6/2DD3C0R4U/tL8UcIW2fcuLdMbiJYmfA94wqtyD8R5kc/Q1sS2w7gVjP8AaU00aBxP7O/ajbWc5k0zV/2ZeTQk5S2k/eLnywyPg/4sVu6JFOq3EDh45AJEYbBlIyD+RpDXV9/pKL/EZQ/pyPofpC1ttdl/X7faebf7ULHUH0jhSJyGv7gAjGfhUZNNPs04bk4cn0yydQSLRVIHmd6BavZ/7cf2jINMliZrbRrPnbfKh3P+grR71jpvEtt4agqX5FGOnaq6FtgFR6HJk3r088Z+caWtAN+X0qI2vp1o0Yeb4sbsM1E0GO1c5ZpwpIkE5gdrTbYYzWfe0C+WwRgc5xgGtTkhCoSR0FefPbTrxtrtbZXySRt51bSaYG9cSp6gQ9wPbWupO1w8XxDYU8izjgXCKMUp+yqJm0mKV48FxzfnT/NBgbVPbTFnA8pCfmOYDmgHkKoSwjfpR2eAZORQ+aAntWGMiNI/EDTRA9qqyRddu9FZovixVZ4c52oy5jKNF3V9O54TPEeV13GO9IHE2rXksPhgt4kOds9R3rVdUVVtSDsSKyfXLSVryQINySB3Fdb2G2TtbpK2DcJBoOtwzWEr3Lcsw/CO9O3AOlSSRPqE6ks5yM4z6Vm2kaLdRXrtI/OC3NgjYVsnBkEnunMdlG2K0dc4aziVqJXiFWt/TcdxUZtu53JogU3yAa6EWT0260uo84wxg4WIbqv1rpdPUYJWisUOeoqc24Izy/8AGibYPd4QP7oOnLXSWh5sY2ombfG+KlSAeVeAzJzKcFkDg4BqSWzCLnl26HFEoIcYBFWHgDoVOMGj1Lg8SjGZdxPG9ldpLE5UHbFFeGtUS8cRzONuufSpOKbNTIYmTOO6n9azuLXJNP1VUAI3I61rphELRYjLYEx/UXIkb1/Sl+5fBbINH9at5YZd0JDfIw3DfSly+OAw3BHap0rBolqkPWAr44cj171VVqtTxNPkxnLA7L5/SqGSjEMCCD0NaQIJxM3HEuwNv3q9Cc9KGRtuKvQSZIJ29KIDFrBCdscY3x5bURhk6b9aEwyAEHfrV2KTcbmiiZtq5hm1YDb9KN2WSRjIx1pdt3zj02o9YNkjvVjzELRgRs0lgCMjypz01sqDjIA/OknSmAKj7dacdMfCjJyAM7UtcQBE9PnfgRmS4CKoAz2+1SeNzJkYHcY/lQkXIz5jOD6CpDeKYzliO+3esm1QZ2fZrHcJca65R82POqU1yBLjzqpPeYBPNuOvrVGa9DYIxkHzpXbg5nf6H2hD9rOMbE58qnkugq7Z3FAIL0cuM9a6mv8AsG6V4rnpNULiXpJyD12IPrURn3xkdaGy3oK8wbpUPvw2+LrUqPCQRg5hqK5AIyasx3A5jv13pcF4OYNk1cju8quGOTtVNuDCgZGYWmvd+XNQ++Z7/rVa4s7xEE/hsUJxnFTafp11eXkcCxn46g4HJkbhJHkZyuBjJxVmNZCoXB22p20/2W3V3GJCSF7UXi4AFtMhmUHkOD6ik7NZUnAMkHPSJdhpFzfQhVRsEYO3eimm6DdLGY7iA/CcAkVplnpunWMKqI02HlVPU54GDpbKvNjIx1rH1fagGVEMiM55i3bwHT41k7xnP2oonE6JFzMwKEbgVFJau9ms8wPI5KNt0oENDZ1aGIsyK2x7b1yGotNrkmaddakYMn1/itYbVxGuQwyD50P4Cvf2ktxfsd0kYLt8uR0rq54Wee28N2YI3wk826kGiXDWippdvc2gULIfjyBgMRvn71fTWqpyZ7UKndFVgybM+pPLgnqdq5n04Nes0ikocOc+YFFWshDfMpPwyAMp+tdmBZ0SRQTjZjjPoatZd1Mog24xA/uKwyGdF+UZq/BMqhSyYx8Rx22q+NPRxylt2AxtXEFgFguGYb8+PtQ1sLHAlywI5kVrcLGDPMQibkE9ftVy81ePTbfNwMtKgllBGCq9VT69z9vKuY9N8SSOaZMx26h+XszE/Cv3O59AarXejvqUgeXLeI/xlvxep+9OVlKwCep/aAbDtg9BObfXjKVkFqADsuTnbzqHVuJri2QrZlpJmBARRgk0Yi0UpMfDhVEUbd67sNAtRM91LF4jnp6CjLaCBiSDWDkiZ9PHxlrUijwpYUc7Bjgfl1o/pfCElqqtd3w8TYEH4m/0FODWwVliiiVR1P8ApXQ08FSQFWRzjIHSjCzAlm1RI2qMCV7O3tLdVxb/AC7c7/z3o/aiE8ojwSe9ApLKN5OQtIxXfbYZonZA2/72X4UHQUzRaMe1FLRu6GPGjWpkQDB3ohGW0u7VQuz0M4W1VZZVGAFz0NOV7pKahEk8IGV3rWGLqc1fmEyW/wBduLehmc8cAy3McvL82RmkjXR4emSnzUitR4x0xxahmT4k3rNOIrHUJrApa2M8nMcZEZC/mdv1rMvZ3fBHJmDqqhVacdJiF9w6t7xLa6kFOY+ZeYfpW0cEuz2LQFs+G21AeH+F5JvGNzNZxsvxqHuo2YfZCx/Sj/C0NnYam9q2qI3Pn4I4JCPzYKK0q99qPUfDkTPJAKnznz2oW+uSezziBOGw37SNhN7vynB5+U4wfOvGP9mD2i3L+2m21z2g6hfalINPfTbdnjM00bEjlVd9uhHev6CvbadJC0MhuZA4KkciKMH7mvInE3s99l/sX/tD8HXuhWOrgapcSySwvfp4UTu3LzAGMsRl+nMMVo9g3qLW0tg3B/DzIB4MBqvy94DjH8zZf7RujjXPY1q00d01uLB7fUSxyC0ccg51OPNGYU4cN3MY4G0y9WN4QunRnklzlCFxg59AKM8TaRba7w7qejPbB47y0kh5HPNzEqcfrisbteP30n+zjqfF99qbTz2qXCP48PK0cw28PlG+zDFRQDf2bdWvVGVsfHKn7SzD/avv4+eMfeA/7NH/AO1HHPG/G8igrLqD20JB5lKR/CCDWgcbxG21WKdPhKSg/bIoP/ZM4Vn4e9klhdXkbR3GqFruUFcYLkt/Wm32iWoP70r5EEVnhtt6hfA4h3bfaT+ny4jVaL4tnFIDnKCvrx4qDhiZbjRbdxk4QA/XFEXjxk4pXVJi1h74uDxgwNqmILKRzt8JryP7VWm1Xi+G3jJKGQD9a9U8a3gs9KlyRuK89z6E1/xTb3TKWUuG6VOjISzeZI49qavwDpos9LtYeXGIx/Km6aHPf9KGcOQhBHGOiqB0phmh26fpS2tr7w5lRgGApoe2CcelUJ4d8Y3o/NB12qjPb1lmj3QyGL88J7CqjR8p5umKNTw5oZqIEMBJ22q1enJbEZVjiKWv3ZDMiHpttSvd6eTaSalykFNxmmK8i95m5e5O9fNRtDcJDo8KgtL83pmt2snSoGHWFBgTg7Qxq1nPezqQxJK+op24YRYUe1KjmXPfc11p+lrolsloi4Veu1fHAsb9ZwSI5NjWtt3AN5wY4OYSdOUkEb19jCnscGrDxrKiyrg5G9QiMrsB/wCFCA28RjORJogPLIqyoDDONxVaPIqwpIO3eiAEyhnfhKdwK6VB1xUibjzrrkq209ZGZ9RcYOa6lYFGy3KMZrgsEU5oZqd/4UBVSMtsKMkqeYA1cLJLJ8WVGSP9KyPVLKefiDmjTmAc/DjrWu6lEP2dlY/3jmqWi8M293LHeSRYZOp9aaRifYlWwvMZ5f7JvBs5kl0TjF4pX3Mc37yMHywd6z/i3+xNxtePI2jXWmX0J3jnt5OSVR5FG2cffNaTot3qF7HjSuI1laMASc0R/dnzL/KcUy6PrPFdjOrRcQwTxLuTE2ACPPO35Vy636mpw6FvoZv2aaplKOB+08FccewT2ocAXjR8TcL30NozELdxwtJEy9jzLnl+hxSLd6ddRTNY6lAyTKAY58bMD0z6etf1lt/aNcS2pi1nTY7hVGGeIBlcHzG9BNY9nvsS9omnNpuqcM2duznP7pBE6Me4I3Faa9vXIwFoB+HB9efgZlN2LSQdhI+PI+H8eIn8pjHLBKUmjKlTircZ5GAHfcV7t4u/sC6Tq0Er8H8VKGIJhiugCV8l5h1Hr1rzbxn/AGePab7NnmsuKeErySyRyEvLdPFjx55XpW1pu29PcOfZPkePl4fpMPV9i3Vk7eR5j7/zMwjc8obtVyFiMHcA9PWrA4du4WMUscoRt45CuBnyPka5hhMMgs7xSEc5jkx8prYXUI59k5mDdpLU/MMS7av03o9YyDbG3nS3GktvKYZRhlOCKPWOTF8IJKbnHlRwwxmZF1ZBIIjfpUu4GfvTRZ3XINzvSXpUh/TvTDbTM+FRSSfLzoNx4iFSHvOIwG9BHMew8+9cG9PKW5z8Q3yKEh5QpXJx2zULzyRZL5286zHIHSdj2bWcgmEmundiBnGMGqkkkqsVfof5VxDdPaSpcSLmFjyt5AUYvtFuzaS3EY5lgAdCN+ZDWdbqFQjPjPoHZ1bbc4gmK+OOvTauJNQbrkYPrVO5SazJlYE28+CG8j5VWWGWVZYhklPjXA6iih1IzNF2OYSN4dirfCRneohdHmAznPSrNjoNxNbxScpbnk5QB6im7h/2UapfTLJMpVFfI+lDbUInJM91islpfSoJYoXKnqcdKa+EeFNQ1uZR4RCA55sVtOkezbT49KSOSNedRg+tSm303hi3ZYI1Vxkbbb1mWdqqFO3rCqGPAhDSeDdJbSktruFT8GDkDrX5eEtG0qX3mNEGO9AtP4lvrx2VX5R1A9KnvtUnmiZJHPKFxnyrCs1thzgw6acDho6Wmo24iCxBSPSqepvM3xBSQw2YDvSfoOrtAJLeSQuVwR51BqnHv7OcpcHAU5ANKPZk8mFWls4UQvrBv7XTpL3flAyMVnNlxi/7VQysQnPgnPStPj1my1zQ2liIdJkJGCMA46V5z4xmXTtWeOGRovjJBI2A7g0EqHOBGtKN+VcT0Kyz31k0NtIgjlXxEPqKH2N09tcJzJyt8vKejeY/Kkng/jqMWFsktwcxAdNyp8/pTpa3mj67MpS8ASfBABwx37HsQaWNO45lCWqyrDiS6hqIs52tW5HiY8yt0OD/AKVVubwRvHNDk4XLY7r3qG88drhdMuYkuJbaRvCnG3Ov8J+o2+tcFUiRL22fxbWQFCCcmNx8ynyOKVarDErCLtxzJo7lJ5YkcklGwrf4e35VYtZo4U8HAzHkP+dVbe2S3vBZqGkjuAZreQdAuMMp/nUsEJllWGMKGMbCVenMuKqynPM8ADwJdvSsFzAUf4XwR32rgXSKjkZyXIwe1C724mjt1ifIe0AIPmudjVzh1YrjUJLib4olBuGyNsAZx9zgfevKpztXxk93tQs3hDFyViW3tiBzR/FMP8bD+gwPzr7Gojt4uX4SxJ6UMs2upL24tbv4peZmJPc5z/Wr6FmXLZ5o3AIz2NestJOR08PhBirZxCEMGYZCZOZj69akizGzKAAQN6+oEjQxq2DtgVWCymeVycJkYPnV1sKYMHszmXGtoXlMznZVyNuhr7M0dpEJuX59l+tfI1Dx85z8W2Ks+AvhI0+AEY4JO2f60yljMcQLDHWVbuQwonhj94wy2RuKozzMLY3U3MFXfHQD6k7D70WaLxQUCczO3MWkGwHbb/Wkfj6aeWHklnPhp8KIOhNOoQq88mWoU2OF6Rr0LiC2xzR3KkjtH8Q/Pp+Wa0zhfiwyFbYkkeprz/wjb3PhB2Y8qgH6mtd4MtwZFlentG9otBTiT2jTSqnPM07XLOO+0xpYzhgvUda86e0GN438GZmc5Pzkt/OvREt2I9NYBtuWsK9olg9zMZ1XON/tmne1XRbUHj1nHvp3srNg8IG4FtQI3fHwnbFVtSP7J1qOXpl+XNHuELcRWOemaq8bWIaMXAXcYIPqKS0l+zUgnoeJj3DC/DmN9qwmhjlXcMOteRf7a2o/sTjbgjVoIwksEkrmTGxClGwfyr1ZwvcePpEJJBZRg151/tb8KjjLjDgbh25/dQXtzcQideqOYvh+xx+lPaCz8J2kjH/iSfkDB24dCp6HH1InovgzXbfifhbSuIrZlMd/axzgg7bivEHt5460iC/4g9lnCPEUl9b61xMs1zDETyxl2XxYsnY/Ge30869L/wBnLXNQi0jUPZpqsAM/Bvh2LSr0cb4/MYP3rx3/AGlOBL72c+3a/wBb0jQL2w0u7uYtRtLhoi8JmY5cq3yj48/CfOt/TIml7RspB9mweyf/AOWIYfSUpYugc5JXB/UcH6z+iXDmifsDh3S9JEPhC3tI0CZBxt6fSgfHdsHtSxHVapew3WdW4k9mukcQa1qHvd1exF3bwgnLv0AFHOMbbx7HA7gj9KxL0SjVMlZJUHgnrPVlsAv1kHAziTRUTO6HBpgZRj7UpezxitnNas393IevXem+Y8sTH0qNWM2kyTwSJmPtLvGIS1XfnYAigFjogSSK68MYwDVvjCZrrX44VOQGNMx08Q6TG4XfApcAqVAl24RR5z5w9/eqMYHemmSLIz2pX0MkTr23pxKfAPPFFuTPWUPWCpoObOKoywgdh6Uaki36VTmjFLGjxll4gGeEk9KVuIJgMRggYp1vVEUbufKs/wBYfxZWyTk7UzRQB7RjNfMGW0Y/eTOM8gzRLhfTDc3kmqzIMZ+EYqCO2Myx2sWeZj8QFOVlZJZ2qQoMADf61babXz4CF8YO1e3HJ4ijGetBpk8W3ZCAWTemq8jEkJBpaZeSUhj12rVoG5dplj0zJ9JufGg5HAyNqulATjY+VA7OT3S+aPm+Fv1pgTJAPn0xUsvMushVOVgSOtTLjrXYjHavqrirAT0ljHapcDuKjQDrX2WVY0ZyelTgESMSjfThW5Ac49aWbu694vggA5U361f1K75Y5JCT0OKXoZmZi2N2NeU7RmSFOIcs4jfyFQvwrt9aZNOsVs42hIG+/SqXDdkEVWZfvR67jCqHQAYo1Jx7Uo3PEy7k4lvrWO81LV9QhtmXnAnkEcS+QCjGT6D86JQ6m8UHPbTC7jtwFkmlZxGCRsoHc/SkloNU1O8hgv70z3MuORGfIiB/E/8ACMb4/M9q0P8AauicKSWui2nialdwKFgs7XA5Xb5priRvhQt15RkgYHpXOjTls4OJ19loQAYz7hLNhY6/Oh1O7itNLtgoZZbx2T4exCDBxTFomq6NdviTX1uvC6yWNrIFX6ux3oLfX4uljuL7SPeJGPMgNzyR+peSQZPoFFTnRbm6hjm1XiOPS7TYrEkXhod+isd2+wFebTbTgc+v0i/fixfb4+Hon9o+6frpjnHuutahN4ZyFMZO3ptTHae1FDcHTNXhS6iIAdHTfB81YVlkHDGoEBdCv9QKNuHt5ssw8yGxgfapJNL1azEaXvFNzDInwqtwnO2fLON6XdLFGFGPXvlVWlj+b+fpNE4n9lPsV9oMLe86LbWssyjEkA8Ng3ntWF8df2JJWglfhLVo723ALKkh5ZAd8FT51oCa80McUE+uK7g7GMhOfHnzUZ0zje7gm93AY4GcKTz49MZBqBfZS2aiVPu6fLpKvpQ6bXAYe8TxvqvsO4v0iF4OIdHlivLJsLJ4ZxNF6+ZHmKEabwjc2ty3iRP4LqVIx0/1r+h1jxhomsKtjrOni5yNvFiGR+dC9S9lPs4166d9PUW0xJbwyByk/etOrtjWqpGAwPlxj9PrMW7sHRWMDypHn4+un9zxVa8D3Lwq1uxLDyHWmvRvZxqs6xTQwtlfmBHzDzFenj7E7Wyw9pE0q82eZUVh+QNW4tAg0sCMW6Bl2wRyMfs2P0od3+RapF2suICn/EdGXDq2Zhl57IJbjTfeIFKyhRtik6b2bao5eCaAh91BxtntXqYT28JMEsRQjYhhg/kapy2WnPzMEXmNYw7cuGRmdMnY2nQhtv8Ac876D7Pbi4t5NL1O2wAeXmI/WnfhX2fvFay6bekvyoYeY9x2z9tq0xbXTxHI/IocDPTyqgNVtrWY4APMMnekNT2q9nU9ZpU6YIMIOkyX/wDC03SXGkSwfBztyHGB6Va0f2LNG6+8qcR8yEkfhPStctNTsbj4QqKxzv3zRi3urd7dWJViNmHnTNXalhX80iyrB5Ez+z9mujWKxL4S5Ug4x3Hejl3bDT+VbWNcbDamK505ZZR4R/vBlcn0pY1ma40ySMyk8r7fcCq2ayxvzGerrVjx1l2zmvZoU5VIG4IoZrWmQXAHjDd85zV3TOILOCOOdyApIU58zVrVoLa/5nt7hQoORvtmvCzIzIIKNg8RS/2fFtaNdWTh3Q4x6VUeBrUc9wQ6z7FemMiurtr+zWSCCZmLczcvcEDpS5FxD+0rUC5Z4yxbnB6jlONqG1pI4jaIeueJdja3F61ikgWTk5gc52AoZxbw5LqoMHMFklh/dn/EBnFU+DLa71biFr6OYMis0LAjbB+U006nLHPr9tbKrMVUSEN2YbH9aCSwbMZ4rYKsVfZ3d6joYj0i/jm8KZ2RyRnkcDJFJvtd0u6sLs6hAviJyF3B3V164+uK2u3Nrb6m9peRFJ7qPxYSy4HiJ1GD3KmqXEPBw4l4emKQ+PMjKsQGMOpBAG9XSzawsPjBhx3pPTM81WHEcOn3sU0UrG2ZeflU83hg439V7HyrXrG6057a21HTrtYbe62SQnKxynof8uds1ko4Fu+HtX5bppYLET+FNk5eykzs234cfpW0cKcDQ32n3Ol3VtHBOsbsvhsVhlznEiDouTsw6DINM6gV8MktYTjLQxw1ezalK0GoxKt1C5SU82RzKdiD59P086bbixtbqIo6yILqPMsa/AVderg9j39aA8D8MTQSiK8jeS45FhuEOztyD4ZB5OowD5jHam4QNBNGom54pUZJVx8RBPXB/nSbYycRN29rjwgXStPHNZQCUORM4jdRnn26jy6bj60VXTgXUSxcklsTGSO6EjIP0NWJtLl0i+V7Zle2uLiOZGDAeG4IVvzBGR60a1C3h1Ex36ry++RlZ/D6FlGM/XYVHdZXPlKG7DZ8ItzaD78rocAvIYQ3bI7ffriotA0JrNLq2duVr1jHEWHURjmP5sVH+7TTe2/u1vpeqWj88Uq4lQDbIx8XoRXzUYVnmtHgPNc2ZVMY2Yn4/ts2/wBKgUBck9enz/rMn8QzAKOn8f3iCH04yXFteyKqOIgsmO5XFfJ7AwS3Ky7tyiVSBTE6JdRJCiktDK+eUfDtjf8AOoWhSYFpd2kXw1AOfi7j6UFqsDiWW4nrALZeS3mRfhxjI6H61Ys1NwpXGTzkAY3NEP2eYtOY8uDDjc7DB864tLYoUeIYVoyxY9Sf9KDsK+00uXBGFkaKsPhxtgt5dQD/AFqa6ieSNU5sn5iT2HlX6GNZZssu6oWGe5qbJbAI+YYBoitn4QLDmcqqxRFsks64xSXrmkjULhuZeYJuB6mnabkRHdTkgbelURZ45GdSNuZs9803U+OTPIShyICs7A2MCxhR8WCcdqedAukgVFGB2pav8/CYk6nYAVJZXcsBLOD8IpxNYKTmRZWblmk3mpc9mIUbtSZxAkLwN44zgHrVE8R3TOIwpxnFWtXgur3TuZB8RHTuTS1upbW3hhF7NN3GnYYg7QgggYRjbNfuI4BLpzNjJSvui2c9nAYp1wwq3fRiW0ljx1U152ats+U4W1CGwYE4Au2ktJbY9Y3OR96zT+0eYrXifgDU+c+JDrsaBM9Q6MDT5wazW2tXNux2fcUg/wBqFVY8ISRriePXrUo/8O5z+lbdjZ11Tjo2PqImT/qPu+xhG6mX2ef2gtMu7WXwdO4+sua+DnEYmt0C831Ksn5U3f2h9MXU/YrxhbNbrK66XNIoZc4dF5gR6ggYod7beHbnW/ZiNX06CN9T0DwtSt3bYiNCPGUHtmLmFNvv2mcd+zf9oW4E1jrekMQA2cq8ZU79/rTvejUdm1XjlqW2H4dUP7r+khT3WoKnoTn68/Xn9Yp/2Z9RGp+xnQJPDK+DF4R32bB6jFaBrsRexbAyRv0rE/7FN5eTeyA2VxJzxWF/Lb2753ZBjOfvn863i9j8S2kXHVdq92qQuvsI8Tn58yFUqNp8IkcFyNDrNzbMcc2Djp0z/wAKcdRbwrR2yBtSVpoFpxOhIxz5Gf8An6U18TTrb6dIzH8JqdUCdre6EYZbHnModBf8TZJyA+K0nULTk0eMKOi0i8LW3vWs+MFOGfP61qN9biSyMeDstLgHefdCW/mAHhETS5PDuuUgbGnqL44lI7is+YNbX5XtzbZp70yYT2aEGnGTMhl5zOnTrVOaPfeiEgx36+VVZRt9PtUCvzlgMRZ4im8KAxrjcdKQ7hBNcAEbd6a+IrkPMyhunr3oBaW5mlJ68xxRWXasZVdq5lzQ7DMhuXXoNtqPH0PWura0EFuoA3IzX51I3JqFr28SVHjIJMbg9cdKXtTh5GblHU5FMMuTjOPOhWqQgx+Iucij1+wQ0IBniLl7GGjWdPmjxnFGdJvEuYVKsDgb0KkYJzIw2cVW0i590v2t3GzE4px1B5HjLgY6xyUA+oNSeEDv5VHAQwBHQ1aAFBXpLESIJ1xQ3VrgInhA4Jos55cnOKVdUui9yzc2y71VjiSBmB9an2WBGY+eKj0i1Mky9Sg657GqlzO1xcFubvj7UxaDbBVXPU71B5wJLDjEa9LjEMIwMHtV6TlkiK4+lVIGCoBUvinGAcdqKrQW2eftCNxaMdb1a68IMPGigT5m/hcj6/KD5Z8qZuHQxBniWLT1nJW2e4Y82D80gAHNIx8wO/zd6UWvJrSOOXkWW6kkAjjK5CbDBI7ncURskvmDzTXkhupxh7gseZVHUA9h16eprHWzHWdbbUWBM0ePUNJ4fRpLHTZNa1eVCI57whVB6EknZUB/kfLNS2Wo3KoNf1rU7QXDYEcyR83OT+GEEFuXO3MB26ilPT3V5I4p7YfEvjtzL0hUfAgU9PPJ2GR3NF7z3lreC7u+eTUNRPiJBGpZ5VGyjzCL2GwJ7Yo//wCTpM9k2nBkur683K1pHqd/c3Dnn5pZeSJM9MICWbPYsWzRHh+LUNWdLW+uLy9tV2aG4t1MLH+EeJk/UjFftH0Rbd0sFs/edbu/3kuACsIPUu3oPz7bU2xRppUDQ+9JE3LytK+OZiew8h38z9KqaT4mUa9VG1RIrCw4X0mOVJNB93WMZaS2YLHgfwh8/pjPlVrSo9FvpTJojWcTYyqy5SXPqd0J+jflQo6dpMTIrq17eTfE7TNzHHYsM4VfIbn0qeSO+jBFxf21uqL4fvDAKkKnoFTz+pz6DpS71hDkgSVsLeJhnVbzUtNjiguYbhzI2I2kVVz9D3oeOL5bW5C363QWPvHIrcp88A1U0yw0jSnlVdb1e/muVzIsuGix/wByRyAepGaFnTvZvrF46Q8NXCSxHElxZzlYlb/ui2PrgrS7ozng49ef/kZqdF/MMjzmgaZ7VGtJAy3rPbscBs7j6inbTuO9P1U+HdQQzxOm3ONjWGi1srGSaTRNH0zVRApE3upLvEuOskR+MfXlI9apQ+0L9nWQMlmi2yE5aEhuX6YO2PKlmssqO1+fjDfh0tGap6CubHR72E+5TC3Un+5l+NPsD0+2KBajwXdypJJplyqELnlZ8oT5Buq/fI9aQeFuO11SMxe/xXMIwUkQ4dPRhTCvGt1o92sJlBhlPn+dI3V0WNllxCKdRScA5ibr+ra5oE5t9Vs57Zn2+IHBHmD0I9RS1FxFdXE04UHnjAJUnqp7it0u9U0LiuzfTdRtophjKqezY6qeqk+Y28wazK84EhstRmvLHEtpGDkEYkjU9VkHl0IYbH0O1Zup0gq9pTkTU0mvRwVdcN9JX0W/uZpEkBJQkHbyP/Gmy1nMUa2zyENIpIJ7n/WlnT0W1iyMjwjyOezqTkGic94nxKzkujKyN6d/0pBMq3ELa/eHAjnZ6iXWO3ckyJGCp8waF8QeBdB45m2wqqc9GJ3oDpWqXDXQkdnYJF8OD1Aq1qNxDNcwgEuOrJnrncGnms3piJrXssirq8UsMkEMTsqSk4H+Ne1BtL46FnrLaFdy5Z+Z4+Y9x1FNut24flZWPigs8W2zPg/DWGcSySRa+mruUR7ZmPr1AOfzo2nGTjM0kAvQgibnFqNrq1uWacRtzqM4w2cbH6E5pW4usF/2hU6fFm3XTJp2UDA8bBYA4oVwxr082lrfvb4gEqWrFtzzqOcH9CPvTJqeoxnTRcxrzGZn+IDBMTrsR6Y/lTe3EzcNXZgTngJl0+9lto0xF4S8zlf+1CKSfTcmj8KWWqcRXF6luSFIh3GFVS2SM+e29VdEsHHDUVzHEA11aGdnO7cxO39fyoToV3q1teX14WKWzXy2z7Z2BU//AKx/Kl7cbiIWsGwlgYy8QQnWLqyNqvh3BiZ4ip+JW5SAd+vn9M0T4FuH1Dhy6eZD4kDbqUwykHckeYOenlS3puoyx8Ranp12ymWwuY57Zuzwsd8eex6U4cGeAmrTzwBhazSeBPGg3UqDhgO3Mo6eanzqqMScGVvTYnHh/wCzPvaNp1mJP2k1oq3aQCK4VVGXjfcEjuQdwf8AjQHhTUb+NWiiu3QQKMkdIvKQD+HpzDyJp79sOnRQ38slwHXmspTFLGpAeJCGT6kfGMfSs34YWW4nh1K1lSX3cNHeRhs+LEQdwo6nGdvI+lWOVyDHKMWUbprejwzz3aXkkTQXdsQkka5BAGDkHoVGdvQ0cnFpqFxEGURy+I3L4fTnG+QP8Xl51WW0McUd5YyRsq28c8EhY4khbA5c/iBDDB9M1LrMduosb21ByhheYt869id+/n61DK6L7UztyO2Vkz3YS1u7W5HjEj3q3YoCCYwGwR57Gr10s8E0rW3wwTyHEabgPgOGH+dT+ZpW1C9ZoWCZd4hIM8uObAww+4bP50Z07U1urGPxHPiPCjRk9CBuvTyyB9qhLsqc+vWJD04wYQVZZfdbOMYilkdWQjHKHw4PpvkYqOB1jvLm7bm+OWOUHGPhbIH2AxVqOWT3szSFQ/hSXGf4eWMnP5jNV4VnmsgA3M7QBQSuF+EfCTRt2a8+OT9P/YADDevXhJtOX3ezaRubmZWcgH8bSD4f5GuLoLcMJLZgqRkzjbAGRvvXaR5t5gCQiRgIMdXA6/r+oqCzmeOyitnTmbwPjA8z0WhH2hg8CFUYJI6y5b2wuNNELluWTDOfTtgH7V8FrJGCkoHUBfUZ6V2L4K0viPkhQBj8I6E/nsPoasRxiX4C5XIGe5yOgAqrbW6T3IlGW08G7lLH4sFVz51C8UoUMF+EjbHlRO8VpZOaJMMRynO5HqT0FfikCx+FzDPIFz/CP6UPuwekncQILCsYmdxhcgflXJ57uJp2wkS7ZzucdhVu4jGAAP3a5xnufOqFxzzYhQnlUYCjYn7dqkNt4MsBunLGCXlETqCo75OP0qqyxt8HioN9yQ25/Kroto7cgSuFAGTio7gKcGKLHl50N8sOZdMA4E7tNMgVOeSWFj/vf/8ANFrN1U/E8TL23P8ApQ5JAkYRuuKnimfwwAux6V5GCHInnBbrDLWNrcoSoHN1yKB31o9uxVl2ozYF1wWJ+lTanaieDnC4+1Os/fLk9ZznaehDLvTrMqiQ6bxAJ3PKhbGKzj+1NczrZcNeBgodZtST5DmzmtY4r0prqMtBlZF7jqKwT246zNd3XDmh3WTMNSt3Hryk5P5VvdlivtChDn/ZSeR5rOQvU1hl8CPuJ6W06CHVOH47K6XniurUwSg9CrqVI/I1mf8AZk1MTcJapwXHLLLBwnqcukQrcAeIsauygMB2yDWk6I//AOS7VRt+6FZzwJpUXD3t747tjexwftu3tdUt7dX5RIjrh25e7eKjb+vrVexHF6arTH/khYfFCD+xP6Qeo4YOPPHz9CIf9i6/iWTjzh+1ikitrDW5vBR3zygyyKFx6BRXpqReeJl7EGvMH9mKS5Pth9qMgijtoLjWbstAMKQ63Ljp9AT9TXqMYx169Ka7XYrqUZv+SIfoPnCnBd/iZmeqO2ncRQuo+EuMj9KL8camV0pPDI+MAdaEcewSQ3QvYgFMJ5s5xtSvf8QfttYYIXLmM5YfXpR7QTUth6QqjNi/CN3s9s/Ek8f8P0rQJF5kZTjcUvcFWAtNOD8uC3nTExpSlgef1kZ3MWiBxHa+BeiYDG9GuGbvmi8FjUvElgLiItjpvS9o92bS6UOx2OMGtQcrmXIyI7SD/hQ3U5xBAzedEQ/iRh17jNLPE93yp4StgnarqkuozFLUJGnlbIO5zV7RLHnlBZcBdjVFFMkoXG/b0pv0mxFva82PiYVYjc3whm8p9lTAx5VTmXBxiiEwwCapTjO5qdskSjJtkg1UnUSKVPcVamAHeqkrAeua8B5QoWK9+hiLr2BzjHagl9IySLdLuVO5zTHrcXx+KuSDsaV7hmAeBj16HP5UWtsrtMIR4x60K8W7tUYHtRlW5R9aQ+E9ReJjbucgHam6W7Crtt3qrkDme254nzUbpYIHOcZ2BpI1S85Y3YDLSHberXEmuIX8FZdgeoNLazm7m52YmMbDJpcvuMMiEDMu6fB4jhnHenLSUUKDjYUu2KDChep6YpkgYwxAdDioLY4EjGYS8YKNjXwXJHXah5usbjpVd7wHo1eD4ntmZjWmxh3tzI/xvI2SewJ6/XbFMdqxm8eeGFSFHhWwY/CWJ5edv8I6/b1pOtLlrd3kIPwghTnqx2otba015JHayStBZxNzzcm2UQE4/kKy6xmdXfk9I9WNpHHLHFGyO8zIZp5RlmA+XI7IPnIPptRlNVGp3q/7MN4HvLG1j1K6HxuE2Zo0/hG4HYk5JrM9N127vA12yvFbDcKd3k5mAA+p/QUWtpNXmuV0LTnX32+ULd3sj4W1th8yoOwxsOm+TWlW/QLMi6rByx5jlNxLNDqD8LcAxGaeXL6pq9xIBHGg/CD+I9zjbz7CiIuE0/wWjafU9TuR4dvnPKB3kbO0aAfiO52xk7UDkuNC4b09YppEED5ZFzs6ocAkdSgPRfxMeneiv+0VtpdpFJqK+G9w4a1thvLI38UgHQZ2A9O9GCRNm/6iMSRWeiWxu7y4hkupCHY7hQe22SfoPuarxC2Wb3rUJv2hdg+NHbuvLDar/GwHf6nJ9KDxrFJE1/qErOLc8wSQ8qGUndm88HYDf71+Iu9Wj+IeHbu2IreNOVnP8UjfXoKVuGOBJQZ6mMU08OpwSLqZEFqRvyyCPxT9Bv8AzoebnSdGtmFlbQ4x+EZC56fD6+dfILC3kmjt7aNXuEATqDy47k9BjrXFxFpsE8qWV0re77TT4yiN+LB/G/8Az6VnWnPQRqvAOCYB1G5WGcTuDHd/OotY8zIex5xsh+9VJtXXWnNvr+irqS4Ie7S6WDUI/wDM4Xw5evSQE+TCqOtx61xIDa6BdNbQtk+GwxHP6lx8lUV4YbSohacQTPqJxsjDCR7fKpUfF9Tk0obAgwD+nWadag4z193hDI4B4ms2Gr8BXQ1q2VQZLY/ur+3H+KHJ5wP4o2YUQTUbnV4YFmZ4bkHeNzy/F3ANB+HL+bSrxJopGuIoieRY2IngH55bH5itDfXtJ1+ILxJZtOJAAt7EFW6Q9mYn4Zh/nw3+IUjdZXZx+U/T+v1+cZzYpy3tfv8A39JFol3d6fMlteSsebLROT8w/hPrRC61u5stRhfxss2RFKCN+zKR326g7GqGowyWWni7iuV1LTIwEF/B/wBi4+UTIfihY9Pi2PZjSZrPFCrJChJKBiwb+Fx1H32rPsSxTtbg+uRLIBadw6Rtvp4LyaS50cqsiK4uLJTnmA38SEdSB+JOqjcZXoHfXklAwWHMmRlth2P1pH/2glS7W+tLqWKVg9xE6vhopB3HkQRmivv41zTzrWm26e/2Lh9StoxyrJC/zXUSdhvl0Hy7svwkhbfh94yBz69f1GgO6xu6Rs0bVJmhke0mBe0Krj6vg/bGKKWGpxT3tzdzRjEXOFGdub5SPtSpbRyaXdGXxFEV2Y+Uj+Dm+b7ZNMUcTTWkJgiCtb300d3GNudhJjP3G/rXhUSIOxlU/GEbyG5uNPRjIRIjM2V3+EdceXbesZ4u01vf7tJZhlgIWB2wxkVSc+g3+9bVBGy6K0LZjk8EgyH+AuD+YBpL4z4afU4LiaCNo7hlkklCnoUlXxB91DMPpV0/1sDC6a0DIPSZroutppPDtxYzSO80V+skak9XTmVznvkHH3FarwFFBxDptlNduzT6UP3kYOzwyF0DEHsOYf8AIrKuJeFpbfStZu1LZ0/VIYQqZI5XmjyR9sD704+zLjCLQtX0y01F43zc3GlXW3/YF2IP1GWb/drQXFuGPiYPVJ7B7rr1m3w6X4unWEMQ8P3eSISqjbsrSOjflg0maVFJbxfsu5eTmuL65ZcAEuYpSrH6jbb60+6bdyRCWGaP99bz+A6g8ueQEE/fnVvXNJ+qWFzCkN/HE5m0fULt2UdVi543O/4iXLg/5/pS11aoYlpLGbIPrr94sapqkNrxAl6shM1p0LHKmM/hPmQozj0pw4F4jtryeLVLVy1t+0v2ffoDvGZF54nXsMnOPUEd6zeLVYdR1HiDSdRKo2l3yWgfmDeIhU+Dv54518zyAUp+zPi5OFPaBfcL3ryfs/XfEsmUk+GHQq0TAnuHIAPqahNOTnzHMfsAdMePr0J6R9q+kT6joTcjMJYwwDA5ENwnXb+Fxg15p4Q1G60niiGbT7j3ZXnF1biY7RNuHjbbdQ4YH03r1bo15FxVookkl5J5gYJSY/lmj3JI7kHOR5fWvOntA4dtOHOKL23vIWghgn8YSRkN4SyYZXzjBHMrDyPQ4ySIydxHnLdnuNjVHqJ6j4I/Zep6JZywQmKNGkEESnKwAkmSAg5A5WLAeQfbbFS3PDb+5zFyrSRMwBK5JjOeU+uQv5jNZ37LOIZIdKkspbgNNbTBXxlRNgMkcuNjzbNEwO4ZFzWy2mo203isvK5JAKAY+AjIP/8As/Wn6imor2v4fxMLVK+muJWYvxRZXukIpBYN/eSbk/GV5vyK/wBKF8PazM1rZRnYh1UAnflxj+la1xdoEdwJYrmMeHcxwc2X33Rht6fBg/UViq6dPolwYGDHw5WYty4C7tJt5jlK1iais0FkPnNvR2rqUGes0/TryOWyunz8Udq5B7hSVUD/AOb9KsaPycgRsswnDbnYAAj+p/KlLRtZ8O3ukK83OqRDJ2GCCf5D86ZNBuFYSeGA3LhQR0JHzH6Z2+1ErsztHrrF7qNgaGoZ1GnvMImIKgKCfIkZ+p3P2oT4JhuppEB5G+PONmP4QPqc/qaOM0c6eFCzIMgB/Id29Nts+VUbyONpFWIgQRIVQdC52HMB/wA5p2+slBjoP38fX8xOlhk++UIUW6kWKHlysgEjDBDyDfH+VQfzo5pvOwkneRVgViObG7bfmfU0FgBmC28KFYVYcxUY8Q9eX6dc+govayNchrK1MLCIkTTfgRv4R/E36D16Vn1jJjdkml93Q8yoxifdE5TzOfP6VwljcznEkAjkbcL/AADzY9B/Or9vELZgsUhmuW+EuQGbPkB0z+WKse4TcjQ3U7xK2T4SMcsT15m6k/kPrTArJ5xF94EC3K2sOBJKz422/oP6mq72dsm8EEjyMMgYwAPOj50x7cqngooPRTscds1Hcv7qGV5IouY7nqzfQda8a/FuJIf/AK8wH+ynkXxXwue53xVN7ZhJhVZiO56UdLSzIPCDIB3cb/8AjXM2nOwAcfEwyIwcBR5n1qpQN0lhZg8wJPaiI45wXPWpIIOTDk5ANEJtG5SZGUZxgCuBDHAg5yWPYY2FUNRBhO8yOJLaSKr5dxt0Ao5EI57cgYzil+KEbyhcD1FEdPmPOBz7eVGqJU8+MBaocYgLW9OaJnfkyN+vevDv9qHjG90bjrSTFYEG0kEwkxswz0+te/8AXYGkgLAZ2zXmb2xcF6Tr/EOmLqFkknLdAjK+YrU7EsGj7RU4yCD+047tXTbFYiaH7M+Jm4m4UsNTKlTJAhwevTNBOJZLfQfb3wDxExghi1exv9I1GWZMqbeJo5QAT8r4kfB/0pl4V0y10fRoLO1QKqrjHQfSl32ypcJw7o2t2+oQ2P7F4i069nnlTnAt/E5ZUwN/iDKtB7E1y/8A12t2GFZipHufK/eYt6E1EA84z8uZjX9nnWXuP7RPH63V9G9xPq+pZeM5SbluXGVxtgDH5V668QhSQelfz5/sz8SQj233uuWUDRafqWoXPhxyOHkj8ZpJI1J2yQoAJxjNe/VlBQHm2Izmtn/KAKPw5B/44+X9S+P9rCYP/aS4sm4b4dmuoJiknyjY75P+lAfYXqcfFEMEyM0gGPEY9zVz+1SLW64VurchWbGQMZ3qj/ZY0ybTtFjhZNnIIPnRKNZW3ZWLPPiFtXYoYcGem7OFLa3SFOgFTbHrUKtgAdcV0G64NZNOoGZ4LgTi7hE0LKR2pH1aye3nMiKdvKn3OetAtfsS0TSRjtW1pbgw2k9YRYN0jia3W3NtcvyuBtmg2q3S3szujBl7b1nPtI1q80GFruGTkKHJ8xQbgr2lDV51gdmJYgHNaKoyr7Xzl1Gw8zX9E05pp+dkOAc03FQkYVewqnw9FHJYrOCOYirsox1FeXiWB3cylOPKqM4ODkiiMozmh84xkedXHuhVg+bBHr5UPnzuBtRGcHfAxQ6frv2qjcQywXqUYmhYYGRuKTNS5owXIzy7Hzp2n64pW1a3Hisrr8D/AMqEH2nMMBniDbG5aGaOdCQO4zTHf62ItPMiNlsY60nSXJ04vHMMjfYmgDcRyvctDLLyxdOufoKl0LjaJAIDZMJXeoPNOZHYkE7CvsGoYYIPrQ1pYpctE4znYVNYxSPKB0JPSk2zWOesb4fpHHR7x2Ic5wPOjTalkEdqBWi+DCB026VK829Lm4sZPdiEJL/IOM/Sq/vhzs1UzN1PN6Vwzb9T+dWFh8ZYIJml6HQMowM7n0/0qhLqEtlYSxRgFpCVyT1HUk/kBiiF2/ibqBj1O1B7myWZgoHMcjrVkXibrcdYZ0i4unsrJrmXL3EpaKJTnJTpnyUbk+Zpms9ctrCe6e4uOTxY8OkRy7E9Sx7bDAA7nJpBGsvah0sVbMMDQRN36b8o7DJr9w9Z3Wr2/wCzI5PChV+WWZmwCDvIxbsNsff1ppAQciJWrnrH/hjVLrWb9uINRtB4VqBMEbdQi/3Nug6LuQzHr96btCsbvWtUk4gvGklZHPNIEGWONxFnZRnbm3+vahemW1pHYrKyk2iFUgjI5TOF+Y47A+Z7Udn4hgs9NFzfpFbRk4jgXbKjpkeQ8sfXyoxOFmbYdxwsN3N5DDNbclvBPKmWgtw2Yk2+Yt3x3b8qmiuIZue61HUiyuSXmzyoAPwRDoF9eprNjr1rqniXsa3TQBsLGr8glx5t2X6da4stJ17ibUop9euJI9MQg21jDnkOO7HuB19aSsPOWhFqA6Rxl12TXZJtJ0KcWemWxze3MWQWH/ow/c464zVWe8W/YafdaeP2TCo8OHcSPjoxI6D0P3qXVNRl0GyTTdH0t3QkAER/FKx/EcfKKgZLq4tjFc26XMsg5mjcGM/Zh09M1m2WA/ljtaY6w4hDoW0zUII4UQh0fAOfIMOw8qpxwWk0RgfxGkHx+IN1/wCH6UmapEZJImW31DRUhOFWRS8TeeOXf7nrRWDiS5lsoktHhvnjXlSWJwGI9RsdvKs+4blyPX6xqtCDxGH9m2ZtluzGlyYSHEikJIp77jcj60NvtQ/cM0dzkRnl+o8jQ8cSiPEyoEbdZlPQHG4INAZNajjll2ISRSJEYE4XOxHnWeUZjH61J6w1qHF2saHeQ6voV9LbSleUSRH5k7qykEOvYqwIIO4r9cPw77Q4RHbXVjwxrwQmSCRvC0u8JPLzRuc+5yZIOGzCfOOlOTU42aTTZkR5BIHR1YfGNunrjp51d022jtuKrSF51a2vbUrG+AVaQggAjybOCKe057te7cZHl/HkfRBlrUAXvF4bz/nzHoQZZaRxHpmo6nomraTeWuq6Q7NcWcyFXCnZwR5EbgjIIIIzT5oml/s7SLW+0u6zLPZyR212rcrRzRMXjJPZsEKR0I9CRTvwld2upXiaDxPZteQ2lqptpCQbyyt5DyNHGxOZIg43hY4GQUKnrUThbUOFhPpeout1pkkrvZalEQ0MinZZPMMhblkQgMAQSOhJbaOO8Tp+x9/2PT9gk2t3nu34P7/D+P36yfVra11vRdI1ywgjgEMlsb+zUY93S4Xcrj8HMSMdiCPLPxrvNsJy/JLGIWZSNzIrgM2MbEBv61Q4R1aexsrmzSIXF3o6PJJZPu1zZO+Hh9QCMqeoOAO1fOLfedG0Ky4ztdQOpabO6KzMFDXESPhHfHSTw28KQd2UN0NBdQx3LK1khhWf0/iFNV1OKydZgpaC2nkt5+boGDjl+xB/MGmaDQV1WBtTsHDtLlvDByHdQQyEdiw29ayPiPXJdOn1xXInilaOdMr/AHiqQGYY/wABQ7+daN7NeIRLPfWsBIhE5urblbIeKRQxI/xKxbbuCfKgVIGYBvGGuDLVvWI3E+kfsvhi8miVzBcraygv2y0a5b1BjA37k1ieja9fadxqIAiNKbhfDEzYV5lIZASegYqyZ/8AWGvYWt8N22r6dqfDaIhHhvLbqGxk8rGSPfqFkAcD1PlXl72xcET6de32sWVsqfs42886hDiTnRWIB7hUD5HoaZ067G2P0MYo1S3IR4/aek+BNX/bdvcRT8iXd1bzQj3gFXSSF+X4h1BCRrzd+9EeLkS54WuHtmW3l3Lj8Xhycjnf+IAj+fasT9gPGrawtrHfSZ1PTrpbV3Y5FyifAjsTvzNA4ic9ysRPU1s+vanYPpIkeEhZGiQgDm5GEhDEn/Izr/uCq6n2GIJ9dYilZWwYExTTITo/th440jU4FOnzyxqwOByYkDxTqe2wbBH8JHekviXSpdM1sahqUNx4Mmqm3IjUc8HOhZWX1JUEdjgjO9alb6fd617R+I7S6iEAg0OMDIyvNFciRAT9JJBk91pM173q+tJuDtQv8ara3i20My/LMvM6RlsbbeLGc9jv3q1bAsG9w+U0MnBHjNW9mnE95pbiK9kBE0sQuCjEBZ3HLHLjO6yE8pPYsme9W/anptjqWlz6lDGZLg2CSwsYx8aJIpMbj+IczDHXrWbcGadccR6DFeeK1tcJG1lfxOSTHHKDyORtkR3CcrZ7MKZI+Kr65s7rQdVldrlYGjjlU5OWVHXcfxBW3z8wNBtQAYHUQVQIu3qfjBvs64hfS9YW0u5CLSaFRFK5+J4ZYwU+L0KsP9zzr0xDIGht7iORlZoIbecA55JVPw7+vLjNeW9CjhvbzSLS9xbSFfc+byRmaW2f7N46Z/8AVnzrefZ3r3vNrELxy8c9uIGRtsSodjnsfhP3zQabCLCh8ekt2pUHAtTqOvr9M/KaneWA1SztrjlC+BEWcKOq55wfsQRj1rLuKNEElyPDOIpHdPl6qAg279OYema1jTJVit4AZvEQwgkdjGc7/wDPnQTWdJhvbOWFi6+Gyw8yjDMAQWH3Cr+dP6vTC9Qw6zF0epND+6efra9lja8hUYMUoiGT1IbDYPptTVol/gpp8bEeGAZmBznvy59e/oD50sa1BLZOUEPL4qNcMcYwvOWOPopX7sPKqOh67MJxEox4j5cnuSd8nsvTP0xXPVsVbM662oW1kibfYSeJComdAjKC2/bGcH/Sh+qXi+CZfE5U5CzyfiK9gPr5j7ZNCtG1GHU0cMS9rC4Vw55fHcjYHG+OmQOwxRTULc3koRecxxDmVgBjYfMB5noPTfyrZLm2rCznwnd2+1A1jfvq9w9pAZYYwP3zBsMN/lH8P8xsOvR204IkMccCxwxrhAY+uPJewPm25oXpuixaVbgO/L4jhyEGGYbnGT5+f1+tXXuwMhFSNEHKCSR9RnGw69PX1oVWnaoZfrLXXrYcJ0hmE2tqhEcI8iQdwfJew+u/3qz74tovNFbxRMRkkuXc/bv9TtSuvEMUJPJIkZycSEgBRjr5/wBaoXXF1tbkhcRo7D95IR4sxxtgHoPU4owdUHXEX7p3OAI3SyXd6zNNeS+G2yoh3P2XA/WqrR2sKk80a5B+IuOY/TG9LJ4jaWIMk8SxONuQkgnuS34v5VXl18DZLscx+bK5P3NK23pnnkxmvTWHgRkE7wuGihbl7F/h++9ULni/T7Cc2sVwtxcE/GwIwn3rOOJeJdZnR7eyui0b7cwwMD+ZpStLHWbg8lnbu7OCWc/KPXP9aWXUEnCTSr7OG3dacT0Pa8Q6TPH4HvEUkjDMhD5xXy6FuwD2wUY8z0HrWI6bPqGjOIoy7uT8UrfiPmB2Ap/0nUH1BPCV9+UZGepp8WbxgiKW6XuuVPEYvf1lLKm5GxIqzarJs4OKDwYthgBVx+tEbfUoyPDBqfjAEY6QlPdGSExk7gYrEva5HJY3VlqBU8qXEefoTj+ta2Zcy4zisn/tF+NBwnLdwZ5oWVy3kAQaa0Q3aqtj4H9+Jjdq6fvKWx5Rj06TmtIXzkFcih/HmnjV+Cdcsz4fOLGW4iZ1yqSwjxUYjfIDICRjcVDwbqMepcM6feggmSJSd/QUD9s/CnEnG3s81LSOEuKb/RNSiR7qJ7PPNdhI3zbNghgHzjY9cZyM1g7Rpu0wlrFAr9fLB6/pOXVdwBE8kf2drGNtNvuK7Ys82l8S6WJmRSVEEkU2AGwB85J89hXvmXUEh0v3nOAE/pX80vYxqs1rqllo1zb3NlY3Vx4iyJ4kXvEq/CFdR8EgjJ3zuufM4r3vxfr8NpwjbFJMGeFOnmQM/pX0L/LdEPwddqnJ3/IFQMe/lc+HWK0EvcFI65/fP3mWe0O3u+N9QWyjyYi55/LG2BT/AOzDToNFvU0y3TCQIqgeuKrcG6MX0d9XuI/3jAsCe3YfpRTgvbiCYfQ/euSTUbtMax0BjV3tEnwHAmoq5rsOKrBq7V8jFKVW8iW2yyrb18mRZYmBAO3eow2d6g1G7W2t2cntW1pLCSJ7Exj2r8Nx60Xto03OR9DWfcAez+bR79zIpKhjgkHOM9c1tV43vkzsyhiW770waVwrbva+OIwGIz9a6OnWZ9hukIeFAMGcPX8unKlvMCFOwBpmkkWRBIhyCO1LWoWrW8jRlTkDY1Po2qEH3Scjfp60fG048JXoYVkYDbNU59tx+dW5cZqjcNt1ryNzzCLKNx3Oenehk/nRCdqHXDKcjPWvOYdYNuTjOOtCNQg8ZScHIFFrg43xQq6kABGNyMEHtSdjYjCxF4kURr43MST1Hes41S6czfujjG5ycZp84ynYZiRjlduvWs4u7ocxSQEEnYg7U7pHD9espcpHSHdG1EyhYiN870/6RbBkWYgYIzWb6DZuXEnKQvnWnaROrWwRSOYDHSl9cvBIhKCehl/nx5fSuDIT39a4O2/X0r4G23z1rKGOsd4E65j1ziuWbbANclgMjIrkvjYt1qd/lPcTPL20nsZGWRSF+nWhzzM/NGowzDAJIGBWja/paXLSKycrDIG1Zxq2g3Vs7MzNy56Cm9Oyt7LdZrFw4DzmK2hSTkWWNmKlFwTgZ6nA3Jp10mCy03SVkmnW1jIzgqFLL6jruaQbCSK2l+NSigEnB+JvTNT3Ooalq8vheGVTICgLgAfenNuIlZlziM8/tBmjLw6F8MxyDcSLzci9MLVKB9S1a6HvDy3MwACrIdz6t/CPr+VVki07TIVe4lUzHBIYgBR9uv0oxpS3epwNJa2ssdgch3RcNIPLmOFX6k0FmI5kBUHSXrexis7gvqGpQ3ksYDeEPht4j2Lnvjy6elXrvim8tLWT9ll724Y8gcKeUnyAHRR5d6Bz6jw8ka2Gsahp1rFG21pp4a8lT1cp8HMfV6YNCh4VgiS40Kwu7qaQHme5vFtPsVjDN+TikrfN+nvl0A/4jn15wfo2r8UafcSapqGoSm6YhFgLZGfUdBjypz03jqWeMjUI4Sg2Y28oV+Yeamqkd7bXi+AuicOW9yTyp71bSXZz580rsPzFUbib2iaRN41hfW9rFG6gDTbKzjGM7/LECfpmkbWRzknHwH/kMBxtx8z/AADDMvFtjqAazhuoiB8LrJjnQdid/wBaEXUcNyfB06W0llB5SGZdu4JIOR9TRGX2jce27BLnim+AQbASmIsPquMH0oZbe1Tj+11RoX4u1Oe1mO7SSLKR6FXU/wA6UapCchj8h/MPVvHskD5n+JVF9w9dlrbU7wXGpWw5ZILNgOdfIyHr9QPvUMGr+APfNM0DTUtxh5BNEblxjZ8mTIB3B2A2zRPinibjiGWK+tLrSNQfH7yG80SwlJ+7wc2/TGfvRPh/VdO1WSKW54F4caSWLMkSW1xp8gbGHQrDKEP3Q+deCVkZVvmP4zDlmrGWGfgf/BAXDfF2rTavPoMupCxMDlrWaCFEjdOoQhVyNjsRnBHrT5qzavJo0kst7FOYP+kRTSWcM/hd1kAK5Kk9cb/MOuKW34c9nfELSRabLruganbDmUJcQ3otyD2SQQuQOm0hODvTrodjqMt34Gl61pGtXfg/vNPRjY3z7fPHDPy5Y43VGdW2NXOnZ1BQ5Pu/jrFbLk3Zxj9Pv0+sFy6qlw2m8WajottbX9g6CW5tJmiilWTlAkQjKFGIGQQCGAO2KdkvPGefWeH7KS+tZybXXdDkHK8oAPLOi5OJE5tnTOVbG6jFBtM0+0trybRbiw5BOrRTabe2zQv4bfMBBJsR6DbuOlGZOHpvd4TpTRm9tEaK2mnlws8GQRH4g3V15flkGdvhYjNEqZwMj5fuMfbxi12wkD1698VOPbC44Y1Kw450l3uNMdhaXF6BySW4woAlA+U7AMp2Iwyny709tFu9Om4U1C7hSy1sme3mIPhwXXxL4mDsgO6Sr9GHSrUPHE8NzdaPr2myTJPGIry0njDeNEdirD/tB1ww3U4IJzylP4ys04cu/etOnF5wtrsvvWl3rHmFrcLgS20hHQ7ZI2O+fPA7ApXvKuniPj9vLyPHkSxSGYiuzr4Hzx9x9RFPiie799jtL6EQanpsklhcxyNygE/uzGx7AjGG6fLvuDTT7KtSk0+9s0gibxYh4FxA5IPJg8pbfPLkMh8jg0rcXr+3kSeANJquk2xju4mOHvdPUcqyAfikiACnGSUVT+E1J7I9asdbvrzhy51RrXiHTz4mj3F2AI7uIsCbR5wcAsWUxs4XDHlLENsNaTYMrzjn1/E0bXC1Yb4H15faennsNVfUraaOdnR45bKUvnMqOPEt7pG6cwVnRvPHSkD2laOur6LqFwtuLmfVLJniCjlC3Mdu6Oh9MyN552HY1qXDfi3WiPZ3EMyGLkvIIzGVe3PMTLAyn4lIwxBXcZYdhkHrWn3V43gyqJIIiJSYmHxrzN4UqN0OchW7564zR9TWe5Dr16/z9/jMTS37LsHwnj3geCTQeLUsnUpBqDYjIzzBzG8edu+cH6qtehZNels+HodY1GF5Lp7+3EsYf4XLgkOuB0cSAj6is8u+Hrey4pS+v7cGCzeO4mYZXkty8Rdx5FfGikx5Bx2NaU2gRDhC40a5m5Al1cWbTeIMwR+I0tpcg5/7NnaMjyx2UVms/wCIAZus6PU92jhh0Pr1+kJ3mgXOn8Xajf2MytDqOgu5UD42kDRsmM/h+Bz6ZPnWTcacMft28kvrCSKG5gax585Bd2hLIVbO+Ao6jfJ8q3fRLv8AaE37UvQIZQIyrSAYiWSJ4ZV8+UP4gxvuFNImpQ5n0uRraYu1uLKfChRHd2jR+HnfqfjBP8OakHuznMSptbJB68evkInTyPpmu3HFOmRCaHVLdLqWOM4DLNyiRCvmJQxHng9xTB+z4BrGm68i4TULF9OuIcgqZ4izRuPIGN8gjuopdi0/VrKDTgLUCOJZXW4cnLOk5b5f4SVY7k7SNV3TjNJDDbXMk7SWEvghBnEfIeZCGAGSYTy5z1FMBgesGysOhk0trJZXtnHdQx+DBL7t7wAQQpk8WEkf4ZRMpPTE3rTnpXENpapYX3MBbySEMvdBJMwVvXlfP5iqWp2ok0hpoJQ5gu5LVgy4LhZwoOPNlVM+rVSms4le7W2ZRHDcXEELOxCjllEykjy5AcetKXIc5xLpYLBhumefv+83XhbidZrOa1ldidPPIebtzFT+Wc0zi6SWRg5UBXMh38u/5AbVh3CWrS2uo3DNGVhvrRmyBzKORDv6bqw/KtC/a5zNMHJCx5bfIbA6/fc03VcRXk+vXEzLqAtmB4+v3zET2o6QtvF7wypGs0axc+fkVgXkBH15Bt5+lZQbi5s702sZUSyqGzn4huMDHmAyj6kmvQXFsEXEVjp2nSRK4meGSbmOByjnJG/UZUViunaLearxTfX95HurpyIx5QAytjPbGQ7fYCsm7TkW4XoZ0nZ+rXuCH8PQmlcI20kGlwQwxhiEJA5sgM2OZmP0xv5CnUBDGj27K6ZPxuOuOrH08h9aUrbUrW0i9yhnjjRmxJIT0jTAJ9M4/XHU0L1/2jaFpNtNc3GopFBEmxZgOVAepHr2HVmO2y1saZVrUD16/qYlosvfIHWNera7BAeaab9ypJPMcGVh+JvJRg7d++w3z3jP2w6PoAZb28HvIbEcK5YljjquMsx8sbCsW439vGoXMck2kNJZWskjCO6kQmViPwQp1ZsY36DGf8VZnp2m8b8c3vh2Nrf2VpdMFluDmSebJ/FIPkBzkhcepNMjSW6k56L5+J+AjIXT6IZv5byH3PhNT4s/tGCxf3O61iz0xmKs0ZBmmBA2Zo1BA+jdKFaH7TrXiK6jXSuIm1e5uHGEdOUx/wATd+XApp4P/sXWeqWkE9wJR4twiyyk5JiJ3ZQNgR6k+tZ5x77NJf7N/t7sdFmmFxpOqIngXJHKJYZPlbl7MHBUitG3/HRVR3jo3xOOf0gtL/kFdl4pq2/AA5+f79J6y4M4L990lLqK7Lu6fG3MWLegHYfrRyXgHULt/CPJCgbcKhzjyJNKnAt3JFE9mk00EXNz4hZkYggZ+LOR36Vreg6jaarZxSW0qva8o8LlcupA26/i3HXzrntXoamI2jEMdZdWSSYA0/2Y2CqQ5LjPxnqD6Udj4FsoLRovgRGXGMg5/wCH6UzQyWsS8qydF5vWrUIsXjL3ADOVIIz09P8AhR9Po6q/DmZ9uuusOSZjnEHAy25eS0j5UYczvzDJH9aXtLtZtLmaVCXRfxZ/ma3e/wBA0+TIkjDPgFUclgoPcjpSpqXCloFIZHUZOXxhfsB0odmmZW3L0jdOuBXY0X9PddRXnljQAbdatx6XK0nPC6KnWqEc9pp10bK3Yksd8nJpjsRacoZZWJPXeqkZ6yzEjkdJSjiEdyok7Uh+3OCDUOFL62MZf90cb4Faq2nLITNGnwikXjzSv2hA8HKORgVOe9EUmpd48OZn6s+zMp9i2otccFwW0jfvLVjGe3Q/6Vo9jIXuIkDEczqoI7ZOM1k3s+hl0PinWdALqYiVnRfqMH+QrTbK58O4ik68kit+RFZf+Rjfq+/UcWAN8xORpXC7fIkfKeR/Y5wrw/rljc6xfq02p6ImoRaU/jkRi354Eebwu7mZ5/iPcg7kDGt8a3zyxaPw6jFg6pGCDuDsP0xWceyPTNPstU4y0ATOZuH9U1nTk2APu/ixSrnuRzr0O3cdTlo4WupeKPaDZRMh5LCP4lP12P619K/yBlfs224HxrP6bP5548YlpAReD5b/ALTdY7JbDhiKBBjCeX5UucHsBxFKAdxim/WTyaa0a/hXA/KkHhG7C8WSxE/FgV8z0rFqHAj5TCTWQ31qVCc7VAretSKcd6FSTmWxLK48+1LnE9/yJ4Knr1xRuWYRxlz5GkTWdQ94u3JbbOBW9ouAWkAZOJNo9s11eonUZya0SCNYYVjAxgUp8HWeFNw602c5rV0zZO7znjyYF1+xE0RlQYIFJE/PFLzA4ZT5VpM4Dgqeh2NJXEOnmCQzIuxrXqYONhkDmX9OvlvLcAt8a9d6jue4INL+mXxt7gYyAdqYJyJEDrvkVZh5yyDHEF3D9Rn0oZcycuRmidyvUmhF0OtDLRlIMvLgqD03oDqF4I43dtuXfFFr4ncYpP4muzBblQd2FK2EmNIIqazdm7ndiTtSte2ivMpKjlB3GKK3UwDFT0znrXOn25uZNwD60Spu6G6WwHJBhHQbYpHyjIwP0o/pt0IbgRscA9Qf51SgUWaBAMGoZJzHIJR069aK7d6MwZ9kRu8QfN2rkybHB2G9D7W7Elsrbbdal8c775I9ayHUoxBjIbIzLDv1wpG9cGQ5+mx9PSoPHGxY965aUcuS2+ajMnI6Q9FcR69CY3RUnhXbb5h5Ut6rarMWSWMhlyCp2qeOWSC+S5iuCnhtnr2700yWFtrdqb62iCygZZAN/v5U+aO9XvE6iJdndo9ye4uPs+Ex/U9OdAfCVIyN9lyaEiF1QtPdMoJwSuCx/XH6046/bPEzxuuPQdDSe9sTKWdS57DsPrTFdhYYYTbK+IMljm0+xlWddOhdkGUe5Pjux7Hl2UfkaG6pxLql7ODfTXlzynEcOPgUdgqj4V+wqW5gvJQSgK46bVGmm6xdoIjNHGo3GSQT9TVm2jqZVFJ6eEsaVxLbWTCXVNAg8KLfk5cM31Pc046V7QvZ5qUYN/pFzpjL8KyKQw+oxSM/CE90ytdX64I2BGVz5Y619ThKGO4w92rSdQmWT9CP60lalLc85/WFXeZtdvq/D3gRCz1j3mBjnEsecA+uail1Cxw81pqUeSTsNs1mKQzWEaQAzIrdWROZR/rV+zliupPDvWz15Z4QcbfxL/pWRdQM5EbRMdYz6xJdTxiO4sxIXTPNjmDfcfKaTNWnZXFnK0kTAZhm8j/CaNftS94dlgOphrvTpPjjdD8SDzU9D9K71yzsLuP9oWMiT28wzzx74P08+2KEilOsMrKDtl3hfUW4k0d9L1FjJcQqVAx8e3Q+v1Gav8KanLb3X7C1d/e7XmZVMspWa3kB25WzzcpGdhuPWkOyuDZ6pHDZTBJrggxqflc/4D1Vv8J2p6m4e4j1stc67wxcW2FDe930kdnG4H8ZmZD/ALy7/wA6Ia8NwOsizABUnEYOIIYJtUgfSb2JNYQCQ2GoqVF8qjZo5Vx8eBgkDfbINXbyztNesozc6HKVgfxXtjOqXllN2e3nHwlcE5G3qM0J05rG3todJ1r2g8MCCN/3dvf3pvAgxtyywIwBHb4gfWmHSJW04rcW3G3DF3bOBCjEXbo3+EzCAhs+UgY+tVCEf3FTnjjn15Rk4a4m4ttFh0LUtR07XuH5FCQQ34Et/bEnb4XP71fVCr7dQa07S2lm0/le1ltZLc8ySCaSeIjy5iPeISP4ZVkA/jxvWS23B+gXyytYz6C8krfvrbxnjRmbspKDwyfMcoPfNHdL4L1y1uYpbFtXsVaMIgmiWflx1CXEDEMmB+MN/u9a0KLn6OufXn698QvqTqpx69eEbtf0nTLq1b33R4ZJIBzcvglgEb8aFc/Ac4LJlR5Cse1vTLHh69uBaX0s3D946jUbCdw6xSHZJc9Y2Un4ZSCpBKscErWq23EvFWkN+ytSv7HWYAC/u96jrKgzswPz77DmGR03HSk/jmaz1RTcWczxTQjmW2mcNLCfxKp2LqRnbJ27GlNYqp7dfyx6B9cQ2hZt2x+nn69e+Yhxbot9o2oqujXpX3WRJNOuypJhfqscmeiuCR3VxsCey5oEsp1p+I9Ht47a+s4RcXNmSP3S7LKvKdnhYMd9xy8pztsy65etp9y1vD4U9hKTGbU5DQ5OSqg7YPXlBCnY4VgGrPRcXNhxFDqejXh8SItJD4hKucDMiA48shgeuQSOuRUNuUgTedCFBPP3nt3gTjttQ0nT9R1G2kjMxMPPzcxEoGAVY778hBU9HQjyJtaxDHpuq2V7ZMZdN1ZXPhxNlJH5TzoAB8J5Qwx/lH4VrLPYjxVb3dleaHqr8jqiTIqqBHPaSgeHKuNuZHUo2Nxyqe2+j3s8nhTaZzgWN8wZCf8A91vlYNHIP4fiwD2IYUZrC1Y3fP8Amc41QquIHof1KuuaXZ2+r2t5cpa3EF1JJYySgYY+JC2AwI+VimP9/HaqlvZLqWntZQzo9ssi2k/iAAxyIIwC2P8A0kTxPnpkvRbUZ7C9hhkaFohdOA8SkFreVXEiY/yuCPMh8b7ig+g30eo2l5pV4kUc4jZEmXYM8PMAh8xyMeU9gzDfAxnCvBwOI8tpKZPhLFjL7hZWUkiuC87WVzzrk+KgIbP+8it2ySfOutasbayePVI357Ce9kuEDDOGkjZvh9cNtntnuKn0+4a+067+BHV74zuhIDiVN8gDzDSrk+Y8q610XH7KeJDG8KiwvIJlA+I8xGcHqCCo9BIPI15qsAkzy2bmxmKU9odVXS7Jo5I5oVgAiU/CoZjC4Bz8QzHkelVuH7eF9QtooZZFt1RopEmOzgIcDH+EOQOnyEVJd+8aHa2MkihZtN1Wa0knB3e2KrPA4HcKOaM56co9antkgs9Mlht3kNyZHtpGUnDcrh1cfc/kx7VI4OTCtyMD9P5+8KXMDyaZLG8cUU1mwuWySBIG8ORTnzBjC/SqGpaFcPeXdtE8BBWeZRITnxS6NEPuh5Cem+aYjy3gtNQR43jlkSaNDkho+WRWU+YIGR/lrnUtLi07WUMjvKt1pjrbBgCQypkxn/EFwQf8JqHIbgylJKnj3ylaW4tJEsHyiva8glDZKtIrbHz6rn1ps0OSR9FFteKXRVZUlBYleXnVfrhkIP8Axpfhube/hs5onBEuQHCjDPEevXbKlM/5T503cP6fDaWclnIhHjS3HKSfh+NwSQex2Jx6tRaV3uAOhxA3sVX2uuYR0+2PuNvLJhnijYc2PlACtg9zu3as/wBWsY9Fe9u5VQRJIqDA+YhckD6szD6A1pNvzWluWln5kaNW3P4jlD+eFNZD7Wtag07TTIZ+WJXGOUZLyE7ADy3yTR9XWqVrt69J7QFrbdvgZmPtB9oo0BTahg87DmIB6fNgbd8kn7VjGvcS3P7qfXVN7qdxiSz01WIULjaSX+FcDYDcjYY3NVuMOJTJfzatNi4nmZobGJkyq4O8rDuq9Bn5ifIGueFOGp7vUjeXzu11MFkZ5UPO7HqSTkdPyxgbU1p6E0lYtsGT4TR1esFX+mng+JnHss9w9o2vW13f3slxdM/LJCYx/wBHRTuqqNlTodu3XeveXAvs/wBB4f08fu45AIy3OOVUQ4PyDbA265NeFPZ9pf8A+G2q8SWdjHGdWjimZ2clXubZxzRoF7Lseg6geVe2OCfaHpUnBFjxHMyXPv8Ap8U9uqJzF/EjBGe22d/oa7urR1dnqmssIZLF3KfAcdPX2nzi7X2a8tSPZdTg+/3+vvNx4cu7G2t44rVFzIytkNkev6E14B/ty8V6Rxn7YI34TmintdM1D9nWs8ZLBnj8MuVJG48ViB2yDWi+0v298Q2Okto2neHp9+4Pi6lbjkkkiIxyIo2Gd8sa8wcHafNxd7RNOskDSafohN3MXOxAbnOfMluRf/CidodrU67TbKvif4h+yezbNNqRY568D9fH19p6+4HjupFFiZ2jiP7qSUkGQseoUdzj7DvW16Daw28a2tiP3afACTnP/Pn+VYf7NLS31SR7icOwWTmIXaMt0UZHzHbOPStsjvVjhW2jlYkj5guwA7ADvXzWx0zjwE7jVA7seMYbaZ/eAFVfDj+J3bYVYbWtMS6ZLYqZVPxzFs8ufIdPsKTr7UI4bcrJPh+X+72L7dWbBP5b+WaC6brMN/dosMr+5g/G+MeI+dx9PPH0pazUFDtlKtLvUt5TUbbUZbxmleXliOCrSbc/ry/6mvl45uwInukA8hglj50Du1laJLiaZ7aHkPIObPMB1AXuf+c1Nw9dx3EqxQqGbP8ACOb79hTKWktsMXNPs7x4RZ4o01dOk/aMFmilT8T8u+KraVr1tOBkAM3fGK0zX9JbVLUQyxxEEZPxDY1ifE+g6lot48qXAKZJVVHT7UHU1mp8jpG9JYty7W6zS7XUUCYaRceVBuJo4pbVpV3PbbYUh6NqupXEwV3cjP0p9uEZ9KLSHHw/U14P3lZEDraO7U4nnaeKTTfavHcSuyxXsDRjtkjf/WntXKuVzuCRST7Uo57a6tdcslHi2M4br1Gf9KaI71J4obtWBWdA+QeuaT7RT8T2dTeOqZQ/uJx6psvZfPn1+omD6bf2PB3tx9q2nNp3iftC3k1e3n5d4ZXSOSRM5xyusjde6LRP+zIbjXtU1TiiZTyyOFQ42CgbUjf2gdYveF/aNq1xpqMkuuaZa5Y4xITHJGRn6RYH0rv+ydxzLFcPw3K0qGQAphth55Fdpfpjr+wUYPj/AFoTx1KZH1+0VH+q5lxyW+hAP26T11qjc1i49DWaaFJ4PGQ7Myj+daJey5s2Gd8Y+tZvZjl4thkGBnI69a4HQLmp/hNBlxNljYkAmplYVQilJQeoqcS4XmJFVrGTI2yrr9/7tZtytuRikOJ3vbtYwCSzf1ojxdqZL8gbIHUCo+DrVrq5Fw42HStkHu6wo6meA2jcZoOkwC1s0TGDjer3iZFVVcKOVegGK+l81qUYCgQOJI7evSh2pW63VuyHGcVdJ2qJ9x0rRrJE8BMy1NJLC7KsPhzTBpF0tzbBCd8VHxdpvOhmQfFvQjh68CzmEnONqfXD8y5GRkQ3cruR5UJulzmj10gYc46GhU8ec0CxSDiGTmLl3GN8is64um5pygOy1p2pARwSSHsNvrWU8QkvI+Op6UqwywEMDE66Yuxyd+m4o5w7adHI9M0Me2M1yqBc4OMU5abp/gWqgJ8Xehah9q4hk4GZS1FCGwADnv5UOc84Krvijd/AWTP8jQNgVfbpU6O3KlTBWnHSW9LnMZMbHp+VXmYhyF6ZwKFQqyS84OcedEWBZVfsR286rq8D2xK1Xc4zOjOQMkmuWlwM83SoiCWHnnyr5g9MbdOlJBxDh5Y1geBzTDYk7HyqjoHFd/od2c3bzW8h+Nc5JorxLHiFl9Cay7VLye3dhExBz0FbHZtngZzF5wwImocRXFrq1u19ajLAZIyM1mp1PF34Y5uuCPTNWOCuIZhfNZ3Kc6SjB2yaKcQaF7nqKXUCYD9jtVtQe5u2kdek6rsy86ijk9JCtwhtfEXqe+KDXWoDmI8fw8dzRO/cR25RUKv+IY2pQ1aXkU8y4J71BAYzSqYqIWtrqUTBxrR5j8uRsPX0pgtH1u45TDdWsq9SeUEsPvWSXN/JEcwE5Bzmrencc6pY4BVlVcZJUnaq2aR3GVnu/RD7U1lri5kQxchjMYIY7g/XuKpyLqltIt3B4nOhHLLCwJ+46Gl/TOKrnWB4ccvJIN89Vx6k9KP6dxDYWzOk8EUk2MFkz4P5dT/L61k2VPWTkRyuxWEN2Oo2+vWMlrd2RMZyZZA4SJGH4vi2B9F39KqaX+ydEE0djdy8Rgnm8FJDbxRj/Ev97JjzHJUcqNqRXUBLJNGg6xYLRfROmPoKpPZ2U863CXVpM0O6868sg+xGf1pcEQuMnrC1zxNxDJbleHLi30WFxnk04LbP6gygGRvUOxr9onEaXbC31jVrWW6I/c3QuEknGPwtk5YfcUU0rX9OtrZ1Md5BI4y8tvK6kHoTkqQfuamukvbvTx/s1xjZTsmSq6lB4m3Ug9MfUVUtuG1xx68gZQnacqIRgvVkCxXVhYTlgoEllciM56Z5WOD9MjFEY7WC0maVNMmtppAFWUgBebOwbALHP8QP2pb0/WuMDIqSRaGZo8E+B7vySL6JJzN/Km+x4j1z3dYr/RXXxQQ3i21usa77HA5QR9D5UHBB4IniQeMTu0udLin91u/GspuYSCa31ONHXfcgNEjKc9961vgniJwkllccQ6veW5ARnnhtLsMD0JlhaNh9dzWUaxfaPHbxzahZiAhctNbo2xB65duUD86p6dfcBXssaXGiwzKxyZ2ljDLnof3RVz9iaJTqXobgcfE4+ki7SrqE5+x/eemYW0nUbWOxu5475lDmIXgZwM9omlJI9VD49KVuM+C7aaxa3hNxJDGhBWQEmLfZQfmIHlvjzpE0XVOALGf3TSeKksLkqEktru8uAAx6fBK24PpmmmObiaBDe2s1rLCrcwlhuo5RsP4TyHp2y3TamrrV1KYZflzMxaH01mVOPjxPO/HWhe5SFo7lnYEqCvzMPItuGGexwayjU9QeIyRrK7XELLIhmUrKHXo38LHsT+IdR3r0h7T+H7K6WfVb7TTHPOoaRra3KnmAPxNj5e3Y1541mwkWQA2UcrpKWhbxjzSEbkA5wcj9TSejIDFW8J0m/vaQwmqex/iy0n8BbuM2avA8AwcoGfGcEjKgNgZ3wQofYhhsOoa89nbzTzlriLKW9yF7AEczFfQNn1U98bebvZ/puhywS6lpepeBeQyJL7vIzYI3BjyvwsrdASqspDK2+M6lacRCW4IvllKzwNF8Q/dzxlcHcbBgcffnwcNRrQASq8TKsry27rNJ126u9O12a+tpFNtfwePb4XmDTIpLKR3PKGOOp5cdRS9bcYafeaxFAwMJ1Eq0Ds+0Ejg5QkdV5lb1BGe+KqtqUd5wfEouFW4t5EMEoc4YhlGd91fIH+/jsSKynWNVvtBvGWAbrPb3dueXEYLZYrt5lCP/ABoG3efZk0oGGG6jibHo/EUtvPczxhld4veYgi5/6RGDHcW7fXwwV33L/wCKnVPdFtLnSHMMtvLao0RO5MAJcqhH8Pi86+mf4a8/W/GTLq117vJNFdQXTXEcBchZA6Bih+pQEf4ga1Ph3X5L8QW1vexD3aVbW2Zmx4clxGxhLEduZFTP+IZ+aibPBoOxSvI9eUNWFs2qQyLNyLdPJbTw5ccrs6lZAP8ACXRsf95v1r9apBY6dpFrDbB4733uD96TzgomShJ35uXYZ/h9KCx64Ybu3ujarEYZL0NE/wA0TLAJQnquM48jEwpqvrgeEZUiR2tAroyuCwmSQqJAvcMmx8wp86VKbDDFiwAPrw/uX9DWM2cWlvI8rpA7QOF3KZ50ZcbZzLjpjDkdqYNUs/gjuhyeLaSRtGAccwADjr02Ykdug9KU4WOlNa3txBKn7KljWVl3YwvEEEg6ZxybjvyetP1xHY6gzrb3MbySc0MlvGeXJK86lcj/ABbZ23G5BrzpuQt5Qedrg+cWbDR7OG5W0s71Y4be595tnZSVjUqOZD/h5WQd9gD2p30HT7gusbwqyvIHCZ5uSXl5HQ+hyMEbUnOEsr9w6h4Ut0XcchKAlV79eXK47cuK0vhi3PuNskLkgIgVmJLLy+eeuxwT3GPKi9lsrWFSIPtFWVQ+esWNQjfSNECJI8kdsEQFwSSvidDn8QB/T0rzF7dta5ltLaBiqI8qu+cMo7HHYA5375r2Xxho9rqVjJCsIJuVYSrn8WMfXIOOleIPaPoerQ8XS6FqlsjQXF6kUHI+c9cLt+LAPw/XrTV1YGoG7oohOzHC1tYPzTEND0u61fWZbtwq+KVSBZQSqKDhV+u+T6k1puiWr2ZZ76YQx20nJ8UmArE/KVOcjYHJ+1calwpLZypqMNqSiEyvleVw2NiADv06YqQGNrWMrIolLFlCIGySP4fL1Oe9Wst/FruWZ1r923WVOMdE1zU4rbjHga8t/wDaTTLdoFgYLItzC2eZBk4YjO23UjG1ffYrxhqVv7LLbR79ZBJpFxPYBJSqFCpz4bDqoAPQ1DeX9zbX00pCoLcq9uYHx8JXGVI38j9BSVqHEMmoaxeWWiQzXF5qc8k5WIZknlOAXIHbbdjsMdaaqt1VukXQMcqDuHu93w8fjEk0tBvbUePT4yXj3ieV5n/dh7mU+DGkYLFyx+FVzknJI29afPZTwTqfD2nNoHu3NrGpyLPqroctBHjKwg9dgSWI2yT5VX9mXst1CPUI9YlaG61mT92l0CHt9N7MYQSBNKBkc4yqnZcnJr03wjwfpOhxRgyoXIzJzHld27s/dj9sDtVtf2gtFf4bTnnxPl7hNrQaTuT+I1A5/wCK/c+UvcH6BFo+kwlGWC3UAIc5Lei9BjzI+5o5qnEX7E08v4YhUZIknjLEkDry4G3kMD7DqO1biGCyJlSe3t1jQg3IBaTlB3KjB5VHr8RPRaz2TXTxhcAQyuIUPMJ71m52VTu/IMgDOMZ6E9Mmuaazu+F5M0a6W1Ld5Z0lo/7T8SsRcXlwlq/xyo8oTKbk5C5JJz3PTyzWg8KabDpqLDP40jpjl+H4jg7DfZQPL88UO0e0FhYpJGZLaKOPxXkaLmklkz8+MbADpkHfoM4o3aRNe3MYurp4YEUSqjHlZ89ByZyfv+gGKiurJB6mXv1IYbBwsdYWi1BS0lrFEhTCSMTIc58xsfzxUlnayW55IJ48qOZ2XHTywO9V7S7s0jCXEs8jKMEREuQfInOOb07VzcaqkN5+y7S5mUOcvBEy84J7MQK0Nqg7jMwMx9lYftY75lDJyNE3R/XvtQ7U+FoL53e5UyZz0G2aNWdhdGFQ+I1A3APf69TV2NZljEPKFX6U4agQAwifelGJUzL5uGGtpm5bfkRTkH0qW/mji09oVYE8pHWnrWbFpYGVvhB8utJV5p8UMbqNwN8mgNSE4WMC03qQ0xHjHTJtRgurYRbMpIPrQD2fXvvHDUlldXWbzTZWidSRnlB2/Q/pTxxZKIrh08UAeQrFml/2N9oQvwXay1wiCRc7B8HB/Pb70HsxBb33Z5//AGDj/wD0On0nN6te6YW/9Tz8D/eIi/2jVs0470zUZ1JcaQEiDEFTJ4/wkjrgK0g8t6YP7OXs/wBFg5uKwhNxgKCHyMZ6YpO/tTXCH2k6LpsYKrY6QjSNn/0khIz+VaX/AGfbq3HDUghcsQRkHtW9rVs0/wDjKVngggH4ZJxFBg6zjy+wm1Xdxi1Y53xSBFIDxRbOCPmI+1Nd3d4tHIONqRYJ1PFFsQQMEjGetcf2cmUf4TQcTY4ZhyqM9q6u7tYLdnJwMVQhnBAOe1CeKNVS2s2UyYJFRp6y7gCeK5ivrF811fFVbOW6VoXCVkLOxU43I/Wsw4cjfUtWGQSoPNj77frWx2UYggSMdhWiP9l2B0EpYMACXgcD712Mmol3xUqDsK1qVxBYnXTvXJya6A7V+IxmtFFkbfKDtUtFubZkYdtqzvwTp2p8oyMmtRdAVI86RuJbMxXJlVehz0p2oeEsB4Q1Bie2GCDt1qjcRDJqbQJS9uqHdgMVYu4cM2Ns1e9Ohl6x4RN4kIS1ZcjJFZZq0fM7Mex7itP4nYMCPvSFf2/isRjOTikCOYyBxiBtB0r3u75zHkCnF7DlTAXoKtcN6QIrcy+Hgtv0onPa9cL9M70lcCxlwcRVnsucHbr6UralYtFKcH16VpElnnOR+VAte0vnj8QJvjrS1RNb7vCCsijaI0yhG7ZztRW3tyyMhHbPSq8EBhlzRq0h5wGPU9qevHepkRQZByIKNqfLevhtDjfajz2RD/Lv1rj3Eb/Dn61i5IMZU5g/iNAVYHpjfasi4kYrI4RcHvjtWw8RDdsnNZHxPyI7kDJwTW32YczBu90pcG3tta6zHJOcKD/FjatO4hniuVgukVWhHVgcisHWd0vlcvyID2O9bRot5p2scM+6wXP7yNOnNk/Wmu2KDXsvHhNfsC8MTV0zJr3Q4dStg9q2Dy7d6SdX4dvYcqYw/wBRvR3S+Mhpdx+z78ZRSRkCjt7cWeoIrwkSKwyO+PyoQsXaGE3lLI2xpkE2i3hm/dohGc1NDoqiUC7Ux5OxRTt9T2FNes2ywMcLjuBQZLe7umxb7MNs5qjXEjJOI2tankCX7LTpJAsMZtJUQ7eG/hMv1z1+tT6jomoRJiE+MG6cjAkfcV9tNNaEE30oCj5iV/0qxJPpMMfhWeoi3mwQCSQP9Kz3tJbiMCsCL8ScR2EnPasUkB5gHPhP/oRRmHWJGZTqfD0lxLJ/eFFDAnucDI/Wq1xNNO3Nc20N6mMB492+xzUEEGmvP/0e81GA9o8MB+lVOH6iW27OI46ZpNzcTJc2+gB4cjleG78J07bo5AH60aPAcLye96lomjozkOEkm8V3HY/MoJ/Ogmg32s2ye7aNp+olsjJS3MjP6jBPL9cUettKlY+Jr4e0dPmjmmLuwPblVwf/AIjj0pNiwPB9fOVOesuWy2dlImn2trHzy7BY5xECR/hiOaLW/CmhXXM2o6XYmQDJws0xQjoMrIcnJ6Ej1rnSvdrbMNjodxZRHdWULuuOpUcpb6seXfqaZoRxTPbibTLc2sYUiOfUYUOfUR8y/mWIoe5vOCZgDwZFo2n6vpspj0W2LQ/IRzXUYCDf4hK/Km9HrGz0ucCXiLhvRElKkSOlxHI7DtkKy4+uTQhJdRSJkbjHTmKkBuVpIpHc9SPAk2I+oqxHd663LLFeam8KgK1y95NDChB3JJR3Y/U96uhzyTBszHn69DGaw0XhW5hMWkS/s2ddkjj1YiOX/CVlLpv3+DrRWLhcyMbiwsZrWd9zJaS2zYx2YwSISPqm++9J0Wrx3Msdn/tFOxRWzBNbxzq++zAyKr4HmrD86Lw6/o0MY8aTUofEXAKePJCxHcBiwX6nNNo6cAj7RZ0tHQn9cmXNa0eYRtJq9nJKwO11EskUm3U5UdfqrD1rEeNPZ1YancyXenxqHOfi3CTEndXVdkbycAb9VFaXqPHkdnzrLpPEHJFs15YQLcxxD+J4g78o+nL54pd1b2m8PRtzT3FneRtgrMyeFIreXLklR92Ge3aqWJk7lHr7xjTG1OkxvSuCrzTeIJbW3lZbvJPhS4UTpjDRk7BiPhIYbggZGMEaZZWNvqOjSK0RZA+ZoCPitpcckhUdviCsR5nyIqjfa3wzxAiXEMq3FuqvNzcyiaDA+LcEZZdj6j9L+j6lFDcS3NtKks8kKtMwJZZznlDEdiRlTjzwQCBUbyTh+sParEZHWc8PwyQWt3YXtuZrS5WYXMIzkFowCynyIwwI3DKrdzSzxlpC3yRxeJzSrboRKT87eISB9QSfsPWn/To7eeEyQAtbqTAGbZlQFsAnODgM6k+npVObh+31FvdcFZYky7dcER8zZPkOYfc1OQBkQAsxYc8TGNftnbVbZowAiIsbfhdl+IhfTlZW++aZ+D+ILj321uoZnDosaXSjBDxr8SHGeocgfUCofaloUdoyXcCnMcjhgoxh1YjA9CzN+dKXDNxdTXF6sEoRGtJEjCsMg4C83pkqDijAAp8IcNuXjxnpnQr+y4jX9rpb83v5ljmCDlLSyR4QgHcEsrKe2Jc9qIWzoNPtZYHcX9vctNChAT3m393DFmHb5myB0JNZnwRfahLaTz2RYTyRWk8Q6eGwZsvjyBMh+grSLG7ntJbAiVZo9PNxKC0YZvikB5MDqu4xv+Nh0xSrICcLBZK+vdHrTLK11nS5NNmuf3NxBm2mjAZ7aPnccyjG/IXXI/wtjrTCbXk06YmCKC7iMT5hl5QAzcrRhj+AnDIfwnKnYilzg2z03UuFbHw57iIpzQCSKMq8alyObA7AKNx5AmnCwhgvbTMNwlzLbz8zpEVAkhJHMyjm5SvNuV28sKRVVrFqdM+v3HWDdjXZ+vr5ytrOj3LXDh0aEyNEfEROYE9yR2UnB8hk+dE+AuIzZ8tlq4KSQEcrD4Tyf5e+DkY7fQirDPaWsQtiJQk0gAMWcoT3IO6Y65HwlSOu9Qz6BCWS6hSXlLvFIrqPhB3yDtlc/cbHzpIltNd3lfURobb6u7s6R21I20li0tvKvLMOeLBB3H5jPmP5dK8le2XTL/UrtLzQIPer7TpZru6tDB4khiRQpkUr8rBm2PzHqK9Az6rGlu0MjcizgcyfKwYjBYjsemfP86Rbm+fSuJbfVYL9rOYxGJwrArKwyUJGN8nlA32z0rRXtGt9QpK/39oOjSNVU49089aNx5oWuwL+2PDDKedrhVw8WwHxRjBfc7kYPfFLnFtrZW8s1noNxJdSlTG0dlE7Agt1bAwAOxNbCLTQNEhvLu1tLZWiRp7iQKnNz55tjnphsYz3+tBtH4gtNVvDbmGeEuWCStF+7YkZILK2B/vYoBtr0rF6umTx16Rheyl1fL5wPXvmTaP7MuOuK0jku7hLK3h2MwXmmVcDbJ2GM9gfKn/hP2RcNcNK4Lvcu7f9KRCPElIJ5fELnmdQcHlJVemBWj2MtrlPGgg5YgVjLqMEnsT2+9cX73wVYw9wiE5ARl3Hpk9PWl7e1rrhtHA93H9xins6jTN7A/U8n18JPp40q0SOG1s4o0ADYGDIfIEdR9BtUuo8cQ6dbzWlhHLdyhSWiiAUZ8mx1PoTgdSDS5rGoambBobaWG3DKR4gfLsPJiOn69KH6TaXFwrRP4i2y45rrky0gBwVihUZ2Yj4nJyQcLtSZO7npGO6Vvac5lzVH1DWpIzrN8lvzlAbaPDvgbqpOct/lHKoG5B6A3wwunaasjWWn3NzcFlQPyrsSSFCA432PxHAG5HnQ630OC0jlmaCWGzlwoxIvjyjpl5TsoJJ2X174pgstQtFRBZ6eBDbsD4caFRIxHygblzj9Ou1QpUNnMs7MybQOPdwJPqusXumaY2qMiLzyjlKH4R3CpnZifPfOOpqtwzxJdpHJfzXCRyuSxL5O38IJ36eQJ8qu3fDHFnF19FcyiG2i5S/PJIqrAp2zznJZvMqNzsMACmnh/2OQLJ415czzxsApeRPDMhHUgtg8voNqPXTda3+scRZrtNRXiwjPu5/SLV5xlqmoyPZaXBK6qAsksahREB/iJ2/OtB9lWgTSAXcoWNhvy/Ox9TjYfejdn7OuHIAokDzSD4mji6DzPwnCj6YPqaedCgsNPiS2tbdCO6qMKv5bVraLs63vBZaZk6ztKrujXSMSreTXRfw4FXAOC30qSOToiqQf4qocQcWw2EjQRG254zuFOcf0FAo+Nonk5ZLiMtjZV3NOX3ojlQYhVQ9i7sRqu3VgfEyxx0xSVxHNFbQyMY8ZBwOpNNNnqCX0QcIM46mg/EsEcsfhrEOZu5qBWLRkSVY1E5mC6vpF/rl+zQRkJnriher+ybUdStFkNqzmFg6465B869AaHw3A7BnRevlTtZaFZBAhjX8qHpuzlW4W7uQciI2nIORnM/nT7YPYvxhxTr2ocVvpzqrWNvbBMEsBG5JP61a9h/Dt7w9pV5ZXUbI/OHZWUjl3IH6Yr+h15wTp17CUaFWU5ztWc8Q+yXTY5JZLW0ROY5PKMZroO0NK+s0TV5zkgxNTXvBxgzz1qF34VnIc7gVn8F+p4ntiCBgkGvUR9ldoyFXt1PN12qhJ7GtFllWVtPi506Ny71g6Dse6pGHGTDW21gdYmQXWYwzHtSNxzq4kk91R/i6da1LizhFdBtHngdl5R8hORXnrijUwb8O7czFgo37k4oOn7Lu0znevTpCVur4KniaZ7NLLmj98cZ5t9/IdK0yJ87UmcErHHpETRgYdR+VNsMucdx6UOjTsp9rrIPtHMIRnNTruKpxuT2q3G29a9VWIMiSgbCvpG1fVH6195c9qdRJGJEy57dKXuJrMuniKu+PKmXk8qoavbCW2ZcbimVGJIEVtAcI3JtRrUsLF4nYigVmvu91y4wM0V1S5BsSo6gUawbkzLAe1xETWz4kjdh0oHBp7XV0qKnU7mj96hdie/Sr3Duk8z+My/Q0gy+cP05k9vYiC3Vcb43qKS1z9Btij0lsANqqyW2dwOnnS7pmSD4QJJab9Pzqje6essLKU3FMb2xBwO1Qvbg9qTeuUPPEy66sDDcMMHbPaiGnwnAycY8qLa9pfhzeIF6/rVW0QjAI7/nR6faXBgCueku+6c8eQK4FmB0WitlECnKe9TNakMF5aR1NG1siFryZnWvEFWOelZJxOAZCWHXOa1PiCUcrkbnf+VZVxQ3OGddx32p7s1SCJztxGIiXiq0pRQfX0p99mSxWszJPcYR1wRzCs51GVkc4bl3q3oeoe7yiQ3DE/XArotZQ1+nKg9Z7QagU3BiPtG/jW1aPUZJLZGMZbIOKF6TxBqGlt8UjsOgGdqbtKEHENm0apzSoOuck0patA9ndNH4AJBwDXL1k0nuWHSd7VYmpUWKesNjiCfUMCSFZObbOOlErCCOaNizCFsZ5Q21K+nRvNhjbsQO+TtRlLUyoea1lYnurb0vc3OJoUqZde1gTmHvM84HzIOmKHPaxvn3CymXB3aVM4+mRioi0S3IVjdQAkA5bBP3zVu41O0tysUOqysM4dVxj7sc1VczxweTP1raXGCkl7HCQduSPB9PPNGNKn0+2cE3t00hOB4rsoz5BQN/yodpl0b9/3F4rRofwxBz+eMmj1u18mY7W6uZmTflVFRQfVmx+poNpBODJXIHEP218dSmNvaWl/ceDhfDSVgCPQJ2+ozRq20sQvHJPpwsV2KW7/DLIx3zg5cD1Kr6ZoLpup3kbqtxxDMHcgGG2YJGfJXkHX6AH0pht9c4f0VxPd3k1xeROWWCzRY1Vu3M53P1Y9s7Ur4wLhh0h6x07UVRbiKyewf5mMao7H/EzzcxUeuAdtsdahvL+1RwjKt0ytgKshAUgdZZpDue+FX6E0IueLb/UrGVtavrbSNNUZ/eSyTzyKd883MqjP1/Os/4t9r2laDb+6aBbW0bw4DThSoU9twAzsfIY9c1dK2sbbWM/CDSvA3WHEfNQ4h1pFU2Oo3EUikt7w07rH13/ABHAx0LlfROlIHEXtp0jSZWaea1v59+Yq6tluxJCKAdzkYrD+NPaTr/EjCK+1Se4LOWSJn+BSe5Ubfbp9etLyWh8MSXLNJIxzk7n7eVbVHY2AG1B6+A/mK29qV1kpQuSPE9PlNUuv7Qt/wAzG2snLEZyb2dlLfxcuQOmw7UqX/td4qupmeLUL+35yciC4ZBv6ZpXjsec87AjG+4FXIrNWGTGjkfEN/mrTXQ6SrkJn4zObtPVueGx8AJePtG4nlBV9V1gqx3zekc36b0Pn4nuJGJujd7nfNwDv96K+xzQ9K4r47tOGeI7yW3024eR3EZHO7LuI1Y/LzdMjcdt69r8O8F8N6Xrur8PLw1po0poLJktXsUaFEMRVgQQc7xZOSSTknvW7pux1cByFUHge/5THu7btXI3MSPCeGrDi68sJRJbajMjDB5ZRjcdDkbfnTpontf1DTJPfJDmTlYMuwjIK4JAG3YZpw/tK8Aey/Stdij9nWlrZXiQudSgtZCbNJeYcoRTnlJXJIUgZxtWIro0kauELEAbgdMd6ytVpNPvNb4yPKaGl7TvKBx0PnPUfBPtFs9b0h2luB4ck6MwO2cEgnHbYtnzBBrV9Mtkvbh5S5MLjll5duY4zkH1+H9K8F6Vrdzp0wjt52XlYZUMRuOn1r1X7KfaTa31nBp6yKJ2Q+IPiLIgVAzH6gYGOhWsHV6M6Y7hys2a711SZX80a/aPpAvuG79IXVbhImnLg7krIpA/Pf1rANOjuNMuJPBixPIbiAgnLEBgyH03BX6CvS+umxl0m8tXdAvKpkCjBwrq3KPMY5s1g3gxPxJeW/MIml5pio3WJXJYkHscjp2zSqPyRG6F/wBfM0Pg25NqxhacyBBJDNNJnAiZ+RVC/XP2XPetQj0dGsG/Z5lUiMNHyt1BOH+pwg+mayThO7SLVoY5oZ/FiCyeAX+FGY5XmPohXz7nrWw2d282k3MCSo0sCyMJElVGZN+ZgWOMZO1A70BsGetrYYIjRwFqV7a3k+nNrdxbiOOBY4Qpl/7MFn5VCsCCBupwBjzrR5+eaaGc2UBuIXDpduwgkJJ3VlLEjO3zdR2rG+GDdQSzXnK93JC+FVYOVkGQCMk/Ec4I7bA+lanoVxHFbJaLMq+PmXxkhUsw/hJXbbc/XagUPyVA9frxIvrxhvX8/OElkcgWdxJDGplPhh3JKD+EMoIx9MdK6STUtPdrW4jyknyvhmDpnIO2wwc4PrUU8/uSQ8lqrCQ4BKoCmwyX68x2PTz9Kln1ARxCS4jMfirmPDY3I7LnA386rcrHOTzLVHjgcStrmjJqh8WF5I3HyuHBOMjb1ORnB6ZrIOIrfWNL1FoNQDyrbsTGwzjDHIJHUbBsj09K1+wvOXxbK4jkaZ3DifGeV8ZA2JHTOdvOqOvadFrljcWqvFHd+EVhfIPNzDJI+v8Az0rKsTLbh1mrp7jV7LciedLqC/uNZuGtOX3O5UNJJ4oeQZIU80ZXD4GRvtgjNV7fhN0kZBapAiKAskEjK2zbYX5cY3x0HSmnWdKvdAuB7wVe5CqGSQEtjoBkdslMef16XNM1G0Fw0AhnsTHtIFlbDjGOZRISPXpSrXN0M2hhV3Vxe0/QpMiObUkijDhR4zKHO/qRv9KZp7OxslWM2/vcrYBdpeWMY81BGcd9znypkjt9L1OJPD1eBJSAJBcScjqQMANhSN/sDQa84f1C2YQxQwXKk8rEtjnXG3L8IB+wb86NXYfAZmba3eN7RxFr3zlvlXwormUnmQLkBCD1wqkk+ijOw3AyaIgMlusVyrCWVT46nl/dL2DkbA4wOXJ64wTk0Uj0fUrK8NxqGmJY8q4jijlYZ26MScjPoCT6VZuWhtxHLL4Vs0jZgCW/NyP35FYgs47sQoFW9o9ZTegICj1+kgtNNu7pRczcyRQgYe6TkBbbpH1GAP1Ge1OXD+jaWJY47i2dxIAVWUnnmzgnmCj5TgYRdio3yKAQRI4SRro+DbOshlnTxJC+TgKD8AOc4LKcbtud6bhdR6ZavaWyFtRnTxTHHG09wUPxfG7/AAx5/jkYHHRdhTWmpDNuPhEtVccYEabVXeVIUtbSFBvNO48SVttgu/mMALyqAOtGg6yxS+7tDEXXEspjWSQdvmOI4+vRQx/nWZWOpail+09xJFcuoIYiNnjh22VScKcdc/Ec5PKOtfuIfaTovDlkl3d3kkkszcluG5mknYD/ALOPv6k8qjb0req1NQTn1690w7dNYzgLzNEWWHTo3jbUYWXIzLM/MgHoAAM/XFV9S4wit7V7PRwt7O23KoxkY6tn5R9aw1OP+L+LLpLeygNlaRnlDzP4s2/foET7ZNaXp2lrplisUcMsskwy55z8TeZJqadW+pJSoYA8Ze7RLpQGt5Pl/MDaraarqJebU9SSFfmKQgKiKOwpet9XWG6930yNpMHDTnfP0px1LhrVtTtzHPFKEYY8GIlFx6nqfzqpLwjLparb2ttGDyjOO39TS2o0pXLL184zp9WGGG6eUbOEtWIt1EhBPU0Q1C6W7uAM9KTbDxdNHLNJjlG9fl4liWVmMoxnzo9LlKgG6xPUANYSs0fTWijQbgUZgvo0GzCshm49t7f4TOB96ks+P0nOElBo1esqq/MeYA6aywZAm1wasiLuw6VQ1PU7d1IIU5rPYuK3kX+82I86rXfETt0fr61pDtRNmBEzoju5jVcapbx/KF6UMl1uNGY+GhA9KTr/AFpkBZpCPvS1d8UFXKiY5+tKp2kwbKy7aFXEN8eX1rfWUqRthiMcp715r17gK4uLz3ogqokL5xtW4NfxXpAlPMTviq2o2Nv4JIA/0pwao2HJgxpxSuBFbg26kS0FrKMeEAg36042zEkHGNqRluYtP1IogwM4A7U2WF0sqBlI375oHdDdme/KIchc5q9CaFwSZA9avwP2J+lNIsqeYQTHl+tShAarxuewqyhzjNMKJTE/Fc7A1HcQ+JEwA7VZVc9TX5kHKc7VfEtiZ/qaizlaQ7EUJi1lLmfwy4IO3WrvH90LSGVlzkAmsi0LiYy6m0OSW5sUdPaHMsB0mlvbeNOIoxnem7TdO91tV23I60M4Rszct7xMBv0+nnTe8IUAKNu1JsvMuW3cQPJbgdAetVngNGJYcZ2qu8GdsUArmezA7W5B6VEYMn5aLPD12qIwelDZAZBMXNW05biHLDcUsR25ik5WG4NaLJbBwVYZBGCKVdSsPAueYL1Pl3oSrtaeIzOLJCME0U8HxEDYP1qhaKSQMfajdmnOvL1xV7q96yFGDMC16bAbGTnPXoazHiOT5/Udq0TiEsckZG5GxrL+I5GZmG/rXuzQDOWZ+Ij6o5LnBqlp8wNwqvzYJq3fKXcjI9aJcK6baS3sRniV/i/KutytdXMUrVnfAmp+zfT28BpoyyDl/hOMUP4kgU30g5FYk55sVqljb2NjwoPdIsHkGNtzWY37mW6Z2jYknvXAau/vdSzAT6R2XpzVpwDBCxTRxbuyjrgYxXQurhF5ku2BXy7VJeakIHxNEzAYHy7UMuNWE8nLyBUPVQKGqFvCa27HGZcae2uV5764Tbc5Usf9KtwDhy4Phx28l0wHNhV5VHp9aHWNlc6jIy2dthAN2cDApjs4rbT4/DkuFeRz8UcYAwfU9Kq5C8AyFBbr0lmy0u2eMFLFoiT8uQfpsKuwJBHDJGkMbMg3jEeM488nP51Wm1i5hj8T3a2RFG2X+Egd/rS3e8ZqwdGZIkXfw4ByIf8AMRu35igCt7DxL5AOBGWTiD3IeJDG0COeVHji3Pnyk9x0zQm/4sFk5XTbB5Lldkur3LmLO/wIcjPrjPpShecbX11KIbSedEb4FSAdv6D6VNa2t3eXEfjycniMPhkYgn6dz9f0ppNNsGXEEW3dJHqF9rOq3xk1C7eW4JzzSS5b8t+Wqk3CF9fwSXMg5goyA22x7jI2rQdA4VuJ5UtLdi7BiXWGLEceP4pj1PXIGSemK0NOERaabJJHZ3N082AOSIBvIjDYKqPoOlHr1PdkbBF7K1cbXnknXOHX02e3vVhPhswRvLJ6USv4TyKY0ZQem2/rWz8U+zy4ureXT7+1aOO4XmX4cEE77fTbfpWWy6DdwO+k6tG8d5AMAN0lUdHUnse/ka1vxItCsT0mPbpDUTjxlKxthzy8uAU2QMM82CAfyzRePSVNnDIkTNlsMWPoTsPt9aDi5ki1MShOVGYc22wPfb9frTIb1TCgdIpIoj8EiKVw52Pw99ulWsGeYquegmba4L/hbXEexupbO5jPjwzQScrL5YYdDtXqbQvbLqPGHDdpdRaYYLuTSYbO4lW4OZZ1Zz4wDZxnn6E+ZzWDcRWNjxKpgkK29win3eY7gkZ2OPOmrgiIWXDdpbeOIZ4IQs5zj95uTjzwO9MajtW0aQVIcHPI/Tr9pnNoQtneMOPXELcXxpBAk0iM3OrACaTmycD4gfLrsPSktY1W1mEkLMuARvyqfr570y69f2lyIo5dTupQg5VDfGFGM9e22+BSpqF7aQ2gildppZSQiKASD22O4H+tI0qe7wRzDAbnGDFG6a1ayvAbeFp3vYXSUt8aKBJzKozupyuTjso7008I6/c6Q6XLOyFRg9sjrvVzTOCLaKL33VIxLNLylEPyJ5f8mqF1pdvLbzGxWdmSUIcAY9OXG5NO3WV21BT0mnpqrdPYXPU+E2/Q/aZFxDpru1xICNyhbCyAnff7H7H8lO31oSa1eX9zFPJLccvMoCgmMAfCfqQc+lZ3p93PpAFphUbxQrKANzuN9+xOfrTdwutwtyZUaNZHlLB23xvy4yfUb1zz6UUMzDpOkSwWoB4+M1fhicXytK9sSt7KY0uNmxhyS+O+QR9eUVq3C+pWSiQKJvDkhUCWZFJiVg0eOUnpy5z1zvtWCw6mLK2a1hSSErHKpXm5QwyAvKB1JGT960fgC5v7W0EkF7HLBBEyNDP8RVm+JQW3z1+nQVmtWwbcIZwGSaal9FZRqvvcNxzOP3kYJXwyQAyDG3TJHXbHatA0C4Sa5kl00iNo5WjT8SkhQSOXp1yR9ayTS2trG5tI7Jz4E5RolJ5kOSQcj8JBI/M0+6HqFtZySTRGTxd5HOccxYDmIA2yMZH3q1NJJ3HiLXNxgc+vKas8NneafJCickzcryDqRsAd+m+TkUH1hbgMiBxJLKFh5unIMZyoA79DU1vIWsRHZRchZGlQFjzF/IZ7Hc1VbUbi8uo7NZiHRQrM2VOBjIxnfbNNaqrjb0iunY5zF7UrpraBb+aPxJeZMFyeUE9cYO2PTerrT+/Wy28jtB8JaOSPLAMPLO4orNImoGWzv4o2hUOYQm6qSQcY7VFb6fKJXcxlUQAYBIAGPXtWDqtKUOVOfXM2Kbwy+0MGAr+1h1Im5vbNI7pFHJJjLNKFAU+WAu4/zUgapw17rcvOjNLcLzLI7AIvzHO5AJ9MHOPrWpuIHna3d05YzzRsy5yCR5bnbA+gqhq+jXUkKyzXsbQAAxotsZJn7HJY8qD0AJ260myB1zGqrjS/EUNCvtRtkIjKtyn4TJHkKD3+IZxt2Y0YvdSjuLc2rzwIwbIEQ5FJP4lxhyfocVTudOsLTwhp1ldhhj92shKSHvlFOxJz6VNCk9lmG3AilkxyiZQrqeuyBiSO3XahBSnEvYUsO7Emfh7UwyPDBDyy4OHuAjMCPnfJYsCO2/0qePSyt1/0026xBgSgdXEm5zzF0ARMAAKFJJ7d6507T7dLiS69wtpJmcI0py7SNk8wJXfy70Yt7a3lk99eysYZQpKRHxE8Mj8T/wAOO2GyfTenKiDyfX0iVuRwPX1kqWlvcRwvOyRQRjKkjEvIu58NcpFAN8s7DJPY9KGnR4by7lSzt7qSHr4CNJLzg7lstjxDjHxNyKB2Owo1a6PrmqXTzTXkc8JBjCxxkAbZAjVgST58vTq2avT2TojLDbOJCoZ7iZWbG2xO45u2B3PatWpDZjAmZZb3WeYr65qNtp1uLDTY7iEyY5kRPFkOCcggDI6EE5A7AdSFma6h13VDaWnDJuZlAjaa7VOUZ6gIme/mx6dKc73R5GgaFZrtELZklunCzMD25V2QdNl39R0qbh7SoNHjU2yBCBjndcu30G+BTA0dmofDdPXSLfjEoXKjLS/wvwlHp0CTXFpAZQeZFW3WNIz5KBR+5vYLLEtwltER3kbLH7VDbNeToqRSMUO7EnlAqnqyaXFjNu09ydlVVLsx+wJrVNFdFWKREO9e+zNphmz1hb08pv2YDYHlwPtVDXHFsjSxF5Cd+Y1TsHu4V5zBFGR0jTt/mb+g/Oh3Ed1NJblpJCoA+VNqGXJq9ocydoD8HiJHFnEb2MUnNJhjnOKzubjVl5lExz9are0fWyJmgSTvg1nlo9zdXDAE4NZpJM2KalxkxsuuLLu7uORHOM+dNnDWszKqtI5x60l6borJ+8dTkedFRexadHgtjypFqwzZjzWIte0CarbcQEgfvBRGHUvF35sn61jtpxOssgRXxv51ofD7vcxK4O9TY5XCiZ/cj8xljXtQdEJ5jSxaWWoalcl91Qb5p3udDW8XL9aN6Fw9BHEByjNP6Ok2NzKW2LUnHWKVroVxEFYlzjzo1FoclwAHUmnE6TbqnLgZq9Y6dEmOYDFNFdlmB0i27emYl23s9iuWEhtgSf8ADRVPZ+Y4sJZ9P8NaRpos4VAZelG4bmwYBQyg+tb2nrV1mBqLnRziYNf8PTaefldcfhYVVhYq3K2xBrctdsbO6gbxIo3BHkKyjiHRUsZWntgTHndfL1+lEek18jpL06gWcEcylE3r6VchI2zQ2BugHSiMGCBtVVh8cy9EoxjvXN26wwMzEZxUkRAXmO3nQLXdQDt4KHI86J4SMZOJnPtDllmtZ2RSSQQKyngjQrl9YMzrkc2elbFxPavcweAqcxfbpXHDvCyWHLI0YDMc9KuvHAhTgDEcuF7ApbJhMDG9HZIh22rjRI1S38MDcbbVeeLqcVRkgw0GPF12qB4cnbPpRN4vTNRNEM+tCKyMwW8G2SN/KozBnfFEmhOcAD8s1yYfShlZG7iDDbnPShOtaaZIy4Xcb00GDfptUU9oJYipWhsmRPbsRAgjKNylf0oxbDkXmPlXy6sTBMTjvUc1x4EJHeiVru4lifETzxxC2RIMjJNZbxGMMw671pfEMikELncedZpr3xeIeu/lS3Zo5E48vnmId7zlyIyQaKcJ2l2uoxubhFyRsTv18qH3sTGTbAzV3QVVLqJ/eGyW3UGupsP+qRpwTYJ6gtIscJKok5zyZ3A8ulZlqRMMzPzZc52NaVo/hScIRFAw/d4wTv09azTXFiS5kDqWJ67182fJvafTtEf9IIi5qLNL8c1wFGNgGoUqLPKBGPhHViR/WptRGXKhjgdjQ9niDjnUkA7g9K0q14jDPnmGhqNppQH71nZzjPPnH07VBd6jEzc4fGSNzsd6CzTpLPzgJydgxqpqVy/hkRhFHQ43oiacMcwbX4En1TXmJ8OGQkDplsj7UJt2uNSnEOWbmOw+VR9WNUAJriTlQDPmBTFoFoVkX3hUUd/EyPyAyTThrWlc+MTW1rW90PcNcGNcyc8t+i8uPhiiaRmIOceWPqRWvaBwjGMRpAlu6rkv4CvNJ6cozgfUgUv8OyTRQq+jac7kLhmIWJBnyLEjPrTZo54gZmuJtQjiRl5XaGMzHy3woXPrvmsTUOzn2ukb37RgR30jS9O01FZJA5hJLTHYA4+WPlIHP6jOO5olNHLPGHsLqO1g5s3Ba3EhaM7kgk7HzY7Z86AaZqWl2pS6M8V00agePqNw9zMe3wRrhFHoD9avnV7+9liS2LzczhhJI9vEFPXYOSowP8JPrQA5UgiBGTyfrCw4R0q5sLgPLN4TOrxxPDGNgMfA7Nkk9frSNxT7NdNucx6npT+EFM0M8cymeLH4xy9Bjz69CO1P8V7rkbr73EWQfGZ7iZS2B+IEYH0xgVJZwx3ry+LbNOzsX5FjLJgjqXOBzeufPFFXVvURx698PWoYHceJ5l1z2IavcGSfh3U7bUUyTySEQykjzB2O46gj6Ul6rwZx3owMWrcN6lFGOkiW7OpA2+ZQRXtW54R4e1WHIjlSYbL4UwZk/wA7A8mPQMaFjgi5RFNhrmoRwITkcvwxgdWZ3KjfAxhT12zua0au1UH5lI+HP8GLWdnVWco2Pjx/M8VppuoOsSwaFqbOTyhEtJSSf/hx9KYrDhzi1po5X4fubKE4SSW8It0j9SzkHz/0r1bPwTf3qrbf7WXs3iEsrxyEHl26YAGOu4P38419kXCKxi61iCbU7skyLFduZhkbLlAR3OcE423J3FebtPTk5Ck/T7mDPZfGHsGPd/4J5qsuBtX12eS10xpdWaIrzSW8TG2TJ25pCBkdflz67U3aX7IppvAFxaoWmCmSWRQhVVAbKqOijOPLv3r0ZDZaJpFssFrokcURcSTeGgBLH8WFABLNk8oAAAG21DNf1ezhhubC2iYzhlErIqgRKMZX6hQM/ljqKU1Xaltg2r7I938x3RaKjTtlFyfMzCOMuF4rOC502ydHcuWMjSAlVxjJI6Ejoo6ZHrSI3DMbaNd3k6SYjIjgESsjMmMjYdQBgk7dj61sF9pFyLy4vprJQqxPcPC/WPPR5PI7g8uepGd+mc3k91dX7adHCYUOVLnBUSH4iz9jgAnHy5wOlC0177eDNW6pLGGZmz6VfXutq17DNKLiQt7wIzh5Bg8qsNi22CD18+9NcWbHTpJUSMM8rvFz9QTKCQft/Wjen6XPo6M7Xht7O9lJjjvboILsL8JJ6cjjORjYc25BxkTxt4sVwtulrIJJHPijIJbAAb77ZPqSe9OG7v2C+ES7kUAkQlFqi3E9tbNbzyeFIC5hOHOcFgPtWi8AapdzQ3GmlUktovhWa4fldPjPKGddi3bp0rIdOurpJ0mikcSxRNMkkTchDAbn69ad/ZvMzX8oE0aGSPkIkOCS3RkxtkEjr1FBsqhVbcs3a0tXupIbi0IW3aVZIkGPhJOTnvjrTtoumXVlNEy3KwzAkqnKSArEjGT3G+1LfBdmVRA1xI0efCLcvyg9Tv03GBT9CJYURnIyJy5YjqoHUj0o2l0ws9tvGKX2FTsWHrWeOGS297mZkPVwx5VBO2fLfau7ZojKwCOJNublP4d9ie9LV7ObRobjxlRIhyhlYnKMfiDDv2qlqPEcNoJlhvHIni2DDcPn9KetpQjLDp/EpTp7H/J4zRYbmyaZvEifMfwn4scy9gf9aYbD3a9jeOOJAW2JB/CRjB9awex4xv53ME0hPYEbU48M8SXEXIZZNyfiOetId7S7AEcGOv2dai9Y8a3oMkNu8sWC6kAEDcr2FQaNNbXdv+zruV4rhl8NRhDjHQ75qccQWt5G1tdTDDQseYHocHG4pG4U96ur3mEZlLEA8o+UDpsNztvWVq6VotBqGQeJCK5Qi04I5hziHRQlw8Elg5ul+IzQKuG8iwB8u/TeqTaStvbFFuIZGcZkJgYDftn5mP5D61pB0eLV7FG1FGtWtgViLHZ1I7kEYobNw7PakvDMkOcFgob49ux7fXNK26Ihs44Pr184JNWCu3PT174kppDw45BKYx23Vd+wQAkk+tWrLTH8U3VxNGVTJSMjCJ5BwB8R/wANda5JrkCOmn2EMc0iKjSOHk+E5B+I7j7daraD/tIZYP2jPFgHlCouCq9iCPl+nXrQVREYAZP6ev2hyzshYkQ/bXs8FwA3LzkBEBldJGOdiYVPTOcc5PXJ86OwaQk0TMr5WNj4p5uZi/XdurHPU9B0APUBNMt4jlFUQSFyFHiM8khzuSDvnfocmn3ReHL/AN0ZJrRrMk5AlIB+uDv065710PZam59uMzD7QbulzmJVzo0DS86oYgD8TPjmb6CprXTBzFbCy8Qj5pD8v3J2H3p5m4f0iyOb9pr1ycBII8Lnyydv51JJbahDbLde6aPolmN0nvn8Z/8AcToT/lXNdVToVHX6TnbNSYq2WjXkzgwWstyVG628ZZfu5+AfbNWG0K/u3Nu8trbkLvBC3iOB/i5c/qQK/X3EGieKffb/AFriKRekbObS2P8AuqeYj7j6UP1DiXia7szaaTo8Wn2Q3EVpFhR9SAB9yam1aEHtHPuHX6Znke5jxx8f7lPWbDStFjLT3skrgfJDyqB9WO35ZrJuNuK0EUsFuVjTyDEk/U96m4w124tpHF5dKZO6mQM36bCsv1a/e+kbDcwrldbqwX2VrgTf0unPDOcxQ11JNTvmf4iM0U0LQo48MQMjFWI7NUkOQN/zq2LuO3BX/npWazYmnuJ4WdX7R2cGQRtWa8T69IzsiNjG21M3EWsBYmXm3IJyTWV6xf8AiSM2Qck0aiveeZBbC5h/QNWkN0vNISM+dbxwbrMYtkDtg7E43ry/p2peA6sCBk7b096BxrJbKqK/kOte1GlZjlRJW3cu0z06mrwBNpFqzb8VQw/AsgxWDWvGs0q4Mmx9ambia7I5hKw/rRKAyRexFPUz0PY8RQzMCZB+dMdjqUbgYYGvM+lcY3EMil52A747VqPDXFSTxpzOCSPOmAfayYFkKjiabearJbwl4gCaU7v2h6vYzlUso5Vz3fFWpdVimt9viyPOlPVD4rM6r371q0ucAAzMtUbskR50r2kQX2Le7ie2kO2GOVb6Gqes6jHO3NzZU+tZ20rRn4zykHP0ohbX1xOmJHyoH3p3vWC7TzABFZsrxC8AUseTpmidt0HQUJtMkDJ8h5UTSRYovEbbFUXyhj75JqF8lrbkDqR50ryTGQmRjnyr9qOom6uDhsgV3pds+oXQjAPIpGaJLLwMmX9J0QXkZu5kB8s+Vfb23EUoCrgCm+2tVt7YQKo6b4FAdWg5WPWiquBBbsnM60eTDBD3FGyncDFLemycki7d6aoxzID5irkZErnBlRou4FRtCenWr7R+lRMnYDaqFZ7MomHO+K48IDarxj865MeNumaoUkZlIxb4x3r8Ye2KueHX7w+1UKSMxZ12yAUyD67Vn3EN/wC7qQXxitQ10qICnesV498RY5OTrUoNhyZdDkTHOIJGYHl3+tIGsrlWyTjNO2ryB2bBJ8qTtVXmBwNqS7PGADOLDZOYk30MjtyopJPlRrgrSY3vVN18GSNwvMaoakzeJyoceuaLcKX6Q3SJk5yAWNbuodjpyBHNAFNwJnoW1VbXh9YrbJATDMcZ6VlPEcjCd2ztnbtWhWOrxtpXhAE/DsSev2rNeJZJJp5HxgAkivnqA98cz6Xpz/rEVdQnLOcjfG+O9UcwPCcq2d8sT/Kp7iZ+c5Gx2ofcl8YVMDtmtitfCSzYle5lDSiO3BCd6rXcHxDxJWHffp+VTyJJCAzHBPTArh44lx4z/Ge7Dm/Sm0OBxE35PM70uzsmkUSzzbnBdcCnfTLCyjdBHd3iuDuFRVH5tn9KXtLhtHTFzqCAdeWRRGCP+fSmC1fT0jMllfWoXG+T4g+nTrS95ZjxmWQhOI12up2NnGI4zG7Njn55PD6eeBlj9SBV5NVu4/DcxycrnIdvhGPIFvm+w70l3MtzHJ4okblC/OCFH6DIr7p+uW0Ya2vbu7JkUqTFCABntzMCx+gFItTnkxoEER+hu58ZhvdSiCAhgbhIebsdhnlHT5mWpBe6hpa+8WGoXckuHkVprvnCEgA8ojU53zvt/Wlqxt9SVhLFJY2tupXlXARs9uY8u3r/ADFTrC2r+JzalbC0wWmco8cSYOCBjLOfRDkn86XKkHGflLLg9BD1txAyGJ9X4lvIjn4lW5S0ib/MZmZ8eixZ9c0w2vtB4YzHZNxPbeOhIMdlHc3jHsAFCnmbG+7fas8e04ahhaOygjMkgHMzxyM7467hG5B5AsT51d03RJ25xb39ypeEkRWtuUfOejybBV9FBJob4I9rP7RkImcnibZomvMxaFotVtYEbDtqE8Vryg9OWPJdf94LRyPUuGJj4cpSVGbI5JBc8pwfifw2YL9XZc1hnC2gafYSc9tpr3d0nNzGVnWON++yhmB7/MrHzFMtpq+oWaxWcWkXbyDmAULywxqc7hFOM75JPM3+IUEgLwokd0rHg8zWrrXOH4GFraT8r8gHvDwuMgdFy2FGOvf618t+IXuoAmlW8d2ZCCsqlQpwCMg5yR2zg7+dZjpLe62sjwW8fiOxiV5okkDN0+FFMnM3f4xjpsKIafe2KtHNeWM91HEQvjaleKFLY6IsYWIbdMdP0qhtI5z8pI0y9OT6/SaFdRXsaQm6lhtrkHmSJQMg9CxDEFiM7EDOT2GKE3tjBZTw6ZaQ+ITEzyzyFcjA2UZICDIyx+xx0I2FrdoPe1J00Xp5o4rbYgKc7ugCnz+KQnoOWvt7qml28MsVtbTXFlOB71yL4jzjfCsdyqZ35C3M2csUUgV4HfweJ4VlOBzA+oWyRWP7Publx7y0e6gfvScvkkjHJj5M7EczkYC5wTX7gNe+8afJcRxXLvPmTPxKX22O+Tjm3OcYJxnbbeKBeR6ZJf6yZLSKZGlMUr5ceIAAGc4yxUjIUYAKLkbhcejtyl7aSWt9HC45lLSTBUVQc8kYxknruOvWmqCF5h68tGHg2Oe90KW3h0vUoluVYO/irMFB2ywkUklhnIXIHY9aQeLLNp9VaO8V4fAQJzSFhlk2GMjPQAYPlWqaNpM93ELoQNfSPEPEuJr1jEwxspAUsT16D70mcU6I4jZltyy8/wARlfnZcbbNnmb6Yq1FmLCw8Z6xQQVgLTfd44obhBIGbOMfCrr0xn+L+eBTJwNKougRCrcpMSxP8wxuWP5Uow6n4NuLCRTJC2eVeUqynG+M9jtRLQb2W28S4VlJc5Ujrkin9vnK0+0wAno+x4zjt4xaqxUsijIOcnPUmjcPFGs6jzL4irFy8nLnHw9xmvP+lcQTFldz8XfO1aXw5xGrxDnfGOxoD6lwdoOBNQdnLWm7bkzS1k97tua5lwpUkldj/wA7Ut3rtKT+9HMMFSD2qR9fj91AVzysNwBuaVl1hlumtyCF/Dmpu1AKBSYfRaVskiMsUphCXBIyrb5NWzxmlhhWnRC3QMwBP2pZ1zU5NO0G41URhjCnwqfxOdlH50h8BcE6zxdrQ1LVrmWQyyZZiSeXPQAdhS6q9nFUcPdVgvd0E9OcGaudanjjmJ8JwQcNgnbselatoltpcEyWtpAsbKOUCSPdzjfJANLPs+0q14fsLeGN4UUAHw2XJJ9V8zWilHnhjm5VyDgMVWEj0+lbGn7NIQFuWnBdp9prfcQnCyaKEwSCRWQDGBHsW26HGObH2qbU9QvfdmUNaqwwFMikkfTmxn86FzajaxI0kkVysiYBJJbI/wAJ70M1GwsdehkbTxdJMw3Ml3Oo+8e6n60PVhkUrX1iNGHYM/T4f3KmvaZdSqz2q2b3SgsI2gkJx/uknr3pd4b0PWBdk6rb+A/Nlo4+ZkdT3OSD57A9eopg07hu70+BI7iXwyuSXQfCV752yPsKl/bWmaMFimaCWRuiQMzux+jdT/KsH8IzsHcbR7//ACav4nYprT2oz6XoBtJlvkb3U8xGEURnB9FHTbz39ab7Z3FsWilECYyZJHCg79Wbf/4Rk9qSNN1PUr1fd4dJuLUybh57qGMjyJXmL/6+VMelcN3kirJqGqNNIm+VJUKvko/DXUaCoU8Ipx8v3nP6xjYMuRDweVLfEDoGYf39yAqn/JGfiP1I+wpe1Dh6zmuDe67q11dSsN84gBHlzSZbH0UUXvPd9LtC6RzPsA3JNyn7kDJ+gpP1biu/tQTo1va2j9A/hc8uf87ZNdGrIEw/ymIVctlYattJsogH0jRYdv8AtfdXuG/+OUqn5Cl7jzwl09jqmp3GAp/d+MFH5JgD86WdT1zibUlZtR1C6kPfMpI/LpWd8Y6klvbuHy7YycnekNZr6q6yqp9o3ptI72As3MzPjzW4H1N4LAcsWT9f5mhVieZPEbqRvQTVbvx9SZw3RquRaisUIXmHN6muHc5YmdbgKoUSxqF74WwYZFL17roVSQwyO1Vtb1dVlIzvSVqWrszOA+R0wDUJWXMIq4Eua7rjSoyq+Tg7Uj3d1I7nqfvUt3fZd8OfKhU0wkOVbb18q1aK9nEBY+cgTo3bI2ST1q9p1/IJR+8I6d6AyzDnHN0yNqsWl9HC4YsObPc09tBWJ5YNzNN0W/c4BbrjG9M0F54hC5Oeu5rL7PXVj5SCAQMbd6OWnEjLh0fGDvkUg6MsdHtCPylucOGx3NNOi68bJViMuMCsvi4mVhjxd+mx2orp2qLOUwcj60M5zzIKHwm22fFcnghVk3+tT/t6Vv7w5z6UiaLMzBSQd8U26XYS30ygAkdacpsA4BiVqeJk11cNcOqgAAn70X0/ZVyCNqsNw0UUSyI23eogogcR+WBT5z1MzlIzxDVo222ap61qojX3eNtzsd6in1FLS3Ls2NqVp9RNxK0rtk9RRU6cywG44hSJnlZUQZdzgVoPDmmrY2ys6/ER3pS4Q0w3L++TptnYEU+xvjAGwoicnMixvAS6hzQ3VoA2SB1q9HJviuL1PEizjO1HEFnEVov3c3XptTbpriWAUqXKeHNkDGaO6HdfFyE1ceUqxwYYKZqNlqwR6VwQMV7E9uErlN64KZ/rVggYx2rnHXNRiRmV+U42zXxlABPlU/Lg1T1CZYYjk4r22ezF/WpfEyqmsz4r05rkNzL+lP17KXkJU996HXGknUCCF270JlzDVEDrPI2qOzFsHv5Ur37BgR2J6dqYNRfZmIyMmlq+YBcDGCO1J6QcCcOhyuTFvVYnycY39a+cN3L2d4hZOffoNq+anM+SeY9MUKt7+SGYN4mN63WrNlJXzjWlsFbhp6D0a7W503PhBMjbPU0k8UMElYAn6elU+GeILuUKoeRsjA2q/r6q6F2XLtn864a/THT34M+k6HUDUUgiJdxMqHpk52qCXDAZySegru7idX5sZwc7mqUviMQzE9flFOoAYRjz0ks9u0mGaRV5TsCcmq8yyLlVhZtvm6VLBhWLSx82K7lvkj+S3RYwd+dzk0cEjiBIB5Mm0y2F0MKkSuvUBOY/mabrWze3tlJYkgdFEeB/Wg2jXAnKmFbcNy4BKk/lTNbJc2oaSa28Rj0YoMD8jSl784MlEA9oSsbKRo/EW3lEbYGUP/E4+1DrbTjJKzR3qQSKxOZJQkm2/XB3opcXksxKvCDgdM8o/Mb1Bdyalaw+JHaGHb4XDgqPuwzQwrEcQofZObrSLshV8aRnILgeNI5Ge7HGB9K70ZNSFwJYb9UeAlgwAJ8sjmK4+u/0oAOI7yJ2W4vrpVU55bdgSx8uvLv9KatI4vSSD3E2CR9CXkxM69jjISNP1+tQ1TY5hVsPQCSalxxxVBI8b6jeTRqwVWjueRVPmAg3P3qnp+t6/fP4mn3d8hRjzTPcsAhPmxK5+7ECj0mlWV/aGQ3rT7q4DILg5OfJuRPz+1EbDh3VIoQkFlBDHjmMs0qoVDdDhsHPfYYHpQMVqMAAGXDjGWgpodeMIXW9et5beF+ZYRclhzt5GJWHnvnPrRzRpILFkjL3li0i83iQ28SBk77yMGkHlg586X9bgjtTJcXt9e3KR7eLFeh41A22OGx06LvQm241e2ijtInWdMkOUWYuy/4mZh1Pp9qEaWtX2YzXYomkanrySgOoLqHCLJPd+K7Jk7lHGEz5DI8gaKQT8STSR6peyCwtlXlhQRWyvyBSBgkgKO5OSNxWWaMZ9RunFjaxPISSI5FwIF7lm2C9hkknyNOLcPajpKxTa1a2FtJNGZYnjIVpMEYCLIXO2xyA3+Wl30+Osu1ygbQI5aBfabB4+uTabqesLG4/fzWczRhttg37tJCMnYOsYUfKaPahxFqctqkl7YQ2Vqsoks7SdVhid+qu0Yy8p/EclEGfuc7h4gt7k20Uc8lzexOW8W9VpeRxkgQwNs7joHkVI03Y9KgvdVjnvZ79J73UNQEXJc3Ac3Mat5LKwCYXvygLnOA3Wq91gcD175QnJyfXwnfEvF9zxTqlxJq2pLKrN4j3TxGRZZFB5VCjI5UwSFXKg4JzjNVOF7W4t1Fxam5uJLuMKAytCJBnbJQMyIT1zu3elWeaBJLi1s9O8Z5W5WlkmLZJ3K4B3z1PQehpx4XnhtYJr+4vZYRE4jaPx/hyAfhPKArnf5c4Gd8UVkYDIhmsVFwBHfw7G20t7y5ligdAsbR2vM7PKdhhWH16ClK70SXUJJmlswgVBH4gaMvnqQSCFUjbIBz260xGJ57SB4biGKK4VwnKh5+Yr8TBUAQeuSfuat2+lXiQiBtNhvZGiDL7tHytEvQsu3KufMn6VSpD/wAYs1wQHJmI8ZcLahAkrG2kXkYKvNszbbbAkHpSja315pMkMWowuI1OM43Feqbfh1rqOH3e1PhRrmRQysyAjo7HYZI7tk74GKpt7HdM1SaZ7mT4ccwUjYHp2HnW5RXZjYVyImdagbfnBEwaXifTrS3NxaO9y5X4YlU7n18qWn9pntFtbrxrU20UQPwxGMEAV6Xm9gFj7qDBjmMmWblweXy3pA4r9jV7pcskscYeFMDYb/Xp0o66VKsl0z8ZpDtJtThFsx8JJ7O/adLxNp7ftKH3W8gPLLGDlTtsy+lNbziS7inXowxtWRaHpcuja08IjKCRQAc7N3rSRNOllHc7/u8bYrE1dQDMqDidRoLAFUseehmmy6NHr/CF1aoQZIwkwA78pyR+VHfZtpFhAyc1tCytj4mYAA/Q7Zpa4R1qNdPdjNhTGep65FMfs0umN7IJxDyhjylgG29VPX7U92W+xQrDmYnbRZK3APHWbpoks+lxeFLYIsRGxWPnyPMEnamC1iilZZbe4tLlmG8VzG2fsR/WlWxuWEcQaa4jJ6SwEPFg+YO4ovG15by8/vkMatsGbmBYehG29bzMMcdB69ZE4DknPjCWvz3FpAk4tJbXAwPdXIwPMEj9KXZ77VY1SYTT3ManaWV8P6AlOU4+tX77TIbqJJGPhuGwrtIHXHkOYg1PY2htCPfJ5YVXo8aZjx5n4jWbqQ9zccD18BG6Sla56n18YFi1vWll5Q2oCBmwzxxtIq/RmUkfnRey02K8UzJqNw/inmKTXPUf5VQbfei/unDxtnaCdI2k+Z7dwu+epGdqHSz3NuRb6dFeT5Ozx+Hgfm5J/KgfgnT2nORCHUq/CDEYdLs5LeGNFnjgABBdjJISp6kDI3+uRRWyv5bq6Ww0/UDI4OWMkeXA6dEBA/Wgel2d7dukl3C0A+Zm8AO4wOvVh17Baa7FrxBym9uZkK4AMTwjGN9hsfyrZ09GFB9fvMu+zJMtXXDur3qEXF/ZogHxPIxx+WM0BuuGtCtsifiWEsDv4Fs8n6nFSaxb6hdKDBpN0VP43flH1AOKEXkd5FA3jGGMAb88yf0Na6hNvKmZ2WzjdKerHgWyhYveXl2++fFjwv8A8KsP1Jrz37W+KrNVkt9OkIiIxypCsY/TJ/WnjjjWorNZF8eMk/wtnevOXHGstd3MgL9/+RXJdq6/e3dKAJ0PZukwe8Y5itcXv7xpecnBPU1Wk1dmXIbOPXvQrULkpzfFuc7UJ95ZDlnYA9PSscV7psZ5kuu6jKxL+JjyFJ93qbkkc23p50X1abnT4Tk0DW08eTlYN9qepQKOZRiegg65upXyRn6dqqtcytt3z5daYJtIzty7mqq6GyyBQOo600rqIPumPMBTeMdwSMHJqGOK4ZgBnenG34bEvKStHNO4PjbGYwR0r34tU4nhp93Jippthdug+BthRN7K7iTk5DjrvWiWHDttDGFCdB1H0rq60NH6KBt+tKnVhj0jArAGJm9t72j8uCd6c+G1unkTIO/60RsuFUd8hN/5058P8KiMofD7+WKWtuLcCNB0QYMO8NWM7xrzL1xW6+zrh+1RFkuIUctgnmFIOgaSkMaqRggU7aRxTHohWOeCXA/FHg/oaZ0BUP8A7Ji68tYhFc03VeFNIuLAtEghcr+HYflWLcR2DaJds0sytDnZgenpitAl49s9Rs3W1n+MD5SCrfka83+3T2kTaNASvOS7YOOmM10dlddigp9Jz9ffVkh4Y1viFZmMUUuQvzYr5w7BNq94sSrlEbf1rz5pftQuNS1GO1t3/vDjfevUXANrDBpUU4IZ3UHPnnvQbEKeyYxVcCDjrH3To47WBIYxjAonFJ3oNBKD1NEIpOmTUiVJhKN871Mf3iEGqUTdKtRuc486KGlCfCBdQhIJO+aj024MUq7nrRPUovgLCgKsUlznHpVy2BmQTmPMT88YbPavpI60O0e7E0HKTkiiBI771YNmUDT4a5PpX3m+lc5qQZOZ8JwCT2pe1u66qDnFHLqURwsc4pL1S5MkrHOQagtxPA5MqkCR/qaYtHsVMJcrnI70CsIDNMo7E4pytoxDCqgY2ry8mELeE/nrfspBJ9d6XNQfALUbunyxGOhpf1Fs82ciktLxicSvIi/f5YEDJxQiO3UTc0oBGemaJXrMCcEdKEO8pk+E/eukQZTAjKYBBMedBuHkC2tvyqM9hj9abrrTZVtudiucdc5rPuF7hop1aZs7961C4nFxpoQOoyK43tio02DE73sPUG9cHwmb6uAkjIDnzoTEC7nDADPWjWtW0nikKNj19aHwWZAwygDuzEACh1EbZsWA7p8aNXBAkzk9v5VUm0+4uZ+WPwyAfxEVeupLaKIosjNj/wBGuR+ZqhbXKCbEen85z80su35DFGrz1EBaRjBjRoNjJbxqTEiSE7O7DNN2nWrwtmK3naWTG7DKetBdCv0s0WR7q1tQ3ZEU/wBM0zRS2t/ID41xOzjZ2PKp+1I3tluZKgyZ7W18Flmmiidhh+TILemd6CXWj2U8ryQX86ZYKefLA+mOhNGZ2t7LCv7tlduVcOc+oGSapyTXDEk+Lvj5oFUEHuM9P0qtZPhJII5MW73RbGOIq0ky7YUtbCIfY7Z+9BJtLtbTlkiu023Abmcg/TYdfWtBs7mBrnwze29ryD94GUb/AHGf51di0qwLPODczrISOeGzVifoXZi32AFF3t1EqLQv5pnljr6WH7ySzlkmYcru94yEj05QeUeWN6MR8fxJM6R6RGyuBzN4XMijHnMSznbvgd8U3z8PwTRzS3s11ZBFAAme3UvtkDlUEk+nQd6T77hK1uJnUOGDNzArEm3nliRgZ8vyqnsk5YfXMMLFfgTrUeNbPWVhH+ydvBOmyPHF4jKuABypzKg9CFz3zRPhzg+5hh9+ghuY7ggu8boyHz3LsB/P+lWNA4QGlzQ3SM7Z+Lne0mC+uW+FCNtsZpm5Uihkm/a2us8wO8IEKOOu7qMkfTyoZwTheBJN23gfzAkckunH3bUL/wAd1JdYoYSzK2Ns77b9xv5UK1GS/vNSkLXErOyEyiQqZZNvlAGWxg98Ad270O4gSKKYPZ3dzEcEcjS88knYg4+I/epNBtrvS4lnnJLurckAYrIOmNgCB9cMfVaqEGMw6Pjkw7dT6jp9jy+P7tFP+792Eixcw/hJYA8o+2T50Ml8SFHRtQM8jSc006TFkjXuAq46dMbb1ajbUbi8N9expJNAv7oPdciW5IwSQSzZI35mbOOmxxXF/o8Ecfiard2rT5BjhgchgMbEEqAO/Qee3eoVVBxPb2Jyeso2+niVFNn4s0SPzPLyqI1XP8KjI36jOfPuaatKuNLuSiTyyCJDli68pXG+wXPMTg7ZG350ipKryskFxEkMYOWkkHKzD+FRkE/y7ntUtlrkKyLa+MbhT8DlnYAE4+FB3Pmd/rvipesuuJG4AD3zW4dTtp7UXUAmRJWWOEzTCIO3cZAblG++Cx7Uc0C7s5LmK1v7+MxXJb9xbs7CaRCcBjs0mD+H88b1mF5faq1rFb6TbwRJaR8kchIbkdu5J6HGcKPqeld+ziyvbrXHe5uvF8OPwwzOXabfJVQOiA9hgMetW02EbJgL6yyHE9GQy206M02ps8URDtAGCIuP4iNuvXc+Q6Ve0u/N1PzW1siQhQ/Kq8pOdgST09O57Ui2d3ZwQM91cu7WxYBS4EcLjHNkZwSNvvkDpTFoutW2oatDYwlPCVsRpEebnkGCWY+g3ydhW6j5YGYjKQI/s8aLGmOYKAdwNz2GT+e1V7zQLbWBcxzRKylvidBsfMn+QqF7aO6m5ZwknhqWjCtkKM7Z/nRqzv4raRIY1/doCA7HY7btjufWm94bh+kECU5XrMW9oHsSuW8PVtGgUGPJKKCGJG+32pDYXMdvLZXULRyICpLjl3r2HYXVi0Y94eNEQNNIWOSVIyM58+tZ3x/wfw/rVgl/YxpHOR4jyhdyXORn0ApLUdnqT3qfKb3Z3bboRVcOPOeb+HOJZhFJYxyZkVvDK9O+K3PgCKHSrAT311HmT5vxYbuDnoawFNKbROPbrT71QRMC8JDfCSpwcgfatv0qZ9Tjt5nuIxNHCpYICodcd/Xbr9qSorCsT4iana9xvUAdDzNY0y/eOPxbK9jaJ+b4Y26ffqp+xFXU1OcBpFupsKoOBKrE/UEbGkyxihktRaMDHFIxBDPjDeQJ6H9KPWTJaxC2aV1f/wBYh5wR3B3Box3dB0nMFVBhi34qmAEEN+UAJBFxDkH0JUEEfamO0u5J7UpA8VsZN+azf4GPfboD9qS5ZbGK5Ep5SzDmI5BjH8XL/UUx2ur6VFb8lusDM+Ph5DH4n3OB+Zr1W7cdx6evWJD42jaPXrzhOytbx5cy38sqISPEilBZfIbb/mtOFlGksEaTz+8lV35+Rj9diD+YpJhvXlH/AEUxQxlSWU/GB9UOfzBq7axzXMym5hZolXBms3yv/wALbj7Gm69qdOYu+W90dGX3RWlhs7ViT+K2YNjH1GTUtktzMrOsrwhhzcqfCNvLeq2nm7W3SPTtWhnjxjErNHID5EY5f1qzMhi3ltjEx7dc+oPQ/lWnWmcEev1iDtjgyjc27szSG4kbzy2aUuKdXWyt5FaRgANviNMms3sdrbsfGPQ9sVhHtA4p5nkhDE7+dLdpawaavAPMLo9Ob390R+POJzPPIAxwDjrmsi1q9MhZ3wTnz6Uza7dtNIzM22TSLq1ygyNun1rijlyWM6tFCDasX9QufiPO23lQe7vlUbMPzrrUrkFywP0pfvpjkgHenaU55kPxLjT+K+5JxRO1RVTmIXzpds5lGxzuaLwXakBM70WxSOk9WRnmMENukqiTYnG5NTLp0fzFMY+2ai02bnUBvtRgeHKB8PTfHpSpYjrDHpmV7a1jDqOUHfv2o1AqxMMDlDYxvVGMIFwMZB2xUkcpIxknBx1oL5PSWzmHIZd/gI6VaRUYfEAewNB7eUxbFtz5VYGoKAAXGOuDtQ9rHpPbgOIcsWijkwANumKbtFnUOMgAenaszXUgJQVY56bUz6PqkoIxjf1q4GIF13HImq2l+sa5OBttir9hImoXQRzkUhLrSogUtimbhS9E19Hv3B61NTkGBasFSZqOm8Ew3EHiNHnI2JH9axn27+zxI9MuJGt8qwO5Ga9T8HRLc2SBlztSf7atDtrnh67V1GPDbauw0i5ryJzdjlbcGfzV0Xg+ex1opG5Z1PMABvXqP2UcQm4sTpl18FxAQpUn02x9ayH2daab/jK8jnIaO0coCejDOT/KnzV424Z4jt9btRywSERzAdMZ2NRcd43iCVQCQOom528oIFEYJPOlnR9QS+tYrlHBDrnY0cglP+tLBscS5MLxPnGe1XI3HWhcMo2yauRyetXDShMtTjxEI60s3kfJMwxvTIrgjGaE6pCc+Iv50QNuGJQNgz5ot6YZghbZjTTz7A5pCEjRSArsRTVpV6tzbgk7iqK+3iUY4OYSLVyWqPnyetcSyiNCxIxiiCyeziDtcvBFEUDYzSfKxeTqOvarut6iJpyAcjNUbSMyuPWoD5MupwMw9oVuCwcjYUxFsYGaHaZD4EA3Aq08nrRFfE9u5n88bvlZSwO/TpS5qDHBJxt1NF57gFSC350FvskFtiPQUHTLgiciuYBvGAyAaEucP170WvRnIxQZjyyHO5zXQ1fljC8w9o6OxDO2OXpT5pF/EYREH5yBjJO1ZpZyzlsAkDypz4ftpZmRy4yMHJOAKxe1aDYpLGb/AGTqRS+EHMs66cHKn8qA+IiozSbbflTzrdrbLp4ZFDuBnYdKzfUWKyHAx2rndOd3sidzYcKGlC8lV2KhyST3qTTY1MyggEk/mPKq6QCRy0pz54onp7tG5S0dIf4mxljWgeFwIgMk5jnplqbeNWSCNWxkFkBxV651K8S1ISblYnLu+FP2x0oRooiOMtLO47u2AKKaqIvdlZbQyMAe+AKzX5eMV9IuX3EN7lueeRyfxK5x98AZ/OhZm1C6IZGKAH4ctjH571+uYRcTkSJCf8IkJP6V9ttJtJXVZVWMNnOGJ/mabRQo8pDnxIzLFpE8EwmvGup8bBEcRoG7dck0wrxNLaJmKEWiEYYNcN8Rx3Ee52/iP2qtpuhx+AEtdPlhjY/PJKTn1x5UXtOF9LYF/e3mfugOB9sVV3XPWB4zyJTh4xWB/eI7QyynotrH4Jb0aRyz4+iivo9pmv2rl7azgtHXIQRrzyD/AH5CxHqcA+lEptKihh+DngA+VBgEjucf8aow2Fuz+ILZ5QNiWJAB+g3NCIU9RCjAg88e8UXV2t6lrJLKrZeaS4lYt9W5lwPyFTPqnEuucrXkl5cLkZHMfAQeWDyqfzemu04U1GeNZb4BIiMqryLCDn0O5FFF0iO2QCOKVlUElogI1Hll2Bb8lFECbuggjcq+EUbbQ7uIGd5okcj5UPxD6kgKo+lHtM0tpITHzzmKQ8zyqfgcfw8xxkfc/er0NvcL8NklrbnJP7uNnJPq7jP5VfsrC9vLtLUpfalfyYWOGFmZj2+VAXP0BH2ob0npKjVHqZWSytNOiXwbWBHDA4SJnZd/mz2Oc75HTGaXtdK30bXE8scgjJMhmcEuTnGy7em+T9q0O60Ow0lVteJtXEEvNyrpelwrc3hb+E4Yoh7fG3N/hqhDa6i942n8NaPp/Dxb4i9xIuoarINzks/7u3GM/LGmPOh9wa/zH+fXxhU1Ibpz69dMzPOH9Mnv5JYpbW5VnChQi8qQoTsQoAMjnbbZRnc5pisvZzBa6hDJNhJW+ZZCfgOO+B1+mQPU7U06ToN7ost3eSXKrLKonkeViZXAO2ZH35fUbeXrHqmsm3hN7GnhyApK91N+9eQY+FI1bYEnPKN/MgbUKwsRxDrYc5WEl4e0WK0FpDaQuI0EbmOAlQoAJRQc/ET8zHJ6DfpUF1xVpHC7m20K3IvZMIDEAfCAGMs3cjJ2HT60N0K4uNQu3utTvZuWBWjFoHOYubJzITspJySzYJxsABUt1a2msuP2HbyNbqxRJkTEbtn5xkZZF65OxJAAxk1dENYBP9wbf7DgnP7SeWK51WxUXUhdmRWh022UgRo5z4sx33PZdzuB1OzdwNBqekyQx+ArG5J5kRCZNt+Useg8+31oRoqWWk2cMKyzqrsC55g0k7jOSWHlvkj6DAFF9J4jimv2SK6fwwDCkKLyrnzZupA8h69aeqZQQVMVtBKlcevX/sfdNvnaaS51a7t44oT8KwxZw+cYJJzI2+PKrN/xXYxzzW8yKZ/D5IrcNl8ZG8hGygDr9aUFjlmgMtnl+bBgycDAJAYD1OT/AOFRWHDFrb3DuGMs7AGaZyTzyE55cZ+Ik+e22aOLmHGIIVKTkmaFJO2o27eDcSLHdtyE/wCDHyj/AF9araldvBpahlUqow6g/MgPl3wBj70JtzdPFLLazk8reBEWORjOWJ7Zz/Squv6rZ2dzBZz5RVTkV8fCGLdCPpg/ejG8kHEmur2gJmftFe0tNWhmdwZVyZPD6kkAgDzB2zvV3hviV7vTEKyESAtFGdjlOY/1B/OljWL03E9vbv8AvGiBVnI+Y5H67/rRK0sVjVRD8KxqAWI2we/61mM4UzowgNQB8JrOh8RSvaxQXoEiSAeE+QcMFB5SO4IOPOmTSeJLdXUSBltjkcqksIz3G/QDb1waxlH1K302S1ErgK8Tq/XlcDZh6bAH60w6ZqOpFTbSxtzkMDn8Q7EE7E7sPVTR1vAxkzJu0oOSJsVzeWhZHRwYw3K6O2wJ6bnb6dDV9r62iiU28yglc+HKvIQB1wcYOO+23faseX9r3dskMd+YrmAIsbk83OgJIRweu22/kKMaIOI0uFjZ2MfwNyjflA6lc+X8qKNQhPA6xJtMVHJ6TaNMlt9Q/dm2WK5UAoWXOR5hgcZ+mMimTTNMkcrK0EqSx5BMbFX27j+Ieh3/AJ0r8M6dNyRSoApU8yHHw47oR5dx/StK0uJWC8ylWAxvufp6+h61rUU95gmZVtm3gS1YKyf3/LJ/jZeV/uw6/evt/KLaFnt5yqns2CCf5H74q64KRmTk58DcdCaROMuJILK3kw4XbdTtmn7HXTVEmKKrXOAInce8UrbxyqSqsM/Lt+leb+KeKDNdP+9Ocmmfj/i8zyyhHBGSBk9qx7VLo3ErOWz5EVwer1B1VhJ6Tq9JpxQnPWfNW1l2VviztjY4xSVqF88jMD1+tEr98qwBB7jel+5Dbk9s9KEq4jggy7lPMebpQu5K5ONsjHnVu/dx+E47iqMmGUDG4x1pyscSjAmRoVTDHPpvV6BwWUgjr+ZoZzgNyk+mK7S5IPLnGO2aOVLdII8R2sJyig9MfnRiK4ViACcEb9qQ7PUZM8pc4/lTFp2oI6hGOBikrKinMMtgbgxhaXkHMpGDtUUdypbJYA/Wqr3arGRgVQ97VZBhtj59aqF3CTu8YyteGKPHNknvmhr38hflL+pqs12pjCg+owapS3XK55j+nSrKvGBB7jmMlpOZCCW3z501aVc8qqN9sb1nljqEZYZYZ7U3aPdhlXPf1pexCIcMDGdrx2ZeXO/6VoHs+Z3uY2J3zWe2wWQg464rSeBY+W4jI8xS4YhgJFmNpnqHgN8WoJ7LSv7b9SgtOGL6SRsKsTHr6UxcHsINMDnuKwz+1lxYNO4OuraNjzXP7lQDjc13GjHd6Uu3lOQu9vUYnnr2SQsffNWYfFNK7D6FjWja7YR6vpMtuy5ypIpJ9nEXufD8Mb4DtT3ZT8ylXx6g+VIUW5JQycf8pD7LtdnMEmiXr/vrVihz1IHQ1p0Eo23NYjf83DfFdvrEDcsNyRHLjz7GtcsL0TwpMrAhwDtVXO0yDwcCMUMu25q3FMNsUFiuOgztVyKbJqu+UIhiOUedfLhFmjOetU45ttj+tTeMCKsLcHMGRAd3GY2O+KsaTqJtplVm2JqTUIwwyO4oHLIYW6kYOc161sjcs9jcMGaCk6uvMD1oNr2qrBEY1YAmgNvxla2cLRTSjmA7mgV7rZ1GZmVjy9vpQe/BHEqoLHEsPKZ5u53o9o9rzMHI6UB0+BpHGx6042USwQgY3oqvgQjHHEvhgihR2rhpB1JqFpD51CZcdDVu+lQOZ/O2aT+XShtw4YkButXJW+I56fyobdEjJ2p3Te+cuoyMQdeAEHI7daDPy+KQ5IANF7lzjPl/Kg9wDzfDvvW9WMLCD3QnZXdtERjLH6036JqwYKiqo7jtikK0Kg4ZT17Cm3QuZnXlQgbZ7k0jrqEZCWj+k1NiONk0PkiutNYsjF8bE9KzPX7FxOx8PAz3rWtD09rq2wxCkr+LuKWeK9IjhYjkzjy3zXEpYtV5UT6NTm3TgvMzSNiQrD4V7dqM6dbk4jggC+pqvcWkiyEpFnfoBRHTve4xlkES/qRWmX3LmLAYMN20ctsokldFC7DbfP0qLUruOZWaUSSAjbxG2H2FWovC5PFlhLAb5Y/yFDdRvWmUi3hVAepxuPvSY6w1YBPMB3SyT/BECi5+Y4UCimiaVZKFa41Jh5pF3Pq1CDFavMFur1nOd0jHMT6elMtlFaQLm1ihtcjGZAWdv9KOSVGJDDJhq0E6stvFe2dmhAYeKDIxA6bA7/ei8AluJRDJrM9w2NvCt1iBz/8AMaFabo7SMLiSRIbfGTLKMc3oBkZ/Oi3jWtrIYdNuoYYiPiEKZeT6v/QYFLswJysHg+MlutHtkjPjyyKwY57s31J2H6n0od7pMic1i8MIP4uctKfuen2Aq/PDcXKiRoTyD5VdsBT5+v5VLo/C2u6zK62tn4iQDxJpHIjhhX+J3YhUHqxHpmvLuc9ZYsqjLSvpPu9pMjXmoozZyzNJlifrn+tN2kWk+tvJHozTXSRb3Bt1AigH8Usz4SMf5mHpQt7Tg3QQrS3EGs3OCeQs1vp6HzJHLNcD0HhJ6sKJXFlq+oWFrqHGuvjSNH+awt3tgiFe3udhGF5v+8IVfOQ07SOcNz68T0H198S1Db+QMevAdYWMPB+mYjvb6fWJiOXwNPcpAD5NcsMv/wD2kPo9XLwalaWLWWrXMPCumTjP7K0uMpdXK9vEBPiEH+Kd8eSmgK8UHTpPA4N0mSxOMPqV7Ksl+48kIHLAD5RgHzY0DleZJXaeReZ2LMWyzsT/ADPqd6OXC8J6/Xr9osKyeW+sMT3ZUNpvDmn2+l2zjlfwpC1zIvfxJtiB5hAq0w6fcaNw3pQiRUjjcmWQhFAdhtzux3YDG3McDypRtbw2/KI+T4tifDCjPmSdzijAkuVmhmtbJr2/lKm2M0bSsx/D4UXds9GI+gGM0nzuyYwMEY9GR69qpms01XUbaDTbGSTxBNcHaZv4sY5pXwBgAYUeVc2GlwnT14jv7K4soZYzcW0k7gX88WDmSNTlbWELk+K2XIJK8xOxe74bj4Y1U6vx3cw8QcdFOe30uU+PZ6FFjmElyB8LzY3EQyBtnmJGRk9rqF/eSTXk0+rX+oSKZTeuWyQeYc4OwAI5mUZ+VV8sRYq1nkc/t8f46/tDVsSMKePXT3e/ofDzgS00yXXriK41O0MeltKUtdPiLRxuvquScNjdmJdurHfFOWp39jZyRW2ockK22Gmithyo6jogHUjYDl6bb5O1Q3N0ml2n7Wu7gzXCEKocDCIMqAoGyk4JPkNztjNG00ue4ZpNUAh1C5Vrsgjeztyo5XYHpKVYci/gUqd3cYDyxhgcjPh4evvGexjj1zTJb97Y2ARHUcxwYYhjHidhgZPIO+M9MUB0nS3vNUACPFZqTyuzbsqnDE+bHcHsAT3po0/TPd9JkknItLOJliRCcsxG4UebZG57tgfhqpGbD3xoWDLzqAyq2whBAEfkAd8n65zmrEgkSqZGQP8AyF5OJIo2As4VlaQEGUqOSNBtlR9gAfLOKvmWaVSlsh57ZeZnB+e4dep/yr/MCqdsluFa8Kq8dzIiI+MfAiliR6eQ8qvLPbafp0c7kKnLJIxJ6nbOfXcmjo7PwZQoqngevXEvTXtrpMc0Em6xzKCpGwwAc/nn7ikDirU5tS1NI7KYlVlivEKjI8Nhy4P+6ebH/Cvuq6vdatrt7FakhIbjkYZzzHm2H025gfI1xo2jXUF3a2XMqgoW3GAuCVC+ucgfRDVzYMbRCVJt9owTpGnM05kmthzSShkLKds/EfsAV/IUww6awxaPEeV5DEMdV7dR1+IjcefpR6y0e3nmZYpPFiUtlEHzIwHKRn0DfnRaO1DraXACmB8hmAAw75wR5DHWgYz1jPfeUFaVobMiBwpLKSqnfcfMB3674wdqZNN4ZsS6yRwCCZxuOc4kH2O/23FSWsRke0DRRsswZHBzs6HBAO2+RkfU46Ypy0i0tXXwiodWw/KT8StjqD3/AONErrVjiKai5lGYN0/hyz3d4vizhyTkj79qa9H4eicoUVW5em2D/wCNSHTxlJkBblIXLADfyz16etMGjJDEwDNjH4G6/nWhRQqtgiZVtzMOsP8AD+kQpGABjYZ/1pjtYTGqxvyhj07ZqpZPCyjkOHHRsdat3V5DFHzzFV2zkjY/8a3aVCiZlhJM41C/hhgcmQqy59CDXm72w8XrG0kavlhnfvWr8a8QQQ2788vMFBIcHBrx17XuLhLeSQpMWBYisDtvV717lTNfsnS7n3kRY1rV5b25ctJkc2etC5PEaPckDHnQW21VZpWZjn61budSURMGPriudSvaJvOxPAlO8mUMyjoBjehLlZGJB7+XSuLq8eaUgH4R5d6jjYkAZGQdye9XIl1OOsp6pbgKWH/hS7LIUkGDtmm68QTQlRv3zSnfxcrk8pxnFHobMhwSOJSnkPPsOu2a+wESE5PSoplIUsM1Elx4QwCD9qeVcjiJuxU8wojCIg5K+dErK9AwA5GOlLE2oSY5QNq+xXzLjDEHsKh6Sw5lUuGcR3bUAyYEmw7VRn1BAxbn/Wl39oyHY59aryvcSklQelCXT46wjOW/LGiPW+X4S21dNqIfbn6bUqJbX2c4OPOrMaXi7lTUmtR0MgBz4RntL4RuMuAe1Nujav8AEqZU79jWZwC758rkedMej+9F1Xfy6UvcFAyYREduAJs2h3vjFVB3PQYrZ/Z1pk00scrD4OuayL2Z8OXmpTRPJEeXI3Ir07oGjDSbBMR45RvtvS+jpGpt46CU11v4VNp6mN0nEEOk6Z8ThFRa8Y/2h/aCOL+IbfQbZ+aKKUM++RmtK9uvtFudE0mW0sJuWRwR81eVNEuptY4iF1PIXIOSSckkmuluu21GsdJyxIX2vEzaNDcWtpDCuxVADimW0usOvUA0lWtzggg+go5a3Z5Rv0rn0t2PmMgZXAhfiW0j1HSpY2+ZVypHXI6UU9nmtveaUIJpcyQfA2/ltQu3uVmhAcjcYNBeHbr9h8UzWnPiG6PMoJ71pOe8XiCmyQXO2xq7Fc79f1pahu9v+NXIbs+dZ3feEk8xjS5H8VTrcjzpfjvBjrVhLsdjUG/EoRDDzBxynfal3WyVjPw7dsVe96yOvWhWuXyQWztIwGQetFp1AztMqRjmYrx1r13pd6JxKQvNggmjfBHFH7RCc8mTsOtKfGcaa1fGMKW+LAHb0o5wZw7JZIgBwBvR7KEVRZVKspJys3fQ40aFZj5UZ8cH0pP4e1QRxi2c7jaj/vA8/wAqRbU7pEutPnpmojNv1qqZ/WuGm6elV/ESwE/n/Odycbn0oZdnPNk9d8UTkywIIz/Khd1lSeXp610+n4M5cDiDLg4ycULmJD82aKXRBUkD70HnJ5yTW7T0lwJZtJeV90JFNeh6jyyhVQnsSaUbcBjjfB60z6DB+8VgT/SgawL3ZLQ+lNhsAWbDwhLNdJy8oGPxVzxdpyBDLJIDtvVrg4IIFAxgDsNqI8QQW11AecnA2Ar5pqbcaklRPp+hQrQA0xe5aCKUsAceQ71wt+Y8sI1x5kdKJ8SWkds7CJQcH70mXjS8xPMfzrZoYWLxB2LtMYBrDnBluFUdcLihV1fSTylY0LLndupNCQ3hkmWR/PA3rn3qZ/hh5lAz96YFQByIDvCOIZSRY4+bCKT26Gr+lySSSbPHAOzPuTS9BdNCQSVAzuWHMauDVjtywkkdsYqGQkYEJ3gPWNkbRF/39693PzbSSH4EHoDsKtWerXkt9DaaRHJe3c7eFBbwRl3lf+FVUEsfoNqBWmnXWsWCaxrV9Ho+iBjGLloi7XEi/NHbxAhriQd8EIv43TuRs9Zvrll4V9n2hXllHqH7hvCBn1LUfNJJEGeT/wBTEFjH4ufHNUdzgZeULDogjy2raVw3huIP/wAqako+LTbG4BigYdri6BI5s9Y4eY9i6HarUd/xZx3p/vt9PYaPw5YzY52Y22n2r+QwD4kv+FQ8p7560ow6fovCMnJr8sfEOsIQq6RZzf8AQrU9hdXEZ/eMO8MBx2aQbrXWuXfEXEdxb3GtSEiBfCtYVRYoLRP4IYUASNfRRv3yd68QE4PHuH3MoFDcj5+H6D1+sdbPUOH9DIueE7EXV3Gc/tvVbdSyN521sxKx+jyc7+QSq9/f+/ySXeo381xdSsHluJHLO57lnOWNLejaBeyyKryOzEkhQDn0pni0GO1OZ/3kjDlEaktv/iNUZy5x4eQlSip06yvb3SG3LWBcKMhpTtzeeCdzUsVncOPGfPO3youc+n9KL6Posl7fQ2FuXnnkPJDbwplifIfbqTsBuaddC0cW14tjw+3verPIIJdQhTxUtnYbQ2o2Ek2A37zIAAYgqoL0xWhfiLWOE+MA6Vwvc2s62t1ZpdasQpFm4LR2YbAD3JAJ5idlhGWY7YJ+GnmaaH2axT2mkzC84wuFJvL+cqTpqnqMDKrJvgRrkJtks3y/td1/TPZdaNw9w5JFNxKQxubuN/FTTWYYYI+P3tywJDSn5QcKFGxze1nluWaSYth388s7HsPMn+ZJPlRLmGmBVPzft/f7fHoOtTf7T/l/f+v3+HWfT4Ql1JeO5ZI3MryStzPLJzZB36/H8bMepX0GKuq8RyadYMNOlKSyMw8TI+BD1Zm/i2GT2ozfafFbA2MnKPCAWUj5UYZzGPp0J8yakl0G300Qs9hHcXpKe6WcicwV2OVklU/MxLZWM9SQW2AU5R3DgTRTaxDGBNLWWysItc12L99BEsllZSAEQpy595lUjALAxiKMjLFw7gKVUtmi2jmNItWHiSsxvbtmbmM8pJIUsdyASCc7liKg1HSI0vFs5Zvev2fzXOoXBbma6ut2Ylu45y35fSiem20kk6xTLlH/AH0rdPhT5APqd/tVzYA20+jPEAjIlfiDUZ7dLGzuAsk904jjVTgI8gJZsdsJjH+Y+dWxwvBa3V8HDE28hj6fNyDlI+pfOf8AKKjsbJtY4i4ctZAA15qUUj+YDuEUZ8sBDTXxDLFbS3GoAYS6mneMDufHbOPvmh7e8UufXH9iXL92VQdf7/owfDChEFs5H7mNyeU4A5l3oLxDM81o1vG3wIwaRfONshh9vhP0NXPf447+K2ibeSFRkA4PNGoH/wAxoSOa6kLgZEhVznfCgnI/KjqcCUHXM+6HZKRLIwBkmYHK9SeXGR5bA7/ejMqCCCWZnBfkOAuwEKg//UdvuK50OzJbmRdy5C5HoBn9KuXZjZJWj+IHCKT0wOp/PFVZxLDlpd0C3NpiNDmQrChY9AQAf6Uxafpsa3Xu8S8sNzHzcg6cyjH23UUL0kYmMjqcnmk/ViP6UctiyRxL8QZHXkbuB1oyYIGYCxjk4kVmIowWKkwy4aUZ2R+hb03BP/hTpo8EU2BMc7Eg43B7/wBD5eVJCk+KkwA5ZGYMOuzYP8xTbw/O4twjgkqdiPIdqLpWG7BgdSDtyI8waesiYf5sYLDckdfv9KgaOS0lMRzNH25CSR9Aev061d0V43jWJ3w2Mgf1B7ihnEl6bOUcyyHP4lPz48v8X/O9bFgVU3zMTJbbC9tq5sYlmDs9uT8TKCeU/wCJeqmrl7r0E9oWScEPsQxBFIEfER5155C/MPhnUbsvkw71LPMvhNNEypkZ+A7fkaAdcApCwv4c55EWfajr8VnpsoEiggE7bCvG/GOovf3kjkk5Y7mtu9s/FIjWSzD5J64NeddUvmmJIGBnpXO22HUWlvKb+lr7msDzlKK5aFiObcetWWlkkXuD0oVAyeKMtROGeNhhdyKsy4ELwTzODCTjLb96jPwuAvTvVgN8XMdh9KpythiegzQwMy3STg5UjfHSgWoQDDk469aOQOCCCOhz0qrfQKw3x9M1KHa0v1EUGid2KAdTXS6VI+Sq5+1GobGPxSx2+tFYbSNExyA04b9o4i5qBPMUotElkPKVzV+34ZJ/CTkU3WlkgYFl361dW2hQggb7EfSgPq2PAhK9Mo5xFi24RaYqvLv6CmbSPZyZCvNGDnvimHR7aOR1OBgkHpWiaDawDlYrjH86z7dVY3AhyErGQIg2vssSRQngHf0qw3slABIgwO21bdp9lbsg2XcbbUUFlblPlU/avIlp5ZoBtWM4E82Xfsya3I5Yjg9cLRzhX2dF7iMyREjNbRNoEN0/92vXyo/oXC0ULhzHg/SvANb7BMsdV3awh7N+C4LCCPEWMDyp84gia1091jIU8uM180CAWyqAMY9Kj41vYE02RmlA5Vz1rf0GnWhPZnN625rny08Q/wBojUbpdUa1abIJJIzSFwFaYL3mM5/KrPtj4ij1jiy6WEkrG5TJ774olwjZiDSYyB8/XtVdSdtOPOIkf7MRmt5mODnGCKNWUxGMd+tBoYzgE0TtFJIAzjH5VksOIwoxDdpdGMsrAYxkVV11BIINRtx++gcE/SpRExTIGScA19jPMTbTIcNkU7pbcgAwDjacxt0bUBdWUUytnK+dFop+2aTuGue1drJwcDJXI7UzqDSuqr7p/cZYZhVJ+nepo7jcb4oUsjdqkSYg4zikGfE9C6XJPelbi/VCsZiUg0TmvPChZ2OwFZrxFq8l7ee7xsdz59qqrmQ05s7Nbq794Zd89KebW1ENupxgAYpc4ctOe4Ub/DuacpyvgiNegGKLXrzSNhg9uORKSXZt5VeNtwabdP1H3mBW5s7Ugzycj8rEjNEdE1EQTchbCtS2pbYd69DIY85jwJx/pXLTCqKzgqGU5zXxps9DSK6oy/SeFpmwSRt5mqNww36/lViWT4T/ADofPLjKnP2r6Vp1yeZyyDEpXPT+npQe4zzY2z6UWuHBHQ49aFTgs+ACc7VuVfllhO7diCBn0xTbw/byuyuzcqnH3pXs40jIkkAPlmmCxvnZwsfNjzoGsBasgRnSHbYCZsvDt7awW4RWHNgZH+tErq5SYY3IxjOKSuFlZ41Lu2evWmy5dY4QV2z51811tQW4gT6fonNlKkjETuJ7QfGyLg5JJFIt1aJklkOfrWi6nykMWbrvik7UoXLkhcDPendIxAxL2qGgH3FZM4GAB3qFtPl5uWJAAfKiwjKkrnrtgVe02wuL+9isLGB7m6mJWOGIDJxud+gAAJLEgAAkkAZrQDnPESIA/NAdvpLA/HDknb6k9P12xTP+wdP4aAPENml9qg/u9FBISE9mvWUgg/8A8uhDH/tGQfCxe0kt9HuI7DhWY32uysI/2jbKZBExyPDshjLP2M+M9fDCj42u22k6FwYS2qRW+sayhJNlz89naN/69lP7+Tv4ankB+dm3Wrgkc+P0EEX8B/Z/ge+ULThPWOJ3TizjHVBZac6iGO6kiGZETpBZ26coZV6BUCRJ3Ydy9xdtY2UmkcNWn7D0+4TwrmRpufUL9D2mmXHKh/8AQxhU8+c71QvNXvtWv31TU76S6uXAQyvj4VGwVQAAijoFUAAdBVqExcjTPEcY2LdWoD3Nn2fn4/1LogIG7p5eH9yKy0iCC3WOygWMLvzEdMd80QkutKsIEa4mkuLgnr5nyHlQO91S4RGijVghOyk9RVGGDUdRuFEQbmBznHSqLWTy0s7eUdtP11Iwo5Pd1P4c/Ef9aI6dNq/EN+ul6Pa+JPcMVjjzyjAGSzE7AAZJYnAAJNBOH+E9Q1e9hsLdJJ7iY8oVDu3cksdgoGST0ABJrRtH0lJnfgrg64t3E0Ly6zrMz+HD7vHvIS7Y8O0j6ljgyHBO3KKYrTcePXuEVd9njz65lnhzTLi5lk4X4Qm8cOvLqutqoXx13LRQc2OWHY7kjnwXfCDFNnEHEWm+zKyfhrhmVf260Rhur5QT7gjY5oYQRnxG2LuQG2BbGFjjj1viWw4B0eHh7hLxEvJo1kE0sfJOiMAwuZVIykj7NFEd0Xlkcc/hpHll3HaYMl1OecnmPxEknvlj1Jp53/DrtX837e4fzE1Tv+X/AC/v7z/E4VBOxDRPgtzYLZLb7kn17nrTdodvDo2mtxTdgeO7vBpUbDYyLtJOR/DHnA83I/hNL/D1vDrN60TXJs9PtImu7+7Iz7tapjnfHdiSqIvVnZR3qzrHEGpajqBu7S0XT3RVgsrXPMul2yj92h7NNg8x8mZmOWI5U+g3GNH2jtHr1+36QvCy6XIks7c9+uHjjYcwth2dwer7/Ch6E8zb4FX9KMqRycQXEp54pGit2Y8zPdOCWfPfw0Oc/wAbL5Ur6dAscgRpi7tl5ZD8R9T6nfYdSSB3o1qGvWkd5HpVmo8LTP8Ao+FOV8XOZN+/xDlz35M96XyMZHQQ3d4IB6w9OtlbWvu6jHivhwDk8qAMfzwFH1J719ubl7O2ikcZMsKS7HqWLgAegCAUAj1RLgoQ5cxruR05mOTj/wCUfaj2rmOO00hnKgPpFo2Ce/NLQWKkFvKWCFcA+Ms+ztHl4w0J5UUk6laqBj/0eZXP0+BRUgaTW+DjcOc3GjXiXJHc2t0Ap/8AhmVP/wDJRj2YW0DcaaCpIykVzdY8i1vK2f8A4QlDuFLi0066ifUv+r7u3NnfgDf3eRQGb6qeVx6oKYQKtahuASw+i4+uIJss7EeAB+rfuIGltpozp92qEsLWDt1KOwP/ANFXhp62zyQKCQHKLjyyDt9sUZ1HSZdLC6feY8eynntHZd1bdXDA+TK/MPQ1y8aERTnGGXB8yy/D/LH50ByQSD1h1IIGOnrE+WNt7vbkgAE5Ofr1NfZ7QACMqRyKAwx3O5/pVtp4oFVpAORMEjHzN2X+p9PrXActErtu0hLfUmgk54l1GOZNYZQ+I22QUH3G/wClGxI3w8rdY2GfJuoNBRNHyrGDkgbY9DVw6iiLCwO5JJBPUY3/AJ5pqt+MGLWKSeBCsECy/Ay4J3wPXf8A5+lGLO49xUoHAMnwqWOAG7fTfI9M0tPqASGGSMjnQYO/zAf+NXdQ1KO4sYbtMfvAVcA9+oJ/1o6MqZYdYFkZsA9I22XFds5EEoeGaLBIxl4W/iA/EvmK71LVDdA+K6spAIZfiQ+vp/zmkNg946XsLHxEVckdc0a05mkwrOVJ3HkaJ+MdxtaU/DKORDFra21zluVRjfboTQzi7WLfRNLkIdQcHbNE55YtLtWkJHQn6Vg/tX4ud45Ykm8x1rO1N21cKOY1pqu8cZPEy72h8SPq2pyOJAyg4H51m2p3mTyrk98/6V1r+sye9vzOTn1oO92JV5s5+te09ZVBmPWEZ4kkckrMeUjJ3PpRXT42YAEDA60CguVjfbuQBTHaSqsIZOh9aK+QMTy4PWTTlgCB1+naqXNIcAgjOc/SrLTo7lc4BOME/pXzkUgcx69QKByOstjMrRXXJIQdt+lSXEoI5jg52obdOUJPQioDfmQNzHf0q/dZOZAbBhCPBffbBohEDynfoe3nQiznaTlwc5NFoWfY9qhgRxJHWE7V1BAI6irXMCRjciqEbiNiSOg/Ku2uVU+Y9TS2MmMbsQ5p9yYWXB6U46Nrgj5eY4BPn0rMkvCGBydj2NEbTVgCMP12xmoNWeYB3BGJt+n8RDlBEg/OjVrrbSuBzjpWK2PEQAGZNgabtD1vndOZxg+vWhvvxiLhQBmbJo5WZlZsZO1PmkwRGMbA1lXD2qx/Dlh6Vo+h6iJAoBp/SIqxDUs0YWcWiF+bGKyD2vcXyWek3TQSfEFON/StL1vVI0hMRkVWYELnbJxXkf27cbR2sk1hz/vVYpICCOUgkEf0rpdJpRYNp4zMnUWkLkdZgF3M+qcQO53Z5izfnWwaVaiC0hi5flQZHlWfcGyWd5rjXEkSLErjNalaxhzzIOYHcEGs7tOhqWCGK02i1iZPBAWA+H60VtYMEYG9R2sBI6Y2z1orb22OijFZYXMdU8y1a2wZSD5eVVrq0e2n8cHYn7UVtkAwPyqzc2K3MJXHbaj117TKPzIrWITJHdRqA6bmj8CiWJZAOo8qWdOn92mNrI/Q4/40zWAKnkwcNvTdtIvq94g1O3rPzRcvYZqIjcelEJItqpTDkDNnYb1jWac4hgYB4q1VbCxYeJylh51nmmFrq7e6f8J2q5xxrYuL73RCCAcECvvD9jmSKAKTnBag9yUXJlRgmPPDdv4MHjMNz0oq75OwqGBFghWJdgoAr6WBGM1gagndukMOIL1VDkup+m+KqWtwQ436HrRS7j8SMrjNASPBuCvbOKLVYbEKGLtxHrTLzxoAOYZAqy0nrS9otxh8Z2NG2ORt3rLuzW3Esh45nhp5Cc7jP0qlOd8jv0qXxMA4ONx3zVeYgjY/WvslC4M5xVwMSnMSevT+dUXYCTJq5OSBv0odMdzitavO2T0MtREM25oxp7AMBG29LsTktgk0b01yrAjNB1Iyhh9OfbGJp3DjiGAOWy31zRe4vHdcs+KUNFvuUKM5x6elHmk8ZAQo8t6+fatCtpLT6VoLF7oBZHdSo/MOfm+/QUDumjyyncZ6D/Wr90rRqRnGe5FULO1N5cSyvMsVvbKJLq6kBKQITgEgblidlQbsdh3ItSuTxCs4UZaR2ek3GrXLWtlCicqGWaaV+SKCIdZJG/CoyPMkkAAkgEvY6bLfwXmj8K4tdKjVTrGs32YVlTO3incxw5GUt1y7kAsGOAtxUs30yC41YXWk8OM3jWtrHy/tDWJFyPG3+FV6gSN+7jBIjDtzEjtX1661qOOzWCGx060Ym0062yIISRu5J+KSQ/ikfLH0GANFR3Y9r1685nszWNgdPXzPu8JK3EOlaJDJp3Ccc6eKpjudUnXku7sHqqAE+7wn+BTzMPnY/KB0aXN5gLJHDGBjAGMCqvgxZ588zenSo55XX8e3kKoxLdIRVCjPjDttp6RYma4Uld8YzVoSpzeJPcKsXkdz9qVhfXky+DFzKg7jarFuXlcCRyxwdjvVSpB6ywGekZIIbO8mWQMTGfPv9KN2Mc8t9Do+haY011ct4ccKY53b1z0Hck4AAJJwDS/pcF5Lcw2WmW0tzeXTrFDHGuXdz0VR5/oBuaZluZbCccDcHt+09c1Tmt9Rv4ZByuACz20EhwEgQKWlnJAYKxJEa73RM8n1/cFYxPA59dYz2SXd5MOAuCDHqGo36tHqOoRSBYnVfieONzgR20YHM8pwH5ST8IALD+1NM4K4dgg050vjfyLc2Qli21iaNiE1CdG3FjC4Pu0Df30gMrghcUHS90LgnhW5tI2S70zxPdtUnUtE3Ed6gD/s6I7PHYxZR522ZgUU4eQLHmGqcY6nr2sXGr6pePPd3b5llVQi9AFRFGyIqgKqjZVUAbCmS3cAf9v29fX4fmAtXenHh+/rw8vj+VuvNckeaee5uZLu+uWaSaRzztJIxyzMx6knJJ86GGd7kL7xkEsFCoOYknooHck7ADuRQR9Za2j8NSG5+3Uk0y8K3rcOaVd+0C7I9/tZ20/QEYAquolQ0k+Oje7Rsr+QlkhHUNhdTvPJwPOMGvYvI58BGvU72x4TshwRZvG2oRTJca5cghgl2oPJbKfxeACc9hKXPVVIWTqkCIVgyEQklj3ali2kMKeGec82SSzczEnuT3J3JJq9DJPF/wBNlBVYdreMDJaT+LH+HqP8WPWg26jeeOnhGKtLsHPWNMF9+yop9RZghsuQAdS963N4KfSIBpWH8SKD2ofpYubhUgRBHCq4GepH18/WuNaRdLW30dsNLYK3jAHJe7kwZST35cJFn/1Z86pR308ERijkC83znHSlXtzwIylIxn17o3jUbDToUUEEr0z3PpUnE2p3mvarwjplvIVF3w/pzEqfhjV3mDN+QP5Vm9/fTySx21sDJNL8IJ/CPOtSg0wWen8PXOf3lrwfZQBx1Mjy3Ea/cKzn7VdcLWSYNkwwj97Grpr32grfyAoJIbxoVz8sfhFVHphSBS+b1mSK3B3OA2PIUW9jNyG9oum2kQwvgXSE+Z8Bjj9KXcKskjd1YqB570O1ydMhP/Zv2WVrrA1DD3L+7R/9/HEHCbcgL6noIjeXHWexAKCT1MPMqt/g5D+E0GsbwSRStLljAfFVQcZ7Nv5D4fyqHhe71Gw1uGfTrjwLiSKSGJ8BgJGXKAg7MpYKpU7EEg9av3Om2t3arxPw7b+Dp8h5b6xBJOnSSDBTfcwNk+G3b5G3AJl2N6i0dRwf5/bPz8TiAi0sUPQ8j+Pd7vlxxmlLey3sy83ypsqgYA7/APHzopPKYCqk/wB0ir98b/qTVOytFg5pXHww5Y+pHT8zXU5Z0DE5LKh/Sh1KSCxlrCucCdXFy0U648ga+zzSie2KZKBt/QEYqq48a6DnJXGPrUvh5j8OTOIzgEdR/qKJzKHEL80vMsbkKdgM0U061le2ltcgggMAD5VQtxNNEhkCyHGxbo33pj0pIWkSMwNFKV6MaarQExOxiBKmnWs1rcht8dwB2pmiWyhjNwGwOpHrVN41t5f368vL0PnSxxbxhBYQukbDlYHpQLbRT7MlK2uIIkfHnFkMML+DLtjzrzfxlrwvJZC0hJz+VGeNeMveXdEmPxds1lerXdxcMxzsfzNKVg3NuaaKVilMRX4juH8YuucZ61UtLrxUwWBPlmrOqpJNEwxvQOwlaGUxt2NbVSgpxFnbD5hZiysCM/SjelXnNF4ZO9BWxIMqR619s7lrefJUivFdwxPA45jIX5XHMfyqx43MvOD3oW1wJF51b5q7huGIVCMAnelynGYQNg8TrUYmKFx070CQsLgqc5pmdfHhKsf0pdvEaO4LbbVek8Yg7PZ5MK2A5B2HrReCdQCM+opetLocgyRnHarcNwSR8RwD+lUdMk5kCzPSHI7jm3HQ/wA6hkmHLkNv61FDNhDnJ71BPMG5sfbegqnJxCd4ccT7JfMNi+T1z6VHHqzxt8R+2e1UbhixJ/LNUX5s/EelMqgxFmsJEaLfWyDs3xDpTjw1rLyyqBJnfoayeKRw4U05cG+93F2kUCMzZBAFAvqAXMtXYTxPR3CZluEQjPb7VsHDllLFb+K/l0rOfZzod1Fbxy3qcuRnFaVfaxZ6VYGd5FCRjDb9KY7N0rWsMTP1t2wFZnXt11jUIuFdQTR5mW9SF5I+UkHAG+CO+OleN+MOIrz2h6evEk9wguriV1vEXqJ1Ay2DvhgQ31LDtW4+0TjSbVdZmtoXjkhWTlCvEHG3TY/WvMNzrGnRcQzT6MJYkkuHjngZQOb4mAI+wH0Nb+nfcTX4DB+ExC+/BHh9cxj4H0i9aMSI0hyc7DqK3LTYAkaIBgKoApI4R09NIhtbj3iKdHUboCCrHqrDsR0269ehFaJaRcj8qrtnYnypXtitlu9qA0bh8/GErSL4RhSAOoonBH06ZG1VbVQAB0xsTRW3jBXOAT13rLRPGaAMkt4wfL/SikMQKYqvBGM4x+dEYV26Y27UYLJi1rlibSZb5F2U4bFGtJukmjXEnxAbf0q5e2iXNu0bKPiFKlncSaZftZyKQASVOOo7/lTlXBGZUjxjvzB03O42xS/xRqSabp8kjNhsHFFreZXjD5A8/wDWsn9p3EL3F0um202DncCh3afBJxxJDZEXbLn1fVHvJASmS2++9P8Aw1ZhCbh+o6UscPaX4FsiYPM5yc09QILaFYl2OMn61lapNiEecuPdCImyBXBl7bYqoJ8HrXzxst1P5VzGoTwnmPjLeQTnfHlQrU4OVvEGwJojEQ22a5v4/Et+2R5UnS22wRazPWV9Om5CDk7EGmeFxLEGBBFJlpKqPjp5edM+mTiSIqSMio11fGZVW5nhsnY469TUbsemfSuwT/iHcVG474FfYKxMACVphzdvWh8ynmyPvV99gcflVOc8uc1orwMS2MjmcwqM77UVtHCkAAk0Kikx1A9au2snlQb1LCFpIQxv0dyxUb/lTR4pWEYIyBtSVpM7Iy4ODTpomjahr0rrZmJIrdBLd3lw3JbWcROPElf8IydgMsx2UEmuM7QobvZ3XZl6mnOekgs9Mu9XuTCkjBAQZH8Nn8ME4ACr8Tux2VF+Jm2Hci3q9zo/DYSwnsob28tnLW+luyy29rLjBnvWX4bi4P8A6JT4cY+Ek4KmXiHjGx0u1OgcCieO1TmWbVJk8O7vGIwzqB/cKw2Cg83L8JIBIKIcR9+XHQDpipqArHmfpGiGtO48D6y/e6pe6ndzalrF3JcXc55pJZGyzY2H0AGwAwANgMVQe7JYANhOuBXDMZTlsfSopSY8scUVBk5Mqwx06CX7e4Eg5VYqPPvV2GOFgA+DigNtdKWClsD6URivVlkWCEd+vl61LJ5Sqv4wgVMjeHFgDGwAxVm3snSVIUiknnlYRxxRqWaRycKqgbkkkYAqSytPiDHJ5iAM7k/Ybn6U233JwBDLFGw/2lmiZZZT/wDwqJl3RT2uGU/E3/ZqeUfESRVUyYNr9pxIJY7nhpX4Z0NXveJNSYWV9LaDxGh8QhfcLYr8zsSFkdfmP7tTyhiWbQNHsuGdPvrSPUYbdLeLm4j1yBVnEcauB7nafhlUShY17XFyB/2Fu5apwtw1qmlXkHDmnRsvFurQlbhwQjaFYOmXTmO0dzJGfjY/3MTYJDO/JU4w1exvvduGOGxGug6W3NHIgKpeXCrye8FevIq5SFT8qZY/HK+TqO7HeN6938/LrBly/wDrXx6n7/x8/eVfibXbzirURcyWwsrG1QW2nafHIZEs7YMWEfOd3cszPJIfikkd3PXAFi3aMh16/hHlRg2HKfFZgqgY371OlsQonUAMB8Ofw+tIuXY7jNCsovAEraHoGo6xrNnoulqJdW1GdbeAucJCW/ET2wAWZuiqrHr0O8T3WmapeW2ncPM50LQoP2bpTMOUyxhi0lyw/jnlLyn0ZF6KKJ6Bpw4e4Vu9f5iNQ4hE2lae3Qw2YwL2cer5W3U+Rn8qXr2PwUCQ9AN9tqhgwUJ58/p4fz8p5HUvu8Bx+v8AXT5yCS4itB4cI537uR027Uc4ef3YvxDeohTTESVFfcSTk4gTHf48uf8ADG9ALW2SaQzOf3aZOCMZ9aYNUiktbW00uRSvIBf3i/8ArZFHhIf8kJX/AHpZKCQFjOS3HnKhkUr73cyEs5J5nOSxJ3J8yT3qjPdNOcRjCDJA/wBalMMsoNxMmFJwoPaoUUXMwtYU2ZhzNjc+lBAAPEP4cwhw9p3vN17y3xBcHPn6CtW1xPdtG4bgRh40uiWcr4/CqmZUH/zSH7ik7RrMoI7O2j+Jiqg+bE4H609a7ZoLvTXjz4UGh6dGgPfEWc/fOfvVSxZHx7hBORvXd7zL/saPge0vhx3GFa/W3Ynb+8Vo/wD9cUPkt2j1Oa3dT+4nlB+ocj+lWNCuv2Lqun6kp5ZbW7guM9N1kVv6Uw8QaI1lxrrenyKOaPUrg/7jSFl+3KwoqUtZpwnkx+oH/wAYu9wS8t5gfQn/AOUFwWs6hJYiUl5g6H+EjcH7GmGO4m0TVm1PTCsXvCGVUZA0bxS7vE6nZk5uZSp/h88VDFBzvkfKoAFS/Ddxy2gOZbQNPER1aPGZUHqMc4+j+dMVU7OV6+EWstDHn9YQOlWmtWjvw5EY52+OXTC5Z1x18BjvKnX4fnH+Ib0Fe1fwApDc6xgMCNwRkbjtVywCyKrLgZwy47Y6Yow+qvdMkWuWSahsU8cuYrlR2/egfF/vhqaFSWDPQ/T+vh0+EBvdDjqPr/f7/GLFrbMyeISBg96M2OkrOA3iYDbE46eRorZ6Vo10HFvqbR46rdwEMh8i0eVYfYf0ozo2ioEMMs9oebdXiuMgjPkQKldKQeRn17pVtRxmD9M0VYuaENGwZsPC4IGfQ9vrRmW193to5EU5iGDzdQM7dOuM9asyaT4EizyXEYXHI5GTgjpkY22pc4s4ot9GieB5W8RRgHsape6aes54g6w1zDHMFce8VDTtLMviqSg2/iBrz5xLxvLqKyOzEKO2aIe0bjb3xGQMABts2dvtWNX+t8+QHz9qw60bUWF26ToK61pr98s6prHiyknOTtjzoVLeyHHh5xVW8nL7hSAR96hinGeXIJXYVppVtHEWd8mfZTytiT8R3FBdStvBkE0WQD1x2o3IonBVyAeg33qpJF4iGJtx09aYQ7DmDYZEp2c3MAG7mrlxETGHQgHtVaG3MMmMbGicLJInIVGcbGrswByJVV4wZWtLghfDcmr0Moyu58tqr+68jcyHqfKrUcICjBPTYiqMwPSSExCEFwnhnffpQXVObmOAN+h61e+TJI2AqtKqysSf171FZCnMFYCeILhd0+EE7d/KiloxIxn8jUJtVGcDGKsWqBScADPpRLHBEoilTzLyTMq45vvXMsy8mebBOahlYRAso6dKFXF8Q2Mn6UJU3HiS/s9ZdnlUts1Q86uQoznpsKHG5kdgAOpxTjwPwtPruowIsZIdgKm1loXc5nqazc21Jb4J9nuucXXccVjaPyEjmcjYV6m4B9hcXDtrFPdRgvy5ZiO9P3sf9m9lo+lwn3eMEKPw7miPtf4ysuB9AaaUOEPw5QZx9aFoq/xrhrOngILV3fhx3df6mJV9rNtoLzQJIuI/4W6fase4u9pVxc6jc6feTFLd0YwherOo5sY75xVfXfaLa3+mSz2wEtzOxIPQkVk3EGpXk1xb6nPFhbaUOwGc4Ox/Q10uiYaPUrnpOZ1NhvDID1E0Pjq1WDUbW7VOSPULSK5QgYB5hn88EVgfHfD19a8Q3erWMJMNxiZ2TA8NwAG/M7575NegtYuZuJeA9I1VLPCaPO9pPKB1VwPDP02xWYcYRqqSqUBVkOQT2xUaus6LXsi9PD4HmC0p7yvJ9GNHAtxea5wzBb3V1LNeLbx30CyuWZbd2dAMntzxP023Hen7RJ2vLUNIPjiIQnHUds1lnsw1e5Ww05pwWj0PVrXQjMF+GO0vIpiUY9h7zDA656NM2PnxWie8fsHiBLcH9xeNzEHbY9R9qa7TqFy785yAYLTNsYjHT+Y52iDbG+aLQRjzwAao2sZBGF+tErdWyMiueVZqCXYIx+dXokOPr61VhH4s5FXoem9GVcCWBnap2Pel7inSDJF77BhZIviyKZkA7jNUddgebTZQjEMFJ8s0VBziQTM6uuO4NL09lkcCXHylsgHypF00rxNrJvi6tzMTgHO1IHtR1q5stUljWX4WJUqDTh7EbW7voBNOxwSGBH8q1Ni2U8xM5rsJmt6bpscWJgvQDbyq1PJg753/AFqZTyoV7L+pqncMckZztXMa8DJEeQ+cjaQ8xyfy6V9STJIyarO/pXcRHUHrXL6keM83MK2x23NTTnmiYdjVWBgBuR9asOwaP6jzrLK+3mBcZEAF2jkzt1xR7Q5+ZioOR60v3hIdiNgDt60Q0ObllUFu3nT96d5VmAXrPG3Pk9c718Z/h75rj8Rr6v4q+sV8cTEzkyGUZNUJ+tEZOp+lDbj5qbQy5Wcod8HpVuGUJg7bVRTv9auWX9/H/wB4v86tjIlTwY98NcNmZLPUNeee0trzeytYsC81D1iDbRxbHM8nwgAlQ+Dhh13i06lZQ8N6PHBaaJZSeKsFtzCO4nxjxWLfFJgHCs+ScltubAg4v/8AzicU/wDu6b/9AtLlt8o+orA7SrAPHE6PsZyevhn+JYucsMBfrgVRljbHMWIzRLy+tVLzofrWEvBwJ1WSesoB/DB5AOlVp2lkPX9KsSdD9qi/7FvrTKmCK+EooJGlMcJ3HzMelXYLqK1Usp2xks3Q4/pVeP8AuH+rVZsf/L7L/wBoi/8ArFMDmKtxmPtjqz8DWUOpXYH+0l5GJbKBxk6ZCw+G4kB6TsDmND8innO5XF/h2+j4b023441d4n1C8LyaBbXADh2ViH1GYN1ijcMIwdpJVLHKRNzJftH/APP7iD/3lP8A/VRzjr/zk0f/APp/Q/8A7OKiBR8vWYHoAfP1iPtxeTcFcNSaVLNIeIeLY1vNWklYmaCwc88cDk/F4s5JmlzvyGNTuzilYahGrjI53OenRase0v8A/OVxN/70u/8A9I1AbH+8X70OxBnHlxJr5AfxMO2VlNe3GWTKAZO+1GtM4ZvNf1az0HTmSNrqURCR/kQHdpG8lRQzE+SmudE/uP8AdNNPBP8A1hqP/ufUP/t3odSCxwD0l7GKDIgrjDWrG91QJpUbrptlClhpkR6raxZCEj+JyWkb/FI1KzwzXE5Dt8P4sfyq/J/5efof5VxB87f896E/tEmFQbABCGj2Vl70jX0PPZWytczp/HHGASv++3LH9Xr4FvNX1CS4vDzyTyNNO2Ni7Hmbf6np5YqxZf8AkV//ANzD/wDp0q5o/wA4+ppWxABiNK5MGa5CEwiqFAGBtXGg6S/Nzcm56k9hVriD+/H+Y0Z0f+8/3KC1YAxDCwlSYZ0mxWzzdg/FDHzg/wCM7L+pz/u0ya2sS3drAo2ttK06Pc9MWkR/rQa2/wCrJfqn8molxF/5XP8A+zWv/wBtFTFNSis/p94B3Lvn14QTFMLm4kkZiUhPXO2RWvcZQrd6vNxAD8UrvZzHylixyn/eiaM/Y1jGif8AVU/+c/zrYtZ/6q1T/wB5Q/8A29N0KO7cfA/v/MVvOXVvj9oFe4hghHLKoB7k4qo8rWY978QxMGDxyg9GByCD060IvP8Aqxfr/WrVx/5rXn/d/wBa8y+XhLLwYek1HT7eCK+gCRRMypLGo2hkboMdkbfl7dV7b2LW8t72c3CHMSY5gDujf6GkzTv+pp//AHM//wBxFV/hLref+z//AKwq5XDSCvX3HEeIWXT9SjvFIaOT4WOdiPI0ws8Omuk0ak2l0c5XB8N/5Z9O4pa03/yU/wCQf/VRkf8AUcn+ZKG7mtSw8IMIHIBlviTXo9L0551nhd+TALE7ivNXH3tGnvZZVkUIucNg4zWs8c/9WH7f1rzhxl/et/mrE1DG6z2jxNXRVKi9OYrcQ6oZoXlSUsp3xikmeVzEZMYNMurf3H2pWuPkf6U9plCrxL2k5nyO8mli+P8AD1+lfUlR3DAjPeoovlb71An96ftTqqImxIMIXEzNupG/866tp1BPiHJNVp/w/SuU/vhUBQRiWzgwoYfFIwM+or8ieG4yTyg1btf7pPpVV/mb/N/WlwctiHxwDLgjVhkE9M7dKh5niYqAcdasQ/KKjn+aqg84niPGffEMi8hxkDNRNDJnIXr51+i6n6/0qwen5fyqc7ekoRk4lcNgnmU5/PFfF2OVzjrUsnX7ioj1+9WBzKEZODIrgsyYzQmaJi+SM70Yk+Y/eqj9qJW2II156ybRdHe7nVQpOTnavVHsF9msk88N21sSqkdutYFwb/5dH9v6V7k9hn/VkP0FZWoc6i9am6R/aNNQXTrNg0DRFsrNIhFj4cb1g/8Aa80iSX2eaqY4y7RwlwM43Br0lbfIKwn+1N/5iav/ANw1bWnqFdyKvmJz17F6nLeRnkD2W8GLLpK3t/K3MFyVJ6UR4l0XT5bSey5ABIpHMB37UX4C/wCoZP8AKKEcQ/j/AM1Oaok3sSZm7EVBgSL2W3lzq2m6nwZcPyi5iMTek0blo2+4GPvSbxhZvyMsifGFKMue+4Ipn9kn/nnN/wC0R/zNDvab/wBZ33/tD/zrY7T/ANtNGob8xGD9IlpkFdroOnWKXs9u7ez4q0vTrqeWPT+JJVtdSiDHlmSNGOD6grGwPUMqsOlbLxVYy3mke/uhF1Z/vG2wQw+cGsI4c/8AODhT/wB4zf8A6M16S1v5tV/7yT+VeJL6VGPgWH6dZCgLqCB5A/XEscE6qus6LFKZQ8kY5H339D+VNttH8O/Ssx9k3y3H2/nWpwfh+1YbDa5AjlZ4lqBBsD+tX40+AE9aqQf0q7H0+9WAl8yRQMZ/nQ3iOZbfSpnY4+A53xRROn3pe42/6kn/AMp/kauBIPAzPJnHOhy61qUt3GC55yGAFat7HNOWz0wI2RkbH0NKUP8Afzf5/wChp/8AZ/8A3X2FN1sSoEFYPGOkhC5UHJ60OupcE71dl+Y/U0Ouu1YvaACsYwvIxKryEE71LFISd8j0xVY/MPqf5VLB0+9c1qFAlgMnEJQvnGM471cDEpvvQ+DoKvx/3YrKskMOIF1HCynlzvviv2ly8kiEnvvXWof3o+n9KrWP98f8wp1BvqwYoODif//Z"
+    },
+    "type": "object",
+    "properties": {
+      "filename": {
+        "description": "",
+        "example": "cat",
+        "type": "string"
+      },
+      "image": {
+        "description": "",
+        "example": "/9j/4AAQSkZJRgABAQEBLAEsAAD/4QDiRXhpZgAATU0AKgAAAAgABAEPAAIAAAASAAAAPgEQAAIAAAAMAAAAUIKaAAUAAAABAAAAXIdpAAQAAAABAAAAZAAAAABOSUtPTiBDT1JQT1JBVElPTgBOSUtPTiBEMzIwMAAAAAAKAAAfQAAGgpoABQAAAAEAAACugp0ABQAAAAEAAAC2iCcAAwAAAAIBkAAAkAMAAgAAABQAAAC+kgkAAwAAAAIAEAAAkgoABQAAAAEAAADSAAAACgAAH0AAAAAmAAAACjIwMTU6MTE6MTUgMTE6NTQ6MzcAAAADUgAAAAr/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAGpAoADASIAAhEBAxEB/8QAHQAAAgMBAQEBAQAAAAAAAAAABQYDBAcCCAEACf/EAFYQAAIBAwIEAwYDBQUEBQoBDQECAwAEEQUhBhIxQRNRYQcUIjJxgUKRoRUjUrHBCDNictEWguHwJDVDc/E0NlNjdHWSorK0FyU3s8ImREVkdoOTo9L/xAAbAQACAwEBAQAAAAAAAAAAAAADBAECBQYAB//EADkRAAICAQMBBQYGAgMAAQUBAAECAAMRBBIhMQUTQVHwImFxkaHBFDKBsdHhBiNCUvHSFSQzQ2Jy/9oADAMBAAIRAxEAPwDyHfw/EzHJxk70qaxj4snO9PWrQiNGGxPcedI+r9SN9+9KaI5MY1gwIqTr8X1rhB5CppwQxx1FRID16VrY5mU3EmjHxZ38qvwABftVGMHG9XoTgYxt9KIvETt5k6dcYzjar1uB1O5qimdv+f1q/bg9hnO9X5ziJ2cCFbMZOMfemCwUEigVnjmB86YNP2wcdNq9Mu08ZjLppCYOd6NWp5yM9f0pftnAAUDbqfrTBpzcxz16AUjqeOYpQCXxC1pCxIBOcf8AO1MVjbqeUgHJwfKhNmFBXG2cHGOn+tMNiMgYGP61y+sJJnZdnoBiEraBQOma+XbLGu1WogBHnA32odqEgLkDpWI6EmdRQfZlYHnbI2qZSBgnzqCJh9Tn86lQ57iqNXiO189ZbQBsZH1xV+3yBjoMd6p2ihsHHQ4q2rhDnPSqBPCNgGQ3L/vcVXmPMvzA57etc3EvNIWByetRtJzKMAen1ond+UsvBn6IlcY3+1WUG+wH3qqpOcAmrlspO/YVOzMZUeM5e6mtZ1mt5eR1OVIGfqCDsR6HY1O8UOoW8l5p0IjljBee0GTyr3kj7lPNeq+o3FKfPOR96+QyS28qTwSvFLG3Ojo2CrDuDRBXgbTJPPIlaVvjBB29K7t5GLdaJm1t9fPNZRpb6oc89qoCx3J84uyyecfQ/h3+Gh0EbKxDKQwJUgjBBHUEdj6UwKyolQwYyC7mIbGeu1D7tQwBA2O/1q9dDmP3qnKg8P6URR0kEQJyF5Sd/vROy+Fc4PWq3hHxc4Iz5USjhAgx023o88BK16BIec/bFDZIjy82djRB258qfw9qhkhyMDqaLWBBPnMrWwLBlxt51ZFm9xLBaQL8bsF/XrXNrEVVmYYPNtTJodqscvvswHMwxGD/ADpTW6gaZCR1Mb09PedeghBNLEECWCMCkRy7D8R9aYrLmghRYUCnG5I6CqVlEj4ZjklizZphsFEi8zJ16LisOgGxi7dTG3O1cSzp8cwCygAnu7HYfQUXSK55chvFPkp2qG3V0T4VVcdNs1agS6l+ExFx2IbFala+Ez3OTPqe8KMPZnY9MZx+VWLaSNTmNGI8jGRXx9O1s4a1m5R1+FgCPrX2ObiSwk5LjT5JQe4IYGruSg5B+UmtQ/Qj5yzKtvKnOsMZPfBww/1r6LYhOdEZlPk+cfnViGbT74ATWbJL3DLXL2GnwEsJJ7cn8SHmX7is6+vvOVx+00Km2eyc5gDU7QM6yKT16E012+nJqPCFzAVXJiZd9+opa1VAilkmEnqBimHhN5p9Lnhd8jlo/Yrd3fgyO1kNukzPGmpeLba7f2EijMUrAY9DXVu2MH/hTTx/DY23GN9aJajn8Rg7KNs5paWLkdl2yD1862NfVsfJ8Zz+jt3JAHtBYx6C0g25DnPnTDwLrknEHBOn3cq5kgXw2IPbp/QUue0ZC3DcoQYzt9KGf2fNUubjTtR0GZt4mMiqT5+X5UxpEF2htr8Rg/KB1L7NWjeYx95qPiHGFBzWCf2hOGOJb/iHT9bg1e4vLS6jMcVrMzeFYmCNSSNyCCCSBy5zkb5Fb+ID2xikf2kTNpuu8C6hHOivDxAhSNlJSQ4QrzenOseaW7GJGtStTgMcH18ZbtHb+HY4zjkSh7GNY1O94fv9M1PRLWxuNJv/AHad4rFbV3uDEplhkUDPNCy8m/cnpnFPlzzvbSBVDHlJCnv6UQm0mHTJ5rK2aN0jnlPPGgUSuzlmk27sxLE9SSa493+EjHzDv5UtrdQb9S1jcHP7cfaF0yrXp1XrxLnBmkSycMXlvHJzSeDzlebPnkY9KW9UcW9lNK2RyoTTf7OmFndTWbOS7u7OCflJ6Y26bUo8bgafp18JlwVZlx5Vr9rhbBReP+S4+UT0VhrNtZPQ/vMV0oftXjMEY/vcn862F0yN1xsMbVlPsttHvOJ57rlBC5PTpWxmBgckYwPzrN1jAMB5R3TtjJgt0z1AFBNQtgbsFhtynf8AlTU1v2GT26UJ1K1Pjr8O+Pz2qmlsHerDW2ZWXhCsuluCQBynB8sb1mWrBbvViudo8DI/OtTQvHokxcYAT8tqydZOaSads/ETWlqlAsz7orp7PZIkun2Jub0Y3GenpTesQjQIMYG1UOGbMEGds53NGmiwM9/Ss66wM2I/R7IlFkyc527V9jgLSqPMb471YMWOvbvmpEjAZTynfpQa2w4jFrZrIgmaBY7gsmBnvTJHEDEhOMctCrq2w4ZATjrtRyxX/ocfN9SftTWrya8iJ0NhsThYdtu/TNDtXYonhqPvijRAVObuKXtWkJkIJ8+9ZyElsRtzxzF+7CqDk/Nt9K/afaGV1OO9dyKJnwDRnSbIcwYjYetNs+xeYEc8y5DbCOEAAH1qxHCSdqlYZBwO2MeVSwoeYbd6AGMswA5n1LcbA/SuBByzMoBIbYURjjHYZ+lfpoOV1k64IPpRq7drgmK2rkQDcQe73AbcA/yotymSBTndNutR6pBmJXRejE/arOm/v4uVh1Falw31mIqdrSo6NjYEVwVZTnYd6uSRkHlJ74x1r54O/mc461iMQBGwcmZhrceebGxOw2pC1lSCwO5PTG9aHrRHxZ6b49Kz7W1GWB23/Suq0B6Cc7rfy8xVuvnOd8+lRKvTapbgnnIGNqiAwc5rZMxzwJLHkHFW4ziq0Qyc/wBKsx4xgjeiCLPzLkYJ3FXYN2xiqduSQAOtX7YHmBqwHjEbTCtnvjIO9MFlsB2yN6BWYOwPSjURwoGN6mZduScQ3ZnmYbE0x6cDsSN+lLOm5YjApq09eUjAORSOq4EHp1BeMlkuFXOObp0pgsFJ6g77/egWnDmUEHbAP/IpjsY+UDbt9a5m9cnBnY6FMgYhDn5Yjt2oVdPkmrc8hUcuNhQ+XOcEnH0pE15nR6dMT7D06ZzUiD4sHtn71CmU2Odv1qxCAWGT3ob1ZmjUuDL9rgAd8V1ePyD4SB518jAUAj61FcNzg4AzQRVzmN4lTmLZJ69dq/RvzY8qjyQCuf8AjX2MfFjc/wA6MKxiWAlkL3Aq/AoSEt6VWiUHl7+lWHcRpgHpXlryIbmU5mw9cK3cdMYr9K2fvUJz065o4rzKzsBXJz9qPRzR67CsWoypHqQAEV3IeVbjySY9ObsJD9G8wChXmZcdKtzryxcvmMGr4xxPbM8yheQTwTy29zC0UsTFHjcYZWHUEdqoyjGQtMUU667CmnXjhb6JRHaXDnHiAbLBIf0Rj0PwnYjAGeNklaKRWV1YoysMFWGxBHYg9qsK8dJ5OTgyosWTzY2q9yYgJK9v1qOGPJCnG/r3qzcqEi5N96uEzCbcQLJHiXJBNSBSqr3IBzX6RM+WPOrNpC0sioULMSOnff8A4V6xhSpLSFq7w4n7TNPe+kZDsi/FIf6UaWIF4+TcfKoB6CoGVNMRo48lpCecD+VWdJiPNk52OT9+1cpqdQb33HpNeuoVr7MZNOtyeUnHkBTDbRyKBy4H2oRZBgAFTHqaLxy8pBa4Cgdd9qPUwURS0EmErVLlhhQQD5rV62hvI3w8iEYzgrgUHbUrSJQZr1EUeZODX1Nbs3UFLkt/uNg08lkVNTHoIzwpMuOWfkxuQDmiVnqKRjkn1CD6bb0nwXtpMCqqST35sfoTV5IrWQhmtFbH8LAkUytzKMiD/DgnDRziuVnA/c20mPwl9z96/SJpM4KtB7u56Enal23S1VQkFvMmO6kgCrPvdug8OYkqO/MSa93gsHtASwq2H2SYL161mszvZxyxk7OpJGKOcIWzNbyFUCc69B0oZNesJfDjUOjfXpTNw+T4b8oC/BS2nVU1K7Y1qmY6Ugzy37Y9IfSeMry6EyYmcN0/OlE24kZZUGzAE0/e3TTJH4vmuzIHTlHw56Gk7RIPerUofmhbGPStrtAmyrI6icnpm7s7Yoe0KELw3KCAfQ9RST7OIZeHeJdP1UE+BqLeC+PX/jWke06yKaAU5fmPc0unRprf2fxavBD4ktnKsoOOgByf5UDszUCplV+jNtPwIxLaw7gWHgM/Kay1qFkK+R27VmPt3vP2NacKaonK0lrrLzRwhyryMsDYAPYZIBPbIxWqaZP+09LsdTC7XNuj5Hc4FYx/anuzZ6Twqvgx5/aVxMsnWRGWEAADPQlt/UCltADp+1EQ/wDFpa9xbpz4gibXeWVlFcsmnQGK0CoYY8Y5VKKcY+pNVzbb9Om4rrh24Oo8I8MagZBP7xoVgWnBz4zrEEdz6l0bPqDV4wnOSOtJ9pf6tZdWPBm/eXoszUpz4CArO7utF18SwJ8E3K7HyIIH5bmgHt9vYbJJBspvh4i+RJ7inDWLNLe2XVprmOBIcliwzt9Kx3X+IIPbBqVrokVzFC9lN4bFBnIz1AJ+ldHo0bXdmL/2RuPgZn23d3qvcRz7sdJY9jmhGOwl1Fo/7w4B/wBK0V7TrjO350Q0nhEcL2MWlrhiiA8wXqKsNaY2wa5jU6gvaZpK/GQYDe0J3Yd8/eqN1Y80ycq7ZyKZ3tCcnl3qCWyPOsrKAE3Joen1GLVnns45i3qVs0GjNCoAZ1wAemO9ZW1n/wBJ8JAfnIx960fV9ejF8bZ0BUEp1/X60vaPpfvmsy/BlRJsa6ntMitFtHlEtHc2WJEK6Rp5t7JF5cZHYVYe2AGw3o2bPkQR42G1V5bcgk43Ncv+IyczWSyBWgKkEfau44cMpwAAc4q9Jb77qd658IKw7cpzRK7ssIzvDqRK11ZkjIBGN+mau2cJS0zjOD+RogbUSKGU8pIz0rtbYx2rYAGDvitrUJmkmJVW4sAge+lMUbbdQdqUNRuvjYjfHrvTHrk/KpGfTekyZ2nmIGcc24rPqXJyY6zZMuWERkcEqCScU12tv4EIUDc7nNCdGtgzKT2/nTAwCr9BiqWvkyymVsjPfGNqmgI5hg9/KoHZc7etdxMFYHJ8sUIGQ7ZhaHmBGRsOlSTAsmAPzqGBsjbv1yKnzgY26dv1qwJEAeesruiz27IeqjequlOUZou6nzq0OaKTlO4Y+VDnJtb/ADy4Vz2862dO+5OYjYu0wncxnxObfc9qjHKqsxxvvV2KP3iAMNiNx3qG8gWOJsY361l6isq5WMK+RMm1hwS5zjOcelIessSG696dNWckkjY0j6u5y2DkV1OimBrSMRWudpPLtXCb9OvSurn5+tcIcdP51siY7HykqEj4e3lVqLruc1VXJPT/AMatwDfGc1cQD9JehBBzsM0Stx0ND4BuBjftRO0GdiNxRF64mbeeYUtAFAJotAxY8pIOOgoXb5UYzjuMURtW5mG/oak++ZrZ6w7pyHmGd803acucDPXelawX5T16bHypu0tchQRkdqTvyRBUHNsZNKT5VYD+tMlunJHjyzQTS0w6nl2zjyo65Kx4x18q569eTO57MUFeJUmfLffpmomwVORjFSSDJ6CozkHAxvSjIB0nT6dATIiD1BwfKrNuCe2agTJO4zVmE8m+NzVSuRNEV4loPhCSKg5uYYz+lcTylF5cmoEkHN9aH3cKFn11+PfO9TRxjIONqgLEPnHpU0MnMME+vSrbfGWCkwhbqAM1DeSgNgnGBUsLYUdT22qjeSFmJ5sAHy71UJC7eJy79/SoGYMxVSfPavwbKYJzg1yNm5jTCriSExyZdtwOYDO+M1PeyfAF2O3WoLbPKCSAB51xcy+JmNWHlUbfOW2cSm0vNzIdwdvtV25mGsW7XTEnULRA0573EQ25/wDOvRvMYPUGh0nw74696ktZJLe5juLZuWSNuZSdx9/Q9CPWiDA6yoTxEntV58NnPepruIsiqBnOOlFbPRXmYXFpCRBOOeNf4PNPsf0xRyz4UeQpJOuB6ilrtVXpxljChN3SIw01pDyhDg9NqM2OmrYKlzIvTp6+tF9YS007lgiALnY4obqdw6QxRnfG7bdK53U9pNrCVH5RG00/cgHxMF6hBI17I6sGy22OlFdLtjEi8x+o9aGQy+NI0gA5c77d6N2BU4Oc0jnJjRUhcQ7awZGARnG9Xo9MeYAs5UDpgdap2sjKPhHQZwKuw3UnKPGmVQ3YHemksUeESZW8JJHoOl5zLeuWzkgb0Qg0jRAOVpCceZHWhUl+wk8C3Gw/ExNfHv7yCETOyRN+At/9X08qartA8JQ12NxujGtjYWQUCLHfdtxXwX9tBkQHwuX+FAT+ppTW6iuGAk1aSZz2QttXydbOEE++uDtkCQ4x61J1JPTiGTR4/OST8IwXetw+IA91cTt3B+DFdwamjLzx6c+R3b4qXYNR0sOI7efxZQewL4oxBc6jMR4EaNt0xiiV8nJP3l2rC8Y+0P6fq1zdTLC0EIXyA3py06MCKTBIylKfDdpeSv4l1Zxqc+VPOmQpzMj4GVO1Er3nULzEdYUFZCzzX7TrNrjiG+LHm5HyoP0pL4Zg8DXGilziVenatj9pOmwx8QTtGn96oYn9KzG8tJ7K7S7SIt4L52/hrXU5sek+M5BjtAYeEV/a5EkdtDZqoyzj+flRjTOGhd+z57LABmtz26HGaX+M9Qh4m1yzitFVlVsMQ2cGtb0rTxFpMNqVwPC5Dj6VmXK1RCjqDmHzlj8pnvsdupdW4IjgmlV5NMnktWx1AViB/Kse/thQG3veEZlgkB8O8Afmypw0Z5ceY659cVrvsbsk0viTjDh0y/u470zwqxHNhxnp9c1nn9q/Tje8eeznTBA6G8nMAmJyp57mNSvL6Zz961b0C9rLcOjDd81zEqW/+12nw4+Rx9poHsLvI9V9kHDRjbLWMc9i8fXw2WUyde+fF5vQkjtTyLb/AA0j/wBmnSBp3Ams8O3EExvND1ya0upHmBRbjncOiJj5eVEbOdy5rVvcQegrK/yCrZrncdGCsP1AP8wumf8A17fLP7zMvafoc+o8LXkcF89u5jK7bDGK8p+zrROJrDjOK+sOd1hl/vBkd/MV6r9vuppoPBNzMTglCo3wcnbalv8As76faXmiQvfWY8WRTICy9ab7Guup0drg9OkrcRwSPGahZC7uLG3kvSTN4YByc1I9pncr0ox7n2xj7V8a18hXIXXtY5c9TCBtowPCA3tM9qC8TTiy09z0+HPlmnI2u/y9KW+L7CC5sWgkXd1Ir1DlrQsh7Mjmea9Y4kmbXPd1kxzPsc1rvBGmI1oLllHORnNZ6PZ4bjiAyiInfIIHbNbLwjojWNoImJwg2Ga6ztrUCvTpXnwg6hgjE/TWmMgLVKa1O4VcUzz2g8qpS2xJ6etcmt2Y+rxaktSTjGfoKhktyFJHnk5o9La/4elVpbbmUjB37UZbscwytmcWhjeJC+xI2qxJCGtZAuebl2+1CreQxzrA+dtt/LNW9X1GOyZeQ7NtnPbvXYaewaikDzidrd0czPNdlkeVowNwcfehVtZvz+O/Y0yX1tDfXLXEPQsc4rmHS/HvIrWHBXP6Uu9RoXa3WO13bukv6Pp7Lb+Jy9atSROOwyM5o5HppihSLGCBuAKil0+QjoMGk2rYnkQvexbkDqd+g3rhHIYAg47UZm0l2PynJ/SoxocrEZB/LrXhUc5xPG4dTP1u4IB8x1FW13OM9Tv9a7i0eRACWNWhpbA/1zUip5XvB4GUpE5uV8Daq2q2JeJZ0PT0o7HprsMEZI2ruXTWktTGynan9ICvsmLWnPSVOHmWaEISMDapdXteVWUDfG1UtMjaxuREWIGds+VMF3bG6hUrjPQkd6ZtoNg3eUEtm04nnHVJOYtlsUm6sd29KZtRlyWJ6DO1K+oDnDZ61r6QbRMnVcxbuB8RJ89qhB3/AJVPefCarg43FaucTKYZ4llBkbAVag67Ej61UhOTjH0q1CQrVfHHEBZxCMAAG2+KJ2gAfr12NC7c9OmKKW+AOYfzoq4mVfCanYDbIPaiNl8w2xn1oXCxJGeporZAB68c4iLrxmNGlrnHTfrTZpiZHKNx2pV0obj4fKm/Sxhthn7UrbFaD/sjXpyZRSO2OlFJWypGKG6eQFwRtjcgdNqsGYEelYWoXJ4nedlvgTmTKk7feo3I5+uxrovnO+49apySkdT09aVwek7LSL5S3Ge/c1cUARgnf+lDIpAxI89queKFj5SwyPzr22aeyR3L5IwetVg4ICnz339ailmJzk53qLxR3/8AGvbMDMlU5l9mBAOd67hbBx64qkkxIwTnOwqS3m+ME4wO9e2QoQCGixEZwRiqLtzBt96/PcgRkDoexqt4wwd8kdKptMttwJ1GxViu24r8rAnHc7586rSTcrHfoa68Yk82TjtV9vjLAZhGNk8Pr8386rzZU8/3r48nLBzk+g2r5AWI+LcE7VU8CWInc1nLJFzKM8u236V3ptnLNIv7skZANMOgWfiusT45XHemvT+GYLfmm5Ad81hW9rCljWYYUcZEKcOR2EGnqkgUNjmAx3xQXiLiNLOJxCQNjjBr9qSXEEReAleXoR2pYuonvrwwunOsyk48vP8AWucvvfUtGKqlT2j0kNs8uo3bXswPhgfDv1NR3QErSu2d9sE+VTypJZJHaQ746jvVC8lC/AWwTgEHsTualf8AWuwSwHevuH6SFIhGEhTZc8xOdzR+0Aj2UdBjNA7H95OAw9Bmjkau8ykHbOOUV4+1xDWDHWE7cN8xY7j1rv8A6ZkfPy5+HB/pUMXheMAjZJ2I3o1bJC7KqLyMBnmPRQOpNFTYDiKN7PM5gt5FUytA8ijblJzzHy9B51ZTSfHk94urRA79idhUg1OEsEV15FXCDfJ/413Hdyq/7kIpPYg5pkWJ+VYIbx7Um/YzmLl5Uiz05RvUD6BpSkRzQC4kPzF/9O9Q397cqfhueUgdW6Chja00ALS6xliegP8ApR6+T0ngLD0MZrdNE0oYtLeBcDcFQN6rXWvSxuIbRFRGO5RcCgMutPcKGWXlHZipJNT2CatcyK3iYh/xjc0wbMcAy6afHtWfWPvDlxM6B5JSc05aShnnxv0pP0WIwooC4OKa9BuWF0fICraNWbUKW6RDWsvdtsiL7TtLMeoCXlG6gVjvtAtr1dFnlsWKOIzgg9TW3e0q9ae9Eajt5Vnuq20b2Eolj5hjoac11wq1BZPCcinPBnmf2KarJqnEdzp93FiWGb94WODnO21epY7cKqrjsK8vW9uNB9rTSWcfhC7+ZV6H1/OvUmkye+WME3cqBTfaTi9UuAxkCBoygKE9DEXRuGI9M9sF1f8AIqrrFkOXBwGeMnOfXDfoay7+0fZtP7bPZRp0UCLO98v7wyZwBcxnBT7Eg98+lb5xbo3iwW2swc63WlzLPGydSB1U+hGaxb2op+2v7W/s1to0WRbax98YqnxD52yx7jYY+9Oov4rS16odawVb4YOD9cQAPdu9X/Y5H6/2DD3C0R4U/tL8UcIW2fcuLdMbiJYmfA94wqtyD8R5kc/Q1sS2w7gVjP8AaU00aBxP7O/ajbWc5k0zV/2ZeTQk5S2k/eLnywyPg/4sVu6JFOq3EDh45AJEYbBlIyD+RpDXV9/pKL/EZQ/pyPofpC1ttdl/X7faebf7ULHUH0jhSJyGv7gAjGfhUZNNPs04bk4cn0yydQSLRVIHmd6BavZ/7cf2jINMliZrbRrPnbfKh3P+grR71jpvEtt4agqX5FGOnaq6FtgFR6HJk3r088Z+caWtAN+X0qI2vp1o0Yeb4sbsM1E0GO1c5ZpwpIkE5gdrTbYYzWfe0C+WwRgc5xgGtTkhCoSR0FefPbTrxtrtbZXySRt51bSaYG9cSp6gQ9wPbWupO1w8XxDYU8izjgXCKMUp+yqJm0mKV48FxzfnT/NBgbVPbTFnA8pCfmOYDmgHkKoSwjfpR2eAZORQ+aAntWGMiNI/EDTRA9qqyRddu9FZovixVZ4c52oy5jKNF3V9O54TPEeV13GO9IHE2rXksPhgt4kOds9R3rVdUVVtSDsSKyfXLSVryQINySB3Fdb2G2TtbpK2DcJBoOtwzWEr3Lcsw/CO9O3AOlSSRPqE6ks5yM4z6Vm2kaLdRXrtI/OC3NgjYVsnBkEnunMdlG2K0dc4aziVqJXiFWt/TcdxUZtu53JogU3yAa6EWT0260uo84wxg4WIbqv1rpdPUYJWisUOeoqc24Izy/8AGibYPd4QP7oOnLXSWh5sY2ombfG+KlSAeVeAzJzKcFkDg4BqSWzCLnl26HFEoIcYBFWHgDoVOMGj1Lg8SjGZdxPG9ldpLE5UHbFFeGtUS8cRzONuufSpOKbNTIYmTOO6n9azuLXJNP1VUAI3I61rphELRYjLYEx/UXIkb1/Sl+5fBbINH9at5YZd0JDfIw3DfSly+OAw3BHap0rBolqkPWAr44cj171VVqtTxNPkxnLA7L5/SqGSjEMCCD0NaQIJxM3HEuwNv3q9Cc9KGRtuKvQSZIJ29KIDFrBCdscY3x5bURhk6b9aEwyAEHfrV2KTcbmiiZtq5hm1YDb9KN2WSRjIx1pdt3zj02o9YNkjvVjzELRgRs0lgCMjypz01sqDjIA/OknSmAKj7dacdMfCjJyAM7UtcQBE9PnfgRmS4CKoAz2+1SeNzJkYHcY/lQkXIz5jOD6CpDeKYzliO+3esm1QZ2fZrHcJca65R82POqU1yBLjzqpPeYBPNuOvrVGa9DYIxkHzpXbg5nf6H2hD9rOMbE58qnkugq7Z3FAIL0cuM9a6mv8AsG6V4rnpNULiXpJyD12IPrURn3xkdaGy3oK8wbpUPvw2+LrUqPCQRg5hqK5AIyasx3A5jv13pcF4OYNk1cju8quGOTtVNuDCgZGYWmvd+XNQ++Z7/rVa4s7xEE/hsUJxnFTafp11eXkcCxn46g4HJkbhJHkZyuBjJxVmNZCoXB22p20/2W3V3GJCSF7UXi4AFtMhmUHkOD6ik7NZUnAMkHPSJdhpFzfQhVRsEYO3eimm6DdLGY7iA/CcAkVplnpunWMKqI02HlVPU54GDpbKvNjIx1rH1fagGVEMiM55i3bwHT41k7xnP2oonE6JFzMwKEbgVFJau9ms8wPI5KNt0oENDZ1aGIsyK2x7b1yGotNrkmaddakYMn1/itYbVxGuQwyD50P4Cvf2ktxfsd0kYLt8uR0rq54Wee28N2YI3wk826kGiXDWippdvc2gULIfjyBgMRvn71fTWqpyZ7UKndFVgybM+pPLgnqdq5n04Nes0ikocOc+YFFWshDfMpPwyAMp+tdmBZ0SRQTjZjjPoatZd1Mog24xA/uKwyGdF+UZq/BMqhSyYx8Rx22q+NPRxylt2AxtXEFgFguGYb8+PtQ1sLHAlywI5kVrcLGDPMQibkE9ftVy81ePTbfNwMtKgllBGCq9VT69z9vKuY9N8SSOaZMx26h+XszE/Cv3O59AarXejvqUgeXLeI/xlvxep+9OVlKwCep/aAbDtg9BObfXjKVkFqADsuTnbzqHVuJri2QrZlpJmBARRgk0Yi0UpMfDhVEUbd67sNAtRM91LF4jnp6CjLaCBiSDWDkiZ9PHxlrUijwpYUc7Bjgfl1o/pfCElqqtd3w8TYEH4m/0FODWwVliiiVR1P8ApXQ08FSQFWRzjIHSjCzAlm1RI2qMCV7O3tLdVxb/AC7c7/z3o/aiE8ojwSe9ApLKN5OQtIxXfbYZonZA2/72X4UHQUzRaMe1FLRu6GPGjWpkQDB3ohGW0u7VQuz0M4W1VZZVGAFz0NOV7pKahEk8IGV3rWGLqc1fmEyW/wBduLehmc8cAy3McvL82RmkjXR4emSnzUitR4x0xxahmT4k3rNOIrHUJrApa2M8nMcZEZC/mdv1rMvZ3fBHJmDqqhVacdJiF9w6t7xLa6kFOY+ZeYfpW0cEuz2LQFs+G21AeH+F5JvGNzNZxsvxqHuo2YfZCx/Sj/C0NnYam9q2qI3Pn4I4JCPzYKK0q99qPUfDkTPJAKnznz2oW+uSezziBOGw37SNhN7vynB5+U4wfOvGP9mD2i3L+2m21z2g6hfalINPfTbdnjM00bEjlVd9uhHev6CvbadJC0MhuZA4KkciKMH7mvInE3s99l/sX/tD8HXuhWOrgapcSySwvfp4UTu3LzAGMsRl+nMMVo9g3qLW0tg3B/DzIB4MBqvy94DjH8zZf7RujjXPY1q00d01uLB7fUSxyC0ccg51OPNGYU4cN3MY4G0y9WN4QunRnklzlCFxg59AKM8TaRba7w7qejPbB47y0kh5HPNzEqcfrisbteP30n+zjqfF99qbTz2qXCP48PK0cw28PlG+zDFRQDf2bdWvVGVsfHKn7SzD/avv4+eMfeA/7NH/AO1HHPG/G8igrLqD20JB5lKR/CCDWgcbxG21WKdPhKSg/bIoP/ZM4Vn4e9klhdXkbR3GqFruUFcYLkt/Wm32iWoP70r5EEVnhtt6hfA4h3bfaT+ny4jVaL4tnFIDnKCvrx4qDhiZbjRbdxk4QA/XFEXjxk4pXVJi1h74uDxgwNqmILKRzt8JryP7VWm1Xi+G3jJKGQD9a9U8a3gs9KlyRuK89z6E1/xTb3TKWUuG6VOjISzeZI49qavwDpos9LtYeXGIx/Km6aHPf9KGcOQhBHGOiqB0phmh26fpS2tr7w5lRgGApoe2CcelUJ4d8Y3o/NB12qjPb1lmj3QyGL88J7CqjR8p5umKNTw5oZqIEMBJ22q1enJbEZVjiKWv3ZDMiHpttSvd6eTaSalykFNxmmK8i95m5e5O9fNRtDcJDo8KgtL83pmt2snSoGHWFBgTg7Qxq1nPezqQxJK+op24YRYUe1KjmXPfc11p+lrolsloi4Veu1fHAsb9ZwSI5NjWtt3AN5wY4OYSdOUkEb19jCnscGrDxrKiyrg5G9QiMrsB/wCFCA28RjORJogPLIqyoDDONxVaPIqwpIO3eiAEyhnfhKdwK6VB1xUibjzrrkq209ZGZ9RcYOa6lYFGy3KMZrgsEU5oZqd/4UBVSMtsKMkqeYA1cLJLJ8WVGSP9KyPVLKefiDmjTmAc/DjrWu6lEP2dlY/3jmqWi8M293LHeSRYZOp9aaRifYlWwvMZ5f7JvBs5kl0TjF4pX3Mc37yMHywd6z/i3+xNxtePI2jXWmX0J3jnt5OSVR5FG2cffNaTot3qF7HjSuI1laMASc0R/dnzL/KcUy6PrPFdjOrRcQwTxLuTE2ACPPO35Vy636mpw6FvoZv2aaplKOB+08FccewT2ocAXjR8TcL30NozELdxwtJEy9jzLnl+hxSLd6ddRTNY6lAyTKAY58bMD0z6etf1lt/aNcS2pi1nTY7hVGGeIBlcHzG9BNY9nvsS9omnNpuqcM2duznP7pBE6Me4I3Faa9vXIwFoB+HB9efgZlN2LSQdhI+PI+H8eIn8pjHLBKUmjKlTircZ5GAHfcV7t4u/sC6Tq0Er8H8VKGIJhiugCV8l5h1Hr1rzbxn/AGePab7NnmsuKeErySyRyEvLdPFjx55XpW1pu29PcOfZPkePl4fpMPV9i3Vk7eR5j7/zMwjc8obtVyFiMHcA9PWrA4du4WMUscoRt45CuBnyPka5hhMMgs7xSEc5jkx8prYXUI59k5mDdpLU/MMS7av03o9YyDbG3nS3GktvKYZRhlOCKPWOTF8IJKbnHlRwwxmZF1ZBIIjfpUu4GfvTRZ3XINzvSXpUh/TvTDbTM+FRSSfLzoNx4iFSHvOIwG9BHMew8+9cG9PKW5z8Q3yKEh5QpXJx2zULzyRZL5286zHIHSdj2bWcgmEmundiBnGMGqkkkqsVfof5VxDdPaSpcSLmFjyt5AUYvtFuzaS3EY5lgAdCN+ZDWdbqFQjPjPoHZ1bbc4gmK+OOvTauJNQbrkYPrVO5SazJlYE28+CG8j5VWWGWVZYhklPjXA6iih1IzNF2OYSN4dirfCRneohdHmAznPSrNjoNxNbxScpbnk5QB6im7h/2UapfTLJMpVFfI+lDbUInJM91islpfSoJYoXKnqcdKa+EeFNQ1uZR4RCA55sVtOkezbT49KSOSNedRg+tSm303hi3ZYI1Vxkbbb1mWdqqFO3rCqGPAhDSeDdJbSktruFT8GDkDrX5eEtG0qX3mNEGO9AtP4lvrx2VX5R1A9KnvtUnmiZJHPKFxnyrCs1thzgw6acDho6Wmo24iCxBSPSqepvM3xBSQw2YDvSfoOrtAJLeSQuVwR51BqnHv7OcpcHAU5ANKPZk8mFWls4UQvrBv7XTpL3flAyMVnNlxi/7VQysQnPgnPStPj1my1zQ2liIdJkJGCMA46V5z4xmXTtWeOGRovjJBI2A7g0EqHOBGtKN+VcT0Kyz31k0NtIgjlXxEPqKH2N09tcJzJyt8vKejeY/Kkng/jqMWFsktwcxAdNyp8/pTpa3mj67MpS8ASfBABwx37HsQaWNO45lCWqyrDiS6hqIs52tW5HiY8yt0OD/AKVVubwRvHNDk4XLY7r3qG88drhdMuYkuJbaRvCnG3Ov8J+o2+tcFUiRL22fxbWQFCCcmNx8ynyOKVarDErCLtxzJo7lJ5YkcklGwrf4e35VYtZo4U8HAzHkP+dVbe2S3vBZqGkjuAZreQdAuMMp/nUsEJllWGMKGMbCVenMuKqynPM8ADwJdvSsFzAUf4XwR32rgXSKjkZyXIwe1C724mjt1ifIe0AIPmudjVzh1YrjUJLib4olBuGyNsAZx9zgfevKpztXxk93tQs3hDFyViW3tiBzR/FMP8bD+gwPzr7Gojt4uX4SxJ6UMs2upL24tbv4peZmJPc5z/Wr6FmXLZ5o3AIz2NestJOR08PhBirZxCEMGYZCZOZj69akizGzKAAQN6+oEjQxq2DtgVWCymeVycJkYPnV1sKYMHszmXGtoXlMznZVyNuhr7M0dpEJuX59l+tfI1Dx85z8W2Ks+AvhI0+AEY4JO2f60yljMcQLDHWVbuQwonhj94wy2RuKozzMLY3U3MFXfHQD6k7D70WaLxQUCczO3MWkGwHbb/Wkfj6aeWHklnPhp8KIOhNOoQq88mWoU2OF6Rr0LiC2xzR3KkjtH8Q/Pp+Wa0zhfiwyFbYkkeprz/wjb3PhB2Y8qgH6mtd4MtwZFlentG9otBTiT2jTSqnPM07XLOO+0xpYzhgvUda86e0GN438GZmc5Pzkt/OvREt2I9NYBtuWsK9olg9zMZ1XON/tmne1XRbUHj1nHvp3srNg8IG4FtQI3fHwnbFVtSP7J1qOXpl+XNHuELcRWOemaq8bWIaMXAXcYIPqKS0l+zUgnoeJj3DC/DmN9qwmhjlXcMOteRf7a2o/sTjbgjVoIwksEkrmTGxClGwfyr1ZwvcePpEJJBZRg151/tb8KjjLjDgbh25/dQXtzcQideqOYvh+xx+lPaCz8J2kjH/iSfkDB24dCp6HH1InovgzXbfifhbSuIrZlMd/axzgg7bivEHt5460iC/4g9lnCPEUl9b61xMs1zDETyxl2XxYsnY/Ge30869L/wBnLXNQi0jUPZpqsAM/Bvh2LSr0cb4/MYP3rx3/AGlOBL72c+3a/wBb0jQL2w0u7uYtRtLhoi8JmY5cq3yj48/CfOt/TIml7RspB9mweyf/AOWIYfSUpYugc5JXB/UcH6z+iXDmifsDh3S9JEPhC3tI0CZBxt6fSgfHdsHtSxHVapew3WdW4k9mukcQa1qHvd1exF3bwgnLv0AFHOMbbx7HA7gj9KxL0SjVMlZJUHgnrPVlsAv1kHAziTRUTO6HBpgZRj7UpezxitnNas393IevXem+Y8sTH0qNWM2kyTwSJmPtLvGIS1XfnYAigFjogSSK68MYwDVvjCZrrX44VOQGNMx08Q6TG4XfApcAqVAl24RR5z5w9/eqMYHemmSLIz2pX0MkTr23pxKfAPPFFuTPWUPWCpoObOKoywgdh6Uaki36VTmjFLGjxll4gGeEk9KVuIJgMRggYp1vVEUbufKs/wBYfxZWyTk7UzRQB7RjNfMGW0Y/eTOM8gzRLhfTDc3kmqzIMZ+EYqCO2Myx2sWeZj8QFOVlZJZ2qQoMADf61babXz4CF8YO1e3HJ4ijGetBpk8W3ZCAWTemq8jEkJBpaZeSUhj12rVoG5dplj0zJ9JufGg5HAyNqulATjY+VA7OT3S+aPm+Fv1pgTJAPn0xUsvMushVOVgSOtTLjrXYjHavqrirAT0ljHapcDuKjQDrX2WVY0ZyelTgESMSjfThW5Ac49aWbu694vggA5U361f1K75Y5JCT0OKXoZmZi2N2NeU7RmSFOIcs4jfyFQvwrt9aZNOsVs42hIG+/SqXDdkEVWZfvR67jCqHQAYo1Jx7Uo3PEy7k4lvrWO81LV9QhtmXnAnkEcS+QCjGT6D86JQ6m8UHPbTC7jtwFkmlZxGCRsoHc/SkloNU1O8hgv70z3MuORGfIiB/E/8ACMb4/M9q0P8AauicKSWui2nialdwKFgs7XA5Xb5priRvhQt15RkgYHpXOjTls4OJ19loQAYz7hLNhY6/Oh1O7itNLtgoZZbx2T4exCDBxTFomq6NdviTX1uvC6yWNrIFX6ux3oLfX4uljuL7SPeJGPMgNzyR+peSQZPoFFTnRbm6hjm1XiOPS7TYrEkXhod+isd2+wFebTbTgc+v0i/fixfb4+Hon9o+6frpjnHuutahN4ZyFMZO3ptTHae1FDcHTNXhS6iIAdHTfB81YVlkHDGoEBdCv9QKNuHt5ssw8yGxgfapJNL1azEaXvFNzDInwqtwnO2fLON6XdLFGFGPXvlVWlj+b+fpNE4n9lPsV9oMLe86LbWssyjEkA8Ng3ntWF8df2JJWglfhLVo723ALKkh5ZAd8FT51oCa80McUE+uK7g7GMhOfHnzUZ0zje7gm93AY4GcKTz49MZBqBfZS2aiVPu6fLpKvpQ6bXAYe8TxvqvsO4v0iF4OIdHlivLJsLJ4ZxNF6+ZHmKEabwjc2ty3iRP4LqVIx0/1r+h1jxhomsKtjrOni5yNvFiGR+dC9S9lPs4166d9PUW0xJbwyByk/etOrtjWqpGAwPlxj9PrMW7sHRWMDypHn4+un9zxVa8D3Lwq1uxLDyHWmvRvZxqs6xTQwtlfmBHzDzFenj7E7Wyw9pE0q82eZUVh+QNW4tAg0sCMW6Bl2wRyMfs2P0od3+RapF2suICn/EdGXDq2Zhl57IJbjTfeIFKyhRtik6b2bao5eCaAh91BxtntXqYT28JMEsRQjYhhg/kapy2WnPzMEXmNYw7cuGRmdMnY2nQhtv8Ac876D7Pbi4t5NL1O2wAeXmI/WnfhX2fvFay6bekvyoYeY9x2z9tq0xbXTxHI/IocDPTyqgNVtrWY4APMMnekNT2q9nU9ZpU6YIMIOkyX/wDC03SXGkSwfBztyHGB6Va0f2LNG6+8qcR8yEkfhPStctNTsbj4QqKxzv3zRi3urd7dWJViNmHnTNXalhX80iyrB5Ez+z9mujWKxL4S5Ug4x3Hejl3bDT+VbWNcbDamK505ZZR4R/vBlcn0pY1ma40ySMyk8r7fcCq2ayxvzGerrVjx1l2zmvZoU5VIG4IoZrWmQXAHjDd85zV3TOILOCOOdyApIU58zVrVoLa/5nt7hQoORvtmvCzIzIIKNg8RS/2fFtaNdWTh3Q4x6VUeBrUc9wQ6z7FemMiurtr+zWSCCZmLczcvcEDpS5FxD+0rUC5Z4yxbnB6jlONqG1pI4jaIeueJdja3F61ikgWTk5gc52AoZxbw5LqoMHMFklh/dn/EBnFU+DLa71biFr6OYMis0LAjbB+U006nLHPr9tbKrMVUSEN2YbH9aCSwbMZ4rYKsVfZ3d6joYj0i/jm8KZ2RyRnkcDJFJvtd0u6sLs6hAviJyF3B3V164+uK2u3Nrb6m9peRFJ7qPxYSy4HiJ1GD3KmqXEPBw4l4emKQ+PMjKsQGMOpBAG9XSzawsPjBhx3pPTM81WHEcOn3sU0UrG2ZeflU83hg439V7HyrXrG6057a21HTrtYbe62SQnKxynof8uds1ko4Fu+HtX5bppYLET+FNk5eykzs234cfpW0cKcDQ32n3Ol3VtHBOsbsvhsVhlznEiDouTsw6DINM6gV8MktYTjLQxw1ezalK0GoxKt1C5SU82RzKdiD59P086bbixtbqIo6yILqPMsa/AVderg9j39aA8D8MTQSiK8jeS45FhuEOztyD4ZB5OowD5jHam4QNBNGom54pUZJVx8RBPXB/nSbYycRN29rjwgXStPHNZQCUORM4jdRnn26jy6bj60VXTgXUSxcklsTGSO6EjIP0NWJtLl0i+V7Zle2uLiOZGDAeG4IVvzBGR60a1C3h1Ex36ry++RlZ/D6FlGM/XYVHdZXPlKG7DZ8ItzaD78rocAvIYQ3bI7ffriotA0JrNLq2duVr1jHEWHURjmP5sVH+7TTe2/u1vpeqWj88Uq4lQDbIx8XoRXzUYVnmtHgPNc2ZVMY2Yn4/ts2/wBKgUBck9enz/rMn8QzAKOn8f3iCH04yXFteyKqOIgsmO5XFfJ7AwS3Ky7tyiVSBTE6JdRJCiktDK+eUfDtjf8AOoWhSYFpd2kXw1AOfi7j6UFqsDiWW4nrALZeS3mRfhxjI6H61Ys1NwpXGTzkAY3NEP2eYtOY8uDDjc7DB864tLYoUeIYVoyxY9Sf9KDsK+00uXBGFkaKsPhxtgt5dQD/AFqa6ieSNU5sn5iT2HlX6GNZZssu6oWGe5qbJbAI+YYBoitn4QLDmcqqxRFsks64xSXrmkjULhuZeYJuB6mnabkRHdTkgbelURZ45GdSNuZs9803U+OTPIShyICs7A2MCxhR8WCcdqedAukgVFGB2pav8/CYk6nYAVJZXcsBLOD8IpxNYKTmRZWblmk3mpc9mIUbtSZxAkLwN44zgHrVE8R3TOIwpxnFWtXgur3TuZB8RHTuTS1upbW3hhF7NN3GnYYg7QgggYRjbNfuI4BLpzNjJSvui2c9nAYp1wwq3fRiW0ljx1U152ats+U4W1CGwYE4Au2ktJbY9Y3OR96zT+0eYrXifgDU+c+JDrsaBM9Q6MDT5wazW2tXNux2fcUg/wBqFVY8ISRriePXrUo/8O5z+lbdjZ11Tjo2PqImT/qPu+xhG6mX2ef2gtMu7WXwdO4+sua+DnEYmt0C831Ksn5U3f2h9MXU/YrxhbNbrK66XNIoZc4dF5gR6ggYod7beHbnW/ZiNX06CN9T0DwtSt3bYiNCPGUHtmLmFNvv2mcd+zf9oW4E1jrekMQA2cq8ZU79/rTvejUdm1XjlqW2H4dUP7r+khT3WoKnoTn68/Xn9Yp/2Z9RGp+xnQJPDK+DF4R32bB6jFaBrsRexbAyRv0rE/7FN5eTeyA2VxJzxWF/Lb2753ZBjOfvn863i9j8S2kXHVdq92qQuvsI8Tn58yFUqNp8IkcFyNDrNzbMcc2Djp0z/wAKcdRbwrR2yBtSVpoFpxOhIxz5Gf8An6U18TTrb6dIzH8JqdUCdre6EYZbHnModBf8TZJyA+K0nULTk0eMKOi0i8LW3vWs+MFOGfP61qN9biSyMeDstLgHefdCW/mAHhETS5PDuuUgbGnqL44lI7is+YNbX5XtzbZp70yYT2aEGnGTMhl5zOnTrVOaPfeiEgx36+VVZRt9PtUCvzlgMRZ4im8KAxrjcdKQ7hBNcAEbd6a+IrkPMyhunr3oBaW5mlJ68xxRWXasZVdq5lzQ7DMhuXXoNtqPH0PWura0EFuoA3IzX51I3JqFr28SVHjIJMbg9cdKXtTh5GblHU5FMMuTjOPOhWqQgx+Iucij1+wQ0IBniLl7GGjWdPmjxnFGdJvEuYVKsDgb0KkYJzIw2cVW0i590v2t3GzE4px1B5HjLgY6xyUA+oNSeEDv5VHAQwBHQ1aAFBXpLESIJ1xQ3VrgInhA4Jos55cnOKVdUui9yzc2y71VjiSBmB9an2WBGY+eKj0i1Mky9Sg657GqlzO1xcFubvj7UxaDbBVXPU71B5wJLDjEa9LjEMIwMHtV6TlkiK4+lVIGCoBUvinGAcdqKrQW2eftCNxaMdb1a68IMPGigT5m/hcj6/KD5Z8qZuHQxBniWLT1nJW2e4Y82D80gAHNIx8wO/zd6UWvJrSOOXkWW6kkAjjK5CbDBI7ncURskvmDzTXkhupxh7gseZVHUA9h16eprHWzHWdbbUWBM0ePUNJ4fRpLHTZNa1eVCI57whVB6EknZUB/kfLNS2Wo3KoNf1rU7QXDYEcyR83OT+GEEFuXO3MB26ilPT3V5I4p7YfEvjtzL0hUfAgU9PPJ2GR3NF7z3lreC7u+eTUNRPiJBGpZ5VGyjzCL2GwJ7Yo//wCTpM9k2nBkur683K1pHqd/c3Dnn5pZeSJM9MICWbPYsWzRHh+LUNWdLW+uLy9tV2aG4t1MLH+EeJk/UjFftH0Rbd0sFs/edbu/3kuACsIPUu3oPz7bU2xRppUDQ+9JE3LytK+OZiew8h38z9KqaT4mUa9VG1RIrCw4X0mOVJNB93WMZaS2YLHgfwh8/pjPlVrSo9FvpTJojWcTYyqy5SXPqd0J+jflQo6dpMTIrq17eTfE7TNzHHYsM4VfIbn0qeSO+jBFxf21uqL4fvDAKkKnoFTz+pz6DpS71hDkgSVsLeJhnVbzUtNjiguYbhzI2I2kVVz9D3oeOL5bW5C363QWPvHIrcp88A1U0yw0jSnlVdb1e/muVzIsuGix/wByRyAepGaFnTvZvrF46Q8NXCSxHElxZzlYlb/ui2PrgrS7ozng49ef/kZqdF/MMjzmgaZ7VGtJAy3rPbscBs7j6inbTuO9P1U+HdQQzxOm3ONjWGi1srGSaTRNH0zVRApE3upLvEuOskR+MfXlI9apQ+0L9nWQMlmi2yE5aEhuX6YO2PKlmssqO1+fjDfh0tGap6CubHR72E+5TC3Un+5l+NPsD0+2KBajwXdypJJplyqELnlZ8oT5Buq/fI9aQeFuO11SMxe/xXMIwUkQ4dPRhTCvGt1o92sJlBhlPn+dI3V0WNllxCKdRScA5ibr+ra5oE5t9Vs57Zn2+IHBHmD0I9RS1FxFdXE04UHnjAJUnqp7it0u9U0LiuzfTdRtophjKqezY6qeqk+Y28wazK84EhstRmvLHEtpGDkEYkjU9VkHl0IYbH0O1Zup0gq9pTkTU0mvRwVdcN9JX0W/uZpEkBJQkHbyP/Gmy1nMUa2zyENIpIJ7n/WlnT0W1iyMjwjyOezqTkGic94nxKzkujKyN6d/0pBMq3ELa/eHAjnZ6iXWO3ckyJGCp8waF8QeBdB45m2wqqc9GJ3oDpWqXDXQkdnYJF8OD1Aq1qNxDNcwgEuOrJnrncGnms3piJrXssirq8UsMkEMTsqSk4H+Ne1BtL46FnrLaFdy5Z+Z4+Y9x1FNut24flZWPigs8W2zPg/DWGcSySRa+mruUR7ZmPr1AOfzo2nGTjM0kAvQgibnFqNrq1uWacRtzqM4w2cbH6E5pW4usF/2hU6fFm3XTJp2UDA8bBYA4oVwxr082lrfvb4gEqWrFtzzqOcH9CPvTJqeoxnTRcxrzGZn+IDBMTrsR6Y/lTe3EzcNXZgTngJl0+9lto0xF4S8zlf+1CKSfTcmj8KWWqcRXF6luSFIh3GFVS2SM+e29VdEsHHDUVzHEA11aGdnO7cxO39fyoToV3q1teX14WKWzXy2z7Z2BU//AKx/Kl7cbiIWsGwlgYy8QQnWLqyNqvh3BiZ4ip+JW5SAd+vn9M0T4FuH1Dhy6eZD4kDbqUwykHckeYOenlS3puoyx8Ranp12ymWwuY57Zuzwsd8eex6U4cGeAmrTzwBhazSeBPGg3UqDhgO3Mo6eanzqqMScGVvTYnHh/wCzPvaNp1mJP2k1oq3aQCK4VVGXjfcEjuQdwf8AjQHhTUb+NWiiu3QQKMkdIvKQD+HpzDyJp79sOnRQ38slwHXmspTFLGpAeJCGT6kfGMfSs34YWW4nh1K1lSX3cNHeRhs+LEQdwo6nGdvI+lWOVyDHKMWUbprejwzz3aXkkTQXdsQkka5BAGDkHoVGdvQ0cnFpqFxEGURy+I3L4fTnG+QP8Xl51WW0McUd5YyRsq28c8EhY4khbA5c/iBDDB9M1LrMduosb21ByhheYt869id+/n61DK6L7UztyO2Vkz3YS1u7W5HjEj3q3YoCCYwGwR57Gr10s8E0rW3wwTyHEabgPgOGH+dT+ZpW1C9ZoWCZd4hIM8uObAww+4bP50Z07U1urGPxHPiPCjRk9CBuvTyyB9qhLsqc+vWJD04wYQVZZfdbOMYilkdWQjHKHw4PpvkYqOB1jvLm7bm+OWOUHGPhbIH2AxVqOWT3szSFQ/hSXGf4eWMnP5jNV4VnmsgA3M7QBQSuF+EfCTRt2a8+OT9P/YADDevXhJtOX3ezaRubmZWcgH8bSD4f5GuLoLcMJLZgqRkzjbAGRvvXaR5t5gCQiRgIMdXA6/r+oqCzmeOyitnTmbwPjA8z0WhH2hg8CFUYJI6y5b2wuNNELluWTDOfTtgH7V8FrJGCkoHUBfUZ6V2L4K0viPkhQBj8I6E/nsPoasRxiX4C5XIGe5yOgAqrbW6T3IlGW08G7lLH4sFVz51C8UoUMF+EjbHlRO8VpZOaJMMRynO5HqT0FfikCx+FzDPIFz/CP6UPuwekncQILCsYmdxhcgflXJ57uJp2wkS7ZzucdhVu4jGAAP3a5xnufOqFxzzYhQnlUYCjYn7dqkNt4MsBunLGCXlETqCo75OP0qqyxt8HioN9yQ25/Kroto7cgSuFAGTio7gKcGKLHl50N8sOZdMA4E7tNMgVOeSWFj/vf/8ANFrN1U/E8TL23P8ApQ5JAkYRuuKnimfwwAux6V5GCHInnBbrDLWNrcoSoHN1yKB31o9uxVl2ozYF1wWJ+lTanaieDnC4+1Os/fLk9ZznaehDLvTrMqiQ6bxAJ3PKhbGKzj+1NczrZcNeBgodZtST5DmzmtY4r0prqMtBlZF7jqKwT246zNd3XDmh3WTMNSt3Hryk5P5VvdlivtChDn/ZSeR5rOQvU1hl8CPuJ6W06CHVOH47K6XniurUwSg9CrqVI/I1mf8AZk1MTcJapwXHLLLBwnqcukQrcAeIsauygMB2yDWk6I//AOS7VRt+6FZzwJpUXD3t747tjexwftu3tdUt7dX5RIjrh25e7eKjb+vrVexHF6arTH/khYfFCD+xP6Qeo4YOPPHz9CIf9i6/iWTjzh+1ikitrDW5vBR3zygyyKFx6BRXpqReeJl7EGvMH9mKS5Pth9qMgijtoLjWbstAMKQ63Ljp9AT9TXqMYx169Ka7XYrqUZv+SIfoPnCnBd/iZmeqO2ncRQuo+EuMj9KL8camV0pPDI+MAdaEcewSQ3QvYgFMJ5s5xtSvf8QfttYYIXLmM5YfXpR7QTUth6QqjNi/CN3s9s/Ek8f8P0rQJF5kZTjcUvcFWAtNOD8uC3nTExpSlgef1kZ3MWiBxHa+BeiYDG9GuGbvmi8FjUvElgLiItjpvS9o92bS6UOx2OMGtQcrmXIyI7SD/hQ3U5xBAzedEQ/iRh17jNLPE93yp4StgnarqkuozFLUJGnlbIO5zV7RLHnlBZcBdjVFFMkoXG/b0pv0mxFva82PiYVYjc3whm8p9lTAx5VTmXBxiiEwwCapTjO5qdskSjJtkg1UnUSKVPcVamAHeqkrAeua8B5QoWK9+hiLr2BzjHagl9IySLdLuVO5zTHrcXx+KuSDsaV7hmAeBj16HP5UWtsrtMIR4x60K8W7tUYHtRlW5R9aQ+E9ReJjbucgHam6W7Crtt3qrkDme254nzUbpYIHOcZ2BpI1S85Y3YDLSHberXEmuIX8FZdgeoNLazm7m52YmMbDJpcvuMMiEDMu6fB4jhnHenLSUUKDjYUu2KDChep6YpkgYwxAdDioLY4EjGYS8YKNjXwXJHXah5usbjpVd7wHo1eD4ntmZjWmxh3tzI/xvI2SewJ6/XbFMdqxm8eeGFSFHhWwY/CWJ5edv8I6/b1pOtLlrd3kIPwghTnqx2otba015JHayStBZxNzzcm2UQE4/kKy6xmdXfk9I9WNpHHLHFGyO8zIZp5RlmA+XI7IPnIPptRlNVGp3q/7MN4HvLG1j1K6HxuE2Zo0/hG4HYk5JrM9N127vA12yvFbDcKd3k5mAA+p/QUWtpNXmuV0LTnX32+ULd3sj4W1th8yoOwxsOm+TWlW/QLMi6rByx5jlNxLNDqD8LcAxGaeXL6pq9xIBHGg/CD+I9zjbz7CiIuE0/wWjafU9TuR4dvnPKB3kbO0aAfiO52xk7UDkuNC4b09YppEED5ZFzs6ocAkdSgPRfxMeneiv+0VtpdpFJqK+G9w4a1thvLI38UgHQZ2A9O9GCRNm/6iMSRWeiWxu7y4hkupCHY7hQe22SfoPuarxC2Wb3rUJv2hdg+NHbuvLDar/GwHf6nJ9KDxrFJE1/qErOLc8wSQ8qGUndm88HYDf71+Iu9Wj+IeHbu2IreNOVnP8UjfXoKVuGOBJQZ6mMU08OpwSLqZEFqRvyyCPxT9Bv8AzoebnSdGtmFlbQ4x+EZC56fD6+dfILC3kmjt7aNXuEATqDy47k9BjrXFxFpsE8qWV0re77TT4yiN+LB/G/8Az6VnWnPQRqvAOCYB1G5WGcTuDHd/OotY8zIex5xsh+9VJtXXWnNvr+irqS4Ie7S6WDUI/wDM4Xw5evSQE+TCqOtx61xIDa6BdNbQtk+GwxHP6lx8lUV4YbSohacQTPqJxsjDCR7fKpUfF9Tk0obAgwD+nWadag4z193hDI4B4ms2Gr8BXQ1q2VQZLY/ur+3H+KHJ5wP4o2YUQTUbnV4YFmZ4bkHeNzy/F3ANB+HL+bSrxJopGuIoieRY2IngH55bH5itDfXtJ1+ILxJZtOJAAt7EFW6Q9mYn4Zh/nw3+IUjdZXZx+U/T+v1+cZzYpy3tfv8A39JFol3d6fMlteSsebLROT8w/hPrRC61u5stRhfxss2RFKCN+zKR326g7GqGowyWWni7iuV1LTIwEF/B/wBi4+UTIfihY9Pi2PZjSZrPFCrJChJKBiwb+Fx1H32rPsSxTtbg+uRLIBadw6Rtvp4LyaS50cqsiK4uLJTnmA38SEdSB+JOqjcZXoHfXklAwWHMmRlth2P1pH/2glS7W+tLqWKVg9xE6vhopB3HkQRmivv41zTzrWm26e/2Lh9StoxyrJC/zXUSdhvl0Hy7svwkhbfh94yBz69f1GgO6xu6Rs0bVJmhke0mBe0Krj6vg/bGKKWGpxT3tzdzRjEXOFGdub5SPtSpbRyaXdGXxFEV2Y+Uj+Dm+b7ZNMUcTTWkJgiCtb300d3GNudhJjP3G/rXhUSIOxlU/GEbyG5uNPRjIRIjM2V3+EdceXbesZ4u01vf7tJZhlgIWB2wxkVSc+g3+9bVBGy6K0LZjk8EgyH+AuD+YBpL4z4afU4LiaCNo7hlkklCnoUlXxB91DMPpV0/1sDC6a0DIPSZroutppPDtxYzSO80V+skak9XTmVznvkHH3FarwFFBxDptlNduzT6UP3kYOzwyF0DEHsOYf8AIrKuJeFpbfStZu1LZ0/VIYQqZI5XmjyR9sD704+zLjCLQtX0y01F43zc3GlXW3/YF2IP1GWb/drQXFuGPiYPVJ7B7rr1m3w6X4unWEMQ8P3eSISqjbsrSOjflg0maVFJbxfsu5eTmuL65ZcAEuYpSrH6jbb60+6bdyRCWGaP99bz+A6g8ueQEE/fnVvXNJ+qWFzCkN/HE5m0fULt2UdVi543O/4iXLg/5/pS11aoYlpLGbIPrr94sapqkNrxAl6shM1p0LHKmM/hPmQozj0pw4F4jtryeLVLVy1t+0v2ffoDvGZF54nXsMnOPUEd6zeLVYdR1HiDSdRKo2l3yWgfmDeIhU+Dv54518zyAUp+zPi5OFPaBfcL3ryfs/XfEsmUk+GHQq0TAnuHIAPqahNOTnzHMfsAdMePr0J6R9q+kT6joTcjMJYwwDA5ENwnXb+Fxg15p4Q1G60niiGbT7j3ZXnF1biY7RNuHjbbdQ4YH03r1bo15FxVookkl5J5gYJSY/lmj3JI7kHOR5fWvOntA4dtOHOKL23vIWghgn8YSRkN4SyYZXzjBHMrDyPQ4ySIydxHnLdnuNjVHqJ6j4I/Zep6JZywQmKNGkEESnKwAkmSAg5A5WLAeQfbbFS3PDb+5zFyrSRMwBK5JjOeU+uQv5jNZ37LOIZIdKkspbgNNbTBXxlRNgMkcuNjzbNEwO4ZFzWy2mo203isvK5JAKAY+AjIP/8As/Wn6imor2v4fxMLVK+muJWYvxRZXukIpBYN/eSbk/GV5vyK/wBKF8PazM1rZRnYh1UAnflxj+la1xdoEdwJYrmMeHcxwc2X33Rht6fBg/UViq6dPolwYGDHw5WYty4C7tJt5jlK1iais0FkPnNvR2rqUGes0/TryOWyunz8Udq5B7hSVUD/AOb9KsaPycgRsswnDbnYAAj+p/KlLRtZ8O3ukK83OqRDJ2GCCf5D86ZNBuFYSeGA3LhQR0JHzH6Z2+1ErsztHrrF7qNgaGoZ1GnvMImIKgKCfIkZ+p3P2oT4JhuppEB5G+PONmP4QPqc/qaOM0c6eFCzIMgB/Id29Nts+VUbyONpFWIgQRIVQdC52HMB/wA5p2+slBjoP38fX8xOlhk++UIUW6kWKHlysgEjDBDyDfH+VQfzo5pvOwkneRVgViObG7bfmfU0FgBmC28KFYVYcxUY8Q9eX6dc+govayNchrK1MLCIkTTfgRv4R/E36D16Vn1jJjdkml93Q8yoxifdE5TzOfP6VwljcznEkAjkbcL/AADzY9B/Or9vELZgsUhmuW+EuQGbPkB0z+WKse4TcjQ3U7xK2T4SMcsT15m6k/kPrTArJ5xF94EC3K2sOBJKz422/oP6mq72dsm8EEjyMMgYwAPOj50x7cqngooPRTscds1Hcv7qGV5IouY7nqzfQda8a/FuJIf/AK8wH+ynkXxXwue53xVN7ZhJhVZiO56UdLSzIPCDIB3cb/8AjXM2nOwAcfEwyIwcBR5n1qpQN0lhZg8wJPaiI45wXPWpIIOTDk5ANEJtG5SZGUZxgCuBDHAg5yWPYY2FUNRBhO8yOJLaSKr5dxt0Ao5EI57cgYzil+KEbyhcD1FEdPmPOBz7eVGqJU8+MBaocYgLW9OaJnfkyN+vevDv9qHjG90bjrSTFYEG0kEwkxswz0+te/8AXYGkgLAZ2zXmb2xcF6Tr/EOmLqFkknLdAjK+YrU7EsGj7RU4yCD+047tXTbFYiaH7M+Jm4m4UsNTKlTJAhwevTNBOJZLfQfb3wDxExghi1exv9I1GWZMqbeJo5QAT8r4kfB/0pl4V0y10fRoLO1QKqrjHQfSl32ypcJw7o2t2+oQ2P7F4i069nnlTnAt/E5ZUwN/iDKtB7E1y/8A12t2GFZipHufK/eYt6E1EA84z8uZjX9nnWXuP7RPH63V9G9xPq+pZeM5SbluXGVxtgDH5V668QhSQelfz5/sz8SQj233uuWUDRafqWoXPhxyOHkj8ZpJI1J2yQoAJxjNe/VlBQHm2Izmtn/KAKPw5B/44+X9S+P9rCYP/aS4sm4b4dmuoJiknyjY75P+lAfYXqcfFEMEyM0gGPEY9zVz+1SLW64VurchWbGQMZ3qj/ZY0ybTtFjhZNnIIPnRKNZW3ZWLPPiFtXYoYcGem7OFLa3SFOgFTbHrUKtgAdcV0G64NZNOoGZ4LgTi7hE0LKR2pH1aye3nMiKdvKn3OetAtfsS0TSRjtW1pbgw2k9YRYN0jia3W3NtcvyuBtmg2q3S3szujBl7b1nPtI1q80GFruGTkKHJ8xQbgr2lDV51gdmJYgHNaKoyr7Xzl1Gw8zX9E05pp+dkOAc03FQkYVewqnw9FHJYrOCOYirsox1FeXiWB3cylOPKqM4ODkiiMozmh84xkedXHuhVg+bBHr5UPnzuBtRGcHfAxQ6frv2qjcQywXqUYmhYYGRuKTNS5owXIzy7Hzp2n64pW1a3Hisrr8D/AMqEH2nMMBniDbG5aGaOdCQO4zTHf62ItPMiNlsY60nSXJ04vHMMjfYmgDcRyvctDLLyxdOufoKl0LjaJAIDZMJXeoPNOZHYkE7CvsGoYYIPrQ1pYpctE4znYVNYxSPKB0JPSk2zWOesb4fpHHR7x2Ic5wPOjTalkEdqBWi+DCB026VK829Lm4sZPdiEJL/IOM/Sq/vhzs1UzN1PN6Vwzb9T+dWFh8ZYIJml6HQMowM7n0/0qhLqEtlYSxRgFpCVyT1HUk/kBiiF2/ibqBj1O1B7myWZgoHMcjrVkXibrcdYZ0i4unsrJrmXL3EpaKJTnJTpnyUbk+Zpms9ctrCe6e4uOTxY8OkRy7E9Sx7bDAA7nJpBGsvah0sVbMMDQRN36b8o7DJr9w9Z3Wr2/wCzI5PChV+WWZmwCDvIxbsNsff1ppAQciJWrnrH/hjVLrWb9uINRtB4VqBMEbdQi/3Nug6LuQzHr96btCsbvWtUk4gvGklZHPNIEGWONxFnZRnbm3+vahemW1pHYrKyk2iFUgjI5TOF+Y47A+Z7Udn4hgs9NFzfpFbRk4jgXbKjpkeQ8sfXyoxOFmbYdxwsN3N5DDNbclvBPKmWgtw2Yk2+Yt3x3b8qmiuIZue61HUiyuSXmzyoAPwRDoF9eprNjr1rqniXsa3TQBsLGr8glx5t2X6da4stJ17ibUop9euJI9MQg21jDnkOO7HuB19aSsPOWhFqA6Rxl12TXZJtJ0KcWemWxze3MWQWH/ow/c464zVWe8W/YafdaeP2TCo8OHcSPjoxI6D0P3qXVNRl0GyTTdH0t3QkAER/FKx/EcfKKgZLq4tjFc26XMsg5mjcGM/Zh09M1m2WA/ljtaY6w4hDoW0zUII4UQh0fAOfIMOw8qpxwWk0RgfxGkHx+IN1/wCH6UmapEZJImW31DRUhOFWRS8TeeOXf7nrRWDiS5lsoktHhvnjXlSWJwGI9RsdvKs+4blyPX6xqtCDxGH9m2ZtluzGlyYSHEikJIp77jcj60NvtQ/cM0dzkRnl+o8jQ8cSiPEyoEbdZlPQHG4INAZNajjll2ISRSJEYE4XOxHnWeUZjH61J6w1qHF2saHeQ6voV9LbSleUSRH5k7qykEOvYqwIIO4r9cPw77Q4RHbXVjwxrwQmSCRvC0u8JPLzRuc+5yZIOGzCfOOlOTU42aTTZkR5BIHR1YfGNunrjp51d022jtuKrSF51a2vbUrG+AVaQggAjybOCKe057te7cZHl/HkfRBlrUAXvF4bz/nzHoQZZaRxHpmo6nomraTeWuq6Q7NcWcyFXCnZwR5EbgjIIIIzT5oml/s7SLW+0u6zLPZyR212rcrRzRMXjJPZsEKR0I9CRTvwld2upXiaDxPZteQ2lqptpCQbyyt5DyNHGxOZIg43hY4GQUKnrUThbUOFhPpeout1pkkrvZalEQ0MinZZPMMhblkQgMAQSOhJbaOO8Tp+x9/2PT9gk2t3nu34P7/D+P36yfVra11vRdI1ywgjgEMlsb+zUY93S4Xcrj8HMSMdiCPLPxrvNsJy/JLGIWZSNzIrgM2MbEBv61Q4R1aexsrmzSIXF3o6PJJZPu1zZO+Hh9QCMqeoOAO1fOLfedG0Ky4ztdQOpabO6KzMFDXESPhHfHSTw28KQd2UN0NBdQx3LK1khhWf0/iFNV1OKydZgpaC2nkt5+boGDjl+xB/MGmaDQV1WBtTsHDtLlvDByHdQQyEdiw29ayPiPXJdOn1xXInilaOdMr/AHiqQGYY/wABQ7+daN7NeIRLPfWsBIhE5urblbIeKRQxI/xKxbbuCfKgVIGYBvGGuDLVvWI3E+kfsvhi8miVzBcraygv2y0a5b1BjA37k1ieja9fadxqIAiNKbhfDEzYV5lIZASegYqyZ/8AWGvYWt8N22r6dqfDaIhHhvLbqGxk8rGSPfqFkAcD1PlXl72xcET6de32sWVsqfs42886hDiTnRWIB7hUD5HoaZ067G2P0MYo1S3IR4/aek+BNX/bdvcRT8iXd1bzQj3gFXSSF+X4h1BCRrzd+9EeLkS54WuHtmW3l3Lj8Xhycjnf+IAj+fasT9gPGrawtrHfSZ1PTrpbV3Y5FyifAjsTvzNA4ic9ysRPU1s+vanYPpIkeEhZGiQgDm5GEhDEn/Izr/uCq6n2GIJ9dYilZWwYExTTITo/th440jU4FOnzyxqwOByYkDxTqe2wbBH8JHekviXSpdM1sahqUNx4Mmqm3IjUc8HOhZWX1JUEdjgjO9alb6fd617R+I7S6iEAg0OMDIyvNFciRAT9JJBk91pM173q+tJuDtQv8ara3i20My/LMvM6RlsbbeLGc9jv3q1bAsG9w+U0MnBHjNW9mnE95pbiK9kBE0sQuCjEBZ3HLHLjO6yE8pPYsme9W/anptjqWlz6lDGZLg2CSwsYx8aJIpMbj+IczDHXrWbcGadccR6DFeeK1tcJG1lfxOSTHHKDyORtkR3CcrZ7MKZI+Kr65s7rQdVldrlYGjjlU5OWVHXcfxBW3z8wNBtQAYHUQVQIu3qfjBvs64hfS9YW0u5CLSaFRFK5+J4ZYwU+L0KsP9zzr0xDIGht7iORlZoIbecA55JVPw7+vLjNeW9CjhvbzSLS9xbSFfc+byRmaW2f7N46Z/8AVnzrefZ3r3vNrELxy8c9uIGRtsSodjnsfhP3zQabCLCh8ekt2pUHAtTqOvr9M/KaneWA1SztrjlC+BEWcKOq55wfsQRj1rLuKNEElyPDOIpHdPl6qAg279OYema1jTJVit4AZvEQwgkdjGc7/wDPnQTWdJhvbOWFi6+Gyw8yjDMAQWH3Cr+dP6vTC9Qw6zF0epND+6efra9lja8hUYMUoiGT1IbDYPptTVol/gpp8bEeGAZmBznvy59e/oD50sa1BLZOUEPL4qNcMcYwvOWOPopX7sPKqOh67MJxEox4j5cnuSd8nsvTP0xXPVsVbM662oW1kibfYSeJComdAjKC2/bGcH/Sh+qXi+CZfE5U5CzyfiK9gPr5j7ZNCtG1GHU0cMS9rC4Vw55fHcjYHG+OmQOwxRTULc3koRecxxDmVgBjYfMB5noPTfyrZLm2rCznwnd2+1A1jfvq9w9pAZYYwP3zBsMN/lH8P8xsOvR204IkMccCxwxrhAY+uPJewPm25oXpuixaVbgO/L4jhyEGGYbnGT5+f1+tXXuwMhFSNEHKCSR9RnGw69PX1oVWnaoZfrLXXrYcJ0hmE2tqhEcI8iQdwfJew+u/3qz74tovNFbxRMRkkuXc/bv9TtSuvEMUJPJIkZycSEgBRjr5/wBaoXXF1tbkhcRo7D95IR4sxxtgHoPU4owdUHXEX7p3OAI3SyXd6zNNeS+G2yoh3P2XA/WqrR2sKk80a5B+IuOY/TG9LJ4jaWIMk8SxONuQkgnuS34v5VXl18DZLscx+bK5P3NK23pnnkxmvTWHgRkE7wuGihbl7F/h++9ULni/T7Cc2sVwtxcE/GwIwn3rOOJeJdZnR7eyui0b7cwwMD+ZpStLHWbg8lnbu7OCWc/KPXP9aWXUEnCTSr7OG3dacT0Pa8Q6TPH4HvEUkjDMhD5xXy6FuwD2wUY8z0HrWI6bPqGjOIoy7uT8UrfiPmB2Ap/0nUH1BPCV9+UZGepp8WbxgiKW6XuuVPEYvf1lLKm5GxIqzarJs4OKDwYthgBVx+tEbfUoyPDBqfjAEY6QlPdGSExk7gYrEva5HJY3VlqBU8qXEefoTj+ta2Zcy4zisn/tF+NBwnLdwZ5oWVy3kAQaa0Q3aqtj4H9+Jjdq6fvKWx5Rj06TmtIXzkFcih/HmnjV+Cdcsz4fOLGW4iZ1yqSwjxUYjfIDICRjcVDwbqMepcM6feggmSJSd/QUD9s/CnEnG3s81LSOEuKb/RNSiR7qJ7PPNdhI3zbNghgHzjY9cZyM1g7Rpu0wlrFAr9fLB6/pOXVdwBE8kf2drGNtNvuK7Ys82l8S6WJmRSVEEkU2AGwB85J89hXvmXUEh0v3nOAE/pX80vYxqs1rqllo1zb3NlY3Vx4iyJ4kXvEq/CFdR8EgjJ3zuufM4r3vxfr8NpwjbFJMGeFOnmQM/pX0L/LdEPwddqnJ3/IFQMe/lc+HWK0EvcFI65/fP3mWe0O3u+N9QWyjyYi55/LG2BT/AOzDToNFvU0y3TCQIqgeuKrcG6MX0d9XuI/3jAsCe3YfpRTgvbiCYfQ/euSTUbtMax0BjV3tEnwHAmoq5rsOKrBq7V8jFKVW8iW2yyrb18mRZYmBAO3eow2d6g1G7W2t2cntW1pLCSJ7Exj2r8Nx60Xto03OR9DWfcAez+bR79zIpKhjgkHOM9c1tV43vkzsyhiW770waVwrbva+OIwGIz9a6OnWZ9hukIeFAMGcPX8unKlvMCFOwBpmkkWRBIhyCO1LWoWrW8jRlTkDY1Po2qEH3Scjfp60fG048JXoYVkYDbNU59tx+dW5cZqjcNt1ryNzzCLKNx3Oenehk/nRCdqHXDKcjPWvOYdYNuTjOOtCNQg8ZScHIFFrg43xQq6kABGNyMEHtSdjYjCxF4kURr43MST1Hes41S6czfujjG5ycZp84ynYZiRjlduvWs4u7ocxSQEEnYg7U7pHD9espcpHSHdG1EyhYiN870/6RbBkWYgYIzWb6DZuXEnKQvnWnaROrWwRSOYDHSl9cvBIhKCehl/nx5fSuDIT39a4O2/X0r4G23z1rKGOsd4E65j1ziuWbbANclgMjIrkvjYt1qd/lPcTPL20nsZGWRSF+nWhzzM/NGowzDAJIGBWja/paXLSKycrDIG1Zxq2g3Vs7MzNy56Cm9Oyt7LdZrFw4DzmK2hSTkWWNmKlFwTgZ6nA3Jp10mCy03SVkmnW1jIzgqFLL6jruaQbCSK2l+NSigEnB+JvTNT3Ooalq8vheGVTICgLgAfenNuIlZlziM8/tBmjLw6F8MxyDcSLzci9MLVKB9S1a6HvDy3MwACrIdz6t/CPr+VVki07TIVe4lUzHBIYgBR9uv0oxpS3epwNJa2ssdgch3RcNIPLmOFX6k0FmI5kBUHSXrexis7gvqGpQ3ksYDeEPht4j2Lnvjy6elXrvim8tLWT9ll724Y8gcKeUnyAHRR5d6Bz6jw8ka2Gsahp1rFG21pp4a8lT1cp8HMfV6YNCh4VgiS40Kwu7qaQHme5vFtPsVjDN+TikrfN+nvl0A/4jn15wfo2r8UafcSapqGoSm6YhFgLZGfUdBjypz03jqWeMjUI4Sg2Y28oV+Yeamqkd7bXi+AuicOW9yTyp71bSXZz580rsPzFUbib2iaRN41hfW9rFG6gDTbKzjGM7/LECfpmkbWRzknHwH/kMBxtx8z/AADDMvFtjqAazhuoiB8LrJjnQdid/wBaEXUcNyfB06W0llB5SGZdu4JIOR9TRGX2jce27BLnim+AQbASmIsPquMH0oZbe1Tj+11RoX4u1Oe1mO7SSLKR6FXU/wA6UapCchj8h/MPVvHskD5n+JVF9w9dlrbU7wXGpWw5ZILNgOdfIyHr9QPvUMGr+APfNM0DTUtxh5BNEblxjZ8mTIB3B2A2zRPinibjiGWK+tLrSNQfH7yG80SwlJ+7wc2/TGfvRPh/VdO1WSKW54F4caSWLMkSW1xp8gbGHQrDKEP3Q+deCVkZVvmP4zDlmrGWGfgf/BAXDfF2rTavPoMupCxMDlrWaCFEjdOoQhVyNjsRnBHrT5qzavJo0kst7FOYP+kRTSWcM/hd1kAK5Kk9cb/MOuKW34c9nfELSRabLruganbDmUJcQ3otyD2SQQuQOm0hODvTrodjqMt34Gl61pGtXfg/vNPRjY3z7fPHDPy5Y43VGdW2NXOnZ1BQ5Pu/jrFbLk3Zxj9Pv0+sFy6qlw2m8WajottbX9g6CW5tJmiilWTlAkQjKFGIGQQCGAO2KdkvPGefWeH7KS+tZybXXdDkHK8oAPLOi5OJE5tnTOVbG6jFBtM0+0trybRbiw5BOrRTabe2zQv4bfMBBJsR6DbuOlGZOHpvd4TpTRm9tEaK2mnlws8GQRH4g3V15flkGdvhYjNEqZwMj5fuMfbxi12wkD1698VOPbC44Y1Kw450l3uNMdhaXF6BySW4woAlA+U7AMp2Iwyny709tFu9Om4U1C7hSy1sme3mIPhwXXxL4mDsgO6Sr9GHSrUPHE8NzdaPr2myTJPGIry0njDeNEdirD/tB1ww3U4IJzylP4ys04cu/etOnF5wtrsvvWl3rHmFrcLgS20hHQ7ZI2O+fPA7ApXvKuniPj9vLyPHkSxSGYiuzr4Hzx9x9RFPiie799jtL6EQanpsklhcxyNygE/uzGx7AjGG6fLvuDTT7KtSk0+9s0gibxYh4FxA5IPJg8pbfPLkMh8jg0rcXr+3kSeANJquk2xju4mOHvdPUcqyAfikiACnGSUVT+E1J7I9asdbvrzhy51RrXiHTz4mj3F2AI7uIsCbR5wcAsWUxs4XDHlLENsNaTYMrzjn1/E0bXC1Yb4H15faennsNVfUraaOdnR45bKUvnMqOPEt7pG6cwVnRvPHSkD2laOur6LqFwtuLmfVLJniCjlC3Mdu6Oh9MyN552HY1qXDfi3WiPZ3EMyGLkvIIzGVe3PMTLAyn4lIwxBXcZYdhkHrWn3V43gyqJIIiJSYmHxrzN4UqN0OchW7564zR9TWe5Dr16/z9/jMTS37LsHwnj3geCTQeLUsnUpBqDYjIzzBzG8edu+cH6qtehZNels+HodY1GF5Lp7+3EsYf4XLgkOuB0cSAj6is8u+Hrey4pS+v7cGCzeO4mYZXkty8Rdx5FfGikx5Bx2NaU2gRDhC40a5m5Al1cWbTeIMwR+I0tpcg5/7NnaMjyx2UVms/wCIAZus6PU92jhh0Pr1+kJ3mgXOn8Xajf2MytDqOgu5UD42kDRsmM/h+Bz6ZPnWTcacMft28kvrCSKG5gax585Bd2hLIVbO+Ao6jfJ8q3fRLv8AaE37UvQIZQIyrSAYiWSJ4ZV8+UP4gxvuFNImpQ5n0uRraYu1uLKfChRHd2jR+HnfqfjBP8OakHuznMSptbJB68evkInTyPpmu3HFOmRCaHVLdLqWOM4DLNyiRCvmJQxHng9xTB+z4BrGm68i4TULF9OuIcgqZ4izRuPIGN8gjuopdi0/VrKDTgLUCOJZXW4cnLOk5b5f4SVY7k7SNV3TjNJDDbXMk7SWEvghBnEfIeZCGAGSYTy5z1FMBgesGysOhk0trJZXtnHdQx+DBL7t7wAQQpk8WEkf4ZRMpPTE3rTnpXENpapYX3MBbySEMvdBJMwVvXlfP5iqWp2ok0hpoJQ5gu5LVgy4LhZwoOPNlVM+rVSms4le7W2ZRHDcXEELOxCjllEykjy5AcetKXIc5xLpYLBhumefv+83XhbidZrOa1ldidPPIebtzFT+Wc0zi6SWRg5UBXMh38u/5AbVh3CWrS2uo3DNGVhvrRmyBzKORDv6bqw/KtC/a5zNMHJCx5bfIbA6/fc03VcRXk+vXEzLqAtmB4+v3zET2o6QtvF7wypGs0axc+fkVgXkBH15Bt5+lZQbi5s702sZUSyqGzn4huMDHmAyj6kmvQXFsEXEVjp2nSRK4meGSbmOByjnJG/UZUViunaLearxTfX95HurpyIx5QAytjPbGQ7fYCsm7TkW4XoZ0nZ+rXuCH8PQmlcI20kGlwQwxhiEJA5sgM2OZmP0xv5CnUBDGj27K6ZPxuOuOrH08h9aUrbUrW0i9yhnjjRmxJIT0jTAJ9M4/XHU0L1/2jaFpNtNc3GopFBEmxZgOVAepHr2HVmO2y1saZVrUD16/qYlosvfIHWNera7BAeaab9ypJPMcGVh+JvJRg7d++w3z3jP2w6PoAZb28HvIbEcK5YljjquMsx8sbCsW439vGoXMck2kNJZWskjCO6kQmViPwQp1ZsY36DGf8VZnp2m8b8c3vh2Nrf2VpdMFluDmSebJ/FIPkBzkhcepNMjSW6k56L5+J+AjIXT6IZv5byH3PhNT4s/tGCxf3O61iz0xmKs0ZBmmBA2Zo1BA+jdKFaH7TrXiK6jXSuIm1e5uHGEdOUx/wATd+XApp4P/sXWeqWkE9wJR4twiyyk5JiJ3ZQNgR6k+tZ5x77NJf7N/t7sdFmmFxpOqIngXJHKJYZPlbl7MHBUitG3/HRVR3jo3xOOf0gtL/kFdl4pq2/AA5+f79J6y4M4L990lLqK7Lu6fG3MWLegHYfrRyXgHULt/CPJCgbcKhzjyJNKnAt3JFE9mk00EXNz4hZkYggZ+LOR36Vreg6jaarZxSW0qva8o8LlcupA26/i3HXzrntXoamI2jEMdZdWSSYA0/2Y2CqQ5LjPxnqD6Udj4FsoLRovgRGXGMg5/wCH6UzQyWsS8qydF5vWrUIsXjL3ADOVIIz09P8AhR9Po6q/DmZ9uuusOSZjnEHAy25eS0j5UYczvzDJH9aXtLtZtLmaVCXRfxZ/ma3e/wBA0+TIkjDPgFUclgoPcjpSpqXCloFIZHUZOXxhfsB0odmmZW3L0jdOuBXY0X9PddRXnljQAbdatx6XK0nPC6KnWqEc9pp10bK3Yksd8nJpjsRacoZZWJPXeqkZ6yzEjkdJSjiEdyok7Uh+3OCDUOFL62MZf90cb4Faq2nLITNGnwikXjzSv2hA8HKORgVOe9EUmpd48OZn6s+zMp9i2otccFwW0jfvLVjGe3Q/6Vo9jIXuIkDEczqoI7ZOM1k3s+hl0PinWdALqYiVnRfqMH+QrTbK58O4ik68kit+RFZf+Rjfq+/UcWAN8xORpXC7fIkfKeR/Y5wrw/rljc6xfq02p6ImoRaU/jkRi354Eebwu7mZ5/iPcg7kDGt8a3zyxaPw6jFg6pGCDuDsP0xWceyPTNPstU4y0ATOZuH9U1nTk2APu/ixSrnuRzr0O3cdTlo4WupeKPaDZRMh5LCP4lP12P619K/yBlfs224HxrP6bP5548YlpAReD5b/ALTdY7JbDhiKBBjCeX5UucHsBxFKAdxim/WTyaa0a/hXA/KkHhG7C8WSxE/FgV8z0rFqHAj5TCTWQ31qVCc7VAretSKcd6FSTmWxLK48+1LnE9/yJ4Knr1xRuWYRxlz5GkTWdQ94u3JbbOBW9ouAWkAZOJNo9s11eonUZya0SCNYYVjAxgUp8HWeFNw602c5rV0zZO7znjyYF1+xE0RlQYIFJE/PFLzA4ZT5VpM4Dgqeh2NJXEOnmCQzIuxrXqYONhkDmX9OvlvLcAt8a9d6jue4INL+mXxt7gYyAdqYJyJEDrvkVZh5yyDHEF3D9Rn0oZcycuRmidyvUmhF0OtDLRlIMvLgqD03oDqF4I43dtuXfFFr4ncYpP4muzBblQd2FK2EmNIIqazdm7ndiTtSte2ivMpKjlB3GKK3UwDFT0znrXOn25uZNwD60Spu6G6WwHJBhHQbYpHyjIwP0o/pt0IbgRscA9Qf51SgUWaBAMGoZJzHIJR069aK7d6MwZ9kRu8QfN2rkybHB2G9D7W7Elsrbbdal8c775I9ayHUoxBjIbIzLDv1wpG9cGQ5+mx9PSoPHGxY965aUcuS2+ajMnI6Q9FcR69CY3RUnhXbb5h5Ut6rarMWSWMhlyCp2qeOWSC+S5iuCnhtnr2700yWFtrdqb62iCygZZAN/v5U+aO9XvE6iJdndo9ye4uPs+Ex/U9OdAfCVIyN9lyaEiF1QtPdMoJwSuCx/XH6046/bPEzxuuPQdDSe9sTKWdS57DsPrTFdhYYYTbK+IMljm0+xlWddOhdkGUe5Pjux7Hl2UfkaG6pxLql7ODfTXlzynEcOPgUdgqj4V+wqW5gvJQSgK46bVGmm6xdoIjNHGo3GSQT9TVm2jqZVFJ6eEsaVxLbWTCXVNAg8KLfk5cM31Pc046V7QvZ5qUYN/pFzpjL8KyKQw+oxSM/CE90ytdX64I2BGVz5Y619ThKGO4w92rSdQmWT9CP60lalLc85/WFXeZtdvq/D3gRCz1j3mBjnEsecA+uail1Cxw81pqUeSTsNs1mKQzWEaQAzIrdWROZR/rV+zliupPDvWz15Z4QcbfxL/pWRdQM5EbRMdYz6xJdTxiO4sxIXTPNjmDfcfKaTNWnZXFnK0kTAZhm8j/CaNftS94dlgOphrvTpPjjdD8SDzU9D9K71yzsLuP9oWMiT28wzzx74P08+2KEilOsMrKDtl3hfUW4k0d9L1FjJcQqVAx8e3Q+v1Gav8KanLb3X7C1d/e7XmZVMspWa3kB25WzzcpGdhuPWkOyuDZ6pHDZTBJrggxqflc/4D1Vv8J2p6m4e4j1stc67wxcW2FDe930kdnG4H8ZmZD/ALy7/wA6Ia8NwOsizABUnEYOIIYJtUgfSb2JNYQCQ2GoqVF8qjZo5Vx8eBgkDfbINXbyztNesozc6HKVgfxXtjOqXllN2e3nHwlcE5G3qM0J05rG3todJ1r2g8MCCN/3dvf3pvAgxtyywIwBHb4gfWmHSJW04rcW3G3DF3bOBCjEXbo3+EzCAhs+UgY+tVCEf3FTnjjn15Rk4a4m4ttFh0LUtR07XuH5FCQQ34Et/bEnb4XP71fVCr7dQa07S2lm0/le1ltZLc8ySCaSeIjy5iPeISP4ZVkA/jxvWS23B+gXyytYz6C8krfvrbxnjRmbspKDwyfMcoPfNHdL4L1y1uYpbFtXsVaMIgmiWflx1CXEDEMmB+MN/u9a0KLn6OufXn698QvqTqpx69eEbtf0nTLq1b33R4ZJIBzcvglgEb8aFc/Ac4LJlR5Cse1vTLHh69uBaX0s3D946jUbCdw6xSHZJc9Y2Un4ZSCpBKscErWq23EvFWkN+ytSv7HWYAC/u96jrKgzswPz77DmGR03HSk/jmaz1RTcWczxTQjmW2mcNLCfxKp2LqRnbJ27GlNYqp7dfyx6B9cQ2hZt2x+nn69e+Yhxbot9o2oqujXpX3WRJNOuypJhfqscmeiuCR3VxsCey5oEsp1p+I9Ht47a+s4RcXNmSP3S7LKvKdnhYMd9xy8pztsy65etp9y1vD4U9hKTGbU5DQ5OSqg7YPXlBCnY4VgGrPRcXNhxFDqejXh8SItJD4hKucDMiA48shgeuQSOuRUNuUgTedCFBPP3nt3gTjttQ0nT9R1G2kjMxMPPzcxEoGAVY778hBU9HQjyJtaxDHpuq2V7ZMZdN1ZXPhxNlJH5TzoAB8J5Qwx/lH4VrLPYjxVb3dleaHqr8jqiTIqqBHPaSgeHKuNuZHUo2Nxyqe2+j3s8nhTaZzgWN8wZCf8A91vlYNHIP4fiwD2IYUZrC1Y3fP8Amc41QquIHof1KuuaXZ2+r2t5cpa3EF1JJYySgYY+JC2AwI+VimP9/HaqlvZLqWntZQzo9ssi2k/iAAxyIIwC2P8A0kTxPnpkvRbUZ7C9hhkaFohdOA8SkFreVXEiY/yuCPMh8b7ig+g30eo2l5pV4kUc4jZEmXYM8PMAh8xyMeU9gzDfAxnCvBwOI8tpKZPhLFjL7hZWUkiuC87WVzzrk+KgIbP+8it2ySfOutasbayePVI357Ce9kuEDDOGkjZvh9cNtntnuKn0+4a+067+BHV74zuhIDiVN8gDzDSrk+Y8q610XH7KeJDG8KiwvIJlA+I8xGcHqCCo9BIPI15qsAkzy2bmxmKU9odVXS7Jo5I5oVgAiU/CoZjC4Bz8QzHkelVuH7eF9QtooZZFt1RopEmOzgIcDH+EOQOnyEVJd+8aHa2MkihZtN1Wa0knB3e2KrPA4HcKOaM56co9antkgs9Mlht3kNyZHtpGUnDcrh1cfc/kx7VI4OTCtyMD9P5+8KXMDyaZLG8cUU1mwuWySBIG8ORTnzBjC/SqGpaFcPeXdtE8BBWeZRITnxS6NEPuh5Cem+aYjy3gtNQR43jlkSaNDkho+WRWU+YIGR/lrnUtLi07WUMjvKt1pjrbBgCQypkxn/EFwQf8JqHIbgylJKnj3ylaW4tJEsHyiva8glDZKtIrbHz6rn1ps0OSR9FFteKXRVZUlBYleXnVfrhkIP8Axpfhube/hs5onBEuQHCjDPEevXbKlM/5T503cP6fDaWclnIhHjS3HKSfh+NwSQex2Jx6tRaV3uAOhxA3sVX2uuYR0+2PuNvLJhnijYc2PlACtg9zu3as/wBWsY9Fe9u5VQRJIqDA+YhckD6szD6A1pNvzWluWln5kaNW3P4jlD+eFNZD7Wtag07TTIZ+WJXGOUZLyE7ADy3yTR9XWqVrt69J7QFrbdvgZmPtB9oo0BTahg87DmIB6fNgbd8kn7VjGvcS3P7qfXVN7qdxiSz01WIULjaSX+FcDYDcjYY3NVuMOJTJfzatNi4nmZobGJkyq4O8rDuq9Bn5ifIGueFOGp7vUjeXzu11MFkZ5UPO7HqSTkdPyxgbU1p6E0lYtsGT4TR1esFX+mng+JnHss9w9o2vW13f3slxdM/LJCYx/wBHRTuqqNlTodu3XeveXAvs/wBB4f08fu45AIy3OOVUQ4PyDbA265NeFPZ9pf8A+G2q8SWdjHGdWjimZ2clXubZxzRoF7Lseg6geVe2OCfaHpUnBFjxHMyXPv8Ap8U9uqJzF/EjBGe22d/oa7urR1dnqmssIZLF3KfAcdPX2nzi7X2a8tSPZdTg+/3+vvNx4cu7G2t44rVFzIytkNkev6E14B/ty8V6Rxn7YI34TmintdM1D9nWs8ZLBnj8MuVJG48ViB2yDWi+0v298Q2Okto2neHp9+4Pi6lbjkkkiIxyIo2Gd8sa8wcHafNxd7RNOskDSafohN3MXOxAbnOfMluRf/CidodrU67TbKvif4h+yezbNNqRY568D9fH19p6+4HjupFFiZ2jiP7qSUkGQseoUdzj7DvW16Daw28a2tiP3afACTnP/Pn+VYf7NLS31SR7icOwWTmIXaMt0UZHzHbOPStsjvVjhW2jlYkj5guwA7ADvXzWx0zjwE7jVA7seMYbaZ/eAFVfDj+J3bYVYbWtMS6ZLYqZVPxzFs8ufIdPsKTr7UI4bcrJPh+X+72L7dWbBP5b+WaC6brMN/dosMr+5g/G+MeI+dx9PPH0pazUFDtlKtLvUt5TUbbUZbxmleXliOCrSbc/ry/6mvl45uwInukA8hglj50Du1laJLiaZ7aHkPIObPMB1AXuf+c1Nw9dx3EqxQqGbP8ACOb79hTKWktsMXNPs7x4RZ4o01dOk/aMFmilT8T8u+KraVr1tOBkAM3fGK0zX9JbVLUQyxxEEZPxDY1ifE+g6lot48qXAKZJVVHT7UHU1mp8jpG9JYty7W6zS7XUUCYaRceVBuJo4pbVpV3PbbYUh6NqupXEwV3cjP0p9uEZ9KLSHHw/U14P3lZEDraO7U4nnaeKTTfavHcSuyxXsDRjtkjf/WntXKuVzuCRST7Uo57a6tdcslHi2M4br1Gf9KaI71J4obtWBWdA+QeuaT7RT8T2dTeOqZQ/uJx6psvZfPn1+omD6bf2PB3tx9q2nNp3iftC3k1e3n5d4ZXSOSRM5xyusjde6LRP+zIbjXtU1TiiZTyyOFQ42CgbUjf2gdYveF/aNq1xpqMkuuaZa5Y4xITHJGRn6RYH0rv+ydxzLFcPw3K0qGQAphth55Fdpfpjr+wUYPj/AFoTx1KZH1+0VH+q5lxyW+hAP26T11qjc1i49DWaaFJ4PGQ7Myj+daJey5s2Gd8Y+tZvZjl4thkGBnI69a4HQLmp/hNBlxNljYkAmplYVQilJQeoqcS4XmJFVrGTI2yrr9/7tZtytuRikOJ3vbtYwCSzf1ojxdqZL8gbIHUCo+DrVrq5Fw42HStkHu6wo6meA2jcZoOkwC1s0TGDjer3iZFVVcKOVegGK+l81qUYCgQOJI7evSh2pW63VuyHGcVdJ2qJ9x0rRrJE8BMy1NJLC7KsPhzTBpF0tzbBCd8VHxdpvOhmQfFvQjh68CzmEnONqfXD8y5GRkQ3cruR5UJulzmj10gYc46GhU8ec0CxSDiGTmLl3GN8is64um5pygOy1p2pARwSSHsNvrWU8QkvI+Op6UqwywEMDE66Yuxyd+m4o5w7adHI9M0Me2M1yqBc4OMU5abp/gWqgJ8Xehah9q4hk4GZS1FCGwADnv5UOc84Krvijd/AWTP8jQNgVfbpU6O3KlTBWnHSW9LnMZMbHp+VXmYhyF6ZwKFQqyS84OcedEWBZVfsR286rq8D2xK1Xc4zOjOQMkmuWlwM83SoiCWHnnyr5g9MbdOlJBxDh5Y1geBzTDYk7HyqjoHFd/od2c3bzW8h+Nc5JorxLHiFl9Cay7VLye3dhExBz0FbHZtngZzF5wwImocRXFrq1u19ajLAZIyM1mp1PF34Y5uuCPTNWOCuIZhfNZ3Kc6SjB2yaKcQaF7nqKXUCYD9jtVtQe5u2kdek6rsy86ijk9JCtwhtfEXqe+KDXWoDmI8fw8dzRO/cR25RUKv+IY2pQ1aXkU8y4J71BAYzSqYqIWtrqUTBxrR5j8uRsPX0pgtH1u45TDdWsq9SeUEsPvWSXN/JEcwE5Bzmrencc6pY4BVlVcZJUnaq2aR3GVnu/RD7U1lri5kQxchjMYIY7g/XuKpyLqltIt3B4nOhHLLCwJ+46Gl/TOKrnWB4ccvJIN89Vx6k9KP6dxDYWzOk8EUk2MFkz4P5dT/L61k2VPWTkRyuxWEN2Oo2+vWMlrd2RMZyZZA4SJGH4vi2B9F39KqaX+ydEE0djdy8Rgnm8FJDbxRj/Ev97JjzHJUcqNqRXUBLJNGg6xYLRfROmPoKpPZ2U863CXVpM0O6868sg+xGf1pcEQuMnrC1zxNxDJbleHLi30WFxnk04LbP6gygGRvUOxr9onEaXbC31jVrWW6I/c3QuEknGPwtk5YfcUU0rX9OtrZ1Md5BI4y8tvK6kHoTkqQfuamukvbvTx/s1xjZTsmSq6lB4m3Ug9MfUVUtuG1xx68gZQnacqIRgvVkCxXVhYTlgoEllciM56Z5WOD9MjFEY7WC0maVNMmtppAFWUgBebOwbALHP8QP2pb0/WuMDIqSRaGZo8E+B7vySL6JJzN/Km+x4j1z3dYr/RXXxQQ3i21usa77HA5QR9D5UHBB4IniQeMTu0udLin91u/GspuYSCa31ONHXfcgNEjKc9961vgniJwkllccQ6veW5ARnnhtLsMD0JlhaNh9dzWUaxfaPHbxzahZiAhctNbo2xB65duUD86p6dfcBXssaXGiwzKxyZ2ljDLnof3RVz9iaJTqXobgcfE4+ki7SrqE5+x/eemYW0nUbWOxu5475lDmIXgZwM9omlJI9VD49KVuM+C7aaxa3hNxJDGhBWQEmLfZQfmIHlvjzpE0XVOALGf3TSeKksLkqEktru8uAAx6fBK24PpmmmObiaBDe2s1rLCrcwlhuo5RsP4TyHp2y3TamrrV1KYZflzMxaH01mVOPjxPO/HWhe5SFo7lnYEqCvzMPItuGGexwayjU9QeIyRrK7XELLIhmUrKHXo38LHsT+IdR3r0h7T+H7K6WfVb7TTHPOoaRra3KnmAPxNj5e3Y1541mwkWQA2UcrpKWhbxjzSEbkA5wcj9TSejIDFW8J0m/vaQwmqex/iy0n8BbuM2avA8AwcoGfGcEjKgNgZ3wQofYhhsOoa89nbzTzlriLKW9yF7AEczFfQNn1U98bebvZ/puhywS6lpepeBeQyJL7vIzYI3BjyvwsrdASqspDK2+M6lacRCW4IvllKzwNF8Q/dzxlcHcbBgcffnwcNRrQASq8TKsry27rNJ126u9O12a+tpFNtfwePb4XmDTIpLKR3PKGOOp5cdRS9bcYafeaxFAwMJ1Eq0Ds+0Ejg5QkdV5lb1BGe+KqtqUd5wfEouFW4t5EMEoc4YhlGd91fIH+/jsSKynWNVvtBvGWAbrPb3dueXEYLZYrt5lCP/ABoG3efZk0oGGG6jibHo/EUtvPczxhld4veYgi5/6RGDHcW7fXwwV33L/wCKnVPdFtLnSHMMtvLao0RO5MAJcqhH8Pi86+mf4a8/W/GTLq117vJNFdQXTXEcBchZA6Bih+pQEf4ga1Ph3X5L8QW1vexD3aVbW2Zmx4clxGxhLEduZFTP+IZ+aibPBoOxSvI9eUNWFs2qQyLNyLdPJbTw5ccrs6lZAP8ACXRsf95v1r9apBY6dpFrDbB4733uD96TzgomShJ35uXYZ/h9KCx64Ybu3ujarEYZL0NE/wA0TLAJQnquM48jEwpqvrgeEZUiR2tAroyuCwmSQqJAvcMmx8wp86VKbDDFiwAPrw/uX9DWM2cWlvI8rpA7QOF3KZ50ZcbZzLjpjDkdqYNUs/gjuhyeLaSRtGAccwADjr02Ykdug9KU4WOlNa3txBKn7KljWVl3YwvEEEg6ZxybjvyetP1xHY6gzrb3MbySc0MlvGeXJK86lcj/ABbZ23G5BrzpuQt5Qedrg+cWbDR7OG5W0s71Y4be595tnZSVjUqOZD/h5WQd9gD2p30HT7gusbwqyvIHCZ5uSXl5HQ+hyMEbUnOEsr9w6h4Ut0XcchKAlV79eXK47cuK0vhi3PuNskLkgIgVmJLLy+eeuxwT3GPKi9lsrWFSIPtFWVQ+esWNQjfSNECJI8kdsEQFwSSvidDn8QB/T0rzF7dta5ltLaBiqI8qu+cMo7HHYA5375r2Xxho9rqVjJCsIJuVYSrn8WMfXIOOleIPaPoerQ8XS6FqlsjQXF6kUHI+c9cLt+LAPw/XrTV1YGoG7oohOzHC1tYPzTEND0u61fWZbtwq+KVSBZQSqKDhV+u+T6k1puiWr2ZZ76YQx20nJ8UmArE/KVOcjYHJ+1calwpLZypqMNqSiEyvleVw2NiADv06YqQGNrWMrIolLFlCIGySP4fL1Oe9Wst/FruWZ1r923WVOMdE1zU4rbjHga8t/wDaTTLdoFgYLItzC2eZBk4YjO23UjG1ffYrxhqVv7LLbR79ZBJpFxPYBJSqFCpz4bDqoAPQ1DeX9zbX00pCoLcq9uYHx8JXGVI38j9BSVqHEMmoaxeWWiQzXF5qc8k5WIZknlOAXIHbbdjsMdaaqt1VukXQMcqDuHu93w8fjEk0tBvbUePT4yXj3ieV5n/dh7mU+DGkYLFyx+FVzknJI29afPZTwTqfD2nNoHu3NrGpyLPqroctBHjKwg9dgSWI2yT5VX9mXst1CPUI9YlaG61mT92l0CHt9N7MYQSBNKBkc4yqnZcnJr03wjwfpOhxRgyoXIzJzHld27s/dj9sDtVtf2gtFf4bTnnxPl7hNrQaTuT+I1A5/wCK/c+UvcH6BFo+kwlGWC3UAIc5Lei9BjzI+5o5qnEX7E08v4YhUZIknjLEkDry4G3kMD7DqO1biGCyJlSe3t1jQg3IBaTlB3KjB5VHr8RPRaz2TXTxhcAQyuIUPMJ71m52VTu/IMgDOMZ6E9Mmuaazu+F5M0a6W1Ld5Z0lo/7T8SsRcXlwlq/xyo8oTKbk5C5JJz3PTyzWg8KabDpqLDP40jpjl+H4jg7DfZQPL88UO0e0FhYpJGZLaKOPxXkaLmklkz8+MbADpkHfoM4o3aRNe3MYurp4YEUSqjHlZ89ByZyfv+gGKiurJB6mXv1IYbBwsdYWi1BS0lrFEhTCSMTIc58xsfzxUlnayW55IJ48qOZ2XHTywO9V7S7s0jCXEs8jKMEREuQfInOOb07VzcaqkN5+y7S5mUOcvBEy84J7MQK0Nqg7jMwMx9lYftY75lDJyNE3R/XvtQ7U+FoL53e5UyZz0G2aNWdhdGFQ+I1A3APf69TV2NZljEPKFX6U4agQAwifelGJUzL5uGGtpm5bfkRTkH0qW/mji09oVYE8pHWnrWbFpYGVvhB8utJV5p8UMbqNwN8mgNSE4WMC03qQ0xHjHTJtRgurYRbMpIPrQD2fXvvHDUlldXWbzTZWidSRnlB2/Q/pTxxZKIrh08UAeQrFml/2N9oQvwXay1wiCRc7B8HB/Pb70HsxBb33Z5//AGDj/wD0On0nN6te6YW/9Tz8D/eIi/2jVs0470zUZ1JcaQEiDEFTJ4/wkjrgK0g8t6YP7OXs/wBFg5uKwhNxgKCHyMZ6YpO/tTXCH2k6LpsYKrY6QjSNn/0khIz+VaX/AGfbq3HDUghcsQRkHtW9rVs0/wDjKVngggH4ZJxFBg6zjy+wm1Xdxi1Y53xSBFIDxRbOCPmI+1Nd3d4tHIONqRYJ1PFFsQQMEjGetcf2cmUf4TQcTY4ZhyqM9q6u7tYLdnJwMVQhnBAOe1CeKNVS2s2UyYJFRp6y7gCeK5ivrF811fFVbOW6VoXCVkLOxU43I/Wsw4cjfUtWGQSoPNj77frWx2UYggSMdhWiP9l2B0EpYMACXgcD712Mmol3xUqDsK1qVxBYnXTvXJya6A7V+IxmtFFkbfKDtUtFubZkYdtqzvwTp2p8oyMmtRdAVI86RuJbMxXJlVehz0p2oeEsB4Q1Bie2GCDt1qjcRDJqbQJS9uqHdgMVYu4cM2Ns1e9Ohl6x4RN4kIS1ZcjJFZZq0fM7Mex7itP4nYMCPvSFf2/isRjOTikCOYyBxiBtB0r3u75zHkCnF7DlTAXoKtcN6QIrcy+Hgtv0onPa9cL9M70lcCxlwcRVnsucHbr6UralYtFKcH16VpElnnOR+VAte0vnj8QJvjrS1RNb7vCCsijaI0yhG7ZztRW3tyyMhHbPSq8EBhlzRq0h5wGPU9qevHepkRQZByIKNqfLevhtDjfajz2RD/Lv1rj3Eb/Dn61i5IMZU5g/iNAVYHpjfasi4kYrI4RcHvjtWw8RDdsnNZHxPyI7kDJwTW32YczBu90pcG3tta6zHJOcKD/FjatO4hniuVgukVWhHVgcisHWd0vlcvyID2O9bRot5p2scM+6wXP7yNOnNk/Wmu2KDXsvHhNfsC8MTV0zJr3Q4dStg9q2Dy7d6SdX4dvYcqYw/wBRvR3S+Mhpdx+z78ZRSRkCjt7cWeoIrwkSKwyO+PyoQsXaGE3lLI2xpkE2i3hm/dohGc1NDoqiUC7Ux5OxRTt9T2FNes2ywMcLjuBQZLe7umxb7MNs5qjXEjJOI2tankCX7LTpJAsMZtJUQ7eG/hMv1z1+tT6jomoRJiE+MG6cjAkfcV9tNNaEE30oCj5iV/0qxJPpMMfhWeoi3mwQCSQP9Kz3tJbiMCsCL8ScR2EnPasUkB5gHPhP/oRRmHWJGZTqfD0lxLJ/eFFDAnucDI/Wq1xNNO3Nc20N6mMB492+xzUEEGmvP/0e81GA9o8MB+lVOH6iW27OI46ZpNzcTJc2+gB4cjleG78J07bo5AH60aPAcLye96lomjozkOEkm8V3HY/MoJ/Ogmg32s2ye7aNp+olsjJS3MjP6jBPL9cUettKlY+Jr4e0dPmjmmLuwPblVwf/AIjj0pNiwPB9fOVOesuWy2dlImn2trHzy7BY5xECR/hiOaLW/CmhXXM2o6XYmQDJws0xQjoMrIcnJ6Ej1rnSvdrbMNjodxZRHdWULuuOpUcpb6seXfqaZoRxTPbibTLc2sYUiOfUYUOfUR8y/mWIoe5vOCZgDwZFo2n6vpspj0W2LQ/IRzXUYCDf4hK/Km9HrGz0ucCXiLhvRElKkSOlxHI7DtkKy4+uTQhJdRSJkbjHTmKkBuVpIpHc9SPAk2I+oqxHd663LLFeam8KgK1y95NDChB3JJR3Y/U96uhzyTBszHn69DGaw0XhW5hMWkS/s2ddkjj1YiOX/CVlLpv3+DrRWLhcyMbiwsZrWd9zJaS2zYx2YwSISPqm++9J0Wrx3Msdn/tFOxRWzBNbxzq++zAyKr4HmrD86Lw6/o0MY8aTUofEXAKePJCxHcBiwX6nNNo6cAj7RZ0tHQn9cmXNa0eYRtJq9nJKwO11EskUm3U5UdfqrD1rEeNPZ1YancyXenxqHOfi3CTEndXVdkbycAb9VFaXqPHkdnzrLpPEHJFs15YQLcxxD+J4g78o+nL54pd1b2m8PRtzT3FneRtgrMyeFIreXLklR92Ge3aqWJk7lHr7xjTG1OkxvSuCrzTeIJbW3lZbvJPhS4UTpjDRk7BiPhIYbggZGMEaZZWNvqOjSK0RZA+ZoCPitpcckhUdviCsR5nyIqjfa3wzxAiXEMq3FuqvNzcyiaDA+LcEZZdj6j9L+j6lFDcS3NtKks8kKtMwJZZznlDEdiRlTjzwQCBUbyTh+sParEZHWc8PwyQWt3YXtuZrS5WYXMIzkFowCynyIwwI3DKrdzSzxlpC3yRxeJzSrboRKT87eISB9QSfsPWn/To7eeEyQAtbqTAGbZlQFsAnODgM6k+npVObh+31FvdcFZYky7dcER8zZPkOYfc1OQBkQAsxYc8TGNftnbVbZowAiIsbfhdl+IhfTlZW++aZ+D+ILj321uoZnDosaXSjBDxr8SHGeocgfUCofaloUdoyXcCnMcjhgoxh1YjA9CzN+dKXDNxdTXF6sEoRGtJEjCsMg4C83pkqDijAAp8IcNuXjxnpnQr+y4jX9rpb83v5ljmCDlLSyR4QgHcEsrKe2Jc9qIWzoNPtZYHcX9vctNChAT3m393DFmHb5myB0JNZnwRfahLaTz2RYTyRWk8Q6eGwZsvjyBMh+grSLG7ntJbAiVZo9PNxKC0YZvikB5MDqu4xv+Nh0xSrICcLBZK+vdHrTLK11nS5NNmuf3NxBm2mjAZ7aPnccyjG/IXXI/wtjrTCbXk06YmCKC7iMT5hl5QAzcrRhj+AnDIfwnKnYilzg2z03UuFbHw57iIpzQCSKMq8alyObA7AKNx5AmnCwhgvbTMNwlzLbz8zpEVAkhJHMyjm5SvNuV28sKRVVrFqdM+v3HWDdjXZ+vr5ytrOj3LXDh0aEyNEfEROYE9yR2UnB8hk+dE+AuIzZ8tlq4KSQEcrD4Tyf5e+DkY7fQirDPaWsQtiJQk0gAMWcoT3IO6Y65HwlSOu9Qz6BCWS6hSXlLvFIrqPhB3yDtlc/cbHzpIltNd3lfURobb6u7s6R21I20li0tvKvLMOeLBB3H5jPmP5dK8le2XTL/UrtLzQIPer7TpZru6tDB4khiRQpkUr8rBm2PzHqK9Az6rGlu0MjcizgcyfKwYjBYjsemfP86Rbm+fSuJbfVYL9rOYxGJwrArKwyUJGN8nlA32z0rRXtGt9QpK/39oOjSNVU49089aNx5oWuwL+2PDDKedrhVw8WwHxRjBfc7kYPfFLnFtrZW8s1noNxJdSlTG0dlE7Agt1bAwAOxNbCLTQNEhvLu1tLZWiRp7iQKnNz55tjnphsYz3+tBtH4gtNVvDbmGeEuWCStF+7YkZILK2B/vYoBtr0rF6umTx16Rheyl1fL5wPXvmTaP7MuOuK0jku7hLK3h2MwXmmVcDbJ2GM9gfKn/hP2RcNcNK4Lvcu7f9KRCPElIJ5fELnmdQcHlJVemBWj2MtrlPGgg5YgVjLqMEnsT2+9cX73wVYw9wiE5ARl3Hpk9PWl7e1rrhtHA93H9xins6jTN7A/U8n18JPp40q0SOG1s4o0ADYGDIfIEdR9BtUuo8cQ6dbzWlhHLdyhSWiiAUZ8mx1PoTgdSDS5rGoambBobaWG3DKR4gfLsPJiOn69KH6TaXFwrRP4i2y45rrky0gBwVihUZ2Yj4nJyQcLtSZO7npGO6Vvac5lzVH1DWpIzrN8lvzlAbaPDvgbqpOct/lHKoG5B6A3wwunaasjWWn3NzcFlQPyrsSSFCA432PxHAG5HnQ630OC0jlmaCWGzlwoxIvjyjpl5TsoJJ2X174pgstQtFRBZ6eBDbsD4caFRIxHygblzj9Ou1QpUNnMs7MybQOPdwJPqusXumaY2qMiLzyjlKH4R3CpnZifPfOOpqtwzxJdpHJfzXCRyuSxL5O38IJ36eQJ8qu3fDHFnF19FcyiG2i5S/PJIqrAp2zznJZvMqNzsMACmnh/2OQLJ415czzxsApeRPDMhHUgtg8voNqPXTda3+scRZrtNRXiwjPu5/SLV5xlqmoyPZaXBK6qAsksahREB/iJ2/OtB9lWgTSAXcoWNhvy/Ox9TjYfejdn7OuHIAokDzSD4mji6DzPwnCj6YPqaedCgsNPiS2tbdCO6qMKv5bVraLs63vBZaZk6ztKrujXSMSreTXRfw4FXAOC30qSOToiqQf4qocQcWw2EjQRG254zuFOcf0FAo+Nonk5ZLiMtjZV3NOX3ojlQYhVQ9i7sRqu3VgfEyxx0xSVxHNFbQyMY8ZBwOpNNNnqCX0QcIM46mg/EsEcsfhrEOZu5qBWLRkSVY1E5mC6vpF/rl+zQRkJnriher+ybUdStFkNqzmFg6465B869AaHw3A7BnRevlTtZaFZBAhjX8qHpuzlW4W7uQciI2nIORnM/nT7YPYvxhxTr2ocVvpzqrWNvbBMEsBG5JP61a9h/Dt7w9pV5ZXUbI/OHZWUjl3IH6Yr+h15wTp17CUaFWU5ztWc8Q+yXTY5JZLW0ROY5PKMZroO0NK+s0TV5zkgxNTXvBxgzz1qF34VnIc7gVn8F+p4ntiCBgkGvUR9ldoyFXt1PN12qhJ7GtFllWVtPi506Ny71g6Dse6pGHGTDW21gdYmQXWYwzHtSNxzq4kk91R/i6da1LizhFdBtHngdl5R8hORXnrijUwb8O7czFgo37k4oOn7Lu0znevTpCVur4KniaZ7NLLmj98cZ5t9/IdK0yJ87UmcErHHpETRgYdR+VNsMucdx6UOjTsp9rrIPtHMIRnNTruKpxuT2q3G29a9VWIMiSgbCvpG1fVH6195c9qdRJGJEy57dKXuJrMuniKu+PKmXk8qoavbCW2ZcbimVGJIEVtAcI3JtRrUsLF4nYigVmvu91y4wM0V1S5BsSo6gUawbkzLAe1xETWz4kjdh0oHBp7XV0qKnU7mj96hdie/Sr3Duk8z+My/Q0gy+cP05k9vYiC3Vcb43qKS1z9Btij0lsANqqyW2dwOnnS7pmSD4QJJab9Pzqje6essLKU3FMb2xBwO1Qvbg9qTeuUPPEy66sDDcMMHbPaiGnwnAycY8qLa9pfhzeIF6/rVW0QjAI7/nR6faXBgCueku+6c8eQK4FmB0WitlECnKe9TNakMF5aR1NG1siFryZnWvEFWOelZJxOAZCWHXOa1PiCUcrkbnf+VZVxQ3OGddx32p7s1SCJztxGIiXiq0pRQfX0p99mSxWszJPcYR1wRzCs51GVkc4bl3q3oeoe7yiQ3DE/XArotZQ1+nKg9Z7QagU3BiPtG/jW1aPUZJLZGMZbIOKF6TxBqGlt8UjsOgGdqbtKEHENm0apzSoOuck0patA9ndNH4AJBwDXL1k0nuWHSd7VYmpUWKesNjiCfUMCSFZObbOOlErCCOaNizCFsZ5Q21K+nRvNhjbsQO+TtRlLUyoea1lYnurb0vc3OJoUqZde1gTmHvM84HzIOmKHPaxvn3CymXB3aVM4+mRioi0S3IVjdQAkA5bBP3zVu41O0tysUOqysM4dVxj7sc1VczxweTP1raXGCkl7HCQduSPB9PPNGNKn0+2cE3t00hOB4rsoz5BQN/yodpl0b9/3F4rRofwxBz+eMmj1u18mY7W6uZmTflVFRQfVmx+poNpBODJXIHEP218dSmNvaWl/ceDhfDSVgCPQJ2+ozRq20sQvHJPpwsV2KW7/DLIx3zg5cD1Kr6ZoLpup3kbqtxxDMHcgGG2YJGfJXkHX6AH0pht9c4f0VxPd3k1xeROWWCzRY1Vu3M53P1Y9s7Ur4wLhh0h6x07UVRbiKyewf5mMao7H/EzzcxUeuAdtsdahvL+1RwjKt0ytgKshAUgdZZpDue+FX6E0IueLb/UrGVtavrbSNNUZ/eSyTzyKd883MqjP1/Os/4t9r2laDb+6aBbW0bw4DThSoU9twAzsfIY9c1dK2sbbWM/CDSvA3WHEfNQ4h1pFU2Oo3EUikt7w07rH13/ABHAx0LlfROlIHEXtp0jSZWaea1v59+Yq6tluxJCKAdzkYrD+NPaTr/EjCK+1Se4LOWSJn+BSe5Ubfbp9etLyWh8MSXLNJIxzk7n7eVbVHY2AG1B6+A/mK29qV1kpQuSPE9PlNUuv7Qt/wAzG2snLEZyb2dlLfxcuQOmw7UqX/td4qupmeLUL+35yciC4ZBv6ZpXjsec87AjG+4FXIrNWGTGjkfEN/mrTXQ6SrkJn4zObtPVueGx8AJePtG4nlBV9V1gqx3zekc36b0Pn4nuJGJujd7nfNwDv96K+xzQ9K4r47tOGeI7yW3024eR3EZHO7LuI1Y/LzdMjcdt69r8O8F8N6Xrur8PLw1po0poLJktXsUaFEMRVgQQc7xZOSSTknvW7pux1cByFUHge/5THu7btXI3MSPCeGrDi68sJRJbajMjDB5ZRjcdDkbfnTpontf1DTJPfJDmTlYMuwjIK4JAG3YZpw/tK8Aey/Stdij9nWlrZXiQudSgtZCbNJeYcoRTnlJXJIUgZxtWIro0kauELEAbgdMd6ytVpNPvNb4yPKaGl7TvKBx0PnPUfBPtFs9b0h2luB4ck6MwO2cEgnHbYtnzBBrV9Mtkvbh5S5MLjll5duY4zkH1+H9K8F6Vrdzp0wjt52XlYZUMRuOn1r1X7KfaTa31nBp6yKJ2Q+IPiLIgVAzH6gYGOhWsHV6M6Y7hys2a711SZX80a/aPpAvuG79IXVbhImnLg7krIpA/Pf1rANOjuNMuJPBixPIbiAgnLEBgyH03BX6CvS+umxl0m8tXdAvKpkCjBwrq3KPMY5s1g3gxPxJeW/MIml5pio3WJXJYkHscjp2zSqPyRG6F/wBfM0Pg25NqxhacyBBJDNNJnAiZ+RVC/XP2XPetQj0dGsG/Z5lUiMNHyt1BOH+pwg+mayThO7SLVoY5oZ/FiCyeAX+FGY5XmPohXz7nrWw2d282k3MCSo0sCyMJElVGZN+ZgWOMZO1A70BsGetrYYIjRwFqV7a3k+nNrdxbiOOBY4Qpl/7MFn5VCsCCBupwBjzrR5+eaaGc2UBuIXDpduwgkJJ3VlLEjO3zdR2rG+GDdQSzXnK93JC+FVYOVkGQCMk/Ec4I7bA+lanoVxHFbJaLMq+PmXxkhUsw/hJXbbc/XagUPyVA9frxIvrxhvX8/OElkcgWdxJDGplPhh3JKD+EMoIx9MdK6STUtPdrW4jyknyvhmDpnIO2wwc4PrUU8/uSQ8lqrCQ4BKoCmwyX68x2PTz9Kln1ARxCS4jMfirmPDY3I7LnA386rcrHOTzLVHjgcStrmjJqh8WF5I3HyuHBOMjb1ORnB6ZrIOIrfWNL1FoNQDyrbsTGwzjDHIJHUbBsj09K1+wvOXxbK4jkaZ3DifGeV8ZA2JHTOdvOqOvadFrljcWqvFHd+EVhfIPNzDJI+v8Az0rKsTLbh1mrp7jV7LciedLqC/uNZuGtOX3O5UNJJ4oeQZIU80ZXD4GRvtgjNV7fhN0kZBapAiKAskEjK2zbYX5cY3x0HSmnWdKvdAuB7wVe5CqGSQEtjoBkdslMef16XNM1G0Fw0AhnsTHtIFlbDjGOZRISPXpSrXN0M2hhV3Vxe0/QpMiObUkijDhR4zKHO/qRv9KZp7OxslWM2/vcrYBdpeWMY81BGcd9znypkjt9L1OJPD1eBJSAJBcScjqQMANhSN/sDQa84f1C2YQxQwXKk8rEtjnXG3L8IB+wb86NXYfAZmba3eN7RxFr3zlvlXwormUnmQLkBCD1wqkk+ijOw3AyaIgMlusVyrCWVT46nl/dL2DkbA4wOXJ64wTk0Uj0fUrK8NxqGmJY8q4jijlYZ26MScjPoCT6VZuWhtxHLL4Vs0jZgCW/NyP35FYgs47sQoFW9o9ZTegICj1+kgtNNu7pRczcyRQgYe6TkBbbpH1GAP1Ge1OXD+jaWJY47i2dxIAVWUnnmzgnmCj5TgYRdio3yKAQRI4SRro+DbOshlnTxJC+TgKD8AOc4LKcbtud6bhdR6ZavaWyFtRnTxTHHG09wUPxfG7/AAx5/jkYHHRdhTWmpDNuPhEtVccYEabVXeVIUtbSFBvNO48SVttgu/mMALyqAOtGg6yxS+7tDEXXEspjWSQdvmOI4+vRQx/nWZWOpail+09xJFcuoIYiNnjh22VScKcdc/Ec5PKOtfuIfaTovDlkl3d3kkkszcluG5mknYD/ALOPv6k8qjb0req1NQTn1690w7dNYzgLzNEWWHTo3jbUYWXIzLM/MgHoAAM/XFV9S4wit7V7PRwt7O23KoxkY6tn5R9aw1OP+L+LLpLeygNlaRnlDzP4s2/foET7ZNaXp2lrplisUcMsskwy55z8TeZJqadW+pJSoYA8Ze7RLpQGt5Pl/MDaraarqJebU9SSFfmKQgKiKOwpet9XWG6930yNpMHDTnfP0px1LhrVtTtzHPFKEYY8GIlFx6nqfzqpLwjLparb2ttGDyjOO39TS2o0pXLL184zp9WGGG6eUbOEtWIt1EhBPU0Q1C6W7uAM9KTbDxdNHLNJjlG9fl4liWVmMoxnzo9LlKgG6xPUANYSs0fTWijQbgUZgvo0GzCshm49t7f4TOB96ks+P0nOElBo1esqq/MeYA6aywZAm1wasiLuw6VQ1PU7d1IIU5rPYuK3kX+82I86rXfETt0fr61pDtRNmBEzoju5jVcapbx/KF6UMl1uNGY+GhA9KTr/AFpkBZpCPvS1d8UFXKiY5+tKp2kwbKy7aFXEN8eX1rfWUqRthiMcp715r17gK4uLz3ogqokL5xtW4NfxXpAlPMTviq2o2Nv4JIA/0pwao2HJgxpxSuBFbg26kS0FrKMeEAg36042zEkHGNqRluYtP1IogwM4A7U2WF0sqBlI375oHdDdme/KIchc5q9CaFwSZA9avwP2J+lNIsqeYQTHl+tShAarxuewqyhzjNMKJTE/Fc7A1HcQ+JEwA7VZVc9TX5kHKc7VfEtiZ/qaizlaQ7EUJi1lLmfwy4IO3WrvH90LSGVlzkAmsi0LiYy6m0OSW5sUdPaHMsB0mlvbeNOIoxnem7TdO91tV23I60M4Rszct7xMBv0+nnTe8IUAKNu1JsvMuW3cQPJbgdAetVngNGJYcZ2qu8GdsUArmezA7W5B6VEYMn5aLPD12qIwelDZAZBMXNW05biHLDcUsR25ik5WG4NaLJbBwVYZBGCKVdSsPAueYL1Pl3oSrtaeIzOLJCME0U8HxEDYP1qhaKSQMfajdmnOvL1xV7q96yFGDMC16bAbGTnPXoazHiOT5/Udq0TiEsckZG5GxrL+I5GZmG/rXuzQDOWZ+Ij6o5LnBqlp8wNwqvzYJq3fKXcjI9aJcK6baS3sRniV/i/KutytdXMUrVnfAmp+zfT28BpoyyDl/hOMUP4kgU30g5FYk55sVqljb2NjwoPdIsHkGNtzWY37mW6Z2jYknvXAau/vdSzAT6R2XpzVpwDBCxTRxbuyjrgYxXQurhF5ku2BXy7VJeakIHxNEzAYHy7UMuNWE8nLyBUPVQKGqFvCa27HGZcae2uV5764Tbc5Usf9KtwDhy4Phx28l0wHNhV5VHp9aHWNlc6jIy2dthAN2cDApjs4rbT4/DkuFeRz8UcYAwfU9Kq5C8AyFBbr0lmy0u2eMFLFoiT8uQfpsKuwJBHDJGkMbMg3jEeM488nP51Wm1i5hj8T3a2RFG2X+Egd/rS3e8ZqwdGZIkXfw4ByIf8AMRu35igCt7DxL5AOBGWTiD3IeJDG0COeVHji3Pnyk9x0zQm/4sFk5XTbB5Lldkur3LmLO/wIcjPrjPpShecbX11KIbSedEb4FSAdv6D6VNa2t3eXEfjycniMPhkYgn6dz9f0ppNNsGXEEW3dJHqF9rOq3xk1C7eW4JzzSS5b8t+Wqk3CF9fwSXMg5goyA22x7jI2rQdA4VuJ5UtLdi7BiXWGLEceP4pj1PXIGSemK0NOERaabJJHZ3N082AOSIBvIjDYKqPoOlHr1PdkbBF7K1cbXnknXOHX02e3vVhPhswRvLJ6USv4TyKY0ZQem2/rWz8U+zy4ureXT7+1aOO4XmX4cEE77fTbfpWWy6DdwO+k6tG8d5AMAN0lUdHUnse/ka1vxItCsT0mPbpDUTjxlKxthzy8uAU2QMM82CAfyzRePSVNnDIkTNlsMWPoTsPt9aDi5ki1MShOVGYc22wPfb9frTIb1TCgdIpIoj8EiKVw52Pw99ulWsGeYquegmba4L/hbXEexupbO5jPjwzQScrL5YYdDtXqbQvbLqPGHDdpdRaYYLuTSYbO4lW4OZZ1Zz4wDZxnn6E+ZzWDcRWNjxKpgkK29win3eY7gkZ2OPOmrgiIWXDdpbeOIZ4IQs5zj95uTjzwO9MajtW0aQVIcHPI/Tr9pnNoQtneMOPXELcXxpBAk0iM3OrACaTmycD4gfLrsPSktY1W1mEkLMuARvyqfr570y69f2lyIo5dTupQg5VDfGFGM9e22+BSpqF7aQ2gildppZSQiKASD22O4H+tI0qe7wRzDAbnGDFG6a1ayvAbeFp3vYXSUt8aKBJzKozupyuTjso7008I6/c6Q6XLOyFRg9sjrvVzTOCLaKL33VIxLNLylEPyJ5f8mqF1pdvLbzGxWdmSUIcAY9OXG5NO3WV21BT0mnpqrdPYXPU+E2/Q/aZFxDpru1xICNyhbCyAnff7H7H8lO31oSa1eX9zFPJLccvMoCgmMAfCfqQc+lZ3p93PpAFphUbxQrKANzuN9+xOfrTdwutwtyZUaNZHlLB23xvy4yfUb1zz6UUMzDpOkSwWoB4+M1fhicXytK9sSt7KY0uNmxhyS+O+QR9eUVq3C+pWSiQKJvDkhUCWZFJiVg0eOUnpy5z1zvtWCw6mLK2a1hSSErHKpXm5QwyAvKB1JGT960fgC5v7W0EkF7HLBBEyNDP8RVm+JQW3z1+nQVmtWwbcIZwGSaal9FZRqvvcNxzOP3kYJXwyQAyDG3TJHXbHatA0C4Sa5kl00iNo5WjT8SkhQSOXp1yR9ayTS2trG5tI7Jz4E5RolJ5kOSQcj8JBI/M0+6HqFtZySTRGTxd5HOccxYDmIA2yMZH3q1NJJ3HiLXNxgc+vKas8NneafJCickzcryDqRsAd+m+TkUH1hbgMiBxJLKFh5unIMZyoA79DU1vIWsRHZRchZGlQFjzF/IZ7Hc1VbUbi8uo7NZiHRQrM2VOBjIxnfbNNaqrjb0iunY5zF7UrpraBb+aPxJeZMFyeUE9cYO2PTerrT+/Wy28jtB8JaOSPLAMPLO4orNImoGWzv4o2hUOYQm6qSQcY7VFb6fKJXcxlUQAYBIAGPXtWDqtKUOVOfXM2Kbwy+0MGAr+1h1Im5vbNI7pFHJJjLNKFAU+WAu4/zUgapw17rcvOjNLcLzLI7AIvzHO5AJ9MHOPrWpuIHna3d05YzzRsy5yCR5bnbA+gqhq+jXUkKyzXsbQAAxotsZJn7HJY8qD0AJ260myB1zGqrjS/EUNCvtRtkIjKtyn4TJHkKD3+IZxt2Y0YvdSjuLc2rzwIwbIEQ5FJP4lxhyfocVTudOsLTwhp1ldhhj92shKSHvlFOxJz6VNCk9lmG3AilkxyiZQrqeuyBiSO3XahBSnEvYUsO7Emfh7UwyPDBDyy4OHuAjMCPnfJYsCO2/0qePSyt1/0026xBgSgdXEm5zzF0ARMAAKFJJ7d6507T7dLiS69wtpJmcI0py7SNk8wJXfy70Yt7a3lk99eysYZQpKRHxE8Mj8T/wAOO2GyfTenKiDyfX0iVuRwPX1kqWlvcRwvOyRQRjKkjEvIu58NcpFAN8s7DJPY9KGnR4by7lSzt7qSHr4CNJLzg7lstjxDjHxNyKB2Owo1a6PrmqXTzTXkc8JBjCxxkAbZAjVgST58vTq2avT2TojLDbOJCoZ7iZWbG2xO45u2B3PatWpDZjAmZZb3WeYr65qNtp1uLDTY7iEyY5kRPFkOCcggDI6EE5A7AdSFma6h13VDaWnDJuZlAjaa7VOUZ6gIme/mx6dKc73R5GgaFZrtELZklunCzMD25V2QdNl39R0qbh7SoNHjU2yBCBjndcu30G+BTA0dmofDdPXSLfjEoXKjLS/wvwlHp0CTXFpAZQeZFW3WNIz5KBR+5vYLLEtwltER3kbLH7VDbNeToqRSMUO7EnlAqnqyaXFjNu09ydlVVLsx+wJrVNFdFWKREO9e+zNphmz1hb08pv2YDYHlwPtVDXHFsjSxF5Cd+Y1TsHu4V5zBFGR0jTt/mb+g/Oh3Ed1NJblpJCoA+VNqGXJq9ocydoD8HiJHFnEb2MUnNJhjnOKzubjVl5lExz9are0fWyJmgSTvg1nlo9zdXDAE4NZpJM2KalxkxsuuLLu7uORHOM+dNnDWszKqtI5x60l6borJ+8dTkedFRexadHgtjypFqwzZjzWIte0CarbcQEgfvBRGHUvF35sn61jtpxOssgRXxv51ofD7vcxK4O9TY5XCiZ/cj8xljXtQdEJ5jSxaWWoalcl91Qb5p3udDW8XL9aN6Fw9BHEByjNP6Ok2NzKW2LUnHWKVroVxEFYlzjzo1FoclwAHUmnE6TbqnLgZq9Y6dEmOYDFNFdlmB0i27emYl23s9iuWEhtgSf8ADRVPZ+Y4sJZ9P8NaRpos4VAZelG4bmwYBQyg+tb2nrV1mBqLnRziYNf8PTaefldcfhYVVhYq3K2xBrctdsbO6gbxIo3BHkKyjiHRUsZWntgTHndfL1+lEek18jpL06gWcEcylE3r6VchI2zQ2BugHSiMGCBtVVh8cy9EoxjvXN26wwMzEZxUkRAXmO3nQLXdQDt4KHI86J4SMZOJnPtDllmtZ2RSSQQKyngjQrl9YMzrkc2elbFxPavcweAqcxfbpXHDvCyWHLI0YDMc9KuvHAhTgDEcuF7ApbJhMDG9HZIh22rjRI1S38MDcbbVeeLqcVRkgw0GPF12qB4cnbPpRN4vTNRNEM+tCKyMwW8G2SN/KozBnfFEmhOcAD8s1yYfShlZG7iDDbnPShOtaaZIy4Xcb00GDfptUU9oJYipWhsmRPbsRAgjKNylf0oxbDkXmPlXy6sTBMTjvUc1x4EJHeiVru4lifETzxxC2RIMjJNZbxGMMw671pfEMikELncedZpr3xeIeu/lS3Zo5E48vnmId7zlyIyQaKcJ2l2uoxubhFyRsTv18qH3sTGTbAzV3QVVLqJ/eGyW3UGupsP+qRpwTYJ6gtIscJKok5zyZ3A8ulZlqRMMzPzZc52NaVo/hScIRFAw/d4wTv09azTXFiS5kDqWJ67182fJvafTtEf9IIi5qLNL8c1wFGNgGoUqLPKBGPhHViR/WptRGXKhjgdjQ9niDjnUkA7g9K0q14jDPnmGhqNppQH71nZzjPPnH07VBd6jEzc4fGSNzsd6CzTpLPzgJydgxqpqVy/hkRhFHQ43oiacMcwbX4En1TXmJ8OGQkDplsj7UJt2uNSnEOWbmOw+VR9WNUAJriTlQDPmBTFoFoVkX3hUUd/EyPyAyTThrWlc+MTW1rW90PcNcGNcyc8t+i8uPhiiaRmIOceWPqRWvaBwjGMRpAlu6rkv4CvNJ6cozgfUgUv8OyTRQq+jac7kLhmIWJBnyLEjPrTZo54gZmuJtQjiRl5XaGMzHy3woXPrvmsTUOzn2ukb37RgR30jS9O01FZJA5hJLTHYA4+WPlIHP6jOO5olNHLPGHsLqO1g5s3Ba3EhaM7kgk7HzY7Z86AaZqWl2pS6M8V00agePqNw9zMe3wRrhFHoD9avnV7+9liS2LzczhhJI9vEFPXYOSowP8JPrQA5UgiBGTyfrCw4R0q5sLgPLN4TOrxxPDGNgMfA7Nkk9frSNxT7NdNucx6npT+EFM0M8cymeLH4xy9Bjz69CO1P8V7rkbr73EWQfGZ7iZS2B+IEYH0xgVJZwx3ry+LbNOzsX5FjLJgjqXOBzeufPFFXVvURx698PWoYHceJ5l1z2IavcGSfh3U7bUUyTySEQykjzB2O46gj6Ul6rwZx3owMWrcN6lFGOkiW7OpA2+ZQRXtW54R4e1WHIjlSYbL4UwZk/wA7A8mPQMaFjgi5RFNhrmoRwITkcvwxgdWZ3KjfAxhT12zua0au1UH5lI+HP8GLWdnVWco2Pjx/M8VppuoOsSwaFqbOTyhEtJSSf/hx9KYrDhzi1po5X4fubKE4SSW8It0j9SzkHz/0r1bPwTf3qrbf7WXs3iEsrxyEHl26YAGOu4P38419kXCKxi61iCbU7skyLFduZhkbLlAR3OcE423J3FebtPTk5Ck/T7mDPZfGHsGPd/4J5qsuBtX12eS10xpdWaIrzSW8TG2TJ25pCBkdflz67U3aX7IppvAFxaoWmCmSWRQhVVAbKqOijOPLv3r0ZDZaJpFssFrokcURcSTeGgBLH8WFABLNk8oAAAG21DNf1ezhhubC2iYzhlErIqgRKMZX6hQM/ljqKU1Xaltg2r7I938x3RaKjTtlFyfMzCOMuF4rOC502ydHcuWMjSAlVxjJI6Ejoo6ZHrSI3DMbaNd3k6SYjIjgESsjMmMjYdQBgk7dj61sF9pFyLy4vprJQqxPcPC/WPPR5PI7g8uepGd+mc3k91dX7adHCYUOVLnBUSH4iz9jgAnHy5wOlC0177eDNW6pLGGZmz6VfXutq17DNKLiQt7wIzh5Bg8qsNi22CD18+9NcWbHTpJUSMM8rvFz9QTKCQft/Wjen6XPo6M7Xht7O9lJjjvboILsL8JJ6cjjORjYc25BxkTxt4sVwtulrIJJHPijIJbAAb77ZPqSe9OG7v2C+ES7kUAkQlFqi3E9tbNbzyeFIC5hOHOcFgPtWi8AapdzQ3GmlUktovhWa4fldPjPKGddi3bp0rIdOurpJ0mikcSxRNMkkTchDAbn69ad/ZvMzX8oE0aGSPkIkOCS3RkxtkEjr1FBsqhVbcs3a0tXupIbi0IW3aVZIkGPhJOTnvjrTtoumXVlNEy3KwzAkqnKSArEjGT3G+1LfBdmVRA1xI0efCLcvyg9Tv03GBT9CJYURnIyJy5YjqoHUj0o2l0ws9tvGKX2FTsWHrWeOGS297mZkPVwx5VBO2fLfau7ZojKwCOJNublP4d9ie9LV7ObRobjxlRIhyhlYnKMfiDDv2qlqPEcNoJlhvHIni2DDcPn9KetpQjLDp/EpTp7H/J4zRYbmyaZvEifMfwn4scy9gf9aYbD3a9jeOOJAW2JB/CRjB9awex4xv53ME0hPYEbU48M8SXEXIZZNyfiOetId7S7AEcGOv2dai9Y8a3oMkNu8sWC6kAEDcr2FQaNNbXdv+zruV4rhl8NRhDjHQ75qccQWt5G1tdTDDQseYHocHG4pG4U96ur3mEZlLEA8o+UDpsNztvWVq6VotBqGQeJCK5Qi04I5hziHRQlw8Elg5ul+IzQKuG8iwB8u/TeqTaStvbFFuIZGcZkJgYDftn5mP5D61pB0eLV7FG1FGtWtgViLHZ1I7kEYobNw7PakvDMkOcFgob49ux7fXNK26Ihs44Pr184JNWCu3PT174kppDw45BKYx23Vd+wQAkk+tWrLTH8U3VxNGVTJSMjCJ5BwB8R/wANda5JrkCOmn2EMc0iKjSOHk+E5B+I7j7daraD/tIZYP2jPFgHlCouCq9iCPl+nXrQVREYAZP6ev2hyzshYkQ/bXs8FwA3LzkBEBldJGOdiYVPTOcc5PXJ86OwaQk0TMr5WNj4p5uZi/XdurHPU9B0APUBNMt4jlFUQSFyFHiM8khzuSDvnfocmn3ReHL/AN0ZJrRrMk5AlIB+uDv065710PZam59uMzD7QbulzmJVzo0DS86oYgD8TPjmb6CprXTBzFbCy8Qj5pD8v3J2H3p5m4f0iyOb9pr1ycBII8Lnyydv51JJbahDbLde6aPolmN0nvn8Z/8AcToT/lXNdVToVHX6TnbNSYq2WjXkzgwWstyVG628ZZfu5+AfbNWG0K/u3Nu8trbkLvBC3iOB/i5c/qQK/X3EGieKffb/AFriKRekbObS2P8AuqeYj7j6UP1DiXia7szaaTo8Wn2Q3EVpFhR9SAB9yam1aEHtHPuHX6Znke5jxx8f7lPWbDStFjLT3skrgfJDyqB9WO35ZrJuNuK0EUsFuVjTyDEk/U96m4w124tpHF5dKZO6mQM36bCsv1a/e+kbDcwrldbqwX2VrgTf0unPDOcxQ11JNTvmf4iM0U0LQo48MQMjFWI7NUkOQN/zq2LuO3BX/npWazYmnuJ4WdX7R2cGQRtWa8T69IzsiNjG21M3EWsBYmXm3IJyTWV6xf8AiSM2Qck0aiveeZBbC5h/QNWkN0vNISM+dbxwbrMYtkDtg7E43ry/p2peA6sCBk7b096BxrJbKqK/kOte1GlZjlRJW3cu0z06mrwBNpFqzb8VQw/AsgxWDWvGs0q4Mmx9ambia7I5hKw/rRKAyRexFPUz0PY8RQzMCZB+dMdjqUbgYYGvM+lcY3EMil52A747VqPDXFSTxpzOCSPOmAfayYFkKjiabearJbwl4gCaU7v2h6vYzlUso5Vz3fFWpdVimt9viyPOlPVD4rM6r371q0ucAAzMtUbskR50r2kQX2Le7ie2kO2GOVb6Gqes6jHO3NzZU+tZ20rRn4zykHP0ohbX1xOmJHyoH3p3vWC7TzABFZsrxC8AUseTpmidt0HQUJtMkDJ8h5UTSRYovEbbFUXyhj75JqF8lrbkDqR50ryTGQmRjnyr9qOom6uDhsgV3pds+oXQjAPIpGaJLLwMmX9J0QXkZu5kB8s+Vfb23EUoCrgCm+2tVt7YQKo6b4FAdWg5WPWiquBBbsnM60eTDBD3FGyncDFLemycki7d6aoxzID5irkZErnBlRou4FRtCenWr7R+lRMnYDaqFZ7MomHO+K48IDarxj865MeNumaoUkZlIxb4x3r8Ye2KueHX7w+1UKSMxZ12yAUyD67Vn3EN/wC7qQXxitQ10qICnesV498RY5OTrUoNhyZdDkTHOIJGYHl3+tIGsrlWyTjNO2ryB2bBJ8qTtVXmBwNqS7PGADOLDZOYk30MjtyopJPlRrgrSY3vVN18GSNwvMaoakzeJyoceuaLcKX6Q3SJk5yAWNbuodjpyBHNAFNwJnoW1VbXh9YrbJATDMcZ6VlPEcjCd2ztnbtWhWOrxtpXhAE/DsSev2rNeJZJJp5HxgAkivnqA98cz6Xpz/rEVdQnLOcjfG+O9UcwPCcq2d8sT/Kp7iZ+c5Gx2ofcl8YVMDtmtitfCSzYle5lDSiO3BCd6rXcHxDxJWHffp+VTyJJCAzHBPTArh44lx4z/Ge7Dm/Sm0OBxE35PM70uzsmkUSzzbnBdcCnfTLCyjdBHd3iuDuFRVH5tn9KXtLhtHTFzqCAdeWRRGCP+fSmC1fT0jMllfWoXG+T4g+nTrS95ZjxmWQhOI12up2NnGI4zG7Njn55PD6eeBlj9SBV5NVu4/DcxycrnIdvhGPIFvm+w70l3MtzHJ4okblC/OCFH6DIr7p+uW0Ya2vbu7JkUqTFCABntzMCx+gFItTnkxoEER+hu58ZhvdSiCAhgbhIebsdhnlHT5mWpBe6hpa+8WGoXckuHkVprvnCEgA8ojU53zvt/Wlqxt9SVhLFJY2tupXlXARs9uY8u3r/ADFTrC2r+JzalbC0wWmco8cSYOCBjLOfRDkn86XKkHGflLLg9BD1txAyGJ9X4lvIjn4lW5S0ib/MZmZ8eixZ9c0w2vtB4YzHZNxPbeOhIMdlHc3jHsAFCnmbG+7fas8e04ahhaOygjMkgHMzxyM7467hG5B5AsT51d03RJ25xb39ypeEkRWtuUfOejybBV9FBJob4I9rP7RkImcnibZomvMxaFotVtYEbDtqE8Vryg9OWPJdf94LRyPUuGJj4cpSVGbI5JBc8pwfifw2YL9XZc1hnC2gafYSc9tpr3d0nNzGVnWON++yhmB7/MrHzFMtpq+oWaxWcWkXbyDmAULywxqc7hFOM75JPM3+IUEgLwokd0rHg8zWrrXOH4GFraT8r8gHvDwuMgdFy2FGOvf618t+IXuoAmlW8d2ZCCsqlQpwCMg5yR2zg7+dZjpLe62sjwW8fiOxiV5okkDN0+FFMnM3f4xjpsKIafe2KtHNeWM91HEQvjaleKFLY6IsYWIbdMdP0qhtI5z8pI0y9OT6/SaFdRXsaQm6lhtrkHmSJQMg9CxDEFiM7EDOT2GKE3tjBZTw6ZaQ+ITEzyzyFcjA2UZICDIyx+xx0I2FrdoPe1J00Xp5o4rbYgKc7ugCnz+KQnoOWvt7qml28MsVtbTXFlOB71yL4jzjfCsdyqZ35C3M2csUUgV4HfweJ4VlOBzA+oWyRWP7Publx7y0e6gfvScvkkjHJj5M7EczkYC5wTX7gNe+8afJcRxXLvPmTPxKX22O+Tjm3OcYJxnbbeKBeR6ZJf6yZLSKZGlMUr5ceIAAGc4yxUjIUYAKLkbhcejtyl7aSWt9HC45lLSTBUVQc8kYxknruOvWmqCF5h68tGHg2Oe90KW3h0vUoluVYO/irMFB2ywkUklhnIXIHY9aQeLLNp9VaO8V4fAQJzSFhlk2GMjPQAYPlWqaNpM93ELoQNfSPEPEuJr1jEwxspAUsT16D70mcU6I4jZltyy8/wARlfnZcbbNnmb6Yq1FmLCw8Z6xQQVgLTfd44obhBIGbOMfCrr0xn+L+eBTJwNKougRCrcpMSxP8wxuWP5Uow6n4NuLCRTJC2eVeUqynG+M9jtRLQb2W28S4VlJc5Ujrkin9vnK0+0wAno+x4zjt4xaqxUsijIOcnPUmjcPFGs6jzL4irFy8nLnHw9xmvP+lcQTFldz8XfO1aXw5xGrxDnfGOxoD6lwdoOBNQdnLWm7bkzS1k97tua5lwpUkldj/wA7Ut3rtKT+9HMMFSD2qR9fj91AVzysNwBuaVl1hlumtyCF/Dmpu1AKBSYfRaVskiMsUphCXBIyrb5NWzxmlhhWnRC3QMwBP2pZ1zU5NO0G41URhjCnwqfxOdlH50h8BcE6zxdrQ1LVrmWQyyZZiSeXPQAdhS6q9nFUcPdVgvd0E9OcGaudanjjmJ8JwQcNgnbselatoltpcEyWtpAsbKOUCSPdzjfJANLPs+0q14fsLeGN4UUAHw2XJJ9V8zWilHnhjm5VyDgMVWEj0+lbGn7NIQFuWnBdp9prfcQnCyaKEwSCRWQDGBHsW26HGObH2qbU9QvfdmUNaqwwFMikkfTmxn86FzajaxI0kkVysiYBJJbI/wAJ70M1GwsdehkbTxdJMw3Ml3Oo+8e6n60PVhkUrX1iNGHYM/T4f3KmvaZdSqz2q2b3SgsI2gkJx/uknr3pd4b0PWBdk6rb+A/Nlo4+ZkdT3OSD57A9eopg07hu70+BI7iXwyuSXQfCV752yPsKl/bWmaMFimaCWRuiQMzux+jdT/KsH8IzsHcbR7//ACav4nYprT2oz6XoBtJlvkb3U8xGEURnB9FHTbz39ab7Z3FsWilECYyZJHCg79Wbf/4Rk9qSNN1PUr1fd4dJuLUybh57qGMjyJXmL/6+VMelcN3kirJqGqNNIm+VJUKvko/DXUaCoU8Ipx8v3nP6xjYMuRDweVLfEDoGYf39yAqn/JGfiP1I+wpe1Dh6zmuDe67q11dSsN84gBHlzSZbH0UUXvPd9LtC6RzPsA3JNyn7kDJ+gpP1biu/tQTo1va2j9A/hc8uf87ZNdGrIEw/ymIVctlYattJsogH0jRYdv8AtfdXuG/+OUqn5Cl7jzwl09jqmp3GAp/d+MFH5JgD86WdT1zibUlZtR1C6kPfMpI/LpWd8Y6klvbuHy7YycnekNZr6q6yqp9o3ptI72As3MzPjzW4H1N4LAcsWT9f5mhVieZPEbqRvQTVbvx9SZw3RquRaisUIXmHN6muHc5YmdbgKoUSxqF74WwYZFL17roVSQwyO1Vtb1dVlIzvSVqWrszOA+R0wDUJWXMIq4Eua7rjSoyq+Tg7Uj3d1I7nqfvUt3fZd8OfKhU0wkOVbb18q1aK9nEBY+cgTo3bI2ST1q9p1/IJR+8I6d6AyzDnHN0yNqsWl9HC4YsObPc09tBWJ5YNzNN0W/c4BbrjG9M0F54hC5Oeu5rL7PXVj5SCAQMbd6OWnEjLh0fGDvkUg6MsdHtCPylucOGx3NNOi68bJViMuMCsvi4mVhjxd+mx2orp2qLOUwcj60M5zzIKHwm22fFcnghVk3+tT/t6Vv7w5z6UiaLMzBSQd8U26XYS30ygAkdacpsA4BiVqeJk11cNcOqgAAn70X0/ZVyCNqsNw0UUSyI23eogogcR+WBT5z1MzlIzxDVo222ap61qojX3eNtzsd6in1FLS3Ls2NqVp9RNxK0rtk9RRU6cywG44hSJnlZUQZdzgVoPDmmrY2ys6/ER3pS4Q0w3L++TptnYEU+xvjAGwoicnMixvAS6hzQ3VoA2SB1q9HJviuL1PEizjO1HEFnEVov3c3XptTbpriWAUqXKeHNkDGaO6HdfFyE1ceUqxwYYKZqNlqwR6VwQMV7E9uErlN64KZ/rVggYx2rnHXNRiRmV+U42zXxlABPlU/Lg1T1CZYYjk4r22ezF/WpfEyqmsz4r05rkNzL+lP17KXkJU996HXGknUCCF270JlzDVEDrPI2qOzFsHv5Ur37BgR2J6dqYNRfZmIyMmlq+YBcDGCO1J6QcCcOhyuTFvVYnycY39a+cN3L2d4hZOffoNq+anM+SeY9MUKt7+SGYN4mN63WrNlJXzjWlsFbhp6D0a7W503PhBMjbPU0k8UMElYAn6elU+GeILuUKoeRsjA2q/r6q6F2XLtn864a/THT34M+k6HUDUUgiJdxMqHpk52qCXDAZySegru7idX5sZwc7mqUviMQzE9flFOoAYRjz0ks9u0mGaRV5TsCcmq8yyLlVhZtvm6VLBhWLSx82K7lvkj+S3RYwd+dzk0cEjiBIB5Mm0y2F0MKkSuvUBOY/mabrWze3tlJYkgdFEeB/Wg2jXAnKmFbcNy4BKk/lTNbJc2oaSa28Rj0YoMD8jSl784MlEA9oSsbKRo/EW3lEbYGUP/E4+1DrbTjJKzR3qQSKxOZJQkm2/XB3opcXksxKvCDgdM8o/Mb1Bdyalaw+JHaGHb4XDgqPuwzQwrEcQofZObrSLshV8aRnILgeNI5Ge7HGB9K70ZNSFwJYb9UeAlgwAJ8sjmK4+u/0oAOI7yJ2W4vrpVU55bdgSx8uvLv9KatI4vSSD3E2CR9CXkxM69jjISNP1+tQ1TY5hVsPQCSalxxxVBI8b6jeTRqwVWjueRVPmAg3P3qnp+t6/fP4mn3d8hRjzTPcsAhPmxK5+7ECj0mlWV/aGQ3rT7q4DILg5OfJuRPz+1EbDh3VIoQkFlBDHjmMs0qoVDdDhsHPfYYHpQMVqMAAGXDjGWgpodeMIXW9et5beF+ZYRclhzt5GJWHnvnPrRzRpILFkjL3li0i83iQ28SBk77yMGkHlg586X9bgjtTJcXt9e3KR7eLFeh41A22OGx06LvQm241e2ijtInWdMkOUWYuy/4mZh1Pp9qEaWtX2YzXYomkanrySgOoLqHCLJPd+K7Jk7lHGEz5DI8gaKQT8STSR6peyCwtlXlhQRWyvyBSBgkgKO5OSNxWWaMZ9RunFjaxPISSI5FwIF7lm2C9hkknyNOLcPajpKxTa1a2FtJNGZYnjIVpMEYCLIXO2xyA3+Wl30+Osu1ygbQI5aBfabB4+uTabqesLG4/fzWczRhttg37tJCMnYOsYUfKaPahxFqctqkl7YQ2Vqsoks7SdVhid+qu0Yy8p/EclEGfuc7h4gt7k20Uc8lzexOW8W9VpeRxkgQwNs7joHkVI03Y9KgvdVjnvZ79J73UNQEXJc3Ac3Mat5LKwCYXvygLnOA3Wq91gcD175QnJyfXwnfEvF9zxTqlxJq2pLKrN4j3TxGRZZFB5VCjI5UwSFXKg4JzjNVOF7W4t1Fxam5uJLuMKAytCJBnbJQMyIT1zu3elWeaBJLi1s9O8Z5W5WlkmLZJ3K4B3z1PQehpx4XnhtYJr+4vZYRE4jaPx/hyAfhPKArnf5c4Gd8UVkYDIhmsVFwBHfw7G20t7y5ligdAsbR2vM7PKdhhWH16ClK70SXUJJmlswgVBH4gaMvnqQSCFUjbIBz260xGJ57SB4biGKK4VwnKh5+Yr8TBUAQeuSfuat2+lXiQiBtNhvZGiDL7tHytEvQsu3KufMn6VSpD/wAYs1wQHJmI8ZcLahAkrG2kXkYKvNszbbbAkHpSja315pMkMWowuI1OM43Feqbfh1rqOH3e1PhRrmRQysyAjo7HYZI7tk74GKpt7HdM1SaZ7mT4ccwUjYHp2HnW5RXZjYVyImdagbfnBEwaXifTrS3NxaO9y5X4YlU7n18qWn9pntFtbrxrU20UQPwxGMEAV6Xm9gFj7qDBjmMmWblweXy3pA4r9jV7pcskscYeFMDYb/Xp0o66VKsl0z8ZpDtJtThFsx8JJ7O/adLxNp7ftKH3W8gPLLGDlTtsy+lNbziS7inXowxtWRaHpcuja08IjKCRQAc7N3rSRNOllHc7/u8bYrE1dQDMqDidRoLAFUseehmmy6NHr/CF1aoQZIwkwA78pyR+VHfZtpFhAyc1tCytj4mYAA/Q7Zpa4R1qNdPdjNhTGep65FMfs0umN7IJxDyhjylgG29VPX7U92W+xQrDmYnbRZK3APHWbpoks+lxeFLYIsRGxWPnyPMEnamC1iilZZbe4tLlmG8VzG2fsR/WlWxuWEcQaa4jJ6SwEPFg+YO4ovG15by8/vkMatsGbmBYehG29bzMMcdB69ZE4DknPjCWvz3FpAk4tJbXAwPdXIwPMEj9KXZ77VY1SYTT3ManaWV8P6AlOU4+tX77TIbqJJGPhuGwrtIHXHkOYg1PY2htCPfJ5YVXo8aZjx5n4jWbqQ9zccD18BG6Sla56n18YFi1vWll5Q2oCBmwzxxtIq/RmUkfnRey02K8UzJqNw/inmKTXPUf5VQbfei/unDxtnaCdI2k+Z7dwu+epGdqHSz3NuRb6dFeT5Ozx+Hgfm5J/KgfgnT2nORCHUq/CDEYdLs5LeGNFnjgABBdjJISp6kDI3+uRRWyv5bq6Ww0/UDI4OWMkeXA6dEBA/Wgel2d7dukl3C0A+Zm8AO4wOvVh17Baa7FrxBym9uZkK4AMTwjGN9hsfyrZ09GFB9fvMu+zJMtXXDur3qEXF/ZogHxPIxx+WM0BuuGtCtsifiWEsDv4Fs8n6nFSaxb6hdKDBpN0VP43flH1AOKEXkd5FA3jGGMAb88yf0Na6hNvKmZ2WzjdKerHgWyhYveXl2++fFjwv8A8KsP1Jrz37W+KrNVkt9OkIiIxypCsY/TJ/WnjjjWorNZF8eMk/wtnevOXHGstd3MgL9/+RXJdq6/e3dKAJ0PZukwe8Y5itcXv7xpecnBPU1Wk1dmXIbOPXvQrULkpzfFuc7UJ95ZDlnYA9PSscV7psZ5kuu6jKxL+JjyFJ93qbkkc23p50X1abnT4Tk0DW08eTlYN9qepQKOZRiegg65upXyRn6dqqtcytt3z5daYJtIzty7mqq6GyyBQOo600rqIPumPMBTeMdwSMHJqGOK4ZgBnenG34bEvKStHNO4PjbGYwR0r34tU4nhp93Jippthdug+BthRN7K7iTk5DjrvWiWHDttDGFCdB1H0rq60NH6KBt+tKnVhj0jArAGJm9t72j8uCd6c+G1unkTIO/60RsuFUd8hN/5058P8KiMofD7+WKWtuLcCNB0QYMO8NWM7xrzL1xW6+zrh+1RFkuIUctgnmFIOgaSkMaqRggU7aRxTHohWOeCXA/FHg/oaZ0BUP8A7Ji68tYhFc03VeFNIuLAtEghcr+HYflWLcR2DaJds0sytDnZgenpitAl49s9Rs3W1n+MD5SCrfka83+3T2kTaNASvOS7YOOmM10dlddigp9Jz9ffVkh4Y1viFZmMUUuQvzYr5w7BNq94sSrlEbf1rz5pftQuNS1GO1t3/vDjfevUXANrDBpUU4IZ3UHPnnvQbEKeyYxVcCDjrH3To47WBIYxjAonFJ3oNBKD1NEIpOmTUiVJhKN871Mf3iEGqUTdKtRuc486KGlCfCBdQhIJO+aj024MUq7nrRPUovgLCgKsUlznHpVy2BmQTmPMT88YbPavpI60O0e7E0HKTkiiBI771YNmUDT4a5PpX3m+lc5qQZOZ8JwCT2pe1u66qDnFHLqURwsc4pL1S5MkrHOQagtxPA5MqkCR/qaYtHsVMJcrnI70CsIDNMo7E4pytoxDCqgY2ry8mELeE/nrfspBJ9d6XNQfALUbunyxGOhpf1Fs82ciktLxicSvIi/f5YEDJxQiO3UTc0oBGemaJXrMCcEdKEO8pk+E/eukQZTAjKYBBMedBuHkC2tvyqM9hj9abrrTZVtudiucdc5rPuF7hop1aZs7961C4nFxpoQOoyK43tio02DE73sPUG9cHwmb6uAkjIDnzoTEC7nDADPWjWtW0nikKNj19aHwWZAwygDuzEACh1EbZsWA7p8aNXBAkzk9v5VUm0+4uZ+WPwyAfxEVeupLaKIosjNj/wBGuR+ZqhbXKCbEen85z80su35DFGrz1EBaRjBjRoNjJbxqTEiSE7O7DNN2nWrwtmK3naWTG7DKetBdCv0s0WR7q1tQ3ZEU/wBM0zRS2t/ID41xOzjZ2PKp+1I3tluZKgyZ7W18Flmmiidhh+TILemd6CXWj2U8ryQX86ZYKefLA+mOhNGZ2t7LCv7tlduVcOc+oGSapyTXDEk+Lvj5oFUEHuM9P0qtZPhJII5MW73RbGOIq0ky7YUtbCIfY7Z+9BJtLtbTlkiu023Abmcg/TYdfWtBs7mBrnwze29ryD94GUb/AHGf51di0qwLPODczrISOeGzVifoXZi32AFF3t1EqLQv5pnljr6WH7ySzlkmYcru94yEj05QeUeWN6MR8fxJM6R6RGyuBzN4XMijHnMSznbvgd8U3z8PwTRzS3s11ZBFAAme3UvtkDlUEk+nQd6T77hK1uJnUOGDNzArEm3nliRgZ8vyqnsk5YfXMMLFfgTrUeNbPWVhH+ydvBOmyPHF4jKuABypzKg9CFz3zRPhzg+5hh9+ghuY7ggu8boyHz3LsB/P+lWNA4QGlzQ3SM7Z+Lne0mC+uW+FCNtsZpm5Uihkm/a2us8wO8IEKOOu7qMkfTyoZwTheBJN23gfzAkckunH3bUL/wAd1JdYoYSzK2Ns77b9xv5UK1GS/vNSkLXErOyEyiQqZZNvlAGWxg98Ad270O4gSKKYPZ3dzEcEcjS88knYg4+I/epNBtrvS4lnnJLurckAYrIOmNgCB9cMfVaqEGMw6Pjkw7dT6jp9jy+P7tFP+792Eixcw/hJYA8o+2T50Ml8SFHRtQM8jSc006TFkjXuAq46dMbb1ajbUbi8N9expJNAv7oPdciW5IwSQSzZI35mbOOmxxXF/o8Ecfiard2rT5BjhgchgMbEEqAO/Qee3eoVVBxPb2Jyeso2+niVFNn4s0SPzPLyqI1XP8KjI36jOfPuaatKuNLuSiTyyCJDli68pXG+wXPMTg7ZG350ipKryskFxEkMYOWkkHKzD+FRkE/y7ntUtlrkKyLa+MbhT8DlnYAE4+FB3Pmd/rvipesuuJG4AD3zW4dTtp7UXUAmRJWWOEzTCIO3cZAblG++Cx7Uc0C7s5LmK1v7+MxXJb9xbs7CaRCcBjs0mD+H88b1mF5faq1rFb6TbwRJaR8kchIbkdu5J6HGcKPqeld+ziyvbrXHe5uvF8OPwwzOXabfJVQOiA9hgMetW02EbJgL6yyHE9GQy206M02ps8URDtAGCIuP4iNuvXc+Q6Ve0u/N1PzW1siQhQ/Kq8pOdgST09O57Ui2d3ZwQM91cu7WxYBS4EcLjHNkZwSNvvkDpTFoutW2oatDYwlPCVsRpEebnkGCWY+g3ydhW6j5YGYjKQI/s8aLGmOYKAdwNz2GT+e1V7zQLbWBcxzRKylvidBsfMn+QqF7aO6m5ZwknhqWjCtkKM7Z/nRqzv4raRIY1/doCA7HY7btjufWm94bh+kECU5XrMW9oHsSuW8PVtGgUGPJKKCGJG+32pDYXMdvLZXULRyICpLjl3r2HYXVi0Y94eNEQNNIWOSVIyM58+tZ3x/wfw/rVgl/YxpHOR4jyhdyXORn0ApLUdnqT3qfKb3Z3bboRVcOPOeb+HOJZhFJYxyZkVvDK9O+K3PgCKHSrAT311HmT5vxYbuDnoawFNKbROPbrT71QRMC8JDfCSpwcgfatv0qZ9Tjt5nuIxNHCpYICodcd/Xbr9qSorCsT4iana9xvUAdDzNY0y/eOPxbK9jaJ+b4Y26ffqp+xFXU1OcBpFupsKoOBKrE/UEbGkyxihktRaMDHFIxBDPjDeQJ6H9KPWTJaxC2aV1f/wBYh5wR3B3Box3dB0nMFVBhi34qmAEEN+UAJBFxDkH0JUEEfamO0u5J7UpA8VsZN+azf4GPfboD9qS5ZbGK5Ep5SzDmI5BjH8XL/UUx2ur6VFb8lusDM+Ph5DH4n3OB+Zr1W7cdx6evWJD42jaPXrzhOytbx5cy38sqISPEilBZfIbb/mtOFlGksEaTz+8lV35+Rj9diD+YpJhvXlH/AEUxQxlSWU/GB9UOfzBq7axzXMym5hZolXBms3yv/wALbj7Gm69qdOYu+W90dGX3RWlhs7ViT+K2YNjH1GTUtktzMrOsrwhhzcqfCNvLeq2nm7W3SPTtWhnjxjErNHID5EY5f1qzMhi3ltjEx7dc+oPQ/lWnWmcEev1iDtjgyjc27szSG4kbzy2aUuKdXWyt5FaRgANviNMms3sdrbsfGPQ9sVhHtA4p5nkhDE7+dLdpawaavAPMLo9Ob390R+POJzPPIAxwDjrmsi1q9MhZ3wTnz6Uza7dtNIzM22TSLq1ygyNun1rijlyWM6tFCDasX9QufiPO23lQe7vlUbMPzrrUrkFywP0pfvpjkgHenaU55kPxLjT+K+5JxRO1RVTmIXzpds5lGxzuaLwXakBM70WxSOk9WRnmMENukqiTYnG5NTLp0fzFMY+2ai02bnUBvtRgeHKB8PTfHpSpYjrDHpmV7a1jDqOUHfv2o1AqxMMDlDYxvVGMIFwMZB2xUkcpIxknBx1oL5PSWzmHIZd/gI6VaRUYfEAewNB7eUxbFtz5VYGoKAAXGOuDtQ9rHpPbgOIcsWijkwANumKbtFnUOMgAenaszXUgJQVY56bUz6PqkoIxjf1q4GIF13HImq2l+sa5OBttir9hImoXQRzkUhLrSogUtimbhS9E19Hv3B61NTkGBasFSZqOm8Ew3EHiNHnI2JH9axn27+zxI9MuJGt8qwO5Ga9T8HRLc2SBlztSf7atDtrnh67V1GPDbauw0i5ryJzdjlbcGfzV0Xg+ex1opG5Z1PMABvXqP2UcQm4sTpl18FxAQpUn02x9ayH2daab/jK8jnIaO0coCejDOT/KnzV424Z4jt9btRywSERzAdMZ2NRcd43iCVQCQOom528oIFEYJPOlnR9QS+tYrlHBDrnY0cglP+tLBscS5MLxPnGe1XI3HWhcMo2yauRyetXDShMtTjxEI60s3kfJMwxvTIrgjGaE6pCc+Iv50QNuGJQNgz5ot6YZghbZjTTz7A5pCEjRSArsRTVpV6tzbgk7iqK+3iUY4OYSLVyWqPnyetcSyiNCxIxiiCyeziDtcvBFEUDYzSfKxeTqOvarut6iJpyAcjNUbSMyuPWoD5MupwMw9oVuCwcjYUxFsYGaHaZD4EA3Aq08nrRFfE9u5n88bvlZSwO/TpS5qDHBJxt1NF57gFSC350FvskFtiPQUHTLgiciuYBvGAyAaEucP170WvRnIxQZjyyHO5zXQ1fljC8w9o6OxDO2OXpT5pF/EYREH5yBjJO1ZpZyzlsAkDypz4ftpZmRy4yMHJOAKxe1aDYpLGb/AGTqRS+EHMs66cHKn8qA+IiozSbbflTzrdrbLp4ZFDuBnYdKzfUWKyHAx2rndOd3sidzYcKGlC8lV2KhyST3qTTY1MyggEk/mPKq6QCRy0pz54onp7tG5S0dIf4mxljWgeFwIgMk5jnplqbeNWSCNWxkFkBxV651K8S1ISblYnLu+FP2x0oRooiOMtLO47u2AKKaqIvdlZbQyMAe+AKzX5eMV9IuX3EN7lueeRyfxK5x98AZ/OhZm1C6IZGKAH4ctjH571+uYRcTkSJCf8IkJP6V9ttJtJXVZVWMNnOGJ/mabRQo8pDnxIzLFpE8EwmvGup8bBEcRoG7dck0wrxNLaJmKEWiEYYNcN8Rx3Ee52/iP2qtpuhx+AEtdPlhjY/PJKTn1x5UXtOF9LYF/e3mfugOB9sVV3XPWB4zyJTh4xWB/eI7QyynotrH4Jb0aRyz4+iivo9pmv2rl7azgtHXIQRrzyD/AH5CxHqcA+lEptKihh+DngA+VBgEjucf8aow2Fuz+ILZ5QNiWJAB+g3NCIU9RCjAg88e8UXV2t6lrJLKrZeaS4lYt9W5lwPyFTPqnEuucrXkl5cLkZHMfAQeWDyqfzemu04U1GeNZb4BIiMqryLCDn0O5FFF0iO2QCOKVlUElogI1Hll2Bb8lFECbuggjcq+EUbbQ7uIGd5okcj5UPxD6kgKo+lHtM0tpITHzzmKQ8zyqfgcfw8xxkfc/er0NvcL8NklrbnJP7uNnJPq7jP5VfsrC9vLtLUpfalfyYWOGFmZj2+VAXP0BH2ob0npKjVHqZWSytNOiXwbWBHDA4SJnZd/mz2Oc75HTGaXtdK30bXE8scgjJMhmcEuTnGy7em+T9q0O60Ow0lVteJtXEEvNyrpelwrc3hb+E4Yoh7fG3N/hqhDa6i942n8NaPp/Dxb4i9xIuoarINzks/7u3GM/LGmPOh9wa/zH+fXxhU1Ibpz69dMzPOH9Mnv5JYpbW5VnChQi8qQoTsQoAMjnbbZRnc5pisvZzBa6hDJNhJW+ZZCfgOO+B1+mQPU7U06ToN7ost3eSXKrLKonkeViZXAO2ZH35fUbeXrHqmsm3hN7GnhyApK91N+9eQY+FI1bYEnPKN/MgbUKwsRxDrYc5WEl4e0WK0FpDaQuI0EbmOAlQoAJRQc/ET8zHJ6DfpUF1xVpHC7m20K3IvZMIDEAfCAGMs3cjJ2HT60N0K4uNQu3utTvZuWBWjFoHOYubJzITspJySzYJxsABUt1a2msuP2HbyNbqxRJkTEbtn5xkZZF65OxJAAxk1dENYBP9wbf7DgnP7SeWK51WxUXUhdmRWh022UgRo5z4sx33PZdzuB1OzdwNBqekyQx+ArG5J5kRCZNt+Useg8+31oRoqWWk2cMKyzqrsC55g0k7jOSWHlvkj6DAFF9J4jimv2SK6fwwDCkKLyrnzZupA8h69aeqZQQVMVtBKlcevX/sfdNvnaaS51a7t44oT8KwxZw+cYJJzI2+PKrN/xXYxzzW8yKZ/D5IrcNl8ZG8hGygDr9aUFjlmgMtnl+bBgycDAJAYD1OT/AOFRWHDFrb3DuGMs7AGaZyTzyE55cZ+Ik+e22aOLmHGIIVKTkmaFJO2o27eDcSLHdtyE/wCDHyj/AF9araldvBpahlUqow6g/MgPl3wBj70JtzdPFLLazk8reBEWORjOWJ7Zz/Squv6rZ2dzBZz5RVTkV8fCGLdCPpg/ejG8kHEmur2gJmftFe0tNWhmdwZVyZPD6kkAgDzB2zvV3hviV7vTEKyESAtFGdjlOY/1B/OljWL03E9vbv8AvGiBVnI+Y5H67/rRK0sVjVRD8KxqAWI2we/61mM4UzowgNQB8JrOh8RSvaxQXoEiSAeE+QcMFB5SO4IOPOmTSeJLdXUSBltjkcqksIz3G/QDb1waxlH1K302S1ErgK8Tq/XlcDZh6bAH60w6ZqOpFTbSxtzkMDn8Q7EE7E7sPVTR1vAxkzJu0oOSJsVzeWhZHRwYw3K6O2wJ6bnb6dDV9r62iiU28yglc+HKvIQB1wcYOO+23faseX9r3dskMd+YrmAIsbk83OgJIRweu22/kKMaIOI0uFjZ2MfwNyjflA6lc+X8qKNQhPA6xJtMVHJ6TaNMlt9Q/dm2WK5UAoWXOR5hgcZ+mMimTTNMkcrK0EqSx5BMbFX27j+Ieh3/AJ0r8M6dNyRSoApU8yHHw47oR5dx/StK0uJWC8ylWAxvufp6+h61rUU95gmZVtm3gS1YKyf3/LJ/jZeV/uw6/evt/KLaFnt5yqns2CCf5H74q64KRmTk58DcdCaROMuJILK3kw4XbdTtmn7HXTVEmKKrXOAInce8UrbxyqSqsM/Lt+leb+KeKDNdP+9Ocmmfj/i8zyyhHBGSBk9qx7VLo3ErOWz5EVwer1B1VhJ6Tq9JpxQnPWfNW1l2VviztjY4xSVqF88jMD1+tEr98qwBB7jel+5Dbk9s9KEq4jggy7lPMebpQu5K5ONsjHnVu/dx+E47iqMmGUDG4x1pyscSjAmRoVTDHPpvV6BwWUgjr+ZoZzgNyk+mK7S5IPLnGO2aOVLdII8R2sJyig9MfnRiK4ViACcEb9qQ7PUZM8pc4/lTFp2oI6hGOBikrKinMMtgbgxhaXkHMpGDtUUdypbJYA/Wqr3arGRgVQ97VZBhtj59aqF3CTu8YyteGKPHNknvmhr38hflL+pqs12pjCg+owapS3XK55j+nSrKvGBB7jmMlpOZCCW3z501aVc8qqN9sb1nljqEZYZYZ7U3aPdhlXPf1pexCIcMDGdrx2ZeXO/6VoHs+Z3uY2J3zWe2wWQg464rSeBY+W4jI8xS4YhgJFmNpnqHgN8WoJ7LSv7b9SgtOGL6SRsKsTHr6UxcHsINMDnuKwz+1lxYNO4OuraNjzXP7lQDjc13GjHd6Uu3lOQu9vUYnnr2SQsffNWYfFNK7D6FjWja7YR6vpMtuy5ypIpJ9nEXufD8Mb4DtT3ZT8ylXx6g+VIUW5JQycf8pD7LtdnMEmiXr/vrVihz1IHQ1p0Eo23NYjf83DfFdvrEDcsNyRHLjz7GtcsL0TwpMrAhwDtVXO0yDwcCMUMu25q3FMNsUFiuOgztVyKbJqu+UIhiOUedfLhFmjOetU45ttj+tTeMCKsLcHMGRAd3GY2O+KsaTqJtplVm2JqTUIwwyO4oHLIYW6kYOc161sjcs9jcMGaCk6uvMD1oNr2qrBEY1YAmgNvxla2cLRTSjmA7mgV7rZ1GZmVjy9vpQe/BHEqoLHEsPKZ5u53o9o9rzMHI6UB0+BpHGx6042USwQgY3oqvgQjHHEvhgihR2rhpB1JqFpD51CZcdDVu+lQOZ/O2aT+XShtw4YkButXJW+I56fyobdEjJ2p3Te+cuoyMQdeAEHI7daDPy+KQ5IANF7lzjPl/Kg9wDzfDvvW9WMLCD3QnZXdtERjLH6036JqwYKiqo7jtikK0Kg4ZT17Cm3QuZnXlQgbZ7k0jrqEZCWj+k1NiONk0PkiutNYsjF8bE9KzPX7FxOx8PAz3rWtD09rq2wxCkr+LuKWeK9IjhYjkzjy3zXEpYtV5UT6NTm3TgvMzSNiQrD4V7dqM6dbk4jggC+pqvcWkiyEpFnfoBRHTve4xlkES/qRWmX3LmLAYMN20ctsokldFC7DbfP0qLUruOZWaUSSAjbxG2H2FWovC5PFlhLAb5Y/yFDdRvWmUi3hVAepxuPvSY6w1YBPMB3SyT/BECi5+Y4UCimiaVZKFa41Jh5pF3Pq1CDFavMFur1nOd0jHMT6elMtlFaQLm1ihtcjGZAWdv9KOSVGJDDJhq0E6stvFe2dmhAYeKDIxA6bA7/ei8AluJRDJrM9w2NvCt1iBz/8AMaFabo7SMLiSRIbfGTLKMc3oBkZ/Oi3jWtrIYdNuoYYiPiEKZeT6v/QYFLswJysHg+MlutHtkjPjyyKwY57s31J2H6n0od7pMic1i8MIP4uctKfuen2Aq/PDcXKiRoTyD5VdsBT5+v5VLo/C2u6zK62tn4iQDxJpHIjhhX+J3YhUHqxHpmvLuc9ZYsqjLSvpPu9pMjXmoozZyzNJlifrn+tN2kWk+tvJHozTXSRb3Bt1AigH8Usz4SMf5mHpQt7Tg3QQrS3EGs3OCeQs1vp6HzJHLNcD0HhJ6sKJXFlq+oWFrqHGuvjSNH+awt3tgiFe3udhGF5v+8IVfOQ07SOcNz68T0H198S1Db+QMevAdYWMPB+mYjvb6fWJiOXwNPcpAD5NcsMv/wD2kPo9XLwalaWLWWrXMPCumTjP7K0uMpdXK9vEBPiEH+Kd8eSmgK8UHTpPA4N0mSxOMPqV7Ksl+48kIHLAD5RgHzY0DleZJXaeReZ2LMWyzsT/ADPqd6OXC8J6/Xr9osKyeW+sMT3ZUNpvDmn2+l2zjlfwpC1zIvfxJtiB5hAq0w6fcaNw3pQiRUjjcmWQhFAdhtzux3YDG3McDypRtbw2/KI+T4tifDCjPmSdzijAkuVmhmtbJr2/lKm2M0bSsx/D4UXds9GI+gGM0nzuyYwMEY9GR69qpms01XUbaDTbGSTxBNcHaZv4sY5pXwBgAYUeVc2GlwnT14jv7K4soZYzcW0k7gX88WDmSNTlbWELk+K2XIJK8xOxe74bj4Y1U6vx3cw8QcdFOe30uU+PZ6FFjmElyB8LzY3EQyBtnmJGRk9rqF/eSTXk0+rX+oSKZTeuWyQeYc4OwAI5mUZ+VV8sRYq1nkc/t8f46/tDVsSMKePXT3e/ofDzgS00yXXriK41O0MeltKUtdPiLRxuvquScNjdmJdurHfFOWp39jZyRW2ockK22Gmithyo6jogHUjYDl6bb5O1Q3N0ml2n7Wu7gzXCEKocDCIMqAoGyk4JPkNztjNG00ue4ZpNUAh1C5Vrsgjeztyo5XYHpKVYci/gUqd3cYDyxhgcjPh4evvGexjj1zTJb97Y2ARHUcxwYYhjHidhgZPIO+M9MUB0nS3vNUACPFZqTyuzbsqnDE+bHcHsAT3po0/TPd9JkknItLOJliRCcsxG4UebZG57tgfhqpGbD3xoWDLzqAyq2whBAEfkAd8n65zmrEgkSqZGQP8AyF5OJIo2As4VlaQEGUqOSNBtlR9gAfLOKvmWaVSlsh57ZeZnB+e4dep/yr/MCqdsluFa8Kq8dzIiI+MfAiliR6eQ8qvLPbafp0c7kKnLJIxJ6nbOfXcmjo7PwZQoqngevXEvTXtrpMc0Em6xzKCpGwwAc/nn7ikDirU5tS1NI7KYlVlivEKjI8Nhy4P+6ebH/Cvuq6vdatrt7FakhIbjkYZzzHm2H025gfI1xo2jXUF3a2XMqgoW3GAuCVC+ucgfRDVzYMbRCVJt9owTpGnM05kmthzSShkLKds/EfsAV/IUww6awxaPEeV5DEMdV7dR1+IjcefpR6y0e3nmZYpPFiUtlEHzIwHKRn0DfnRaO1DraXACmB8hmAAw75wR5DHWgYz1jPfeUFaVobMiBwpLKSqnfcfMB3674wdqZNN4ZsS6yRwCCZxuOc4kH2O/23FSWsRke0DRRsswZHBzs6HBAO2+RkfU46Ypy0i0tXXwiodWw/KT8StjqD3/AONErrVjiKai5lGYN0/hyz3d4vizhyTkj79qa9H4eicoUVW5em2D/wCNSHTxlJkBblIXLADfyz16etMGjJDEwDNjH4G6/nWhRQqtgiZVtzMOsP8AD+kQpGABjYZ/1pjtYTGqxvyhj07ZqpZPCyjkOHHRsdat3V5DFHzzFV2zkjY/8a3aVCiZlhJM41C/hhgcmQqy59CDXm72w8XrG0kavlhnfvWr8a8QQQ2788vMFBIcHBrx17XuLhLeSQpMWBYisDtvV717lTNfsnS7n3kRY1rV5b25ctJkc2etC5PEaPckDHnQW21VZpWZjn61budSURMGPriudSvaJvOxPAlO8mUMyjoBjehLlZGJB7+XSuLq8eaUgH4R5d6jjYkAZGQdye9XIl1OOsp6pbgKWH/hS7LIUkGDtmm68QTQlRv3zSnfxcrk8pxnFHobMhwSOJSnkPPsOu2a+wESE5PSoplIUsM1Elx4QwCD9qeVcjiJuxU8wojCIg5K+dErK9AwA5GOlLE2oSY5QNq+xXzLjDEHsKh6Sw5lUuGcR3bUAyYEmw7VRn1BAxbn/Wl39oyHY59aryvcSklQelCXT46wjOW/LGiPW+X4S21dNqIfbn6bUqJbX2c4OPOrMaXi7lTUmtR0MgBz4RntL4RuMuAe1Nujav8AEqZU79jWZwC758rkedMej+9F1Xfy6UvcFAyYREduAJs2h3vjFVB3PQYrZ/Z1pk00scrD4OuayL2Z8OXmpTRPJEeXI3Ir07oGjDSbBMR45RvtvS+jpGpt46CU11v4VNp6mN0nEEOk6Z8ThFRa8Y/2h/aCOL+IbfQbZ+aKKUM++RmtK9uvtFudE0mW0sJuWRwR81eVNEuptY4iF1PIXIOSSckkmuluu21GsdJyxIX2vEzaNDcWtpDCuxVADimW0usOvUA0lWtzggg+go5a3Z5Rv0rn0t2PmMgZXAhfiW0j1HSpY2+ZVypHXI6UU9nmtveaUIJpcyQfA2/ltQu3uVmhAcjcYNBeHbr9h8UzWnPiG6PMoJ71pOe8XiCmyQXO2xq7Fc79f1pahu9v+NXIbs+dZ3feEk8xjS5H8VTrcjzpfjvBjrVhLsdjUG/EoRDDzBxynfal3WyVjPw7dsVe96yOvWhWuXyQWztIwGQetFp1AztMqRjmYrx1r13pd6JxKQvNggmjfBHFH7RCc8mTsOtKfGcaa1fGMKW+LAHb0o5wZw7JZIgBwBvR7KEVRZVKspJys3fQ40aFZj5UZ8cH0pP4e1QRxi2c7jaj/vA8/wAqRbU7pEutPnpmojNv1qqZ/WuGm6elV/ESwE/n/Odycbn0oZdnPNk9d8UTkywIIz/Khd1lSeXp610+n4M5cDiDLg4ycULmJD82aKXRBUkD70HnJ5yTW7T0lwJZtJeV90JFNeh6jyyhVQnsSaUbcBjjfB60z6DB+8VgT/SgawL3ZLQ+lNhsAWbDwhLNdJy8oGPxVzxdpyBDLJIDtvVrg4IIFAxgDsNqI8QQW11AecnA2Ar5pqbcaklRPp+hQrQA0xe5aCKUsAceQ71wt+Y8sI1x5kdKJ8SWkds7CJQcH70mXjS8xPMfzrZoYWLxB2LtMYBrDnBluFUdcLihV1fSTylY0LLndupNCQ3hkmWR/PA3rn3qZ/hh5lAz96YFQByIDvCOIZSRY4+bCKT26Gr+lySSSbPHAOzPuTS9BdNCQSVAzuWHMauDVjtywkkdsYqGQkYEJ3gPWNkbRF/39693PzbSSH4EHoDsKtWerXkt9DaaRHJe3c7eFBbwRl3lf+FVUEsfoNqBWmnXWsWCaxrV9Ho+iBjGLloi7XEi/NHbxAhriQd8EIv43TuRs9Zvrll4V9n2hXllHqH7hvCBn1LUfNJJEGeT/wBTEFjH4ufHNUdzgZeULDogjy2raVw3huIP/wAqako+LTbG4BigYdri6BI5s9Y4eY9i6HarUd/xZx3p/vt9PYaPw5YzY52Y22n2r+QwD4kv+FQ8p7560ow6fovCMnJr8sfEOsIQq6RZzf8AQrU9hdXEZ/eMO8MBx2aQbrXWuXfEXEdxb3GtSEiBfCtYVRYoLRP4IYUASNfRRv3yd68QE4PHuH3MoFDcj5+H6D1+sdbPUOH9DIueE7EXV3Gc/tvVbdSyN521sxKx+jyc7+QSq9/f+/ySXeo381xdSsHluJHLO57lnOWNLejaBeyyKryOzEkhQDn0pni0GO1OZ/3kjDlEaktv/iNUZy5x4eQlSip06yvb3SG3LWBcKMhpTtzeeCdzUsVncOPGfPO3youc+n9KL6Posl7fQ2FuXnnkPJDbwplifIfbqTsBuaddC0cW14tjw+3verPIIJdQhTxUtnYbQ2o2Ek2A37zIAAYgqoL0xWhfiLWOE+MA6Vwvc2s62t1ZpdasQpFm4LR2YbAD3JAJ5idlhGWY7YJ+GnmaaH2axT2mkzC84wuFJvL+cqTpqnqMDKrJvgRrkJtks3y/td1/TPZdaNw9w5JFNxKQxubuN/FTTWYYYI+P3tywJDSn5QcKFGxze1nluWaSYth388s7HsPMn+ZJPlRLmGmBVPzft/f7fHoOtTf7T/l/f+v3+HWfT4Ql1JeO5ZI3MryStzPLJzZB36/H8bMepX0GKuq8RyadYMNOlKSyMw8TI+BD1Zm/i2GT2ozfafFbA2MnKPCAWUj5UYZzGPp0J8yakl0G300Qs9hHcXpKe6WcicwV2OVklU/MxLZWM9SQW2AU5R3DgTRTaxDGBNLWWysItc12L99BEsllZSAEQpy595lUjALAxiKMjLFw7gKVUtmi2jmNItWHiSsxvbtmbmM8pJIUsdyASCc7liKg1HSI0vFs5Zvev2fzXOoXBbma6ut2Ylu45y35fSiem20kk6xTLlH/AH0rdPhT5APqd/tVzYA20+jPEAjIlfiDUZ7dLGzuAsk904jjVTgI8gJZsdsJjH+Y+dWxwvBa3V8HDE28hj6fNyDlI+pfOf8AKKjsbJtY4i4ctZAA15qUUj+YDuEUZ8sBDTXxDLFbS3GoAYS6mneMDufHbOPvmh7e8UufXH9iXL92VQdf7/owfDChEFs5H7mNyeU4A5l3oLxDM81o1vG3wIwaRfONshh9vhP0NXPf447+K2ibeSFRkA4PNGoH/wAxoSOa6kLgZEhVznfCgnI/KjqcCUHXM+6HZKRLIwBkmYHK9SeXGR5bA7/ejMqCCCWZnBfkOAuwEKg//UdvuK50OzJbmRdy5C5HoBn9KuXZjZJWj+IHCKT0wOp/PFVZxLDlpd0C3NpiNDmQrChY9AQAf6Uxafpsa3Xu8S8sNzHzcg6cyjH23UUL0kYmMjqcnmk/ViP6UctiyRxL8QZHXkbuB1oyYIGYCxjk4kVmIowWKkwy4aUZ2R+hb03BP/hTpo8EU2BMc7Eg43B7/wBD5eVJCk+KkwA5ZGYMOuzYP8xTbw/O4twjgkqdiPIdqLpWG7BgdSDtyI8waesiYf5sYLDckdfv9KgaOS0lMRzNH25CSR9Aev061d0V43jWJ3w2Mgf1B7ihnEl6bOUcyyHP4lPz48v8X/O9bFgVU3zMTJbbC9tq5sYlmDs9uT8TKCeU/wCJeqmrl7r0E9oWScEPsQxBFIEfER5155C/MPhnUbsvkw71LPMvhNNEypkZ+A7fkaAdcApCwv4c55EWfajr8VnpsoEiggE7bCvG/GOovf3kjkk5Y7mtu9s/FIjWSzD5J64NeddUvmmJIGBnpXO22HUWlvKb+lr7msDzlKK5aFiObcetWWlkkXuD0oVAyeKMtROGeNhhdyKsy4ELwTzODCTjLb96jPwuAvTvVgN8XMdh9KpythiegzQwMy3STg5UjfHSgWoQDDk469aOQOCCCOhz0qrfQKw3x9M1KHa0v1EUGid2KAdTXS6VI+Sq5+1GobGPxSx2+tFYbSNExyA04b9o4i5qBPMUotElkPKVzV+34ZJ/CTkU3WlkgYFl361dW2hQggb7EfSgPq2PAhK9Mo5xFi24RaYqvLv6CmbSPZyZCvNGDnvimHR7aOR1OBgkHpWiaDawDlYrjH86z7dVY3AhyErGQIg2vssSRQngHf0qw3slABIgwO21bdp9lbsg2XcbbUUFlblPlU/avIlp5ZoBtWM4E82Xfsya3I5Yjg9cLRzhX2dF7iMyREjNbRNoEN0/92vXyo/oXC0ULhzHg/SvANb7BMsdV3awh7N+C4LCCPEWMDyp84gia1091jIU8uM180CAWyqAMY9Kj41vYE02RmlA5Vz1rf0GnWhPZnN625rny08Q/wBojUbpdUa1abIJJIzSFwFaYL3mM5/KrPtj4ij1jiy6WEkrG5TJ774olwjZiDSYyB8/XtVdSdtOPOIkf7MRmt5mODnGCKNWUxGMd+tBoYzgE0TtFJIAzjH5VksOIwoxDdpdGMsrAYxkVV11BIINRtx++gcE/SpRExTIGScA19jPMTbTIcNkU7pbcgAwDjacxt0bUBdWUUytnK+dFop+2aTuGue1drJwcDJXI7UzqDSuqr7p/cZYZhVJ+nepo7jcb4oUsjdqkSYg4zikGfE9C6XJPelbi/VCsZiUg0TmvPChZ2OwFZrxFq8l7ee7xsdz59qqrmQ05s7Nbq794Zd89KebW1ENupxgAYpc4ctOe4Ub/DuacpyvgiNegGKLXrzSNhg9uORKSXZt5VeNtwabdP1H3mBW5s7Ugzycj8rEjNEdE1EQTchbCtS2pbYd69DIY85jwJx/pXLTCqKzgqGU5zXxps9DSK6oy/SeFpmwSRt5mqNww36/lViWT4T/ADofPLjKnP2r6Vp1yeZyyDEpXPT+npQe4zzY2z6UWuHBHQ49aFTgs+ACc7VuVfllhO7diCBn0xTbw/byuyuzcqnH3pXs40jIkkAPlmmCxvnZwsfNjzoGsBasgRnSHbYCZsvDt7awW4RWHNgZH+tErq5SYY3IxjOKSuFlZ41Lu2evWmy5dY4QV2z51811tQW4gT6fonNlKkjETuJ7QfGyLg5JJFIt1aJklkOfrWi6nykMWbrvik7UoXLkhcDPendIxAxL2qGgH3FZM4GAB3qFtPl5uWJAAfKiwjKkrnrtgVe02wuL+9isLGB7m6mJWOGIDJxud+gAAJLEgAAkkAZrQDnPESIA/NAdvpLA/HDknb6k9P12xTP+wdP4aAPENml9qg/u9FBISE9mvWUgg/8A8uhDH/tGQfCxe0kt9HuI7DhWY32uysI/2jbKZBExyPDshjLP2M+M9fDCj42u22k6FwYS2qRW+sayhJNlz89naN/69lP7+Tv4ankB+dm3Wrgkc+P0EEX8B/Z/ge+ULThPWOJ3TizjHVBZac6iGO6kiGZETpBZ26coZV6BUCRJ3Ydy9xdtY2UmkcNWn7D0+4TwrmRpufUL9D2mmXHKh/8AQxhU8+c71QvNXvtWv31TU76S6uXAQyvj4VGwVQAAijoFUAAdBVqExcjTPEcY2LdWoD3Nn2fn4/1LogIG7p5eH9yKy0iCC3WOygWMLvzEdMd80QkutKsIEa4mkuLgnr5nyHlQO91S4RGijVghOyk9RVGGDUdRuFEQbmBznHSqLWTy0s7eUdtP11Iwo5Pd1P4c/Ef9aI6dNq/EN+ul6Pa+JPcMVjjzyjAGSzE7AAZJYnAAJNBOH+E9Q1e9hsLdJJ7iY8oVDu3cksdgoGST0ABJrRtH0lJnfgrg64t3E0Ly6zrMz+HD7vHvIS7Y8O0j6ljgyHBO3KKYrTcePXuEVd9njz65lnhzTLi5lk4X4Qm8cOvLqutqoXx13LRQc2OWHY7kjnwXfCDFNnEHEWm+zKyfhrhmVf260Rhur5QT7gjY5oYQRnxG2LuQG2BbGFjjj1viWw4B0eHh7hLxEvJo1kE0sfJOiMAwuZVIykj7NFEd0Xlkcc/hpHll3HaYMl1OecnmPxEknvlj1Jp53/DrtX837e4fzE1Tv+X/AC/v7z/E4VBOxDRPgtzYLZLb7kn17nrTdodvDo2mtxTdgeO7vBpUbDYyLtJOR/DHnA83I/hNL/D1vDrN60TXJs9PtImu7+7Iz7tapjnfHdiSqIvVnZR3qzrHEGpajqBu7S0XT3RVgsrXPMul2yj92h7NNg8x8mZmOWI5U+g3GNH2jtHr1+36QvCy6XIks7c9+uHjjYcwth2dwer7/Ch6E8zb4FX9KMqRycQXEp54pGit2Y8zPdOCWfPfw0Oc/wAbL5Ur6dAscgRpi7tl5ZD8R9T6nfYdSSB3o1qGvWkd5HpVmo8LTP8Ao+FOV8XOZN+/xDlz35M96XyMZHQQ3d4IB6w9OtlbWvu6jHivhwDk8qAMfzwFH1J719ubl7O2ikcZMsKS7HqWLgAegCAUAj1RLgoQ5cxruR05mOTj/wCUfaj2rmOO00hnKgPpFo2Ce/NLQWKkFvKWCFcA+Ms+ztHl4w0J5UUk6laqBj/0eZXP0+BRUgaTW+DjcOc3GjXiXJHc2t0Ap/8AhmVP/wDJRj2YW0DcaaCpIykVzdY8i1vK2f8A4QlDuFLi0066ifUv+r7u3NnfgDf3eRQGb6qeVx6oKYQKtahuASw+i4+uIJss7EeAB+rfuIGltpozp92qEsLWDt1KOwP/ANFXhp62zyQKCQHKLjyyDt9sUZ1HSZdLC6feY8eynntHZd1bdXDA+TK/MPQ1y8aERTnGGXB8yy/D/LH50ByQSD1h1IIGOnrE+WNt7vbkgAE5Ofr1NfZ7QACMqRyKAwx3O5/pVtp4oFVpAORMEjHzN2X+p9PrXActErtu0hLfUmgk54l1GOZNYZQ+I22QUH3G/wClGxI3w8rdY2GfJuoNBRNHyrGDkgbY9DVw6iiLCwO5JJBPUY3/AJ5pqt+MGLWKSeBCsECy/Ay4J3wPXf8A5+lGLO49xUoHAMnwqWOAG7fTfI9M0tPqASGGSMjnQYO/zAf+NXdQ1KO4sYbtMfvAVcA9+oJ/1o6MqZYdYFkZsA9I22XFds5EEoeGaLBIxl4W/iA/EvmK71LVDdA+K6spAIZfiQ+vp/zmkNg946XsLHxEVckdc0a05mkwrOVJ3HkaJ+MdxtaU/DKORDFra21zluVRjfboTQzi7WLfRNLkIdQcHbNE55YtLtWkJHQn6Vg/tX4ud45Ykm8x1rO1N21cKOY1pqu8cZPEy72h8SPq2pyOJAyg4H51m2p3mTyrk98/6V1r+sye9vzOTn1oO92JV5s5+te09ZVBmPWEZ4kkckrMeUjJ3PpRXT42YAEDA60CguVjfbuQBTHaSqsIZOh9aK+QMTy4PWTTlgCB1+naqXNIcAgjOc/SrLTo7lc4BOME/pXzkUgcx69QKByOstjMrRXXJIQdt+lSXEoI5jg52obdOUJPQioDfmQNzHf0q/dZOZAbBhCPBffbBohEDynfoe3nQiznaTlwc5NFoWfY9qhgRxJHWE7V1BAI6irXMCRjciqEbiNiSOg/Ku2uVU+Y9TS2MmMbsQ5p9yYWXB6U46Nrgj5eY4BPn0rMkvCGBydj2NEbTVgCMP12xmoNWeYB3BGJt+n8RDlBEg/OjVrrbSuBzjpWK2PEQAGZNgabtD1vndOZxg+vWhvvxiLhQBmbJo5WZlZsZO1PmkwRGMbA1lXD2qx/Dlh6Vo+h6iJAoBp/SIqxDUs0YWcWiF+bGKyD2vcXyWek3TQSfEFON/StL1vVI0hMRkVWYELnbJxXkf27cbR2sk1hz/vVYpICCOUgkEf0rpdJpRYNp4zMnUWkLkdZgF3M+qcQO53Z5izfnWwaVaiC0hi5flQZHlWfcGyWd5rjXEkSLErjNalaxhzzIOYHcEGs7tOhqWCGK02i1iZPBAWA+H60VtYMEYG9R2sBI6Y2z1orb22OijFZYXMdU8y1a2wZSD5eVVrq0e2n8cHYn7UVtkAwPyqzc2K3MJXHbaj117TKPzIrWITJHdRqA6bmj8CiWJZAOo8qWdOn92mNrI/Q4/40zWAKnkwcNvTdtIvq94g1O3rPzRcvYZqIjcelEJItqpTDkDNnYb1jWac4hgYB4q1VbCxYeJylh51nmmFrq7e6f8J2q5xxrYuL73RCCAcECvvD9jmSKAKTnBag9yUXJlRgmPPDdv4MHjMNz0oq75OwqGBFghWJdgoAr6WBGM1gagndukMOIL1VDkup+m+KqWtwQ436HrRS7j8SMrjNASPBuCvbOKLVYbEKGLtxHrTLzxoAOYZAqy0nrS9otxh8Z2NG2ORt3rLuzW3Esh45nhp5Cc7jP0qlOd8jv0qXxMA4ONx3zVeYgjY/WvslC4M5xVwMSnMSevT+dUXYCTJq5OSBv0odMdzitavO2T0MtREM25oxp7AMBG29LsTktgk0b01yrAjNB1Iyhh9OfbGJp3DjiGAOWy31zRe4vHdcs+KUNFvuUKM5x6elHmk8ZAQo8t6+fatCtpLT6VoLF7oBZHdSo/MOfm+/QUDumjyyncZ6D/Wr90rRqRnGe5FULO1N5cSyvMsVvbKJLq6kBKQITgEgblidlQbsdh3ItSuTxCs4UZaR2ek3GrXLWtlCicqGWaaV+SKCIdZJG/CoyPMkkAAkgEvY6bLfwXmj8K4tdKjVTrGs32YVlTO3incxw5GUt1y7kAsGOAtxUs30yC41YXWk8OM3jWtrHy/tDWJFyPG3+FV6gSN+7jBIjDtzEjtX1661qOOzWCGx060Ym0062yIISRu5J+KSQ/ikfLH0GANFR3Y9r1685nszWNgdPXzPu8JK3EOlaJDJp3Ccc6eKpjudUnXku7sHqqAE+7wn+BTzMPnY/KB0aXN5gLJHDGBjAGMCqvgxZ588zenSo55XX8e3kKoxLdIRVCjPjDttp6RYma4Uld8YzVoSpzeJPcKsXkdz9qVhfXky+DFzKg7jarFuXlcCRyxwdjvVSpB6ywGekZIIbO8mWQMTGfPv9KN2Mc8t9Do+haY011ct4ccKY53b1z0Hck4AAJJwDS/pcF5Lcw2WmW0tzeXTrFDHGuXdz0VR5/oBuaZluZbCccDcHt+09c1Tmt9Rv4ZByuACz20EhwEgQKWlnJAYKxJEa73RM8n1/cFYxPA59dYz2SXd5MOAuCDHqGo36tHqOoRSBYnVfieONzgR20YHM8pwH5ST8IALD+1NM4K4dgg050vjfyLc2Qli21iaNiE1CdG3FjC4Pu0Df30gMrghcUHS90LgnhW5tI2S70zxPdtUnUtE3Ed6gD/s6I7PHYxZR522ZgUU4eQLHmGqcY6nr2sXGr6pePPd3b5llVQi9AFRFGyIqgKqjZVUAbCmS3cAf9v29fX4fmAtXenHh+/rw8vj+VuvNckeaee5uZLu+uWaSaRzztJIxyzMx6knJJ86GGd7kL7xkEsFCoOYknooHck7ADuRQR9Za2j8NSG5+3Uk0y8K3rcOaVd+0C7I9/tZ20/QEYAquolQ0k+Oje7Rsr+QlkhHUNhdTvPJwPOMGvYvI58BGvU72x4TshwRZvG2oRTJca5cghgl2oPJbKfxeACc9hKXPVVIWTqkCIVgyEQklj3ali2kMKeGec82SSzczEnuT3J3JJq9DJPF/wBNlBVYdreMDJaT+LH+HqP8WPWg26jeeOnhGKtLsHPWNMF9+yop9RZghsuQAdS963N4KfSIBpWH8SKD2ofpYubhUgRBHCq4GepH18/WuNaRdLW30dsNLYK3jAHJe7kwZST35cJFn/1Z86pR308ERijkC83znHSlXtzwIylIxn17o3jUbDToUUEEr0z3PpUnE2p3mvarwjplvIVF3w/pzEqfhjV3mDN+QP5Vm9/fTySx21sDJNL8IJ/CPOtSg0wWen8PXOf3lrwfZQBx1Mjy3Ea/cKzn7VdcLWSYNkwwj97Grpr32grfyAoJIbxoVz8sfhFVHphSBS+b1mSK3B3OA2PIUW9jNyG9oum2kQwvgXSE+Z8Bjj9KXcKskjd1YqB570O1ydMhP/Zv2WVrrA1DD3L+7R/9/HEHCbcgL6noIjeXHWexAKCT1MPMqt/g5D+E0GsbwSRStLljAfFVQcZ7Nv5D4fyqHhe71Gw1uGfTrjwLiSKSGJ8BgJGXKAg7MpYKpU7EEg9av3Om2t3arxPw7b+Dp8h5b6xBJOnSSDBTfcwNk+G3b5G3AJl2N6i0dRwf5/bPz8TiAi0sUPQ8j+Pd7vlxxmlLey3sy83ypsqgYA7/APHzopPKYCqk/wB0ir98b/qTVOytFg5pXHww5Y+pHT8zXU5Z0DE5LKh/Sh1KSCxlrCucCdXFy0U648ga+zzSie2KZKBt/QEYqq48a6DnJXGPrUvh5j8OTOIzgEdR/qKJzKHEL80vMsbkKdgM0U061le2ltcgggMAD5VQtxNNEhkCyHGxbo33pj0pIWkSMwNFKV6MaarQExOxiBKmnWs1rcht8dwB2pmiWyhjNwGwOpHrVN41t5f368vL0PnSxxbxhBYQukbDlYHpQLbRT7MlK2uIIkfHnFkMML+DLtjzrzfxlrwvJZC0hJz+VGeNeMveXdEmPxds1lerXdxcMxzsfzNKVg3NuaaKVilMRX4juH8YuucZ61UtLrxUwWBPlmrOqpJNEwxvQOwlaGUxt2NbVSgpxFnbD5hZiysCM/SjelXnNF4ZO9BWxIMqR619s7lrefJUivFdwxPA45jIX5XHMfyqx43MvOD3oW1wJF51b5q7huGIVCMAnelynGYQNg8TrUYmKFx070CQsLgqc5pmdfHhKsf0pdvEaO4LbbVek8Yg7PZ5MK2A5B2HrReCdQCM+opetLocgyRnHarcNwSR8RwD+lUdMk5kCzPSHI7jm3HQ/wA6hkmHLkNv61FDNhDnJ71BPMG5sfbegqnJxCd4ccT7JfMNi+T1z6VHHqzxt8R+2e1UbhixJ/LNUX5s/EelMqgxFmsJEaLfWyDs3xDpTjw1rLyyqBJnfoayeKRw4U05cG+93F2kUCMzZBAFAvqAXMtXYTxPR3CZluEQjPb7VsHDllLFb+K/l0rOfZzod1Fbxy3qcuRnFaVfaxZ6VYGd5FCRjDb9KY7N0rWsMTP1t2wFZnXt11jUIuFdQTR5mW9SF5I+UkHAG+CO+OleN+MOIrz2h6evEk9wguriV1vEXqJ1Ay2DvhgQ31LDtW4+0TjSbVdZmtoXjkhWTlCvEHG3TY/WvMNzrGnRcQzT6MJYkkuHjngZQOb4mAI+wH0Nb+nfcTX4DB+ExC+/BHh9cxj4H0i9aMSI0hyc7DqK3LTYAkaIBgKoApI4R09NIhtbj3iKdHUboCCrHqrDsR0269ehFaJaRcj8qrtnYnypXtitlu9qA0bh8/GErSL4RhSAOoonBH06ZG1VbVQAB0xsTRW3jBXOAT13rLRPGaAMkt4wfL/SikMQKYqvBGM4x+dEYV26Y27UYLJi1rlibSZb5F2U4bFGtJukmjXEnxAbf0q5e2iXNu0bKPiFKlncSaZftZyKQASVOOo7/lTlXBGZUjxjvzB03O42xS/xRqSabp8kjNhsHFFreZXjD5A8/wDWsn9p3EL3F0um202DncCh3afBJxxJDZEXbLn1fVHvJASmS2++9P8Aw1ZhCbh+o6UscPaX4FsiYPM5yc09QILaFYl2OMn61lapNiEecuPdCImyBXBl7bYqoJ8HrXzxst1P5VzGoTwnmPjLeQTnfHlQrU4OVvEGwJojEQ22a5v4/Et+2R5UnS22wRazPWV9Om5CDk7EGmeFxLEGBBFJlpKqPjp5edM+mTiSIqSMio11fGZVW5nhsnY469TUbsemfSuwT/iHcVG474FfYKxMACVphzdvWh8ynmyPvV99gcflVOc8uc1orwMS2MjmcwqM77UVtHCkAAk0Kikx1A9au2snlQb1LCFpIQxv0dyxUb/lTR4pWEYIyBtSVpM7Iy4ODTpomjahr0rrZmJIrdBLd3lw3JbWcROPElf8IydgMsx2UEmuM7QobvZ3XZl6mnOekgs9Mu9XuTCkjBAQZH8Nn8ME4ACr8Tux2VF+Jm2Hci3q9zo/DYSwnsob28tnLW+luyy29rLjBnvWX4bi4P8A6JT4cY+Ek4KmXiHjGx0u1OgcCieO1TmWbVJk8O7vGIwzqB/cKw2Cg83L8JIBIKIcR9+XHQDpipqArHmfpGiGtO48D6y/e6pe6ndzalrF3JcXc55pJZGyzY2H0AGwAwANgMVQe7JYANhOuBXDMZTlsfSopSY8scUVBk5Mqwx06CX7e4Eg5VYqPPvV2GOFgA+DigNtdKWClsD6URivVlkWCEd+vl61LJ5Sqv4wgVMjeHFgDGwAxVm3snSVIUiknnlYRxxRqWaRycKqgbkkkYAqSytPiDHJ5iAM7k/Ybn6U233JwBDLFGw/2lmiZZZT/wDwqJl3RT2uGU/E3/ZqeUfESRVUyYNr9pxIJY7nhpX4Z0NXveJNSYWV9LaDxGh8QhfcLYr8zsSFkdfmP7tTyhiWbQNHsuGdPvrSPUYbdLeLm4j1yBVnEcauB7nafhlUShY17XFyB/2Fu5apwtw1qmlXkHDmnRsvFurQlbhwQjaFYOmXTmO0dzJGfjY/3MTYJDO/JU4w1exvvduGOGxGug6W3NHIgKpeXCrye8FevIq5SFT8qZY/HK+TqO7HeN6938/LrBly/wDrXx6n7/x8/eVfibXbzirURcyWwsrG1QW2nafHIZEs7YMWEfOd3cszPJIfikkd3PXAFi3aMh16/hHlRg2HKfFZgqgY371OlsQonUAMB8Ofw+tIuXY7jNCsovAEraHoGo6xrNnoulqJdW1GdbeAucJCW/ET2wAWZuiqrHr0O8T3WmapeW2ncPM50LQoP2bpTMOUyxhi0lyw/jnlLyn0ZF6KKJ6Bpw4e4Vu9f5iNQ4hE2lae3Qw2YwL2cer5W3U+Rn8qXr2PwUCQ9AN9tqhgwUJ58/p4fz8p5HUvu8Bx+v8AXT5yCS4itB4cI537uR027Uc4ef3YvxDeohTTESVFfcSTk4gTHf48uf8ADG9ALW2SaQzOf3aZOCMZ9aYNUiktbW00uRSvIBf3i/8ArZFHhIf8kJX/AHpZKCQFjOS3HnKhkUr73cyEs5J5nOSxJ3J8yT3qjPdNOcRjCDJA/wBalMMsoNxMmFJwoPaoUUXMwtYU2ZhzNjc+lBAAPEP4cwhw9p3vN17y3xBcHPn6CtW1xPdtG4bgRh40uiWcr4/CqmZUH/zSH7ik7RrMoI7O2j+Jiqg+bE4H609a7ZoLvTXjz4UGh6dGgPfEWc/fOfvVSxZHx7hBORvXd7zL/saPge0vhx3GFa/W3Ynb+8Vo/wD9cUPkt2j1Oa3dT+4nlB+ocj+lWNCuv2Lqun6kp5ZbW7guM9N1kVv6Uw8QaI1lxrrenyKOaPUrg/7jSFl+3KwoqUtZpwnkx+oH/wAYu9wS8t5gfQn/AOUFwWs6hJYiUl5g6H+EjcH7GmGO4m0TVm1PTCsXvCGVUZA0bxS7vE6nZk5uZSp/h88VDFBzvkfKoAFS/Ddxy2gOZbQNPER1aPGZUHqMc4+j+dMVU7OV6+EWstDHn9YQOlWmtWjvw5EY52+OXTC5Z1x18BjvKnX4fnH+Ib0Fe1fwApDc6xgMCNwRkbjtVywCyKrLgZwy47Y6Yow+qvdMkWuWSahsU8cuYrlR2/egfF/vhqaFSWDPQ/T+vh0+EBvdDjqPr/f7/GLFrbMyeISBg96M2OkrOA3iYDbE46eRorZ6Vo10HFvqbR46rdwEMh8i0eVYfYf0ozo2ioEMMs9oebdXiuMgjPkQKldKQeRn17pVtRxmD9M0VYuaENGwZsPC4IGfQ9vrRmW193to5EU5iGDzdQM7dOuM9asyaT4EizyXEYXHI5GTgjpkY22pc4s4ot9GieB5W8RRgHsape6aes54g6w1zDHMFce8VDTtLMviqSg2/iBrz5xLxvLqKyOzEKO2aIe0bjb3xGQMABts2dvtWNX+t8+QHz9qw60bUWF26ToK61pr98s6prHiyknOTtjzoVLeyHHh5xVW8nL7hSAR96hinGeXIJXYVppVtHEWd8mfZTytiT8R3FBdStvBkE0WQD1x2o3IonBVyAeg33qpJF4iGJtx09aYQ7DmDYZEp2c3MAG7mrlxETGHQgHtVaG3MMmMbGicLJInIVGcbGrswByJVV4wZWtLghfDcmr0Moyu58tqr+68jcyHqfKrUcICjBPTYiqMwPSSExCEFwnhnffpQXVObmOAN+h61e+TJI2AqtKqysSf171FZCnMFYCeILhd0+EE7d/KiloxIxn8jUJtVGcDGKsWqBScADPpRLHBEoilTzLyTMq45vvXMsy8mebBOahlYRAso6dKFXF8Q2Mn6UJU3HiS/s9ZdnlUts1Q86uQoznpsKHG5kdgAOpxTjwPwtPruowIsZIdgKm1loXc5nqazc21Jb4J9nuucXXccVjaPyEjmcjYV6m4B9hcXDtrFPdRgvy5ZiO9P3sf9m9lo+lwn3eMEKPw7miPtf4ysuB9AaaUOEPw5QZx9aFoq/xrhrOngILV3fhx3df6mJV9rNtoLzQJIuI/4W6fase4u9pVxc6jc6feTFLd0YwherOo5sY75xVfXfaLa3+mSz2wEtzOxIPQkVk3EGpXk1xb6nPFhbaUOwGc4Ox/Q10uiYaPUrnpOZ1NhvDID1E0Pjq1WDUbW7VOSPULSK5QgYB5hn88EVgfHfD19a8Q3erWMJMNxiZ2TA8NwAG/M7575NegtYuZuJeA9I1VLPCaPO9pPKB1VwPDP02xWYcYRqqSqUBVkOQT2xUaus6LXsi9PD4HmC0p7yvJ9GNHAtxea5wzBb3V1LNeLbx30CyuWZbd2dAMntzxP023Hen7RJ2vLUNIPjiIQnHUds1lnsw1e5Ww05pwWj0PVrXQjMF+GO0vIpiUY9h7zDA656NM2PnxWie8fsHiBLcH9xeNzEHbY9R9qa7TqFy785yAYLTNsYjHT+Y52iDbG+aLQRjzwAao2sZBGF+tErdWyMiueVZqCXYIx+dXokOPr61VhH4s5FXoem9GVcCWBnap2Pel7inSDJF77BhZIviyKZkA7jNUddgebTZQjEMFJ8s0VBziQTM6uuO4NL09lkcCXHylsgHypF00rxNrJvi6tzMTgHO1IHtR1q5stUljWX4WJUqDTh7EbW7voBNOxwSGBH8q1Ni2U8xM5rsJmt6bpscWJgvQDbyq1PJg753/AFqZTyoV7L+pqncMckZztXMa8DJEeQ+cjaQ8xyfy6V9STJIyarO/pXcRHUHrXL6keM83MK2x23NTTnmiYdjVWBgBuR9asOwaP6jzrLK+3mBcZEAF2jkzt1xR7Q5+ZioOR60v3hIdiNgDt60Q0ObllUFu3nT96d5VmAXrPG3Pk9c718Z/h75rj8Rr6v4q+sV8cTEzkyGUZNUJ+tEZOp+lDbj5qbQy5Wcod8HpVuGUJg7bVRTv9auWX9/H/wB4v86tjIlTwY98NcNmZLPUNeee0trzeytYsC81D1iDbRxbHM8nwgAlQ+Dhh13i06lZQ8N6PHBaaJZSeKsFtzCO4nxjxWLfFJgHCs+ScltubAg4v/8AzicU/wDu6b/9AtLlt8o+orA7SrAPHE6PsZyevhn+JYucsMBfrgVRljbHMWIzRLy+tVLzofrWEvBwJ1WSesoB/DB5AOlVp2lkPX9KsSdD9qi/7FvrTKmCK+EooJGlMcJ3HzMelXYLqK1Usp2xks3Q4/pVeP8AuH+rVZsf/L7L/wBoi/8ArFMDmKtxmPtjqz8DWUOpXYH+0l5GJbKBxk6ZCw+G4kB6TsDmND8innO5XF/h2+j4b023441d4n1C8LyaBbXADh2ViH1GYN1ijcMIwdpJVLHKRNzJftH/APP7iD/3lP8A/VRzjr/zk0f/APp/Q/8A7OKiBR8vWYHoAfP1iPtxeTcFcNSaVLNIeIeLY1vNWklYmaCwc88cDk/F4s5JmlzvyGNTuzilYahGrjI53OenRase0v8A/OVxN/70u/8A9I1AbH+8X70OxBnHlxJr5AfxMO2VlNe3GWTKAZO+1GtM4ZvNf1az0HTmSNrqURCR/kQHdpG8lRQzE+SmudE/uP8AdNNPBP8A1hqP/ufUP/t3odSCxwD0l7GKDIgrjDWrG91QJpUbrptlClhpkR6raxZCEj+JyWkb/FI1KzwzXE5Dt8P4sfyq/J/5efof5VxB87f896E/tEmFQbABCGj2Vl70jX0PPZWytczp/HHGASv++3LH9Xr4FvNX1CS4vDzyTyNNO2Ni7Hmbf6np5YqxZf8AkV//ANzD/wDp0q5o/wA4+ppWxABiNK5MGa5CEwiqFAGBtXGg6S/Nzcm56k9hVriD+/H+Y0Z0f+8/3KC1YAxDCwlSYZ0mxWzzdg/FDHzg/wCM7L+pz/u0ya2sS3drAo2ttK06Pc9MWkR/rQa2/wCrJfqn8molxF/5XP8A+zWv/wBtFTFNSis/p94B3Lvn14QTFMLm4kkZiUhPXO2RWvcZQrd6vNxAD8UrvZzHylixyn/eiaM/Y1jGif8AVU/+c/zrYtZ/6q1T/wB5Q/8A29N0KO7cfA/v/MVvOXVvj9oFe4hghHLKoB7k4qo8rWY978QxMGDxyg9GByCD060IvP8Aqxfr/WrVx/5rXn/d/wBa8y+XhLLwYek1HT7eCK+gCRRMypLGo2hkboMdkbfl7dV7b2LW8t72c3CHMSY5gDujf6GkzTv+pp//AHM//wBxFV/hLref+z//AKwq5XDSCvX3HEeIWXT9SjvFIaOT4WOdiPI0ws8Omuk0ak2l0c5XB8N/5Z9O4pa03/yU/wCQf/VRkf8AUcn+ZKG7mtSw8IMIHIBlviTXo9L0551nhd+TALE7ivNXH3tGnvZZVkUIucNg4zWs8c/9WH7f1rzhxl/et/mrE1DG6z2jxNXRVKi9OYrcQ6oZoXlSUsp3xikmeVzEZMYNMurf3H2pWuPkf6U9plCrxL2k5nyO8mli+P8AD1+lfUlR3DAjPeoovlb71An96ftTqqImxIMIXEzNupG/866tp1BPiHJNVp/w/SuU/vhUBQRiWzgwoYfFIwM+or8ieG4yTyg1btf7pPpVV/mb/N/WlwctiHxwDLgjVhkE9M7dKh5niYqAcdasQ/KKjn+aqg84niPGffEMi8hxkDNRNDJnIXr51+i6n6/0qwen5fyqc7ekoRk4lcNgnmU5/PFfF2OVzjrUsnX7ioj1+9WBzKEZODIrgsyYzQmaJi+SM70Yk+Y/eqj9qJW2II156ybRdHe7nVQpOTnavVHsF9msk88N21sSqkdutYFwb/5dH9v6V7k9hn/VkP0FZWoc6i9am6R/aNNQXTrNg0DRFsrNIhFj4cb1g/8Aa80iSX2eaqY4y7RwlwM43Br0lbfIKwn+1N/5iav/ANw1bWnqFdyKvmJz17F6nLeRnkD2W8GLLpK3t/K3MFyVJ6UR4l0XT5bSey5ABIpHMB37UX4C/wCoZP8AKKEcQ/j/AM1Oaok3sSZm7EVBgSL2W3lzq2m6nwZcPyi5iMTek0blo2+4GPvSbxhZvyMsifGFKMue+4Ipn9kn/nnN/wC0R/zNDvab/wBZ33/tD/zrY7T/ANtNGob8xGD9IlpkFdroOnWKXs9u7ez4q0vTrqeWPT+JJVtdSiDHlmSNGOD6grGwPUMqsOlbLxVYy3mke/uhF1Z/vG2wQw+cGsI4c/8AODhT/wB4zf8A6M16S1v5tV/7yT+VeJL6VGPgWH6dZCgLqCB5A/XEscE6qus6LFKZQ8kY5H339D+VNttH8O/Ssx9k3y3H2/nWpwfh+1YbDa5AjlZ4lqBBsD+tX40+AE9aqQf0q7H0+9WAl8yRQMZ/nQ3iOZbfSpnY4+A53xRROn3pe42/6kn/AMp/kauBIPAzPJnHOhy61qUt3GC55yGAFat7HNOWz0wI2RkbH0NKUP8Afzf5/wChp/8AZ/8A3X2FN1sSoEFYPGOkhC5UHJ60OupcE71dl+Y/U0Ouu1YvaACsYwvIxKryEE71LFISd8j0xVY/MPqf5VLB0+9c1qFAlgMnEJQvnGM471cDEpvvQ+DoKvx/3YrKskMOIF1HCynlzvviv2ly8kiEnvvXWof3o+n9KrWP98f8wp1BvqwYoODif//Z",
+        "type": "string"
+      }
+    },
+    "required": [
+      "filename",
+      "image"
+    ]
+  },
+  "Cat": {
+    "title": "Cat",
+    "example": {
+      "filename": "cat",
+      "hashes": {
+        "tiny": "QmeWpdutDwDHnZsjbmxg9wC5cq2MRMpMGjzLM61Y6kTUA4",
+        "small": "QmVKmrMrNTx5S3eSFezb2gn59Fa2zAUH2AykvnW9zD6dbf",
+        "medium": "QmSBXqS8RvjYQd8hSY9BCisUzn1EgjTDZLT3kzGBoUNeV7",
+        "large": "QmXXBjeGPXjdZa1vQJa3RJZiVpZDT31DLsxtDuCakbhw1B",
+        "original": "QmYUEdjMcR8GwSos2i9s3qx48or9WHXvCUZSSRQAH6UGLT"
+      }
+    },
+    "type": "object",
+    "properties": {
+      "filename": {
+        "description": "",
+        "example": "cat",
+        "type": "string"
+      },
+      "hashes": {
+        "$ref": "#/definitions/Hashes"
+      }
+    },
+    "required": [
+      "filename",
+      "hashes"
+    ]
+  },
+  "UploadImages(e.g.CatImage)request": {
+    "title": "Upload images (e.g. cat image)Request",
+    "example": {
+      "filename": "cat",
+      "image": "/9j/4AAQSkZJRgABAQEBLAEsAAD/4QDiRXhpZgAATU0AKgAAAAgABAEPAAIAAAASAAAAPgEQAAIAAAAMAAAAUIKaAAUAAAABAAAAXIdpAAQAAAABAAAAZAAAAABOSUtPTiBDT1JQT1JBVElPTgBOSUtPTiBEMzIwMAAAAAAKAAAfQAAGgpoABQAAAAEAAACugp0ABQAAAAEAAAC2iCcAAwAAAAIBkAAAkAMAAgAAABQAAAC+kgkAAwAAAAIAEAAAkgoABQAAAAEAAADSAAAACgAAH0AAAAAmAAAACjIwMTU6MTE6MTUgMTE6NTQ6MzcAAAADUgAAAAr/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAGpAoADASIAAhEBAxEB/8QAHQAAAgMBAQEBAQAAAAAAAAAABQYDBAcCCAEACf/EAFYQAAIBAwIEAwYDBQUEBQoBDQECAwAEEQUhBhIxQRNRYQcUIjJxgUKRoRUjUrHBCDNictEWguHwJDVDc/E0NlNjdHWSorK0FyU3s8ImREVkdoOTo9L/xAAbAQACAwEBAQAAAAAAAAAAAAADBAECBQYAB//EADkRAAICAQMBBQYGAgMAAQUBAAECAAMRBBIhMQUTQVHwImFxkaHBFDKBsdHhBiNCUvHSFSQzQ2Jy/9oADAMBAAIRAxEAPwDyHfw/EzHJxk70qaxj4snO9PWrQiNGGxPcedI+r9SN9+9KaI5MY1gwIqTr8X1rhB5CppwQxx1FRID16VrY5mU3EmjHxZ38qvwABftVGMHG9XoTgYxt9KIvETt5k6dcYzjar1uB1O5qimdv+f1q/bg9hnO9X5ziJ2cCFbMZOMfemCwUEigVnjmB86YNP2wcdNq9Mu08ZjLppCYOd6NWp5yM9f0pftnAAUDbqfrTBpzcxz16AUjqeOYpQCXxC1pCxIBOcf8AO1MVjbqeUgHJwfKhNmFBXG2cHGOn+tMNiMgYGP61y+sJJnZdnoBiEraBQOma+XbLGu1WogBHnA32odqEgLkDpWI6EmdRQfZlYHnbI2qZSBgnzqCJh9Tn86lQ57iqNXiO189ZbQBsZH1xV+3yBjoMd6p2ihsHHQ4q2rhDnPSqBPCNgGQ3L/vcVXmPMvzA57etc3EvNIWByetRtJzKMAen1ond+UsvBn6IlcY3+1WUG+wH3qqpOcAmrlspO/YVOzMZUeM5e6mtZ1mt5eR1OVIGfqCDsR6HY1O8UOoW8l5p0IjljBee0GTyr3kj7lPNeq+o3FKfPOR96+QyS28qTwSvFLG3Ojo2CrDuDRBXgbTJPPIlaVvjBB29K7t5GLdaJm1t9fPNZRpb6oc89qoCx3J84uyyecfQ/h3+Gh0EbKxDKQwJUgjBBHUEdj6UwKyolQwYyC7mIbGeu1D7tQwBA2O/1q9dDmP3qnKg8P6URR0kEQJyF5Sd/vROy+Fc4PWq3hHxc4Iz5USjhAgx023o88BK16BIec/bFDZIjy82djRB258qfw9qhkhyMDqaLWBBPnMrWwLBlxt51ZFm9xLBaQL8bsF/XrXNrEVVmYYPNtTJodqscvvswHMwxGD/ADpTW6gaZCR1Mb09PedeghBNLEECWCMCkRy7D8R9aYrLmghRYUCnG5I6CqVlEj4ZjklizZphsFEi8zJ16LisOgGxi7dTG3O1cSzp8cwCygAnu7HYfQUXSK55chvFPkp2qG3V0T4VVcdNs1agS6l+ExFx2IbFala+Ez3OTPqe8KMPZnY9MZx+VWLaSNTmNGI8jGRXx9O1s4a1m5R1+FgCPrX2ObiSwk5LjT5JQe4IYGruSg5B+UmtQ/Qj5yzKtvKnOsMZPfBww/1r6LYhOdEZlPk+cfnViGbT74ATWbJL3DLXL2GnwEsJJ7cn8SHmX7is6+vvOVx+00Km2eyc5gDU7QM6yKT16E012+nJqPCFzAVXJiZd9+opa1VAilkmEnqBimHhN5p9Lnhd8jlo/Yrd3fgyO1kNukzPGmpeLba7f2EijMUrAY9DXVu2MH/hTTx/DY23GN9aJajn8Rg7KNs5paWLkdl2yD1862NfVsfJ8Zz+jt3JAHtBYx6C0g25DnPnTDwLrknEHBOn3cq5kgXw2IPbp/QUue0ZC3DcoQYzt9KGf2fNUubjTtR0GZt4mMiqT5+X5UxpEF2htr8Rg/KB1L7NWjeYx95qPiHGFBzWCf2hOGOJb/iHT9bg1e4vLS6jMcVrMzeFYmCNSSNyCCCSBy5zkb5Fb+ID2xikf2kTNpuu8C6hHOivDxAhSNlJSQ4QrzenOseaW7GJGtStTgMcH18ZbtHb+HY4zjkSh7GNY1O94fv9M1PRLWxuNJv/AHad4rFbV3uDEplhkUDPNCy8m/cnpnFPlzzvbSBVDHlJCnv6UQm0mHTJ5rK2aN0jnlPPGgUSuzlmk27sxLE9SSa493+EjHzDv5UtrdQb9S1jcHP7cfaF0yrXp1XrxLnBmkSycMXlvHJzSeDzlebPnkY9KW9UcW9lNK2RyoTTf7OmFndTWbOS7u7OCflJ6Y26bUo8bgafp18JlwVZlx5Vr9rhbBReP+S4+UT0VhrNtZPQ/vMV0oftXjMEY/vcn862F0yN1xsMbVlPsttHvOJ57rlBC5PTpWxmBgckYwPzrN1jAMB5R3TtjJgt0z1AFBNQtgbsFhtynf8AlTU1v2GT26UJ1K1Pjr8O+Pz2qmlsHerDW2ZWXhCsuluCQBynB8sb1mWrBbvViudo8DI/OtTQvHokxcYAT8tqydZOaSads/ETWlqlAsz7orp7PZIkun2Jub0Y3GenpTesQjQIMYG1UOGbMEGds53NGmiwM9/Ss66wM2I/R7IlFkyc527V9jgLSqPMb471YMWOvbvmpEjAZTynfpQa2w4jFrZrIgmaBY7gsmBnvTJHEDEhOMctCrq2w4ZATjrtRyxX/ocfN9SftTWrya8iJ0NhsThYdtu/TNDtXYonhqPvijRAVObuKXtWkJkIJ8+9ZyElsRtzxzF+7CqDk/Nt9K/afaGV1OO9dyKJnwDRnSbIcwYjYetNs+xeYEc8y5DbCOEAAH1qxHCSdqlYZBwO2MeVSwoeYbd6AGMswA5n1LcbA/SuBByzMoBIbYURjjHYZ+lfpoOV1k64IPpRq7drgmK2rkQDcQe73AbcA/yotymSBTndNutR6pBmJXRejE/arOm/v4uVh1Falw31mIqdrSo6NjYEVwVZTnYd6uSRkHlJ74x1r54O/mc461iMQBGwcmZhrceebGxOw2pC1lSCwO5PTG9aHrRHxZ6b49Kz7W1GWB23/Suq0B6Cc7rfy8xVuvnOd8+lRKvTapbgnnIGNqiAwc5rZMxzwJLHkHFW4ziq0Qyc/wBKsx4xgjeiCLPzLkYJ3FXYN2xiqduSQAOtX7YHmBqwHjEbTCtnvjIO9MFlsB2yN6BWYOwPSjURwoGN6mZduScQ3ZnmYbE0x6cDsSN+lLOm5YjApq09eUjAORSOq4EHp1BeMlkuFXOObp0pgsFJ6g77/egWnDmUEHbAP/IpjsY+UDbt9a5m9cnBnY6FMgYhDn5Yjt2oVdPkmrc8hUcuNhQ+XOcEnH0pE15nR6dMT7D06ZzUiD4sHtn71CmU2Odv1qxCAWGT3ob1ZmjUuDL9rgAd8V1ePyD4SB518jAUAj61FcNzg4AzQRVzmN4lTmLZJ69dq/RvzY8qjyQCuf8AjX2MfFjc/wA6MKxiWAlkL3Aq/AoSEt6VWiUHl7+lWHcRpgHpXlryIbmU5mw9cK3cdMYr9K2fvUJz065o4rzKzsBXJz9qPRzR67CsWoypHqQAEV3IeVbjySY9ObsJD9G8wChXmZcdKtzryxcvmMGr4xxPbM8yheQTwTy29zC0UsTFHjcYZWHUEdqoyjGQtMUU667CmnXjhb6JRHaXDnHiAbLBIf0Rj0PwnYjAGeNklaKRWV1YoysMFWGxBHYg9qsK8dJ5OTgyosWTzY2q9yYgJK9v1qOGPJCnG/r3qzcqEi5N96uEzCbcQLJHiXJBNSBSqr3IBzX6RM+WPOrNpC0sioULMSOnff8A4V6xhSpLSFq7w4n7TNPe+kZDsi/FIf6UaWIF4+TcfKoB6CoGVNMRo48lpCecD+VWdJiPNk52OT9+1cpqdQb33HpNeuoVr7MZNOtyeUnHkBTDbRyKBy4H2oRZBgAFTHqaLxy8pBa4Cgdd9qPUwURS0EmErVLlhhQQD5rV62hvI3w8iEYzgrgUHbUrSJQZr1EUeZODX1Nbs3UFLkt/uNg08lkVNTHoIzwpMuOWfkxuQDmiVnqKRjkn1CD6bb0nwXtpMCqqST35sfoTV5IrWQhmtFbH8LAkUytzKMiD/DgnDRziuVnA/c20mPwl9z96/SJpM4KtB7u56Enal23S1VQkFvMmO6kgCrPvdug8OYkqO/MSa93gsHtASwq2H2SYL161mszvZxyxk7OpJGKOcIWzNbyFUCc69B0oZNesJfDjUOjfXpTNw+T4b8oC/BS2nVU1K7Y1qmY6Ugzy37Y9IfSeMry6EyYmcN0/OlE24kZZUGzAE0/e3TTJH4vmuzIHTlHw56Gk7RIPerUofmhbGPStrtAmyrI6icnpm7s7Yoe0KELw3KCAfQ9RST7OIZeHeJdP1UE+BqLeC+PX/jWke06yKaAU5fmPc0unRprf2fxavBD4ktnKsoOOgByf5UDszUCplV+jNtPwIxLaw7gWHgM/Kay1qFkK+R27VmPt3vP2NacKaonK0lrrLzRwhyryMsDYAPYZIBPbIxWqaZP+09LsdTC7XNuj5Hc4FYx/anuzZ6Twqvgx5/aVxMsnWRGWEAADPQlt/UCltADp+1EQ/wDFpa9xbpz4gibXeWVlFcsmnQGK0CoYY8Y5VKKcY+pNVzbb9Om4rrh24Oo8I8MagZBP7xoVgWnBz4zrEEdz6l0bPqDV4wnOSOtJ9pf6tZdWPBm/eXoszUpz4CArO7utF18SwJ8E3K7HyIIH5bmgHt9vYbJJBspvh4i+RJ7inDWLNLe2XVprmOBIcliwzt9Kx3X+IIPbBqVrokVzFC9lN4bFBnIz1AJ+ldHo0bXdmL/2RuPgZn23d3qvcRz7sdJY9jmhGOwl1Fo/7w4B/wBK0V7TrjO350Q0nhEcL2MWlrhiiA8wXqKsNaY2wa5jU6gvaZpK/GQYDe0J3Yd8/eqN1Y80ycq7ZyKZ3tCcnl3qCWyPOsrKAE3Joen1GLVnns45i3qVs0GjNCoAZ1wAemO9ZW1n/wBJ8JAfnIx960fV9ejF8bZ0BUEp1/X60vaPpfvmsy/BlRJsa6ntMitFtHlEtHc2WJEK6Rp5t7JF5cZHYVYe2AGw3o2bPkQR42G1V5bcgk43Ncv+IyczWSyBWgKkEfau44cMpwAAc4q9Jb77qd658IKw7cpzRK7ssIzvDqRK11ZkjIBGN+mau2cJS0zjOD+RogbUSKGU8pIz0rtbYx2rYAGDvitrUJmkmJVW4sAge+lMUbbdQdqUNRuvjYjfHrvTHrk/KpGfTekyZ2nmIGcc24rPqXJyY6zZMuWERkcEqCScU12tv4EIUDc7nNCdGtgzKT2/nTAwCr9BiqWvkyymVsjPfGNqmgI5hg9/KoHZc7etdxMFYHJ8sUIGQ7ZhaHmBGRsOlSTAsmAPzqGBsjbv1yKnzgY26dv1qwJEAeesruiz27IeqjequlOUZou6nzq0OaKTlO4Y+VDnJtb/ADy4Vz2862dO+5OYjYu0wncxnxObfc9qjHKqsxxvvV2KP3iAMNiNx3qG8gWOJsY361l6isq5WMK+RMm1hwS5zjOcelIessSG696dNWckkjY0j6u5y2DkV1OimBrSMRWudpPLtXCb9OvSurn5+tcIcdP51siY7HykqEj4e3lVqLruc1VXJPT/AMatwDfGc1cQD9JehBBzsM0Stx0ND4BuBjftRO0GdiNxRF64mbeeYUtAFAJotAxY8pIOOgoXb5UYzjuMURtW5mG/oak++ZrZ6w7pyHmGd803acucDPXelawX5T16bHypu0tchQRkdqTvyRBUHNsZNKT5VYD+tMlunJHjyzQTS0w6nl2zjyo65Kx4x18q569eTO57MUFeJUmfLffpmomwVORjFSSDJ6CozkHAxvSjIB0nT6dATIiD1BwfKrNuCe2agTJO4zVmE8m+NzVSuRNEV4loPhCSKg5uYYz+lcTylF5cmoEkHN9aH3cKFn11+PfO9TRxjIONqgLEPnHpU0MnMME+vSrbfGWCkwhbqAM1DeSgNgnGBUsLYUdT22qjeSFmJ5sAHy71UJC7eJy79/SoGYMxVSfPavwbKYJzg1yNm5jTCriSExyZdtwOYDO+M1PeyfAF2O3WoLbPKCSAB51xcy+JmNWHlUbfOW2cSm0vNzIdwdvtV25mGsW7XTEnULRA0573EQ25/wDOvRvMYPUGh0nw74696ktZJLe5juLZuWSNuZSdx9/Q9CPWiDA6yoTxEntV58NnPepruIsiqBnOOlFbPRXmYXFpCRBOOeNf4PNPsf0xRyz4UeQpJOuB6ilrtVXpxljChN3SIw01pDyhDg9NqM2OmrYKlzIvTp6+tF9YS007lgiALnY4obqdw6QxRnfG7bdK53U9pNrCVH5RG00/cgHxMF6hBI17I6sGy22OlFdLtjEi8x+o9aGQy+NI0gA5c77d6N2BU4Oc0jnJjRUhcQ7awZGARnG9Xo9MeYAs5UDpgdap2sjKPhHQZwKuw3UnKPGmVQ3YHemksUeESZW8JJHoOl5zLeuWzkgb0Qg0jRAOVpCceZHWhUl+wk8C3Gw/ExNfHv7yCETOyRN+At/9X08qartA8JQ12NxujGtjYWQUCLHfdtxXwX9tBkQHwuX+FAT+ppTW6iuGAk1aSZz2QttXydbOEE++uDtkCQ4x61J1JPTiGTR4/OST8IwXetw+IA91cTt3B+DFdwamjLzx6c+R3b4qXYNR0sOI7efxZQewL4oxBc6jMR4EaNt0xiiV8nJP3l2rC8Y+0P6fq1zdTLC0EIXyA3py06MCKTBIylKfDdpeSv4l1Zxqc+VPOmQpzMj4GVO1Er3nULzEdYUFZCzzX7TrNrjiG+LHm5HyoP0pL4Zg8DXGilziVenatj9pOmwx8QTtGn96oYn9KzG8tJ7K7S7SIt4L52/hrXU5sek+M5BjtAYeEV/a5EkdtDZqoyzj+flRjTOGhd+z57LABmtz26HGaX+M9Qh4m1yzitFVlVsMQ2cGtb0rTxFpMNqVwPC5Dj6VmXK1RCjqDmHzlj8pnvsdupdW4IjgmlV5NMnktWx1AViB/Kse/thQG3veEZlgkB8O8Afmypw0Z5ceY659cVrvsbsk0viTjDh0y/u470zwqxHNhxnp9c1nn9q/Tje8eeznTBA6G8nMAmJyp57mNSvL6Zz961b0C9rLcOjDd81zEqW/+12nw4+Rx9poHsLvI9V9kHDRjbLWMc9i8fXw2WUyde+fF5vQkjtTyLb/AA0j/wBmnSBp3Ams8O3EExvND1ya0upHmBRbjncOiJj5eVEbOdy5rVvcQegrK/yCrZrncdGCsP1AP8wumf8A17fLP7zMvafoc+o8LXkcF89u5jK7bDGK8p+zrROJrDjOK+sOd1hl/vBkd/MV6r9vuppoPBNzMTglCo3wcnbalv8As76faXmiQvfWY8WRTICy9ab7Guup0drg9OkrcRwSPGahZC7uLG3kvSTN4YByc1I9pncr0ox7n2xj7V8a18hXIXXtY5c9TCBtowPCA3tM9qC8TTiy09z0+HPlmnI2u/y9KW+L7CC5sWgkXd1Ir1DlrQsh7Mjmea9Y4kmbXPd1kxzPsc1rvBGmI1oLllHORnNZ6PZ4bjiAyiInfIIHbNbLwjojWNoImJwg2Ga6ztrUCvTpXnwg6hgjE/TWmMgLVKa1O4VcUzz2g8qpS2xJ6etcmt2Y+rxaktSTjGfoKhktyFJHnk5o9La/4elVpbbmUjB37UZbscwytmcWhjeJC+xI2qxJCGtZAuebl2+1CreQxzrA+dtt/LNW9X1GOyZeQ7NtnPbvXYaewaikDzidrd0czPNdlkeVowNwcfehVtZvz+O/Y0yX1tDfXLXEPQsc4rmHS/HvIrWHBXP6Uu9RoXa3WO13bukv6Pp7Lb+Jy9atSROOwyM5o5HppihSLGCBuAKil0+QjoMGk2rYnkQvexbkDqd+g3rhHIYAg47UZm0l2PynJ/SoxocrEZB/LrXhUc5xPG4dTP1u4IB8x1FW13OM9Tv9a7i0eRACWNWhpbA/1zUip5XvB4GUpE5uV8Daq2q2JeJZ0PT0o7HprsMEZI2ruXTWktTGynan9ICvsmLWnPSVOHmWaEISMDapdXteVWUDfG1UtMjaxuREWIGds+VMF3bG6hUrjPQkd6ZtoNg3eUEtm04nnHVJOYtlsUm6sd29KZtRlyWJ6DO1K+oDnDZ61r6QbRMnVcxbuB8RJ89qhB3/AJVPefCarg43FaucTKYZ4llBkbAVag67Ej61UhOTjH0q1CQrVfHHEBZxCMAAG2+KJ2gAfr12NC7c9OmKKW+AOYfzoq4mVfCanYDbIPaiNl8w2xn1oXCxJGeporZAB68c4iLrxmNGlrnHTfrTZpiZHKNx2pV0obj4fKm/Sxhthn7UrbFaD/sjXpyZRSO2OlFJWypGKG6eQFwRtjcgdNqsGYEelYWoXJ4nedlvgTmTKk7feo3I5+uxrovnO+49apySkdT09aVwek7LSL5S3Ge/c1cUARgnf+lDIpAxI89queKFj5SwyPzr22aeyR3L5IwetVg4ICnz339ailmJzk53qLxR3/8AGvbMDMlU5l9mBAOd67hbBx64qkkxIwTnOwqS3m+ME4wO9e2QoQCGixEZwRiqLtzBt96/PcgRkDoexqt4wwd8kdKptMttwJ1GxViu24r8rAnHc7586rSTcrHfoa68Yk82TjtV9vjLAZhGNk8Pr8386rzZU8/3r48nLBzk+g2r5AWI+LcE7VU8CWInc1nLJFzKM8u236V3ptnLNIv7skZANMOgWfiusT45XHemvT+GYLfmm5Ad81hW9rCljWYYUcZEKcOR2EGnqkgUNjmAx3xQXiLiNLOJxCQNjjBr9qSXEEReAleXoR2pYuonvrwwunOsyk48vP8AWucvvfUtGKqlT2j0kNs8uo3bXswPhgfDv1NR3QErSu2d9sE+VTypJZJHaQ746jvVC8lC/AWwTgEHsTualf8AWuwSwHevuH6SFIhGEhTZc8xOdzR+0Aj2UdBjNA7H95OAw9Bmjkau8ykHbOOUV4+1xDWDHWE7cN8xY7j1rv8A6ZkfPy5+HB/pUMXheMAjZJ2I3o1bJC7KqLyMBnmPRQOpNFTYDiKN7PM5gt5FUytA8ijblJzzHy9B51ZTSfHk94urRA79idhUg1OEsEV15FXCDfJ/413Hdyq/7kIpPYg5pkWJ+VYIbx7Um/YzmLl5Uiz05RvUD6BpSkRzQC4kPzF/9O9Q397cqfhueUgdW6Chja00ALS6xliegP8ApR6+T0ngLD0MZrdNE0oYtLeBcDcFQN6rXWvSxuIbRFRGO5RcCgMutPcKGWXlHZipJNT2CatcyK3iYh/xjc0wbMcAy6afHtWfWPvDlxM6B5JSc05aShnnxv0pP0WIwooC4OKa9BuWF0fICraNWbUKW6RDWsvdtsiL7TtLMeoCXlG6gVjvtAtr1dFnlsWKOIzgg9TW3e0q9ae9Eajt5Vnuq20b2Eolj5hjoac11wq1BZPCcinPBnmf2KarJqnEdzp93FiWGb94WODnO21epY7cKqrjsK8vW9uNB9rTSWcfhC7+ZV6H1/OvUmkye+WME3cqBTfaTi9UuAxkCBoygKE9DEXRuGI9M9sF1f8AIqrrFkOXBwGeMnOfXDfoay7+0fZtP7bPZRp0UCLO98v7wyZwBcxnBT7Eg98+lb5xbo3iwW2swc63WlzLPGydSB1U+hGaxb2op+2v7W/s1to0WRbax98YqnxD52yx7jYY+9Oov4rS16odawVb4YOD9cQAPdu9X/Y5H6/2DD3C0R4U/tL8UcIW2fcuLdMbiJYmfA94wqtyD8R5kc/Q1sS2w7gVjP8AaU00aBxP7O/ajbWc5k0zV/2ZeTQk5S2k/eLnywyPg/4sVu6JFOq3EDh45AJEYbBlIyD+RpDXV9/pKL/EZQ/pyPofpC1ttdl/X7faebf7ULHUH0jhSJyGv7gAjGfhUZNNPs04bk4cn0yydQSLRVIHmd6BavZ/7cf2jINMliZrbRrPnbfKh3P+grR71jpvEtt4agqX5FGOnaq6FtgFR6HJk3r088Z+caWtAN+X0qI2vp1o0Yeb4sbsM1E0GO1c5ZpwpIkE5gdrTbYYzWfe0C+WwRgc5xgGtTkhCoSR0FefPbTrxtrtbZXySRt51bSaYG9cSp6gQ9wPbWupO1w8XxDYU8izjgXCKMUp+yqJm0mKV48FxzfnT/NBgbVPbTFnA8pCfmOYDmgHkKoSwjfpR2eAZORQ+aAntWGMiNI/EDTRA9qqyRddu9FZovixVZ4c52oy5jKNF3V9O54TPEeV13GO9IHE2rXksPhgt4kOds9R3rVdUVVtSDsSKyfXLSVryQINySB3Fdb2G2TtbpK2DcJBoOtwzWEr3Lcsw/CO9O3AOlSSRPqE6ks5yM4z6Vm2kaLdRXrtI/OC3NgjYVsnBkEnunMdlG2K0dc4aziVqJXiFWt/TcdxUZtu53JogU3yAa6EWT0260uo84wxg4WIbqv1rpdPUYJWisUOeoqc24Izy/8AGibYPd4QP7oOnLXSWh5sY2ombfG+KlSAeVeAzJzKcFkDg4BqSWzCLnl26HFEoIcYBFWHgDoVOMGj1Lg8SjGZdxPG9ldpLE5UHbFFeGtUS8cRzONuufSpOKbNTIYmTOO6n9azuLXJNP1VUAI3I61rphELRYjLYEx/UXIkb1/Sl+5fBbINH9at5YZd0JDfIw3DfSly+OAw3BHap0rBolqkPWAr44cj171VVqtTxNPkxnLA7L5/SqGSjEMCCD0NaQIJxM3HEuwNv3q9Cc9KGRtuKvQSZIJ29KIDFrBCdscY3x5bURhk6b9aEwyAEHfrV2KTcbmiiZtq5hm1YDb9KN2WSRjIx1pdt3zj02o9YNkjvVjzELRgRs0lgCMjypz01sqDjIA/OknSmAKj7dacdMfCjJyAM7UtcQBE9PnfgRmS4CKoAz2+1SeNzJkYHcY/lQkXIz5jOD6CpDeKYzliO+3esm1QZ2fZrHcJca65R82POqU1yBLjzqpPeYBPNuOvrVGa9DYIxkHzpXbg5nf6H2hD9rOMbE58qnkugq7Z3FAIL0cuM9a6mv8AsG6V4rnpNULiXpJyD12IPrURn3xkdaGy3oK8wbpUPvw2+LrUqPCQRg5hqK5AIyasx3A5jv13pcF4OYNk1cju8quGOTtVNuDCgZGYWmvd+XNQ++Z7/rVa4s7xEE/hsUJxnFTafp11eXkcCxn46g4HJkbhJHkZyuBjJxVmNZCoXB22p20/2W3V3GJCSF7UXi4AFtMhmUHkOD6ik7NZUnAMkHPSJdhpFzfQhVRsEYO3eimm6DdLGY7iA/CcAkVplnpunWMKqI02HlVPU54GDpbKvNjIx1rH1fagGVEMiM55i3bwHT41k7xnP2oonE6JFzMwKEbgVFJau9ms8wPI5KNt0oENDZ1aGIsyK2x7b1yGotNrkmaddakYMn1/itYbVxGuQwyD50P4Cvf2ktxfsd0kYLt8uR0rq54Wee28N2YI3wk826kGiXDWippdvc2gULIfjyBgMRvn71fTWqpyZ7UKndFVgybM+pPLgnqdq5n04Nes0ikocOc+YFFWshDfMpPwyAMp+tdmBZ0SRQTjZjjPoatZd1Mog24xA/uKwyGdF+UZq/BMqhSyYx8Rx22q+NPRxylt2AxtXEFgFguGYb8+PtQ1sLHAlywI5kVrcLGDPMQibkE9ftVy81ePTbfNwMtKgllBGCq9VT69z9vKuY9N8SSOaZMx26h+XszE/Cv3O59AarXejvqUgeXLeI/xlvxep+9OVlKwCep/aAbDtg9BObfXjKVkFqADsuTnbzqHVuJri2QrZlpJmBARRgk0Yi0UpMfDhVEUbd67sNAtRM91LF4jnp6CjLaCBiSDWDkiZ9PHxlrUijwpYUc7Bjgfl1o/pfCElqqtd3w8TYEH4m/0FODWwVliiiVR1P8ApXQ08FSQFWRzjIHSjCzAlm1RI2qMCV7O3tLdVxb/AC7c7/z3o/aiE8ojwSe9ApLKN5OQtIxXfbYZonZA2/72X4UHQUzRaMe1FLRu6GPGjWpkQDB3ohGW0u7VQuz0M4W1VZZVGAFz0NOV7pKahEk8IGV3rWGLqc1fmEyW/wBduLehmc8cAy3McvL82RmkjXR4emSnzUitR4x0xxahmT4k3rNOIrHUJrApa2M8nMcZEZC/mdv1rMvZ3fBHJmDqqhVacdJiF9w6t7xLa6kFOY+ZeYfpW0cEuz2LQFs+G21AeH+F5JvGNzNZxsvxqHuo2YfZCx/Sj/C0NnYam9q2qI3Pn4I4JCPzYKK0q99qPUfDkTPJAKnznz2oW+uSezziBOGw37SNhN7vynB5+U4wfOvGP9mD2i3L+2m21z2g6hfalINPfTbdnjM00bEjlVd9uhHev6CvbadJC0MhuZA4KkciKMH7mvInE3s99l/sX/tD8HXuhWOrgapcSySwvfp4UTu3LzAGMsRl+nMMVo9g3qLW0tg3B/DzIB4MBqvy94DjH8zZf7RujjXPY1q00d01uLB7fUSxyC0ccg51OPNGYU4cN3MY4G0y9WN4QunRnklzlCFxg59AKM8TaRba7w7qejPbB47y0kh5HPNzEqcfrisbteP30n+zjqfF99qbTz2qXCP48PK0cw28PlG+zDFRQDf2bdWvVGVsfHKn7SzD/avv4+eMfeA/7NH/AO1HHPG/G8igrLqD20JB5lKR/CCDWgcbxG21WKdPhKSg/bIoP/ZM4Vn4e9klhdXkbR3GqFruUFcYLkt/Wm32iWoP70r5EEVnhtt6hfA4h3bfaT+ny4jVaL4tnFIDnKCvrx4qDhiZbjRbdxk4QA/XFEXjxk4pXVJi1h74uDxgwNqmILKRzt8JryP7VWm1Xi+G3jJKGQD9a9U8a3gs9KlyRuK89z6E1/xTb3TKWUuG6VOjISzeZI49qavwDpos9LtYeXGIx/Km6aHPf9KGcOQhBHGOiqB0phmh26fpS2tr7w5lRgGApoe2CcelUJ4d8Y3o/NB12qjPb1lmj3QyGL88J7CqjR8p5umKNTw5oZqIEMBJ22q1enJbEZVjiKWv3ZDMiHpttSvd6eTaSalykFNxmmK8i95m5e5O9fNRtDcJDo8KgtL83pmt2snSoGHWFBgTg7Qxq1nPezqQxJK+op24YRYUe1KjmXPfc11p+lrolsloi4Veu1fHAsb9ZwSI5NjWtt3AN5wY4OYSdOUkEb19jCnscGrDxrKiyrg5G9QiMrsB/wCFCA28RjORJogPLIqyoDDONxVaPIqwpIO3eiAEyhnfhKdwK6VB1xUibjzrrkq209ZGZ9RcYOa6lYFGy3KMZrgsEU5oZqd/4UBVSMtsKMkqeYA1cLJLJ8WVGSP9KyPVLKefiDmjTmAc/DjrWu6lEP2dlY/3jmqWi8M293LHeSRYZOp9aaRifYlWwvMZ5f7JvBs5kl0TjF4pX3Mc37yMHywd6z/i3+xNxtePI2jXWmX0J3jnt5OSVR5FG2cffNaTot3qF7HjSuI1laMASc0R/dnzL/KcUy6PrPFdjOrRcQwTxLuTE2ACPPO35Vy636mpw6FvoZv2aaplKOB+08FccewT2ocAXjR8TcL30NozELdxwtJEy9jzLnl+hxSLd6ddRTNY6lAyTKAY58bMD0z6etf1lt/aNcS2pi1nTY7hVGGeIBlcHzG9BNY9nvsS9omnNpuqcM2duznP7pBE6Me4I3Faa9vXIwFoB+HB9efgZlN2LSQdhI+PI+H8eIn8pjHLBKUmjKlTircZ5GAHfcV7t4u/sC6Tq0Er8H8VKGIJhiugCV8l5h1Hr1rzbxn/AGePab7NnmsuKeErySyRyEvLdPFjx55XpW1pu29PcOfZPkePl4fpMPV9i3Vk7eR5j7/zMwjc8obtVyFiMHcA9PWrA4du4WMUscoRt45CuBnyPka5hhMMgs7xSEc5jkx8prYXUI59k5mDdpLU/MMS7av03o9YyDbG3nS3GktvKYZRhlOCKPWOTF8IJKbnHlRwwxmZF1ZBIIjfpUu4GfvTRZ3XINzvSXpUh/TvTDbTM+FRSSfLzoNx4iFSHvOIwG9BHMew8+9cG9PKW5z8Q3yKEh5QpXJx2zULzyRZL5286zHIHSdj2bWcgmEmundiBnGMGqkkkqsVfof5VxDdPaSpcSLmFjyt5AUYvtFuzaS3EY5lgAdCN+ZDWdbqFQjPjPoHZ1bbc4gmK+OOvTauJNQbrkYPrVO5SazJlYE28+CG8j5VWWGWVZYhklPjXA6iih1IzNF2OYSN4dirfCRneohdHmAznPSrNjoNxNbxScpbnk5QB6im7h/2UapfTLJMpVFfI+lDbUInJM91islpfSoJYoXKnqcdKa+EeFNQ1uZR4RCA55sVtOkezbT49KSOSNedRg+tSm303hi3ZYI1Vxkbbb1mWdqqFO3rCqGPAhDSeDdJbSktruFT8GDkDrX5eEtG0qX3mNEGO9AtP4lvrx2VX5R1A9KnvtUnmiZJHPKFxnyrCs1thzgw6acDho6Wmo24iCxBSPSqepvM3xBSQw2YDvSfoOrtAJLeSQuVwR51BqnHv7OcpcHAU5ANKPZk8mFWls4UQvrBv7XTpL3flAyMVnNlxi/7VQysQnPgnPStPj1my1zQ2liIdJkJGCMA46V5z4xmXTtWeOGRovjJBI2A7g0EqHOBGtKN+VcT0Kyz31k0NtIgjlXxEPqKH2N09tcJzJyt8vKejeY/Kkng/jqMWFsktwcxAdNyp8/pTpa3mj67MpS8ASfBABwx37HsQaWNO45lCWqyrDiS6hqIs52tW5HiY8yt0OD/AKVVubwRvHNDk4XLY7r3qG88drhdMuYkuJbaRvCnG3Ov8J+o2+tcFUiRL22fxbWQFCCcmNx8ynyOKVarDErCLtxzJo7lJ5YkcklGwrf4e35VYtZo4U8HAzHkP+dVbe2S3vBZqGkjuAZreQdAuMMp/nUsEJllWGMKGMbCVenMuKqynPM8ADwJdvSsFzAUf4XwR32rgXSKjkZyXIwe1C724mjt1ifIe0AIPmudjVzh1YrjUJLib4olBuGyNsAZx9zgfevKpztXxk93tQs3hDFyViW3tiBzR/FMP8bD+gwPzr7Gojt4uX4SxJ6UMs2upL24tbv4peZmJPc5z/Wr6FmXLZ5o3AIz2NestJOR08PhBirZxCEMGYZCZOZj69akizGzKAAQN6+oEjQxq2DtgVWCymeVycJkYPnV1sKYMHszmXGtoXlMznZVyNuhr7M0dpEJuX59l+tfI1Dx85z8W2Ks+AvhI0+AEY4JO2f60yljMcQLDHWVbuQwonhj94wy2RuKozzMLY3U3MFXfHQD6k7D70WaLxQUCczO3MWkGwHbb/Wkfj6aeWHklnPhp8KIOhNOoQq88mWoU2OF6Rr0LiC2xzR3KkjtH8Q/Pp+Wa0zhfiwyFbYkkeprz/wjb3PhB2Y8qgH6mtd4MtwZFlentG9otBTiT2jTSqnPM07XLOO+0xpYzhgvUda86e0GN438GZmc5Pzkt/OvREt2I9NYBtuWsK9olg9zMZ1XON/tmne1XRbUHj1nHvp3srNg8IG4FtQI3fHwnbFVtSP7J1qOXpl+XNHuELcRWOemaq8bWIaMXAXcYIPqKS0l+zUgnoeJj3DC/DmN9qwmhjlXcMOteRf7a2o/sTjbgjVoIwksEkrmTGxClGwfyr1ZwvcePpEJJBZRg151/tb8KjjLjDgbh25/dQXtzcQideqOYvh+xx+lPaCz8J2kjH/iSfkDB24dCp6HH1InovgzXbfifhbSuIrZlMd/axzgg7bivEHt5460iC/4g9lnCPEUl9b61xMs1zDETyxl2XxYsnY/Ge30869L/wBnLXNQi0jUPZpqsAM/Bvh2LSr0cb4/MYP3rx3/AGlOBL72c+3a/wBb0jQL2w0u7uYtRtLhoi8JmY5cq3yj48/CfOt/TIml7RspB9mweyf/AOWIYfSUpYugc5JXB/UcH6z+iXDmifsDh3S9JEPhC3tI0CZBxt6fSgfHdsHtSxHVapew3WdW4k9mukcQa1qHvd1exF3bwgnLv0AFHOMbbx7HA7gj9KxL0SjVMlZJUHgnrPVlsAv1kHAziTRUTO6HBpgZRj7UpezxitnNas393IevXem+Y8sTH0qNWM2kyTwSJmPtLvGIS1XfnYAigFjogSSK68MYwDVvjCZrrX44VOQGNMx08Q6TG4XfApcAqVAl24RR5z5w9/eqMYHemmSLIz2pX0MkTr23pxKfAPPFFuTPWUPWCpoObOKoywgdh6Uaki36VTmjFLGjxll4gGeEk9KVuIJgMRggYp1vVEUbufKs/wBYfxZWyTk7UzRQB7RjNfMGW0Y/eTOM8gzRLhfTDc3kmqzIMZ+EYqCO2Myx2sWeZj8QFOVlZJZ2qQoMADf61babXz4CF8YO1e3HJ4ijGetBpk8W3ZCAWTemq8jEkJBpaZeSUhj12rVoG5dplj0zJ9JufGg5HAyNqulATjY+VA7OT3S+aPm+Fv1pgTJAPn0xUsvMushVOVgSOtTLjrXYjHavqrirAT0ljHapcDuKjQDrX2WVY0ZyelTgESMSjfThW5Ac49aWbu694vggA5U361f1K75Y5JCT0OKXoZmZi2N2NeU7RmSFOIcs4jfyFQvwrt9aZNOsVs42hIG+/SqXDdkEVWZfvR67jCqHQAYo1Jx7Uo3PEy7k4lvrWO81LV9QhtmXnAnkEcS+QCjGT6D86JQ6m8UHPbTC7jtwFkmlZxGCRsoHc/SkloNU1O8hgv70z3MuORGfIiB/E/8ACMb4/M9q0P8AauicKSWui2nialdwKFgs7XA5Xb5priRvhQt15RkgYHpXOjTls4OJ19loQAYz7hLNhY6/Oh1O7itNLtgoZZbx2T4exCDBxTFomq6NdviTX1uvC6yWNrIFX6ux3oLfX4uljuL7SPeJGPMgNzyR+peSQZPoFFTnRbm6hjm1XiOPS7TYrEkXhod+isd2+wFebTbTgc+v0i/fixfb4+Hon9o+6frpjnHuutahN4ZyFMZO3ptTHae1FDcHTNXhS6iIAdHTfB81YVlkHDGoEBdCv9QKNuHt5ssw8yGxgfapJNL1azEaXvFNzDInwqtwnO2fLON6XdLFGFGPXvlVWlj+b+fpNE4n9lPsV9oMLe86LbWssyjEkA8Ng3ntWF8df2JJWglfhLVo723ALKkh5ZAd8FT51oCa80McUE+uK7g7GMhOfHnzUZ0zje7gm93AY4GcKTz49MZBqBfZS2aiVPu6fLpKvpQ6bXAYe8TxvqvsO4v0iF4OIdHlivLJsLJ4ZxNF6+ZHmKEabwjc2ty3iRP4LqVIx0/1r+h1jxhomsKtjrOni5yNvFiGR+dC9S9lPs4166d9PUW0xJbwyByk/etOrtjWqpGAwPlxj9PrMW7sHRWMDypHn4+un9zxVa8D3Lwq1uxLDyHWmvRvZxqs6xTQwtlfmBHzDzFenj7E7Wyw9pE0q82eZUVh+QNW4tAg0sCMW6Bl2wRyMfs2P0od3+RapF2suICn/EdGXDq2Zhl57IJbjTfeIFKyhRtik6b2bao5eCaAh91BxtntXqYT28JMEsRQjYhhg/kapy2WnPzMEXmNYw7cuGRmdMnY2nQhtv8Ac876D7Pbi4t5NL1O2wAeXmI/WnfhX2fvFay6bekvyoYeY9x2z9tq0xbXTxHI/IocDPTyqgNVtrWY4APMMnekNT2q9nU9ZpU6YIMIOkyX/wDC03SXGkSwfBztyHGB6Va0f2LNG6+8qcR8yEkfhPStctNTsbj4QqKxzv3zRi3urd7dWJViNmHnTNXalhX80iyrB5Ez+z9mujWKxL4S5Ug4x3Hejl3bDT+VbWNcbDamK505ZZR4R/vBlcn0pY1ma40ySMyk8r7fcCq2ayxvzGerrVjx1l2zmvZoU5VIG4IoZrWmQXAHjDd85zV3TOILOCOOdyApIU58zVrVoLa/5nt7hQoORvtmvCzIzIIKNg8RS/2fFtaNdWTh3Q4x6VUeBrUc9wQ6z7FemMiurtr+zWSCCZmLczcvcEDpS5FxD+0rUC5Z4yxbnB6jlONqG1pI4jaIeueJdja3F61ikgWTk5gc52AoZxbw5LqoMHMFklh/dn/EBnFU+DLa71biFr6OYMis0LAjbB+U006nLHPr9tbKrMVUSEN2YbH9aCSwbMZ4rYKsVfZ3d6joYj0i/jm8KZ2RyRnkcDJFJvtd0u6sLs6hAviJyF3B3V164+uK2u3Nrb6m9peRFJ7qPxYSy4HiJ1GD3KmqXEPBw4l4emKQ+PMjKsQGMOpBAG9XSzawsPjBhx3pPTM81WHEcOn3sU0UrG2ZeflU83hg439V7HyrXrG6057a21HTrtYbe62SQnKxynof8uds1ko4Fu+HtX5bppYLET+FNk5eykzs234cfpW0cKcDQ32n3Ol3VtHBOsbsvhsVhlznEiDouTsw6DINM6gV8MktYTjLQxw1ezalK0GoxKt1C5SU82RzKdiD59P086bbixtbqIo6yILqPMsa/AVderg9j39aA8D8MTQSiK8jeS45FhuEOztyD4ZB5OowD5jHam4QNBNGom54pUZJVx8RBPXB/nSbYycRN29rjwgXStPHNZQCUORM4jdRnn26jy6bj60VXTgXUSxcklsTGSO6EjIP0NWJtLl0i+V7Zle2uLiOZGDAeG4IVvzBGR60a1C3h1Ex36ry++RlZ/D6FlGM/XYVHdZXPlKG7DZ8ItzaD78rocAvIYQ3bI7ffriotA0JrNLq2duVr1jHEWHURjmP5sVH+7TTe2/u1vpeqWj88Uq4lQDbIx8XoRXzUYVnmtHgPNc2ZVMY2Yn4/ts2/wBKgUBck9enz/rMn8QzAKOn8f3iCH04yXFteyKqOIgsmO5XFfJ7AwS3Ky7tyiVSBTE6JdRJCiktDK+eUfDtjf8AOoWhSYFpd2kXw1AOfi7j6UFqsDiWW4nrALZeS3mRfhxjI6H61Ys1NwpXGTzkAY3NEP2eYtOY8uDDjc7DB864tLYoUeIYVoyxY9Sf9KDsK+00uXBGFkaKsPhxtgt5dQD/AFqa6ieSNU5sn5iT2HlX6GNZZssu6oWGe5qbJbAI+YYBoitn4QLDmcqqxRFsks64xSXrmkjULhuZeYJuB6mnabkRHdTkgbelURZ45GdSNuZs9803U+OTPIShyICs7A2MCxhR8WCcdqedAukgVFGB2pav8/CYk6nYAVJZXcsBLOD8IpxNYKTmRZWblmk3mpc9mIUbtSZxAkLwN44zgHrVE8R3TOIwpxnFWtXgur3TuZB8RHTuTS1upbW3hhF7NN3GnYYg7QgggYRjbNfuI4BLpzNjJSvui2c9nAYp1wwq3fRiW0ljx1U152ats+U4W1CGwYE4Au2ktJbY9Y3OR96zT+0eYrXifgDU+c+JDrsaBM9Q6MDT5wazW2tXNux2fcUg/wBqFVY8ISRriePXrUo/8O5z+lbdjZ11Tjo2PqImT/qPu+xhG6mX2ef2gtMu7WXwdO4+sua+DnEYmt0C831Ksn5U3f2h9MXU/YrxhbNbrK66XNIoZc4dF5gR6ggYod7beHbnW/ZiNX06CN9T0DwtSt3bYiNCPGUHtmLmFNvv2mcd+zf9oW4E1jrekMQA2cq8ZU79/rTvejUdm1XjlqW2H4dUP7r+khT3WoKnoTn68/Xn9Yp/2Z9RGp+xnQJPDK+DF4R32bB6jFaBrsRexbAyRv0rE/7FN5eTeyA2VxJzxWF/Lb2753ZBjOfvn863i9j8S2kXHVdq92qQuvsI8Tn58yFUqNp8IkcFyNDrNzbMcc2Djp0z/wAKcdRbwrR2yBtSVpoFpxOhIxz5Gf8An6U18TTrb6dIzH8JqdUCdre6EYZbHnModBf8TZJyA+K0nULTk0eMKOi0i8LW3vWs+MFOGfP61qN9biSyMeDstLgHefdCW/mAHhETS5PDuuUgbGnqL44lI7is+YNbX5XtzbZp70yYT2aEGnGTMhl5zOnTrVOaPfeiEgx36+VVZRt9PtUCvzlgMRZ4im8KAxrjcdKQ7hBNcAEbd6a+IrkPMyhunr3oBaW5mlJ68xxRWXasZVdq5lzQ7DMhuXXoNtqPH0PWura0EFuoA3IzX51I3JqFr28SVHjIJMbg9cdKXtTh5GblHU5FMMuTjOPOhWqQgx+Iucij1+wQ0IBniLl7GGjWdPmjxnFGdJvEuYVKsDgb0KkYJzIw2cVW0i590v2t3GzE4px1B5HjLgY6xyUA+oNSeEDv5VHAQwBHQ1aAFBXpLESIJ1xQ3VrgInhA4Jos55cnOKVdUui9yzc2y71VjiSBmB9an2WBGY+eKj0i1Mky9Sg657GqlzO1xcFubvj7UxaDbBVXPU71B5wJLDjEa9LjEMIwMHtV6TlkiK4+lVIGCoBUvinGAcdqKrQW2eftCNxaMdb1a68IMPGigT5m/hcj6/KD5Z8qZuHQxBniWLT1nJW2e4Y82D80gAHNIx8wO/zd6UWvJrSOOXkWW6kkAjjK5CbDBI7ncURskvmDzTXkhupxh7gseZVHUA9h16eprHWzHWdbbUWBM0ePUNJ4fRpLHTZNa1eVCI57whVB6EknZUB/kfLNS2Wo3KoNf1rU7QXDYEcyR83OT+GEEFuXO3MB26ilPT3V5I4p7YfEvjtzL0hUfAgU9PPJ2GR3NF7z3lreC7u+eTUNRPiJBGpZ5VGyjzCL2GwJ7Yo//wCTpM9k2nBkur683K1pHqd/c3Dnn5pZeSJM9MICWbPYsWzRHh+LUNWdLW+uLy9tV2aG4t1MLH+EeJk/UjFftH0Rbd0sFs/edbu/3kuACsIPUu3oPz7bU2xRppUDQ+9JE3LytK+OZiew8h38z9KqaT4mUa9VG1RIrCw4X0mOVJNB93WMZaS2YLHgfwh8/pjPlVrSo9FvpTJojWcTYyqy5SXPqd0J+jflQo6dpMTIrq17eTfE7TNzHHYsM4VfIbn0qeSO+jBFxf21uqL4fvDAKkKnoFTz+pz6DpS71hDkgSVsLeJhnVbzUtNjiguYbhzI2I2kVVz9D3oeOL5bW5C363QWPvHIrcp88A1U0yw0jSnlVdb1e/muVzIsuGix/wByRyAepGaFnTvZvrF46Q8NXCSxHElxZzlYlb/ui2PrgrS7ozng49ef/kZqdF/MMjzmgaZ7VGtJAy3rPbscBs7j6inbTuO9P1U+HdQQzxOm3ONjWGi1srGSaTRNH0zVRApE3upLvEuOskR+MfXlI9apQ+0L9nWQMlmi2yE5aEhuX6YO2PKlmssqO1+fjDfh0tGap6CubHR72E+5TC3Un+5l+NPsD0+2KBajwXdypJJplyqELnlZ8oT5Buq/fI9aQeFuO11SMxe/xXMIwUkQ4dPRhTCvGt1o92sJlBhlPn+dI3V0WNllxCKdRScA5ibr+ra5oE5t9Vs57Zn2+IHBHmD0I9RS1FxFdXE04UHnjAJUnqp7it0u9U0LiuzfTdRtophjKqezY6qeqk+Y28wazK84EhstRmvLHEtpGDkEYkjU9VkHl0IYbH0O1Zup0gq9pTkTU0mvRwVdcN9JX0W/uZpEkBJQkHbyP/Gmy1nMUa2zyENIpIJ7n/WlnT0W1iyMjwjyOezqTkGic94nxKzkujKyN6d/0pBMq3ELa/eHAjnZ6iXWO3ckyJGCp8waF8QeBdB45m2wqqc9GJ3oDpWqXDXQkdnYJF8OD1Aq1qNxDNcwgEuOrJnrncGnms3piJrXssirq8UsMkEMTsqSk4H+Ne1BtL46FnrLaFdy5Z+Z4+Y9x1FNut24flZWPigs8W2zPg/DWGcSySRa+mruUR7ZmPr1AOfzo2nGTjM0kAvQgibnFqNrq1uWacRtzqM4w2cbH6E5pW4usF/2hU6fFm3XTJp2UDA8bBYA4oVwxr082lrfvb4gEqWrFtzzqOcH9CPvTJqeoxnTRcxrzGZn+IDBMTrsR6Y/lTe3EzcNXZgTngJl0+9lto0xF4S8zlf+1CKSfTcmj8KWWqcRXF6luSFIh3GFVS2SM+e29VdEsHHDUVzHEA11aGdnO7cxO39fyoToV3q1teX14WKWzXy2z7Z2BU//AKx/Kl7cbiIWsGwlgYy8QQnWLqyNqvh3BiZ4ip+JW5SAd+vn9M0T4FuH1Dhy6eZD4kDbqUwykHckeYOenlS3puoyx8Ranp12ymWwuY57Zuzwsd8eex6U4cGeAmrTzwBhazSeBPGg3UqDhgO3Mo6eanzqqMScGVvTYnHh/wCzPvaNp1mJP2k1oq3aQCK4VVGXjfcEjuQdwf8AjQHhTUb+NWiiu3QQKMkdIvKQD+HpzDyJp79sOnRQ38slwHXmspTFLGpAeJCGT6kfGMfSs34YWW4nh1K1lSX3cNHeRhs+LEQdwo6nGdvI+lWOVyDHKMWUbprejwzz3aXkkTQXdsQkka5BAGDkHoVGdvQ0cnFpqFxEGURy+I3L4fTnG+QP8Xl51WW0McUd5YyRsq28c8EhY4khbA5c/iBDDB9M1LrMduosb21ByhheYt869id+/n61DK6L7UztyO2Vkz3YS1u7W5HjEj3q3YoCCYwGwR57Gr10s8E0rW3wwTyHEabgPgOGH+dT+ZpW1C9ZoWCZd4hIM8uObAww+4bP50Z07U1urGPxHPiPCjRk9CBuvTyyB9qhLsqc+vWJD04wYQVZZfdbOMYilkdWQjHKHw4PpvkYqOB1jvLm7bm+OWOUHGPhbIH2AxVqOWT3szSFQ/hSXGf4eWMnP5jNV4VnmsgA3M7QBQSuF+EfCTRt2a8+OT9P/YADDevXhJtOX3ezaRubmZWcgH8bSD4f5GuLoLcMJLZgqRkzjbAGRvvXaR5t5gCQiRgIMdXA6/r+oqCzmeOyitnTmbwPjA8z0WhH2hg8CFUYJI6y5b2wuNNELluWTDOfTtgH7V8FrJGCkoHUBfUZ6V2L4K0viPkhQBj8I6E/nsPoasRxiX4C5XIGe5yOgAqrbW6T3IlGW08G7lLH4sFVz51C8UoUMF+EjbHlRO8VpZOaJMMRynO5HqT0FfikCx+FzDPIFz/CP6UPuwekncQILCsYmdxhcgflXJ57uJp2wkS7ZzucdhVu4jGAAP3a5xnufOqFxzzYhQnlUYCjYn7dqkNt4MsBunLGCXlETqCo75OP0qqyxt8HioN9yQ25/Kroto7cgSuFAGTio7gKcGKLHl50N8sOZdMA4E7tNMgVOeSWFj/vf/8ANFrN1U/E8TL23P8ApQ5JAkYRuuKnimfwwAux6V5GCHInnBbrDLWNrcoSoHN1yKB31o9uxVl2ozYF1wWJ+lTanaieDnC4+1Os/fLk9ZznaehDLvTrMqiQ6bxAJ3PKhbGKzj+1NczrZcNeBgodZtST5DmzmtY4r0prqMtBlZF7jqKwT246zNd3XDmh3WTMNSt3Hryk5P5VvdlivtChDn/ZSeR5rOQvU1hl8CPuJ6W06CHVOH47K6XniurUwSg9CrqVI/I1mf8AZk1MTcJapwXHLLLBwnqcukQrcAeIsauygMB2yDWk6I//AOS7VRt+6FZzwJpUXD3t747tjexwftu3tdUt7dX5RIjrh25e7eKjb+vrVexHF6arTH/khYfFCD+xP6Qeo4YOPPHz9CIf9i6/iWTjzh+1ikitrDW5vBR3zygyyKFx6BRXpqReeJl7EGvMH9mKS5Pth9qMgijtoLjWbstAMKQ63Ljp9AT9TXqMYx169Ka7XYrqUZv+SIfoPnCnBd/iZmeqO2ncRQuo+EuMj9KL8camV0pPDI+MAdaEcewSQ3QvYgFMJ5s5xtSvf8QfttYYIXLmM5YfXpR7QTUth6QqjNi/CN3s9s/Ek8f8P0rQJF5kZTjcUvcFWAtNOD8uC3nTExpSlgef1kZ3MWiBxHa+BeiYDG9GuGbvmi8FjUvElgLiItjpvS9o92bS6UOx2OMGtQcrmXIyI7SD/hQ3U5xBAzedEQ/iRh17jNLPE93yp4StgnarqkuozFLUJGnlbIO5zV7RLHnlBZcBdjVFFMkoXG/b0pv0mxFva82PiYVYjc3whm8p9lTAx5VTmXBxiiEwwCapTjO5qdskSjJtkg1UnUSKVPcVamAHeqkrAeua8B5QoWK9+hiLr2BzjHagl9IySLdLuVO5zTHrcXx+KuSDsaV7hmAeBj16HP5UWtsrtMIR4x60K8W7tUYHtRlW5R9aQ+E9ReJjbucgHam6W7Crtt3qrkDme254nzUbpYIHOcZ2BpI1S85Y3YDLSHberXEmuIX8FZdgeoNLazm7m52YmMbDJpcvuMMiEDMu6fB4jhnHenLSUUKDjYUu2KDChep6YpkgYwxAdDioLY4EjGYS8YKNjXwXJHXah5usbjpVd7wHo1eD4ntmZjWmxh3tzI/xvI2SewJ6/XbFMdqxm8eeGFSFHhWwY/CWJ5edv8I6/b1pOtLlrd3kIPwghTnqx2otba015JHayStBZxNzzcm2UQE4/kKy6xmdXfk9I9WNpHHLHFGyO8zIZp5RlmA+XI7IPnIPptRlNVGp3q/7MN4HvLG1j1K6HxuE2Zo0/hG4HYk5JrM9N127vA12yvFbDcKd3k5mAA+p/QUWtpNXmuV0LTnX32+ULd3sj4W1th8yoOwxsOm+TWlW/QLMi6rByx5jlNxLNDqD8LcAxGaeXL6pq9xIBHGg/CD+I9zjbz7CiIuE0/wWjafU9TuR4dvnPKB3kbO0aAfiO52xk7UDkuNC4b09YppEED5ZFzs6ocAkdSgPRfxMeneiv+0VtpdpFJqK+G9w4a1thvLI38UgHQZ2A9O9GCRNm/6iMSRWeiWxu7y4hkupCHY7hQe22SfoPuarxC2Wb3rUJv2hdg+NHbuvLDar/GwHf6nJ9KDxrFJE1/qErOLc8wSQ8qGUndm88HYDf71+Iu9Wj+IeHbu2IreNOVnP8UjfXoKVuGOBJQZ6mMU08OpwSLqZEFqRvyyCPxT9Bv8AzoebnSdGtmFlbQ4x+EZC56fD6+dfILC3kmjt7aNXuEATqDy47k9BjrXFxFpsE8qWV0re77TT4yiN+LB/G/8Az6VnWnPQRqvAOCYB1G5WGcTuDHd/OotY8zIex5xsh+9VJtXXWnNvr+irqS4Ie7S6WDUI/wDM4Xw5evSQE+TCqOtx61xIDa6BdNbQtk+GwxHP6lx8lUV4YbSohacQTPqJxsjDCR7fKpUfF9Tk0obAgwD+nWadag4z193hDI4B4ms2Gr8BXQ1q2VQZLY/ur+3H+KHJ5wP4o2YUQTUbnV4YFmZ4bkHeNzy/F3ANB+HL+bSrxJopGuIoieRY2IngH55bH5itDfXtJ1+ILxJZtOJAAt7EFW6Q9mYn4Zh/nw3+IUjdZXZx+U/T+v1+cZzYpy3tfv8A39JFol3d6fMlteSsebLROT8w/hPrRC61u5stRhfxss2RFKCN+zKR326g7GqGowyWWni7iuV1LTIwEF/B/wBi4+UTIfihY9Pi2PZjSZrPFCrJChJKBiwb+Fx1H32rPsSxTtbg+uRLIBadw6Rtvp4LyaS50cqsiK4uLJTnmA38SEdSB+JOqjcZXoHfXklAwWHMmRlth2P1pH/2glS7W+tLqWKVg9xE6vhopB3HkQRmivv41zTzrWm26e/2Lh9StoxyrJC/zXUSdhvl0Hy7svwkhbfh94yBz69f1GgO6xu6Rs0bVJmhke0mBe0Krj6vg/bGKKWGpxT3tzdzRjEXOFGdub5SPtSpbRyaXdGXxFEV2Y+Uj+Dm+b7ZNMUcTTWkJgiCtb300d3GNudhJjP3G/rXhUSIOxlU/GEbyG5uNPRjIRIjM2V3+EdceXbesZ4u01vf7tJZhlgIWB2wxkVSc+g3+9bVBGy6K0LZjk8EgyH+AuD+YBpL4z4afU4LiaCNo7hlkklCnoUlXxB91DMPpV0/1sDC6a0DIPSZroutppPDtxYzSO80V+skak9XTmVznvkHH3FarwFFBxDptlNduzT6UP3kYOzwyF0DEHsOYf8AIrKuJeFpbfStZu1LZ0/VIYQqZI5XmjyR9sD704+zLjCLQtX0y01F43zc3GlXW3/YF2IP1GWb/drQXFuGPiYPVJ7B7rr1m3w6X4unWEMQ8P3eSISqjbsrSOjflg0maVFJbxfsu5eTmuL65ZcAEuYpSrH6jbb60+6bdyRCWGaP99bz+A6g8ueQEE/fnVvXNJ+qWFzCkN/HE5m0fULt2UdVi543O/4iXLg/5/pS11aoYlpLGbIPrr94sapqkNrxAl6shM1p0LHKmM/hPmQozj0pw4F4jtryeLVLVy1t+0v2ffoDvGZF54nXsMnOPUEd6zeLVYdR1HiDSdRKo2l3yWgfmDeIhU+Dv54518zyAUp+zPi5OFPaBfcL3ryfs/XfEsmUk+GHQq0TAnuHIAPqahNOTnzHMfsAdMePr0J6R9q+kT6joTcjMJYwwDA5ENwnXb+Fxg15p4Q1G60niiGbT7j3ZXnF1biY7RNuHjbbdQ4YH03r1bo15FxVookkl5J5gYJSY/lmj3JI7kHOR5fWvOntA4dtOHOKL23vIWghgn8YSRkN4SyYZXzjBHMrDyPQ4ySIydxHnLdnuNjVHqJ6j4I/Zep6JZywQmKNGkEESnKwAkmSAg5A5WLAeQfbbFS3PDb+5zFyrSRMwBK5JjOeU+uQv5jNZ37LOIZIdKkspbgNNbTBXxlRNgMkcuNjzbNEwO4ZFzWy2mo203isvK5JAKAY+AjIP/8As/Wn6imor2v4fxMLVK+muJWYvxRZXukIpBYN/eSbk/GV5vyK/wBKF8PazM1rZRnYh1UAnflxj+la1xdoEdwJYrmMeHcxwc2X33Rht6fBg/UViq6dPolwYGDHw5WYty4C7tJt5jlK1iais0FkPnNvR2rqUGes0/TryOWyunz8Udq5B7hSVUD/AOb9KsaPycgRsswnDbnYAAj+p/KlLRtZ8O3ukK83OqRDJ2GCCf5D86ZNBuFYSeGA3LhQR0JHzH6Z2+1ErsztHrrF7qNgaGoZ1GnvMImIKgKCfIkZ+p3P2oT4JhuppEB5G+PONmP4QPqc/qaOM0c6eFCzIMgB/Id29Nts+VUbyONpFWIgQRIVQdC52HMB/wA5p2+slBjoP38fX8xOlhk++UIUW6kWKHlysgEjDBDyDfH+VQfzo5pvOwkneRVgViObG7bfmfU0FgBmC28KFYVYcxUY8Q9eX6dc+govayNchrK1MLCIkTTfgRv4R/E36D16Vn1jJjdkml93Q8yoxifdE5TzOfP6VwljcznEkAjkbcL/AADzY9B/Or9vELZgsUhmuW+EuQGbPkB0z+WKse4TcjQ3U7xK2T4SMcsT15m6k/kPrTArJ5xF94EC3K2sOBJKz422/oP6mq72dsm8EEjyMMgYwAPOj50x7cqngooPRTscds1Hcv7qGV5IouY7nqzfQda8a/FuJIf/AK8wH+ynkXxXwue53xVN7ZhJhVZiO56UdLSzIPCDIB3cb/8AjXM2nOwAcfEwyIwcBR5n1qpQN0lhZg8wJPaiI45wXPWpIIOTDk5ANEJtG5SZGUZxgCuBDHAg5yWPYY2FUNRBhO8yOJLaSKr5dxt0Ao5EI57cgYzil+KEbyhcD1FEdPmPOBz7eVGqJU8+MBaocYgLW9OaJnfkyN+vevDv9qHjG90bjrSTFYEG0kEwkxswz0+te/8AXYGkgLAZ2zXmb2xcF6Tr/EOmLqFkknLdAjK+YrU7EsGj7RU4yCD+047tXTbFYiaH7M+Jm4m4UsNTKlTJAhwevTNBOJZLfQfb3wDxExghi1exv9I1GWZMqbeJo5QAT8r4kfB/0pl4V0y10fRoLO1QKqrjHQfSl32ypcJw7o2t2+oQ2P7F4i069nnlTnAt/E5ZUwN/iDKtB7E1y/8A12t2GFZipHufK/eYt6E1EA84z8uZjX9nnWXuP7RPH63V9G9xPq+pZeM5SbluXGVxtgDH5V668QhSQelfz5/sz8SQj233uuWUDRafqWoXPhxyOHkj8ZpJI1J2yQoAJxjNe/VlBQHm2Izmtn/KAKPw5B/44+X9S+P9rCYP/aS4sm4b4dmuoJiknyjY75P+lAfYXqcfFEMEyM0gGPEY9zVz+1SLW64VurchWbGQMZ3qj/ZY0ybTtFjhZNnIIPnRKNZW3ZWLPPiFtXYoYcGem7OFLa3SFOgFTbHrUKtgAdcV0G64NZNOoGZ4LgTi7hE0LKR2pH1aye3nMiKdvKn3OetAtfsS0TSRjtW1pbgw2k9YRYN0jia3W3NtcvyuBtmg2q3S3szujBl7b1nPtI1q80GFruGTkKHJ8xQbgr2lDV51gdmJYgHNaKoyr7Xzl1Gw8zX9E05pp+dkOAc03FQkYVewqnw9FHJYrOCOYirsox1FeXiWB3cylOPKqM4ODkiiMozmh84xkedXHuhVg+bBHr5UPnzuBtRGcHfAxQ6frv2qjcQywXqUYmhYYGRuKTNS5owXIzy7Hzp2n64pW1a3Hisrr8D/AMqEH2nMMBniDbG5aGaOdCQO4zTHf62ItPMiNlsY60nSXJ04vHMMjfYmgDcRyvctDLLyxdOufoKl0LjaJAIDZMJXeoPNOZHYkE7CvsGoYYIPrQ1pYpctE4znYVNYxSPKB0JPSk2zWOesb4fpHHR7x2Ic5wPOjTalkEdqBWi+DCB026VK829Lm4sZPdiEJL/IOM/Sq/vhzs1UzN1PN6Vwzb9T+dWFh8ZYIJml6HQMowM7n0/0qhLqEtlYSxRgFpCVyT1HUk/kBiiF2/ibqBj1O1B7myWZgoHMcjrVkXibrcdYZ0i4unsrJrmXL3EpaKJTnJTpnyUbk+Zpms9ctrCe6e4uOTxY8OkRy7E9Sx7bDAA7nJpBGsvah0sVbMMDQRN36b8o7DJr9w9Z3Wr2/wCzI5PChV+WWZmwCDvIxbsNsff1ppAQciJWrnrH/hjVLrWb9uINRtB4VqBMEbdQi/3Nug6LuQzHr96btCsbvWtUk4gvGklZHPNIEGWONxFnZRnbm3+vahemW1pHYrKyk2iFUgjI5TOF+Y47A+Z7Udn4hgs9NFzfpFbRk4jgXbKjpkeQ8sfXyoxOFmbYdxwsN3N5DDNbclvBPKmWgtw2Yk2+Yt3x3b8qmiuIZue61HUiyuSXmzyoAPwRDoF9eprNjr1rqniXsa3TQBsLGr8glx5t2X6da4stJ17ibUop9euJI9MQg21jDnkOO7HuB19aSsPOWhFqA6Rxl12TXZJtJ0KcWemWxze3MWQWH/ow/c464zVWe8W/YafdaeP2TCo8OHcSPjoxI6D0P3qXVNRl0GyTTdH0t3QkAER/FKx/EcfKKgZLq4tjFc26XMsg5mjcGM/Zh09M1m2WA/ljtaY6w4hDoW0zUII4UQh0fAOfIMOw8qpxwWk0RgfxGkHx+IN1/wCH6UmapEZJImW31DRUhOFWRS8TeeOXf7nrRWDiS5lsoktHhvnjXlSWJwGI9RsdvKs+4blyPX6xqtCDxGH9m2ZtluzGlyYSHEikJIp77jcj60NvtQ/cM0dzkRnl+o8jQ8cSiPEyoEbdZlPQHG4INAZNajjll2ISRSJEYE4XOxHnWeUZjH61J6w1qHF2saHeQ6voV9LbSleUSRH5k7qykEOvYqwIIO4r9cPw77Q4RHbXVjwxrwQmSCRvC0u8JPLzRuc+5yZIOGzCfOOlOTU42aTTZkR5BIHR1YfGNunrjp51d022jtuKrSF51a2vbUrG+AVaQggAjybOCKe057te7cZHl/HkfRBlrUAXvF4bz/nzHoQZZaRxHpmo6nomraTeWuq6Q7NcWcyFXCnZwR5EbgjIIIIzT5oml/s7SLW+0u6zLPZyR212rcrRzRMXjJPZsEKR0I9CRTvwld2upXiaDxPZteQ2lqptpCQbyyt5DyNHGxOZIg43hY4GQUKnrUThbUOFhPpeout1pkkrvZalEQ0MinZZPMMhblkQgMAQSOhJbaOO8Tp+x9/2PT9gk2t3nu34P7/D+P36yfVra11vRdI1ywgjgEMlsb+zUY93S4Xcrj8HMSMdiCPLPxrvNsJy/JLGIWZSNzIrgM2MbEBv61Q4R1aexsrmzSIXF3o6PJJZPu1zZO+Hh9QCMqeoOAO1fOLfedG0Ky4ztdQOpabO6KzMFDXESPhHfHSTw28KQd2UN0NBdQx3LK1khhWf0/iFNV1OKydZgpaC2nkt5+boGDjl+xB/MGmaDQV1WBtTsHDtLlvDByHdQQyEdiw29ayPiPXJdOn1xXInilaOdMr/AHiqQGYY/wABQ7+daN7NeIRLPfWsBIhE5urblbIeKRQxI/xKxbbuCfKgVIGYBvGGuDLVvWI3E+kfsvhi8miVzBcraygv2y0a5b1BjA37k1ieja9fadxqIAiNKbhfDEzYV5lIZASegYqyZ/8AWGvYWt8N22r6dqfDaIhHhvLbqGxk8rGSPfqFkAcD1PlXl72xcET6de32sWVsqfs42886hDiTnRWIB7hUD5HoaZ067G2P0MYo1S3IR4/aek+BNX/bdvcRT8iXd1bzQj3gFXSSF+X4h1BCRrzd+9EeLkS54WuHtmW3l3Lj8Xhycjnf+IAj+fasT9gPGrawtrHfSZ1PTrpbV3Y5FyifAjsTvzNA4ic9ysRPU1s+vanYPpIkeEhZGiQgDm5GEhDEn/Izr/uCq6n2GIJ9dYilZWwYExTTITo/th440jU4FOnzyxqwOByYkDxTqe2wbBH8JHekviXSpdM1sahqUNx4Mmqm3IjUc8HOhZWX1JUEdjgjO9alb6fd617R+I7S6iEAg0OMDIyvNFciRAT9JJBk91pM173q+tJuDtQv8ara3i20My/LMvM6RlsbbeLGc9jv3q1bAsG9w+U0MnBHjNW9mnE95pbiK9kBE0sQuCjEBZ3HLHLjO6yE8pPYsme9W/anptjqWlz6lDGZLg2CSwsYx8aJIpMbj+IczDHXrWbcGadccR6DFeeK1tcJG1lfxOSTHHKDyORtkR3CcrZ7MKZI+Kr65s7rQdVldrlYGjjlU5OWVHXcfxBW3z8wNBtQAYHUQVQIu3qfjBvs64hfS9YW0u5CLSaFRFK5+J4ZYwU+L0KsP9zzr0xDIGht7iORlZoIbecA55JVPw7+vLjNeW9CjhvbzSLS9xbSFfc+byRmaW2f7N46Z/8AVnzrefZ3r3vNrELxy8c9uIGRtsSodjnsfhP3zQabCLCh8ekt2pUHAtTqOvr9M/KaneWA1SztrjlC+BEWcKOq55wfsQRj1rLuKNEElyPDOIpHdPl6qAg279OYema1jTJVit4AZvEQwgkdjGc7/wDPnQTWdJhvbOWFi6+Gyw8yjDMAQWH3Cr+dP6vTC9Qw6zF0epND+6efra9lja8hUYMUoiGT1IbDYPptTVol/gpp8bEeGAZmBznvy59e/oD50sa1BLZOUEPL4qNcMcYwvOWOPopX7sPKqOh67MJxEox4j5cnuSd8nsvTP0xXPVsVbM662oW1kibfYSeJComdAjKC2/bGcH/Sh+qXi+CZfE5U5CzyfiK9gPr5j7ZNCtG1GHU0cMS9rC4Vw55fHcjYHG+OmQOwxRTULc3koRecxxDmVgBjYfMB5noPTfyrZLm2rCznwnd2+1A1jfvq9w9pAZYYwP3zBsMN/lH8P8xsOvR204IkMccCxwxrhAY+uPJewPm25oXpuixaVbgO/L4jhyEGGYbnGT5+f1+tXXuwMhFSNEHKCSR9RnGw69PX1oVWnaoZfrLXXrYcJ0hmE2tqhEcI8iQdwfJew+u/3qz74tovNFbxRMRkkuXc/bv9TtSuvEMUJPJIkZycSEgBRjr5/wBaoXXF1tbkhcRo7D95IR4sxxtgHoPU4owdUHXEX7p3OAI3SyXd6zNNeS+G2yoh3P2XA/WqrR2sKk80a5B+IuOY/TG9LJ4jaWIMk8SxONuQkgnuS34v5VXl18DZLscx+bK5P3NK23pnnkxmvTWHgRkE7wuGihbl7F/h++9ULni/T7Cc2sVwtxcE/GwIwn3rOOJeJdZnR7eyui0b7cwwMD+ZpStLHWbg8lnbu7OCWc/KPXP9aWXUEnCTSr7OG3dacT0Pa8Q6TPH4HvEUkjDMhD5xXy6FuwD2wUY8z0HrWI6bPqGjOIoy7uT8UrfiPmB2Ap/0nUH1BPCV9+UZGepp8WbxgiKW6XuuVPEYvf1lLKm5GxIqzarJs4OKDwYthgBVx+tEbfUoyPDBqfjAEY6QlPdGSExk7gYrEva5HJY3VlqBU8qXEefoTj+ta2Zcy4zisn/tF+NBwnLdwZ5oWVy3kAQaa0Q3aqtj4H9+Jjdq6fvKWx5Rj06TmtIXzkFcih/HmnjV+Cdcsz4fOLGW4iZ1yqSwjxUYjfIDICRjcVDwbqMepcM6feggmSJSd/QUD9s/CnEnG3s81LSOEuKb/RNSiR7qJ7PPNdhI3zbNghgHzjY9cZyM1g7Rpu0wlrFAr9fLB6/pOXVdwBE8kf2drGNtNvuK7Ys82l8S6WJmRSVEEkU2AGwB85J89hXvmXUEh0v3nOAE/pX80vYxqs1rqllo1zb3NlY3Vx4iyJ4kXvEq/CFdR8EgjJ3zuufM4r3vxfr8NpwjbFJMGeFOnmQM/pX0L/LdEPwddqnJ3/IFQMe/lc+HWK0EvcFI65/fP3mWe0O3u+N9QWyjyYi55/LG2BT/AOzDToNFvU0y3TCQIqgeuKrcG6MX0d9XuI/3jAsCe3YfpRTgvbiCYfQ/euSTUbtMax0BjV3tEnwHAmoq5rsOKrBq7V8jFKVW8iW2yyrb18mRZYmBAO3eow2d6g1G7W2t2cntW1pLCSJ7Exj2r8Nx60Xto03OR9DWfcAez+bR79zIpKhjgkHOM9c1tV43vkzsyhiW770waVwrbva+OIwGIz9a6OnWZ9hukIeFAMGcPX8unKlvMCFOwBpmkkWRBIhyCO1LWoWrW8jRlTkDY1Po2qEH3Scjfp60fG048JXoYVkYDbNU59tx+dW5cZqjcNt1ryNzzCLKNx3Oenehk/nRCdqHXDKcjPWvOYdYNuTjOOtCNQg8ZScHIFFrg43xQq6kABGNyMEHtSdjYjCxF4kURr43MST1Hes41S6czfujjG5ycZp84ynYZiRjlduvWs4u7ocxSQEEnYg7U7pHD9espcpHSHdG1EyhYiN870/6RbBkWYgYIzWb6DZuXEnKQvnWnaROrWwRSOYDHSl9cvBIhKCehl/nx5fSuDIT39a4O2/X0r4G23z1rKGOsd4E65j1ziuWbbANclgMjIrkvjYt1qd/lPcTPL20nsZGWRSF+nWhzzM/NGowzDAJIGBWja/paXLSKycrDIG1Zxq2g3Vs7MzNy56Cm9Oyt7LdZrFw4DzmK2hSTkWWNmKlFwTgZ6nA3Jp10mCy03SVkmnW1jIzgqFLL6jruaQbCSK2l+NSigEnB+JvTNT3Ooalq8vheGVTICgLgAfenNuIlZlziM8/tBmjLw6F8MxyDcSLzci9MLVKB9S1a6HvDy3MwACrIdz6t/CPr+VVki07TIVe4lUzHBIYgBR9uv0oxpS3epwNJa2ssdgch3RcNIPLmOFX6k0FmI5kBUHSXrexis7gvqGpQ3ksYDeEPht4j2Lnvjy6elXrvim8tLWT9ll724Y8gcKeUnyAHRR5d6Bz6jw8ka2Gsahp1rFG21pp4a8lT1cp8HMfV6YNCh4VgiS40Kwu7qaQHme5vFtPsVjDN+TikrfN+nvl0A/4jn15wfo2r8UafcSapqGoSm6YhFgLZGfUdBjypz03jqWeMjUI4Sg2Y28oV+Yeamqkd7bXi+AuicOW9yTyp71bSXZz580rsPzFUbib2iaRN41hfW9rFG6gDTbKzjGM7/LECfpmkbWRzknHwH/kMBxtx8z/AADDMvFtjqAazhuoiB8LrJjnQdid/wBaEXUcNyfB06W0llB5SGZdu4JIOR9TRGX2jce27BLnim+AQbASmIsPquMH0oZbe1Tj+11RoX4u1Oe1mO7SSLKR6FXU/wA6UapCchj8h/MPVvHskD5n+JVF9w9dlrbU7wXGpWw5ZILNgOdfIyHr9QPvUMGr+APfNM0DTUtxh5BNEblxjZ8mTIB3B2A2zRPinibjiGWK+tLrSNQfH7yG80SwlJ+7wc2/TGfvRPh/VdO1WSKW54F4caSWLMkSW1xp8gbGHQrDKEP3Q+deCVkZVvmP4zDlmrGWGfgf/BAXDfF2rTavPoMupCxMDlrWaCFEjdOoQhVyNjsRnBHrT5qzavJo0kst7FOYP+kRTSWcM/hd1kAK5Kk9cb/MOuKW34c9nfELSRabLruganbDmUJcQ3otyD2SQQuQOm0hODvTrodjqMt34Gl61pGtXfg/vNPRjY3z7fPHDPy5Y43VGdW2NXOnZ1BQ5Pu/jrFbLk3Zxj9Pv0+sFy6qlw2m8WajottbX9g6CW5tJmiilWTlAkQjKFGIGQQCGAO2KdkvPGefWeH7KS+tZybXXdDkHK8oAPLOi5OJE5tnTOVbG6jFBtM0+0trybRbiw5BOrRTabe2zQv4bfMBBJsR6DbuOlGZOHpvd4TpTRm9tEaK2mnlws8GQRH4g3V15flkGdvhYjNEqZwMj5fuMfbxi12wkD1698VOPbC44Y1Kw450l3uNMdhaXF6BySW4woAlA+U7AMp2Iwyny709tFu9Om4U1C7hSy1sme3mIPhwXXxL4mDsgO6Sr9GHSrUPHE8NzdaPr2myTJPGIry0njDeNEdirD/tB1ww3U4IJzylP4ys04cu/etOnF5wtrsvvWl3rHmFrcLgS20hHQ7ZI2O+fPA7ApXvKuniPj9vLyPHkSxSGYiuzr4Hzx9x9RFPiie799jtL6EQanpsklhcxyNygE/uzGx7AjGG6fLvuDTT7KtSk0+9s0gibxYh4FxA5IPJg8pbfPLkMh8jg0rcXr+3kSeANJquk2xju4mOHvdPUcqyAfikiACnGSUVT+E1J7I9asdbvrzhy51RrXiHTz4mj3F2AI7uIsCbR5wcAsWUxs4XDHlLENsNaTYMrzjn1/E0bXC1Yb4H15faennsNVfUraaOdnR45bKUvnMqOPEt7pG6cwVnRvPHSkD2laOur6LqFwtuLmfVLJniCjlC3Mdu6Oh9MyN552HY1qXDfi3WiPZ3EMyGLkvIIzGVe3PMTLAyn4lIwxBXcZYdhkHrWn3V43gyqJIIiJSYmHxrzN4UqN0OchW7564zR9TWe5Dr16/z9/jMTS37LsHwnj3geCTQeLUsnUpBqDYjIzzBzG8edu+cH6qtehZNels+HodY1GF5Lp7+3EsYf4XLgkOuB0cSAj6is8u+Hrey4pS+v7cGCzeO4mYZXkty8Rdx5FfGikx5Bx2NaU2gRDhC40a5m5Al1cWbTeIMwR+I0tpcg5/7NnaMjyx2UVms/wCIAZus6PU92jhh0Pr1+kJ3mgXOn8Xajf2MytDqOgu5UD42kDRsmM/h+Bz6ZPnWTcacMft28kvrCSKG5gax585Bd2hLIVbO+Ao6jfJ8q3fRLv8AaE37UvQIZQIyrSAYiWSJ4ZV8+UP4gxvuFNImpQ5n0uRraYu1uLKfChRHd2jR+HnfqfjBP8OakHuznMSptbJB68evkInTyPpmu3HFOmRCaHVLdLqWOM4DLNyiRCvmJQxHng9xTB+z4BrGm68i4TULF9OuIcgqZ4izRuPIGN8gjuopdi0/VrKDTgLUCOJZXW4cnLOk5b5f4SVY7k7SNV3TjNJDDbXMk7SWEvghBnEfIeZCGAGSYTy5z1FMBgesGysOhk0trJZXtnHdQx+DBL7t7wAQQpk8WEkf4ZRMpPTE3rTnpXENpapYX3MBbySEMvdBJMwVvXlfP5iqWp2ok0hpoJQ5gu5LVgy4LhZwoOPNlVM+rVSms4le7W2ZRHDcXEELOxCjllEykjy5AcetKXIc5xLpYLBhumefv+83XhbidZrOa1ldidPPIebtzFT+Wc0zi6SWRg5UBXMh38u/5AbVh3CWrS2uo3DNGVhvrRmyBzKORDv6bqw/KtC/a5zNMHJCx5bfIbA6/fc03VcRXk+vXEzLqAtmB4+v3zET2o6QtvF7wypGs0axc+fkVgXkBH15Bt5+lZQbi5s702sZUSyqGzn4huMDHmAyj6kmvQXFsEXEVjp2nSRK4meGSbmOByjnJG/UZUViunaLearxTfX95HurpyIx5QAytjPbGQ7fYCsm7TkW4XoZ0nZ+rXuCH8PQmlcI20kGlwQwxhiEJA5sgM2OZmP0xv5CnUBDGj27K6ZPxuOuOrH08h9aUrbUrW0i9yhnjjRmxJIT0jTAJ9M4/XHU0L1/2jaFpNtNc3GopFBEmxZgOVAepHr2HVmO2y1saZVrUD16/qYlosvfIHWNera7BAeaab9ypJPMcGVh+JvJRg7d++w3z3jP2w6PoAZb28HvIbEcK5YljjquMsx8sbCsW439vGoXMck2kNJZWskjCO6kQmViPwQp1ZsY36DGf8VZnp2m8b8c3vh2Nrf2VpdMFluDmSebJ/FIPkBzkhcepNMjSW6k56L5+J+AjIXT6IZv5byH3PhNT4s/tGCxf3O61iz0xmKs0ZBmmBA2Zo1BA+jdKFaH7TrXiK6jXSuIm1e5uHGEdOUx/wATd+XApp4P/sXWeqWkE9wJR4twiyyk5JiJ3ZQNgR6k+tZ5x77NJf7N/t7sdFmmFxpOqIngXJHKJYZPlbl7MHBUitG3/HRVR3jo3xOOf0gtL/kFdl4pq2/AA5+f79J6y4M4L990lLqK7Lu6fG3MWLegHYfrRyXgHULt/CPJCgbcKhzjyJNKnAt3JFE9mk00EXNz4hZkYggZ+LOR36Vreg6jaarZxSW0qva8o8LlcupA26/i3HXzrntXoamI2jEMdZdWSSYA0/2Y2CqQ5LjPxnqD6Udj4FsoLRovgRGXGMg5/wCH6UzQyWsS8qydF5vWrUIsXjL3ADOVIIz09P8AhR9Po6q/DmZ9uuusOSZjnEHAy25eS0j5UYczvzDJH9aXtLtZtLmaVCXRfxZ/ma3e/wBA0+TIkjDPgFUclgoPcjpSpqXCloFIZHUZOXxhfsB0odmmZW3L0jdOuBXY0X9PddRXnljQAbdatx6XK0nPC6KnWqEc9pp10bK3Yksd8nJpjsRacoZZWJPXeqkZ6yzEjkdJSjiEdyok7Uh+3OCDUOFL62MZf90cb4Faq2nLITNGnwikXjzSv2hA8HKORgVOe9EUmpd48OZn6s+zMp9i2otccFwW0jfvLVjGe3Q/6Vo9jIXuIkDEczqoI7ZOM1k3s+hl0PinWdALqYiVnRfqMH+QrTbK58O4ik68kit+RFZf+Rjfq+/UcWAN8xORpXC7fIkfKeR/Y5wrw/rljc6xfq02p6ImoRaU/jkRi354Eebwu7mZ5/iPcg7kDGt8a3zyxaPw6jFg6pGCDuDsP0xWceyPTNPstU4y0ATOZuH9U1nTk2APu/ixSrnuRzr0O3cdTlo4WupeKPaDZRMh5LCP4lP12P619K/yBlfs224HxrP6bP5548YlpAReD5b/ALTdY7JbDhiKBBjCeX5UucHsBxFKAdxim/WTyaa0a/hXA/KkHhG7C8WSxE/FgV8z0rFqHAj5TCTWQ31qVCc7VAretSKcd6FSTmWxLK48+1LnE9/yJ4Knr1xRuWYRxlz5GkTWdQ94u3JbbOBW9ouAWkAZOJNo9s11eonUZya0SCNYYVjAxgUp8HWeFNw602c5rV0zZO7znjyYF1+xE0RlQYIFJE/PFLzA4ZT5VpM4Dgqeh2NJXEOnmCQzIuxrXqYONhkDmX9OvlvLcAt8a9d6jue4INL+mXxt7gYyAdqYJyJEDrvkVZh5yyDHEF3D9Rn0oZcycuRmidyvUmhF0OtDLRlIMvLgqD03oDqF4I43dtuXfFFr4ncYpP4muzBblQd2FK2EmNIIqazdm7ndiTtSte2ivMpKjlB3GKK3UwDFT0znrXOn25uZNwD60Spu6G6WwHJBhHQbYpHyjIwP0o/pt0IbgRscA9Qf51SgUWaBAMGoZJzHIJR069aK7d6MwZ9kRu8QfN2rkybHB2G9D7W7Elsrbbdal8c775I9ayHUoxBjIbIzLDv1wpG9cGQ5+mx9PSoPHGxY965aUcuS2+ajMnI6Q9FcR69CY3RUnhXbb5h5Ut6rarMWSWMhlyCp2qeOWSC+S5iuCnhtnr2700yWFtrdqb62iCygZZAN/v5U+aO9XvE6iJdndo9ye4uPs+Ex/U9OdAfCVIyN9lyaEiF1QtPdMoJwSuCx/XH6046/bPEzxuuPQdDSe9sTKWdS57DsPrTFdhYYYTbK+IMljm0+xlWddOhdkGUe5Pjux7Hl2UfkaG6pxLql7ODfTXlzynEcOPgUdgqj4V+wqW5gvJQSgK46bVGmm6xdoIjNHGo3GSQT9TVm2jqZVFJ6eEsaVxLbWTCXVNAg8KLfk5cM31Pc046V7QvZ5qUYN/pFzpjL8KyKQw+oxSM/CE90ytdX64I2BGVz5Y619ThKGO4w92rSdQmWT9CP60lalLc85/WFXeZtdvq/D3gRCz1j3mBjnEsecA+uail1Cxw81pqUeSTsNs1mKQzWEaQAzIrdWROZR/rV+zliupPDvWz15Z4QcbfxL/pWRdQM5EbRMdYz6xJdTxiO4sxIXTPNjmDfcfKaTNWnZXFnK0kTAZhm8j/CaNftS94dlgOphrvTpPjjdD8SDzU9D9K71yzsLuP9oWMiT28wzzx74P08+2KEilOsMrKDtl3hfUW4k0d9L1FjJcQqVAx8e3Q+v1Gav8KanLb3X7C1d/e7XmZVMspWa3kB25WzzcpGdhuPWkOyuDZ6pHDZTBJrggxqflc/4D1Vv8J2p6m4e4j1stc67wxcW2FDe930kdnG4H8ZmZD/ALy7/wA6Ia8NwOsizABUnEYOIIYJtUgfSb2JNYQCQ2GoqVF8qjZo5Vx8eBgkDfbINXbyztNesozc6HKVgfxXtjOqXllN2e3nHwlcE5G3qM0J05rG3todJ1r2g8MCCN/3dvf3pvAgxtyywIwBHb4gfWmHSJW04rcW3G3DF3bOBCjEXbo3+EzCAhs+UgY+tVCEf3FTnjjn15Rk4a4m4ttFh0LUtR07XuH5FCQQ34Et/bEnb4XP71fVCr7dQa07S2lm0/le1ltZLc8ySCaSeIjy5iPeISP4ZVkA/jxvWS23B+gXyytYz6C8krfvrbxnjRmbspKDwyfMcoPfNHdL4L1y1uYpbFtXsVaMIgmiWflx1CXEDEMmB+MN/u9a0KLn6OufXn698QvqTqpx69eEbtf0nTLq1b33R4ZJIBzcvglgEb8aFc/Ac4LJlR5Cse1vTLHh69uBaX0s3D946jUbCdw6xSHZJc9Y2Un4ZSCpBKscErWq23EvFWkN+ytSv7HWYAC/u96jrKgzswPz77DmGR03HSk/jmaz1RTcWczxTQjmW2mcNLCfxKp2LqRnbJ27GlNYqp7dfyx6B9cQ2hZt2x+nn69e+Yhxbot9o2oqujXpX3WRJNOuypJhfqscmeiuCR3VxsCey5oEsp1p+I9Ht47a+s4RcXNmSP3S7LKvKdnhYMd9xy8pztsy65etp9y1vD4U9hKTGbU5DQ5OSqg7YPXlBCnY4VgGrPRcXNhxFDqejXh8SItJD4hKucDMiA48shgeuQSOuRUNuUgTedCFBPP3nt3gTjttQ0nT9R1G2kjMxMPPzcxEoGAVY778hBU9HQjyJtaxDHpuq2V7ZMZdN1ZXPhxNlJH5TzoAB8J5Qwx/lH4VrLPYjxVb3dleaHqr8jqiTIqqBHPaSgeHKuNuZHUo2Nxyqe2+j3s8nhTaZzgWN8wZCf8A91vlYNHIP4fiwD2IYUZrC1Y3fP8Amc41QquIHof1KuuaXZ2+r2t5cpa3EF1JJYySgYY+JC2AwI+VimP9/HaqlvZLqWntZQzo9ssi2k/iAAxyIIwC2P8A0kTxPnpkvRbUZ7C9hhkaFohdOA8SkFreVXEiY/yuCPMh8b7ig+g30eo2l5pV4kUc4jZEmXYM8PMAh8xyMeU9gzDfAxnCvBwOI8tpKZPhLFjL7hZWUkiuC87WVzzrk+KgIbP+8it2ySfOutasbayePVI357Ce9kuEDDOGkjZvh9cNtntnuKn0+4a+067+BHV74zuhIDiVN8gDzDSrk+Y8q610XH7KeJDG8KiwvIJlA+I8xGcHqCCo9BIPI15qsAkzy2bmxmKU9odVXS7Jo5I5oVgAiU/CoZjC4Bz8QzHkelVuH7eF9QtooZZFt1RopEmOzgIcDH+EOQOnyEVJd+8aHa2MkihZtN1Wa0knB3e2KrPA4HcKOaM56co9antkgs9Mlht3kNyZHtpGUnDcrh1cfc/kx7VI4OTCtyMD9P5+8KXMDyaZLG8cUU1mwuWySBIG8ORTnzBjC/SqGpaFcPeXdtE8BBWeZRITnxS6NEPuh5Cem+aYjy3gtNQR43jlkSaNDkho+WRWU+YIGR/lrnUtLi07WUMjvKt1pjrbBgCQypkxn/EFwQf8JqHIbgylJKnj3ylaW4tJEsHyiva8glDZKtIrbHz6rn1ps0OSR9FFteKXRVZUlBYleXnVfrhkIP8Axpfhube/hs5onBEuQHCjDPEevXbKlM/5T503cP6fDaWclnIhHjS3HKSfh+NwSQex2Jx6tRaV3uAOhxA3sVX2uuYR0+2PuNvLJhnijYc2PlACtg9zu3as/wBWsY9Fe9u5VQRJIqDA+YhckD6szD6A1pNvzWluWln5kaNW3P4jlD+eFNZD7Wtag07TTIZ+WJXGOUZLyE7ADy3yTR9XWqVrt69J7QFrbdvgZmPtB9oo0BTahg87DmIB6fNgbd8kn7VjGvcS3P7qfXVN7qdxiSz01WIULjaSX+FcDYDcjYY3NVuMOJTJfzatNi4nmZobGJkyq4O8rDuq9Bn5ifIGueFOGp7vUjeXzu11MFkZ5UPO7HqSTkdPyxgbU1p6E0lYtsGT4TR1esFX+mng+JnHss9w9o2vW13f3slxdM/LJCYx/wBHRTuqqNlTodu3XeveXAvs/wBB4f08fu45AIy3OOVUQ4PyDbA265NeFPZ9pf8A+G2q8SWdjHGdWjimZ2clXubZxzRoF7Lseg6geVe2OCfaHpUnBFjxHMyXPv8Ap8U9uqJzF/EjBGe22d/oa7urR1dnqmssIZLF3KfAcdPX2nzi7X2a8tSPZdTg+/3+vvNx4cu7G2t44rVFzIytkNkev6E14B/ty8V6Rxn7YI34TmintdM1D9nWs8ZLBnj8MuVJG48ViB2yDWi+0v298Q2Okto2neHp9+4Pi6lbjkkkiIxyIo2Gd8sa8wcHafNxd7RNOskDSafohN3MXOxAbnOfMluRf/CidodrU67TbKvif4h+yezbNNqRY568D9fH19p6+4HjupFFiZ2jiP7qSUkGQseoUdzj7DvW16Daw28a2tiP3afACTnP/Pn+VYf7NLS31SR7icOwWTmIXaMt0UZHzHbOPStsjvVjhW2jlYkj5guwA7ADvXzWx0zjwE7jVA7seMYbaZ/eAFVfDj+J3bYVYbWtMS6ZLYqZVPxzFs8ufIdPsKTr7UI4bcrJPh+X+72L7dWbBP5b+WaC6brMN/dosMr+5g/G+MeI+dx9PPH0pazUFDtlKtLvUt5TUbbUZbxmleXliOCrSbc/ry/6mvl45uwInukA8hglj50Du1laJLiaZ7aHkPIObPMB1AXuf+c1Nw9dx3EqxQqGbP8ACOb79hTKWktsMXNPs7x4RZ4o01dOk/aMFmilT8T8u+KraVr1tOBkAM3fGK0zX9JbVLUQyxxEEZPxDY1ifE+g6lot48qXAKZJVVHT7UHU1mp8jpG9JYty7W6zS7XUUCYaRceVBuJo4pbVpV3PbbYUh6NqupXEwV3cjP0p9uEZ9KLSHHw/U14P3lZEDraO7U4nnaeKTTfavHcSuyxXsDRjtkjf/WntXKuVzuCRST7Uo57a6tdcslHi2M4br1Gf9KaI71J4obtWBWdA+QeuaT7RT8T2dTeOqZQ/uJx6psvZfPn1+omD6bf2PB3tx9q2nNp3iftC3k1e3n5d4ZXSOSRM5xyusjde6LRP+zIbjXtU1TiiZTyyOFQ42CgbUjf2gdYveF/aNq1xpqMkuuaZa5Y4xITHJGRn6RYH0rv+ydxzLFcPw3K0qGQAphth55Fdpfpjr+wUYPj/AFoTx1KZH1+0VH+q5lxyW+hAP26T11qjc1i49DWaaFJ4PGQ7Myj+daJey5s2Gd8Y+tZvZjl4thkGBnI69a4HQLmp/hNBlxNljYkAmplYVQilJQeoqcS4XmJFVrGTI2yrr9/7tZtytuRikOJ3vbtYwCSzf1ojxdqZL8gbIHUCo+DrVrq5Fw42HStkHu6wo6meA2jcZoOkwC1s0TGDjer3iZFVVcKOVegGK+l81qUYCgQOJI7evSh2pW63VuyHGcVdJ2qJ9x0rRrJE8BMy1NJLC7KsPhzTBpF0tzbBCd8VHxdpvOhmQfFvQjh68CzmEnONqfXD8y5GRkQ3cruR5UJulzmj10gYc46GhU8ec0CxSDiGTmLl3GN8is64um5pygOy1p2pARwSSHsNvrWU8QkvI+Op6UqwywEMDE66Yuxyd+m4o5w7adHI9M0Me2M1yqBc4OMU5abp/gWqgJ8Xehah9q4hk4GZS1FCGwADnv5UOc84Krvijd/AWTP8jQNgVfbpU6O3KlTBWnHSW9LnMZMbHp+VXmYhyF6ZwKFQqyS84OcedEWBZVfsR286rq8D2xK1Xc4zOjOQMkmuWlwM83SoiCWHnnyr5g9MbdOlJBxDh5Y1geBzTDYk7HyqjoHFd/od2c3bzW8h+Nc5JorxLHiFl9Cay7VLye3dhExBz0FbHZtngZzF5wwImocRXFrq1u19ajLAZIyM1mp1PF34Y5uuCPTNWOCuIZhfNZ3Kc6SjB2yaKcQaF7nqKXUCYD9jtVtQe5u2kdek6rsy86ijk9JCtwhtfEXqe+KDXWoDmI8fw8dzRO/cR25RUKv+IY2pQ1aXkU8y4J71BAYzSqYqIWtrqUTBxrR5j8uRsPX0pgtH1u45TDdWsq9SeUEsPvWSXN/JEcwE5Bzmrencc6pY4BVlVcZJUnaq2aR3GVnu/RD7U1lri5kQxchjMYIY7g/XuKpyLqltIt3B4nOhHLLCwJ+46Gl/TOKrnWB4ccvJIN89Vx6k9KP6dxDYWzOk8EUk2MFkz4P5dT/L61k2VPWTkRyuxWEN2Oo2+vWMlrd2RMZyZZA4SJGH4vi2B9F39KqaX+ydEE0djdy8Rgnm8FJDbxRj/Ev97JjzHJUcqNqRXUBLJNGg6xYLRfROmPoKpPZ2U863CXVpM0O6868sg+xGf1pcEQuMnrC1zxNxDJbleHLi30WFxnk04LbP6gygGRvUOxr9onEaXbC31jVrWW6I/c3QuEknGPwtk5YfcUU0rX9OtrZ1Md5BI4y8tvK6kHoTkqQfuamukvbvTx/s1xjZTsmSq6lB4m3Ug9MfUVUtuG1xx68gZQnacqIRgvVkCxXVhYTlgoEllciM56Z5WOD9MjFEY7WC0maVNMmtppAFWUgBebOwbALHP8QP2pb0/WuMDIqSRaGZo8E+B7vySL6JJzN/Km+x4j1z3dYr/RXXxQQ3i21usa77HA5QR9D5UHBB4IniQeMTu0udLin91u/GspuYSCa31ONHXfcgNEjKc9961vgniJwkllccQ6veW5ARnnhtLsMD0JlhaNh9dzWUaxfaPHbxzahZiAhctNbo2xB65duUD86p6dfcBXssaXGiwzKxyZ2ljDLnof3RVz9iaJTqXobgcfE4+ki7SrqE5+x/eemYW0nUbWOxu5475lDmIXgZwM9omlJI9VD49KVuM+C7aaxa3hNxJDGhBWQEmLfZQfmIHlvjzpE0XVOALGf3TSeKksLkqEktru8uAAx6fBK24PpmmmObiaBDe2s1rLCrcwlhuo5RsP4TyHp2y3TamrrV1KYZflzMxaH01mVOPjxPO/HWhe5SFo7lnYEqCvzMPItuGGexwayjU9QeIyRrK7XELLIhmUrKHXo38LHsT+IdR3r0h7T+H7K6WfVb7TTHPOoaRra3KnmAPxNj5e3Y1541mwkWQA2UcrpKWhbxjzSEbkA5wcj9TSejIDFW8J0m/vaQwmqex/iy0n8BbuM2avA8AwcoGfGcEjKgNgZ3wQofYhhsOoa89nbzTzlriLKW9yF7AEczFfQNn1U98bebvZ/puhywS6lpepeBeQyJL7vIzYI3BjyvwsrdASqspDK2+M6lacRCW4IvllKzwNF8Q/dzxlcHcbBgcffnwcNRrQASq8TKsry27rNJ126u9O12a+tpFNtfwePb4XmDTIpLKR3PKGOOp5cdRS9bcYafeaxFAwMJ1Eq0Ds+0Ejg5QkdV5lb1BGe+KqtqUd5wfEouFW4t5EMEoc4YhlGd91fIH+/jsSKynWNVvtBvGWAbrPb3dueXEYLZYrt5lCP/ABoG3efZk0oGGG6jibHo/EUtvPczxhld4veYgi5/6RGDHcW7fXwwV33L/wCKnVPdFtLnSHMMtvLao0RO5MAJcqhH8Pi86+mf4a8/W/GTLq117vJNFdQXTXEcBchZA6Bih+pQEf4ga1Ph3X5L8QW1vexD3aVbW2Zmx4clxGxhLEduZFTP+IZ+aibPBoOxSvI9eUNWFs2qQyLNyLdPJbTw5ccrs6lZAP8ACXRsf95v1r9apBY6dpFrDbB4733uD96TzgomShJ35uXYZ/h9KCx64Ybu3ujarEYZL0NE/wA0TLAJQnquM48jEwpqvrgeEZUiR2tAroyuCwmSQqJAvcMmx8wp86VKbDDFiwAPrw/uX9DWM2cWlvI8rpA7QOF3KZ50ZcbZzLjpjDkdqYNUs/gjuhyeLaSRtGAccwADjr02Ykdug9KU4WOlNa3txBKn7KljWVl3YwvEEEg6ZxybjvyetP1xHY6gzrb3MbySc0MlvGeXJK86lcj/ABbZ23G5BrzpuQt5Qedrg+cWbDR7OG5W0s71Y4be595tnZSVjUqOZD/h5WQd9gD2p30HT7gusbwqyvIHCZ5uSXl5HQ+hyMEbUnOEsr9w6h4Ut0XcchKAlV79eXK47cuK0vhi3PuNskLkgIgVmJLLy+eeuxwT3GPKi9lsrWFSIPtFWVQ+esWNQjfSNECJI8kdsEQFwSSvidDn8QB/T0rzF7dta5ltLaBiqI8qu+cMo7HHYA5375r2Xxho9rqVjJCsIJuVYSrn8WMfXIOOleIPaPoerQ8XS6FqlsjQXF6kUHI+c9cLt+LAPw/XrTV1YGoG7oohOzHC1tYPzTEND0u61fWZbtwq+KVSBZQSqKDhV+u+T6k1puiWr2ZZ76YQx20nJ8UmArE/KVOcjYHJ+1calwpLZypqMNqSiEyvleVw2NiADv06YqQGNrWMrIolLFlCIGySP4fL1Oe9Wst/FruWZ1r923WVOMdE1zU4rbjHga8t/wDaTTLdoFgYLItzC2eZBk4YjO23UjG1ffYrxhqVv7LLbR79ZBJpFxPYBJSqFCpz4bDqoAPQ1DeX9zbX00pCoLcq9uYHx8JXGVI38j9BSVqHEMmoaxeWWiQzXF5qc8k5WIZknlOAXIHbbdjsMdaaqt1VukXQMcqDuHu93w8fjEk0tBvbUePT4yXj3ieV5n/dh7mU+DGkYLFyx+FVzknJI29afPZTwTqfD2nNoHu3NrGpyLPqroctBHjKwg9dgSWI2yT5VX9mXst1CPUI9YlaG61mT92l0CHt9N7MYQSBNKBkc4yqnZcnJr03wjwfpOhxRgyoXIzJzHld27s/dj9sDtVtf2gtFf4bTnnxPl7hNrQaTuT+I1A5/wCK/c+UvcH6BFo+kwlGWC3UAIc5Lei9BjzI+5o5qnEX7E08v4YhUZIknjLEkDry4G3kMD7DqO1biGCyJlSe3t1jQg3IBaTlB3KjB5VHr8RPRaz2TXTxhcAQyuIUPMJ71m52VTu/IMgDOMZ6E9Mmuaazu+F5M0a6W1Ld5Z0lo/7T8SsRcXlwlq/xyo8oTKbk5C5JJz3PTyzWg8KabDpqLDP40jpjl+H4jg7DfZQPL88UO0e0FhYpJGZLaKOPxXkaLmklkz8+MbADpkHfoM4o3aRNe3MYurp4YEUSqjHlZ89ByZyfv+gGKiurJB6mXv1IYbBwsdYWi1BS0lrFEhTCSMTIc58xsfzxUlnayW55IJ48qOZ2XHTywO9V7S7s0jCXEs8jKMEREuQfInOOb07VzcaqkN5+y7S5mUOcvBEy84J7MQK0Nqg7jMwMx9lYftY75lDJyNE3R/XvtQ7U+FoL53e5UyZz0G2aNWdhdGFQ+I1A3APf69TV2NZljEPKFX6U4agQAwifelGJUzL5uGGtpm5bfkRTkH0qW/mji09oVYE8pHWnrWbFpYGVvhB8utJV5p8UMbqNwN8mgNSE4WMC03qQ0xHjHTJtRgurYRbMpIPrQD2fXvvHDUlldXWbzTZWidSRnlB2/Q/pTxxZKIrh08UAeQrFml/2N9oQvwXay1wiCRc7B8HB/Pb70HsxBb33Z5//AGDj/wD0On0nN6te6YW/9Tz8D/eIi/2jVs0470zUZ1JcaQEiDEFTJ4/wkjrgK0g8t6YP7OXs/wBFg5uKwhNxgKCHyMZ6YpO/tTXCH2k6LpsYKrY6QjSNn/0khIz+VaX/AGfbq3HDUghcsQRkHtW9rVs0/wDjKVngggH4ZJxFBg6zjy+wm1Xdxi1Y53xSBFIDxRbOCPmI+1Nd3d4tHIONqRYJ1PFFsQQMEjGetcf2cmUf4TQcTY4ZhyqM9q6u7tYLdnJwMVQhnBAOe1CeKNVS2s2UyYJFRp6y7gCeK5ivrF811fFVbOW6VoXCVkLOxU43I/Wsw4cjfUtWGQSoPNj77frWx2UYggSMdhWiP9l2B0EpYMACXgcD712Mmol3xUqDsK1qVxBYnXTvXJya6A7V+IxmtFFkbfKDtUtFubZkYdtqzvwTp2p8oyMmtRdAVI86RuJbMxXJlVehz0p2oeEsB4Q1Bie2GCDt1qjcRDJqbQJS9uqHdgMVYu4cM2Ns1e9Ohl6x4RN4kIS1ZcjJFZZq0fM7Mex7itP4nYMCPvSFf2/isRjOTikCOYyBxiBtB0r3u75zHkCnF7DlTAXoKtcN6QIrcy+Hgtv0onPa9cL9M70lcCxlwcRVnsucHbr6UralYtFKcH16VpElnnOR+VAte0vnj8QJvjrS1RNb7vCCsijaI0yhG7ZztRW3tyyMhHbPSq8EBhlzRq0h5wGPU9qevHepkRQZByIKNqfLevhtDjfajz2RD/Lv1rj3Eb/Dn61i5IMZU5g/iNAVYHpjfasi4kYrI4RcHvjtWw8RDdsnNZHxPyI7kDJwTW32YczBu90pcG3tta6zHJOcKD/FjatO4hniuVgukVWhHVgcisHWd0vlcvyID2O9bRot5p2scM+6wXP7yNOnNk/Wmu2KDXsvHhNfsC8MTV0zJr3Q4dStg9q2Dy7d6SdX4dvYcqYw/wBRvR3S+Mhpdx+z78ZRSRkCjt7cWeoIrwkSKwyO+PyoQsXaGE3lLI2xpkE2i3hm/dohGc1NDoqiUC7Ux5OxRTt9T2FNes2ywMcLjuBQZLe7umxb7MNs5qjXEjJOI2tankCX7LTpJAsMZtJUQ7eG/hMv1z1+tT6jomoRJiE+MG6cjAkfcV9tNNaEE30oCj5iV/0qxJPpMMfhWeoi3mwQCSQP9Kz3tJbiMCsCL8ScR2EnPasUkB5gHPhP/oRRmHWJGZTqfD0lxLJ/eFFDAnucDI/Wq1xNNO3Nc20N6mMB492+xzUEEGmvP/0e81GA9o8MB+lVOH6iW27OI46ZpNzcTJc2+gB4cjleG78J07bo5AH60aPAcLye96lomjozkOEkm8V3HY/MoJ/Ogmg32s2ye7aNp+olsjJS3MjP6jBPL9cUettKlY+Jr4e0dPmjmmLuwPblVwf/AIjj0pNiwPB9fOVOesuWy2dlImn2trHzy7BY5xECR/hiOaLW/CmhXXM2o6XYmQDJws0xQjoMrIcnJ6Ej1rnSvdrbMNjodxZRHdWULuuOpUcpb6seXfqaZoRxTPbibTLc2sYUiOfUYUOfUR8y/mWIoe5vOCZgDwZFo2n6vpspj0W2LQ/IRzXUYCDf4hK/Km9HrGz0ucCXiLhvRElKkSOlxHI7DtkKy4+uTQhJdRSJkbjHTmKkBuVpIpHc9SPAk2I+oqxHd663LLFeam8KgK1y95NDChB3JJR3Y/U96uhzyTBszHn69DGaw0XhW5hMWkS/s2ddkjj1YiOX/CVlLpv3+DrRWLhcyMbiwsZrWd9zJaS2zYx2YwSISPqm++9J0Wrx3Msdn/tFOxRWzBNbxzq++zAyKr4HmrD86Lw6/o0MY8aTUofEXAKePJCxHcBiwX6nNNo6cAj7RZ0tHQn9cmXNa0eYRtJq9nJKwO11EskUm3U5UdfqrD1rEeNPZ1YancyXenxqHOfi3CTEndXVdkbycAb9VFaXqPHkdnzrLpPEHJFs15YQLcxxD+J4g78o+nL54pd1b2m8PRtzT3FneRtgrMyeFIreXLklR92Ge3aqWJk7lHr7xjTG1OkxvSuCrzTeIJbW3lZbvJPhS4UTpjDRk7BiPhIYbggZGMEaZZWNvqOjSK0RZA+ZoCPitpcckhUdviCsR5nyIqjfa3wzxAiXEMq3FuqvNzcyiaDA+LcEZZdj6j9L+j6lFDcS3NtKks8kKtMwJZZznlDEdiRlTjzwQCBUbyTh+sParEZHWc8PwyQWt3YXtuZrS5WYXMIzkFowCynyIwwI3DKrdzSzxlpC3yRxeJzSrboRKT87eISB9QSfsPWn/To7eeEyQAtbqTAGbZlQFsAnODgM6k+npVObh+31FvdcFZYky7dcER8zZPkOYfc1OQBkQAsxYc8TGNftnbVbZowAiIsbfhdl+IhfTlZW++aZ+D+ILj321uoZnDosaXSjBDxr8SHGeocgfUCofaloUdoyXcCnMcjhgoxh1YjA9CzN+dKXDNxdTXF6sEoRGtJEjCsMg4C83pkqDijAAp8IcNuXjxnpnQr+y4jX9rpb83v5ljmCDlLSyR4QgHcEsrKe2Jc9qIWzoNPtZYHcX9vctNChAT3m393DFmHb5myB0JNZnwRfahLaTz2RYTyRWk8Q6eGwZsvjyBMh+grSLG7ntJbAiVZo9PNxKC0YZvikB5MDqu4xv+Nh0xSrICcLBZK+vdHrTLK11nS5NNmuf3NxBm2mjAZ7aPnccyjG/IXXI/wtjrTCbXk06YmCKC7iMT5hl5QAzcrRhj+AnDIfwnKnYilzg2z03UuFbHw57iIpzQCSKMq8alyObA7AKNx5AmnCwhgvbTMNwlzLbz8zpEVAkhJHMyjm5SvNuV28sKRVVrFqdM+v3HWDdjXZ+vr5ytrOj3LXDh0aEyNEfEROYE9yR2UnB8hk+dE+AuIzZ8tlq4KSQEcrD4Tyf5e+DkY7fQirDPaWsQtiJQk0gAMWcoT3IO6Y65HwlSOu9Qz6BCWS6hSXlLvFIrqPhB3yDtlc/cbHzpIltNd3lfURobb6u7s6R21I20li0tvKvLMOeLBB3H5jPmP5dK8le2XTL/UrtLzQIPer7TpZru6tDB4khiRQpkUr8rBm2PzHqK9Az6rGlu0MjcizgcyfKwYjBYjsemfP86Rbm+fSuJbfVYL9rOYxGJwrArKwyUJGN8nlA32z0rRXtGt9QpK/39oOjSNVU49089aNx5oWuwL+2PDDKedrhVw8WwHxRjBfc7kYPfFLnFtrZW8s1noNxJdSlTG0dlE7Agt1bAwAOxNbCLTQNEhvLu1tLZWiRp7iQKnNz55tjnphsYz3+tBtH4gtNVvDbmGeEuWCStF+7YkZILK2B/vYoBtr0rF6umTx16Rheyl1fL5wPXvmTaP7MuOuK0jku7hLK3h2MwXmmVcDbJ2GM9gfKn/hP2RcNcNK4Lvcu7f9KRCPElIJ5fELnmdQcHlJVemBWj2MtrlPGgg5YgVjLqMEnsT2+9cX73wVYw9wiE5ARl3Hpk9PWl7e1rrhtHA93H9xins6jTN7A/U8n18JPp40q0SOG1s4o0ADYGDIfIEdR9BtUuo8cQ6dbzWlhHLdyhSWiiAUZ8mx1PoTgdSDS5rGoambBobaWG3DKR4gfLsPJiOn69KH6TaXFwrRP4i2y45rrky0gBwVihUZ2Yj4nJyQcLtSZO7npGO6Vvac5lzVH1DWpIzrN8lvzlAbaPDvgbqpOct/lHKoG5B6A3wwunaasjWWn3NzcFlQPyrsSSFCA432PxHAG5HnQ630OC0jlmaCWGzlwoxIvjyjpl5TsoJJ2X174pgstQtFRBZ6eBDbsD4caFRIxHygblzj9Ou1QpUNnMs7MybQOPdwJPqusXumaY2qMiLzyjlKH4R3CpnZifPfOOpqtwzxJdpHJfzXCRyuSxL5O38IJ36eQJ8qu3fDHFnF19FcyiG2i5S/PJIqrAp2zznJZvMqNzsMACmnh/2OQLJ415czzxsApeRPDMhHUgtg8voNqPXTda3+scRZrtNRXiwjPu5/SLV5xlqmoyPZaXBK6qAsksahREB/iJ2/OtB9lWgTSAXcoWNhvy/Ox9TjYfejdn7OuHIAokDzSD4mji6DzPwnCj6YPqaedCgsNPiS2tbdCO6qMKv5bVraLs63vBZaZk6ztKrujXSMSreTXRfw4FXAOC30qSOToiqQf4qocQcWw2EjQRG254zuFOcf0FAo+Nonk5ZLiMtjZV3NOX3ojlQYhVQ9i7sRqu3VgfEyxx0xSVxHNFbQyMY8ZBwOpNNNnqCX0QcIM46mg/EsEcsfhrEOZu5qBWLRkSVY1E5mC6vpF/rl+zQRkJnriher+ybUdStFkNqzmFg6465B869AaHw3A7BnRevlTtZaFZBAhjX8qHpuzlW4W7uQciI2nIORnM/nT7YPYvxhxTr2ocVvpzqrWNvbBMEsBG5JP61a9h/Dt7w9pV5ZXUbI/OHZWUjl3IH6Yr+h15wTp17CUaFWU5ztWc8Q+yXTY5JZLW0ROY5PKMZroO0NK+s0TV5zkgxNTXvBxgzz1qF34VnIc7gVn8F+p4ntiCBgkGvUR9ldoyFXt1PN12qhJ7GtFllWVtPi506Ny71g6Dse6pGHGTDW21gdYmQXWYwzHtSNxzq4kk91R/i6da1LizhFdBtHngdl5R8hORXnrijUwb8O7czFgo37k4oOn7Lu0znevTpCVur4KniaZ7NLLmj98cZ5t9/IdK0yJ87UmcErHHpETRgYdR+VNsMucdx6UOjTsp9rrIPtHMIRnNTruKpxuT2q3G29a9VWIMiSgbCvpG1fVH6195c9qdRJGJEy57dKXuJrMuniKu+PKmXk8qoavbCW2ZcbimVGJIEVtAcI3JtRrUsLF4nYigVmvu91y4wM0V1S5BsSo6gUawbkzLAe1xETWz4kjdh0oHBp7XV0qKnU7mj96hdie/Sr3Duk8z+My/Q0gy+cP05k9vYiC3Vcb43qKS1z9Btij0lsANqqyW2dwOnnS7pmSD4QJJab9Pzqje6essLKU3FMb2xBwO1Qvbg9qTeuUPPEy66sDDcMMHbPaiGnwnAycY8qLa9pfhzeIF6/rVW0QjAI7/nR6faXBgCueku+6c8eQK4FmB0WitlECnKe9TNakMF5aR1NG1siFryZnWvEFWOelZJxOAZCWHXOa1PiCUcrkbnf+VZVxQ3OGddx32p7s1SCJztxGIiXiq0pRQfX0p99mSxWszJPcYR1wRzCs51GVkc4bl3q3oeoe7yiQ3DE/XArotZQ1+nKg9Z7QagU3BiPtG/jW1aPUZJLZGMZbIOKF6TxBqGlt8UjsOgGdqbtKEHENm0apzSoOuck0patA9ndNH4AJBwDXL1k0nuWHSd7VYmpUWKesNjiCfUMCSFZObbOOlErCCOaNizCFsZ5Q21K+nRvNhjbsQO+TtRlLUyoea1lYnurb0vc3OJoUqZde1gTmHvM84HzIOmKHPaxvn3CymXB3aVM4+mRioi0S3IVjdQAkA5bBP3zVu41O0tysUOqysM4dVxj7sc1VczxweTP1raXGCkl7HCQduSPB9PPNGNKn0+2cE3t00hOB4rsoz5BQN/yodpl0b9/3F4rRofwxBz+eMmj1u18mY7W6uZmTflVFRQfVmx+poNpBODJXIHEP218dSmNvaWl/ceDhfDSVgCPQJ2+ozRq20sQvHJPpwsV2KW7/DLIx3zg5cD1Kr6ZoLpup3kbqtxxDMHcgGG2YJGfJXkHX6AH0pht9c4f0VxPd3k1xeROWWCzRY1Vu3M53P1Y9s7Ur4wLhh0h6x07UVRbiKyewf5mMao7H/EzzcxUeuAdtsdahvL+1RwjKt0ytgKshAUgdZZpDue+FX6E0IueLb/UrGVtavrbSNNUZ/eSyTzyKd883MqjP1/Os/4t9r2laDb+6aBbW0bw4DThSoU9twAzsfIY9c1dK2sbbWM/CDSvA3WHEfNQ4h1pFU2Oo3EUikt7w07rH13/ABHAx0LlfROlIHEXtp0jSZWaea1v59+Yq6tluxJCKAdzkYrD+NPaTr/EjCK+1Se4LOWSJn+BSe5Ubfbp9etLyWh8MSXLNJIxzk7n7eVbVHY2AG1B6+A/mK29qV1kpQuSPE9PlNUuv7Qt/wAzG2snLEZyb2dlLfxcuQOmw7UqX/td4qupmeLUL+35yciC4ZBv6ZpXjsec87AjG+4FXIrNWGTGjkfEN/mrTXQ6SrkJn4zObtPVueGx8AJePtG4nlBV9V1gqx3zekc36b0Pn4nuJGJujd7nfNwDv96K+xzQ9K4r47tOGeI7yW3024eR3EZHO7LuI1Y/LzdMjcdt69r8O8F8N6Xrur8PLw1po0poLJktXsUaFEMRVgQQc7xZOSSTknvW7pux1cByFUHge/5THu7btXI3MSPCeGrDi68sJRJbajMjDB5ZRjcdDkbfnTpontf1DTJPfJDmTlYMuwjIK4JAG3YZpw/tK8Aey/Stdij9nWlrZXiQudSgtZCbNJeYcoRTnlJXJIUgZxtWIro0kauELEAbgdMd6ytVpNPvNb4yPKaGl7TvKBx0PnPUfBPtFs9b0h2luB4ck6MwO2cEgnHbYtnzBBrV9Mtkvbh5S5MLjll5duY4zkH1+H9K8F6Vrdzp0wjt52XlYZUMRuOn1r1X7KfaTa31nBp6yKJ2Q+IPiLIgVAzH6gYGOhWsHV6M6Y7hys2a711SZX80a/aPpAvuG79IXVbhImnLg7krIpA/Pf1rANOjuNMuJPBixPIbiAgnLEBgyH03BX6CvS+umxl0m8tXdAvKpkCjBwrq3KPMY5s1g3gxPxJeW/MIml5pio3WJXJYkHscjp2zSqPyRG6F/wBfM0Pg25NqxhacyBBJDNNJnAiZ+RVC/XP2XPetQj0dGsG/Z5lUiMNHyt1BOH+pwg+mayThO7SLVoY5oZ/FiCyeAX+FGY5XmPohXz7nrWw2d282k3MCSo0sCyMJElVGZN+ZgWOMZO1A70BsGetrYYIjRwFqV7a3k+nNrdxbiOOBY4Qpl/7MFn5VCsCCBupwBjzrR5+eaaGc2UBuIXDpduwgkJJ3VlLEjO3zdR2rG+GDdQSzXnK93JC+FVYOVkGQCMk/Ec4I7bA+lanoVxHFbJaLMq+PmXxkhUsw/hJXbbc/XagUPyVA9frxIvrxhvX8/OElkcgWdxJDGplPhh3JKD+EMoIx9MdK6STUtPdrW4jyknyvhmDpnIO2wwc4PrUU8/uSQ8lqrCQ4BKoCmwyX68x2PTz9Kln1ARxCS4jMfirmPDY3I7LnA386rcrHOTzLVHjgcStrmjJqh8WF5I3HyuHBOMjb1ORnB6ZrIOIrfWNL1FoNQDyrbsTGwzjDHIJHUbBsj09K1+wvOXxbK4jkaZ3DifGeV8ZA2JHTOdvOqOvadFrljcWqvFHd+EVhfIPNzDJI+v8Az0rKsTLbh1mrp7jV7LciedLqC/uNZuGtOX3O5UNJJ4oeQZIU80ZXD4GRvtgjNV7fhN0kZBapAiKAskEjK2zbYX5cY3x0HSmnWdKvdAuB7wVe5CqGSQEtjoBkdslMef16XNM1G0Fw0AhnsTHtIFlbDjGOZRISPXpSrXN0M2hhV3Vxe0/QpMiObUkijDhR4zKHO/qRv9KZp7OxslWM2/vcrYBdpeWMY81BGcd9znypkjt9L1OJPD1eBJSAJBcScjqQMANhSN/sDQa84f1C2YQxQwXKk8rEtjnXG3L8IB+wb86NXYfAZmba3eN7RxFr3zlvlXwormUnmQLkBCD1wqkk+ijOw3AyaIgMlusVyrCWVT46nl/dL2DkbA4wOXJ64wTk0Uj0fUrK8NxqGmJY8q4jijlYZ26MScjPoCT6VZuWhtxHLL4Vs0jZgCW/NyP35FYgs47sQoFW9o9ZTegICj1+kgtNNu7pRczcyRQgYe6TkBbbpH1GAP1Ge1OXD+jaWJY47i2dxIAVWUnnmzgnmCj5TgYRdio3yKAQRI4SRro+DbOshlnTxJC+TgKD8AOc4LKcbtud6bhdR6ZavaWyFtRnTxTHHG09wUPxfG7/AAx5/jkYHHRdhTWmpDNuPhEtVccYEabVXeVIUtbSFBvNO48SVttgu/mMALyqAOtGg6yxS+7tDEXXEspjWSQdvmOI4+vRQx/nWZWOpail+09xJFcuoIYiNnjh22VScKcdc/Ec5PKOtfuIfaTovDlkl3d3kkkszcluG5mknYD/ALOPv6k8qjb0req1NQTn1690w7dNYzgLzNEWWHTo3jbUYWXIzLM/MgHoAAM/XFV9S4wit7V7PRwt7O23KoxkY6tn5R9aw1OP+L+LLpLeygNlaRnlDzP4s2/foET7ZNaXp2lrplisUcMsskwy55z8TeZJqadW+pJSoYA8Ze7RLpQGt5Pl/MDaraarqJebU9SSFfmKQgKiKOwpet9XWG6930yNpMHDTnfP0px1LhrVtTtzHPFKEYY8GIlFx6nqfzqpLwjLparb2ttGDyjOO39TS2o0pXLL184zp9WGGG6eUbOEtWIt1EhBPU0Q1C6W7uAM9KTbDxdNHLNJjlG9fl4liWVmMoxnzo9LlKgG6xPUANYSs0fTWijQbgUZgvo0GzCshm49t7f4TOB96ks+P0nOElBo1esqq/MeYA6aywZAm1wasiLuw6VQ1PU7d1IIU5rPYuK3kX+82I86rXfETt0fr61pDtRNmBEzoju5jVcapbx/KF6UMl1uNGY+GhA9KTr/AFpkBZpCPvS1d8UFXKiY5+tKp2kwbKy7aFXEN8eX1rfWUqRthiMcp715r17gK4uLz3ogqokL5xtW4NfxXpAlPMTviq2o2Nv4JIA/0pwao2HJgxpxSuBFbg26kS0FrKMeEAg36042zEkHGNqRluYtP1IogwM4A7U2WF0sqBlI375oHdDdme/KIchc5q9CaFwSZA9avwP2J+lNIsqeYQTHl+tShAarxuewqyhzjNMKJTE/Fc7A1HcQ+JEwA7VZVc9TX5kHKc7VfEtiZ/qaizlaQ7EUJi1lLmfwy4IO3WrvH90LSGVlzkAmsi0LiYy6m0OSW5sUdPaHMsB0mlvbeNOIoxnem7TdO91tV23I60M4Rszct7xMBv0+nnTe8IUAKNu1JsvMuW3cQPJbgdAetVngNGJYcZ2qu8GdsUArmezA7W5B6VEYMn5aLPD12qIwelDZAZBMXNW05biHLDcUsR25ik5WG4NaLJbBwVYZBGCKVdSsPAueYL1Pl3oSrtaeIzOLJCME0U8HxEDYP1qhaKSQMfajdmnOvL1xV7q96yFGDMC16bAbGTnPXoazHiOT5/Udq0TiEsckZG5GxrL+I5GZmG/rXuzQDOWZ+Ij6o5LnBqlp8wNwqvzYJq3fKXcjI9aJcK6baS3sRniV/i/KutytdXMUrVnfAmp+zfT28BpoyyDl/hOMUP4kgU30g5FYk55sVqljb2NjwoPdIsHkGNtzWY37mW6Z2jYknvXAau/vdSzAT6R2XpzVpwDBCxTRxbuyjrgYxXQurhF5ku2BXy7VJeakIHxNEzAYHy7UMuNWE8nLyBUPVQKGqFvCa27HGZcae2uV5764Tbc5Usf9KtwDhy4Phx28l0wHNhV5VHp9aHWNlc6jIy2dthAN2cDApjs4rbT4/DkuFeRz8UcYAwfU9Kq5C8AyFBbr0lmy0u2eMFLFoiT8uQfpsKuwJBHDJGkMbMg3jEeM488nP51Wm1i5hj8T3a2RFG2X+Egd/rS3e8ZqwdGZIkXfw4ByIf8AMRu35igCt7DxL5AOBGWTiD3IeJDG0COeVHji3Pnyk9x0zQm/4sFk5XTbB5Lldkur3LmLO/wIcjPrjPpShecbX11KIbSedEb4FSAdv6D6VNa2t3eXEfjycniMPhkYgn6dz9f0ppNNsGXEEW3dJHqF9rOq3xk1C7eW4JzzSS5b8t+Wqk3CF9fwSXMg5goyA22x7jI2rQdA4VuJ5UtLdi7BiXWGLEceP4pj1PXIGSemK0NOERaabJJHZ3N082AOSIBvIjDYKqPoOlHr1PdkbBF7K1cbXnknXOHX02e3vVhPhswRvLJ6USv4TyKY0ZQem2/rWz8U+zy4ureXT7+1aOO4XmX4cEE77fTbfpWWy6DdwO+k6tG8d5AMAN0lUdHUnse/ka1vxItCsT0mPbpDUTjxlKxthzy8uAU2QMM82CAfyzRePSVNnDIkTNlsMWPoTsPt9aDi5ki1MShOVGYc22wPfb9frTIb1TCgdIpIoj8EiKVw52Pw99ulWsGeYquegmba4L/hbXEexupbO5jPjwzQScrL5YYdDtXqbQvbLqPGHDdpdRaYYLuTSYbO4lW4OZZ1Zz4wDZxnn6E+ZzWDcRWNjxKpgkK29win3eY7gkZ2OPOmrgiIWXDdpbeOIZ4IQs5zj95uTjzwO9MajtW0aQVIcHPI/Tr9pnNoQtneMOPXELcXxpBAk0iM3OrACaTmycD4gfLrsPSktY1W1mEkLMuARvyqfr570y69f2lyIo5dTupQg5VDfGFGM9e22+BSpqF7aQ2gildppZSQiKASD22O4H+tI0qe7wRzDAbnGDFG6a1ayvAbeFp3vYXSUt8aKBJzKozupyuTjso7008I6/c6Q6XLOyFRg9sjrvVzTOCLaKL33VIxLNLylEPyJ5f8mqF1pdvLbzGxWdmSUIcAY9OXG5NO3WV21BT0mnpqrdPYXPU+E2/Q/aZFxDpru1xICNyhbCyAnff7H7H8lO31oSa1eX9zFPJLccvMoCgmMAfCfqQc+lZ3p93PpAFphUbxQrKANzuN9+xOfrTdwutwtyZUaNZHlLB23xvy4yfUb1zz6UUMzDpOkSwWoB4+M1fhicXytK9sSt7KY0uNmxhyS+O+QR9eUVq3C+pWSiQKJvDkhUCWZFJiVg0eOUnpy5z1zvtWCw6mLK2a1hSSErHKpXm5QwyAvKB1JGT960fgC5v7W0EkF7HLBBEyNDP8RVm+JQW3z1+nQVmtWwbcIZwGSaal9FZRqvvcNxzOP3kYJXwyQAyDG3TJHXbHatA0C4Sa5kl00iNo5WjT8SkhQSOXp1yR9ayTS2trG5tI7Jz4E5RolJ5kOSQcj8JBI/M0+6HqFtZySTRGTxd5HOccxYDmIA2yMZH3q1NJJ3HiLXNxgc+vKas8NneafJCickzcryDqRsAd+m+TkUH1hbgMiBxJLKFh5unIMZyoA79DU1vIWsRHZRchZGlQFjzF/IZ7Hc1VbUbi8uo7NZiHRQrM2VOBjIxnfbNNaqrjb0iunY5zF7UrpraBb+aPxJeZMFyeUE9cYO2PTerrT+/Wy28jtB8JaOSPLAMPLO4orNImoGWzv4o2hUOYQm6qSQcY7VFb6fKJXcxlUQAYBIAGPXtWDqtKUOVOfXM2Kbwy+0MGAr+1h1Im5vbNI7pFHJJjLNKFAU+WAu4/zUgapw17rcvOjNLcLzLI7AIvzHO5AJ9MHOPrWpuIHna3d05YzzRsy5yCR5bnbA+gqhq+jXUkKyzXsbQAAxotsZJn7HJY8qD0AJ260myB1zGqrjS/EUNCvtRtkIjKtyn4TJHkKD3+IZxt2Y0YvdSjuLc2rzwIwbIEQ5FJP4lxhyfocVTudOsLTwhp1ldhhj92shKSHvlFOxJz6VNCk9lmG3AilkxyiZQrqeuyBiSO3XahBSnEvYUsO7Emfh7UwyPDBDyy4OHuAjMCPnfJYsCO2/0qePSyt1/0026xBgSgdXEm5zzF0ARMAAKFJJ7d6507T7dLiS69wtpJmcI0py7SNk8wJXfy70Yt7a3lk99eysYZQpKRHxE8Mj8T/wAOO2GyfTenKiDyfX0iVuRwPX1kqWlvcRwvOyRQRjKkjEvIu58NcpFAN8s7DJPY9KGnR4by7lSzt7qSHr4CNJLzg7lstjxDjHxNyKB2Owo1a6PrmqXTzTXkc8JBjCxxkAbZAjVgST58vTq2avT2TojLDbOJCoZ7iZWbG2xO45u2B3PatWpDZjAmZZb3WeYr65qNtp1uLDTY7iEyY5kRPFkOCcggDI6EE5A7AdSFma6h13VDaWnDJuZlAjaa7VOUZ6gIme/mx6dKc73R5GgaFZrtELZklunCzMD25V2QdNl39R0qbh7SoNHjU2yBCBjndcu30G+BTA0dmofDdPXSLfjEoXKjLS/wvwlHp0CTXFpAZQeZFW3WNIz5KBR+5vYLLEtwltER3kbLH7VDbNeToqRSMUO7EnlAqnqyaXFjNu09ydlVVLsx+wJrVNFdFWKREO9e+zNphmz1hb08pv2YDYHlwPtVDXHFsjSxF5Cd+Y1TsHu4V5zBFGR0jTt/mb+g/Oh3Ed1NJblpJCoA+VNqGXJq9ocydoD8HiJHFnEb2MUnNJhjnOKzubjVl5lExz9are0fWyJmgSTvg1nlo9zdXDAE4NZpJM2KalxkxsuuLLu7uORHOM+dNnDWszKqtI5x60l6borJ+8dTkedFRexadHgtjypFqwzZjzWIte0CarbcQEgfvBRGHUvF35sn61jtpxOssgRXxv51ofD7vcxK4O9TY5XCiZ/cj8xljXtQdEJ5jSxaWWoalcl91Qb5p3udDW8XL9aN6Fw9BHEByjNP6Ok2NzKW2LUnHWKVroVxEFYlzjzo1FoclwAHUmnE6TbqnLgZq9Y6dEmOYDFNFdlmB0i27emYl23s9iuWEhtgSf8ADRVPZ+Y4sJZ9P8NaRpos4VAZelG4bmwYBQyg+tb2nrV1mBqLnRziYNf8PTaefldcfhYVVhYq3K2xBrctdsbO6gbxIo3BHkKyjiHRUsZWntgTHndfL1+lEek18jpL06gWcEcylE3r6VchI2zQ2BugHSiMGCBtVVh8cy9EoxjvXN26wwMzEZxUkRAXmO3nQLXdQDt4KHI86J4SMZOJnPtDllmtZ2RSSQQKyngjQrl9YMzrkc2elbFxPavcweAqcxfbpXHDvCyWHLI0YDMc9KuvHAhTgDEcuF7ApbJhMDG9HZIh22rjRI1S38MDcbbVeeLqcVRkgw0GPF12qB4cnbPpRN4vTNRNEM+tCKyMwW8G2SN/KozBnfFEmhOcAD8s1yYfShlZG7iDDbnPShOtaaZIy4Xcb00GDfptUU9oJYipWhsmRPbsRAgjKNylf0oxbDkXmPlXy6sTBMTjvUc1x4EJHeiVru4lifETzxxC2RIMjJNZbxGMMw671pfEMikELncedZpr3xeIeu/lS3Zo5E48vnmId7zlyIyQaKcJ2l2uoxubhFyRsTv18qH3sTGTbAzV3QVVLqJ/eGyW3UGupsP+qRpwTYJ6gtIscJKok5zyZ3A8ulZlqRMMzPzZc52NaVo/hScIRFAw/d4wTv09azTXFiS5kDqWJ67182fJvafTtEf9IIi5qLNL8c1wFGNgGoUqLPKBGPhHViR/WptRGXKhjgdjQ9niDjnUkA7g9K0q14jDPnmGhqNppQH71nZzjPPnH07VBd6jEzc4fGSNzsd6CzTpLPzgJydgxqpqVy/hkRhFHQ43oiacMcwbX4En1TXmJ8OGQkDplsj7UJt2uNSnEOWbmOw+VR9WNUAJriTlQDPmBTFoFoVkX3hUUd/EyPyAyTThrWlc+MTW1rW90PcNcGNcyc8t+i8uPhiiaRmIOceWPqRWvaBwjGMRpAlu6rkv4CvNJ6cozgfUgUv8OyTRQq+jac7kLhmIWJBnyLEjPrTZo54gZmuJtQjiRl5XaGMzHy3woXPrvmsTUOzn2ukb37RgR30jS9O01FZJA5hJLTHYA4+WPlIHP6jOO5olNHLPGHsLqO1g5s3Ba3EhaM7kgk7HzY7Z86AaZqWl2pS6M8V00agePqNw9zMe3wRrhFHoD9avnV7+9liS2LzczhhJI9vEFPXYOSowP8JPrQA5UgiBGTyfrCw4R0q5sLgPLN4TOrxxPDGNgMfA7Nkk9frSNxT7NdNucx6npT+EFM0M8cymeLH4xy9Bjz69CO1P8V7rkbr73EWQfGZ7iZS2B+IEYH0xgVJZwx3ry+LbNOzsX5FjLJgjqXOBzeufPFFXVvURx698PWoYHceJ5l1z2IavcGSfh3U7bUUyTySEQykjzB2O46gj6Ul6rwZx3owMWrcN6lFGOkiW7OpA2+ZQRXtW54R4e1WHIjlSYbL4UwZk/wA7A8mPQMaFjgi5RFNhrmoRwITkcvwxgdWZ3KjfAxhT12zua0au1UH5lI+HP8GLWdnVWco2Pjx/M8VppuoOsSwaFqbOTyhEtJSSf/hx9KYrDhzi1po5X4fubKE4SSW8It0j9SzkHz/0r1bPwTf3qrbf7WXs3iEsrxyEHl26YAGOu4P38419kXCKxi61iCbU7skyLFduZhkbLlAR3OcE423J3FebtPTk5Ck/T7mDPZfGHsGPd/4J5qsuBtX12eS10xpdWaIrzSW8TG2TJ25pCBkdflz67U3aX7IppvAFxaoWmCmSWRQhVVAbKqOijOPLv3r0ZDZaJpFssFrokcURcSTeGgBLH8WFABLNk8oAAAG21DNf1ezhhubC2iYzhlErIqgRKMZX6hQM/ljqKU1Xaltg2r7I938x3RaKjTtlFyfMzCOMuF4rOC502ydHcuWMjSAlVxjJI6Ejoo6ZHrSI3DMbaNd3k6SYjIjgESsjMmMjYdQBgk7dj61sF9pFyLy4vprJQqxPcPC/WPPR5PI7g8uepGd+mc3k91dX7adHCYUOVLnBUSH4iz9jgAnHy5wOlC0177eDNW6pLGGZmz6VfXutq17DNKLiQt7wIzh5Bg8qsNi22CD18+9NcWbHTpJUSMM8rvFz9QTKCQft/Wjen6XPo6M7Xht7O9lJjjvboILsL8JJ6cjjORjYc25BxkTxt4sVwtulrIJJHPijIJbAAb77ZPqSe9OG7v2C+ES7kUAkQlFqi3E9tbNbzyeFIC5hOHOcFgPtWi8AapdzQ3GmlUktovhWa4fldPjPKGddi3bp0rIdOurpJ0mikcSxRNMkkTchDAbn69ad/ZvMzX8oE0aGSPkIkOCS3RkxtkEjr1FBsqhVbcs3a0tXupIbi0IW3aVZIkGPhJOTnvjrTtoumXVlNEy3KwzAkqnKSArEjGT3G+1LfBdmVRA1xI0efCLcvyg9Tv03GBT9CJYURnIyJy5YjqoHUj0o2l0ws9tvGKX2FTsWHrWeOGS297mZkPVwx5VBO2fLfau7ZojKwCOJNublP4d9ie9LV7ObRobjxlRIhyhlYnKMfiDDv2qlqPEcNoJlhvHIni2DDcPn9KetpQjLDp/EpTp7H/J4zRYbmyaZvEifMfwn4scy9gf9aYbD3a9jeOOJAW2JB/CRjB9awex4xv53ME0hPYEbU48M8SXEXIZZNyfiOetId7S7AEcGOv2dai9Y8a3oMkNu8sWC6kAEDcr2FQaNNbXdv+zruV4rhl8NRhDjHQ75qccQWt5G1tdTDDQseYHocHG4pG4U96ur3mEZlLEA8o+UDpsNztvWVq6VotBqGQeJCK5Qi04I5hziHRQlw8Elg5ul+IzQKuG8iwB8u/TeqTaStvbFFuIZGcZkJgYDftn5mP5D61pB0eLV7FG1FGtWtgViLHZ1I7kEYobNw7PakvDMkOcFgob49ux7fXNK26Ihs44Pr184JNWCu3PT174kppDw45BKYx23Vd+wQAkk+tWrLTH8U3VxNGVTJSMjCJ5BwB8R/wANda5JrkCOmn2EMc0iKjSOHk+E5B+I7j7daraD/tIZYP2jPFgHlCouCq9iCPl+nXrQVREYAZP6ev2hyzshYkQ/bXs8FwA3LzkBEBldJGOdiYVPTOcc5PXJ86OwaQk0TMr5WNj4p5uZi/XdurHPU9B0APUBNMt4jlFUQSFyFHiM8khzuSDvnfocmn3ReHL/AN0ZJrRrMk5AlIB+uDv065710PZam59uMzD7QbulzmJVzo0DS86oYgD8TPjmb6CprXTBzFbCy8Qj5pD8v3J2H3p5m4f0iyOb9pr1ycBII8Lnyydv51JJbahDbLde6aPolmN0nvn8Z/8AcToT/lXNdVToVHX6TnbNSYq2WjXkzgwWstyVG628ZZfu5+AfbNWG0K/u3Nu8trbkLvBC3iOB/i5c/qQK/X3EGieKffb/AFriKRekbObS2P8AuqeYj7j6UP1DiXia7szaaTo8Wn2Q3EVpFhR9SAB9yam1aEHtHPuHX6Znke5jxx8f7lPWbDStFjLT3skrgfJDyqB9WO35ZrJuNuK0EUsFuVjTyDEk/U96m4w124tpHF5dKZO6mQM36bCsv1a/e+kbDcwrldbqwX2VrgTf0unPDOcxQ11JNTvmf4iM0U0LQo48MQMjFWI7NUkOQN/zq2LuO3BX/npWazYmnuJ4WdX7R2cGQRtWa8T69IzsiNjG21M3EWsBYmXm3IJyTWV6xf8AiSM2Qck0aiveeZBbC5h/QNWkN0vNISM+dbxwbrMYtkDtg7E43ry/p2peA6sCBk7b096BxrJbKqK/kOte1GlZjlRJW3cu0z06mrwBNpFqzb8VQw/AsgxWDWvGs0q4Mmx9ambia7I5hKw/rRKAyRexFPUz0PY8RQzMCZB+dMdjqUbgYYGvM+lcY3EMil52A747VqPDXFSTxpzOCSPOmAfayYFkKjiabearJbwl4gCaU7v2h6vYzlUso5Vz3fFWpdVimt9viyPOlPVD4rM6r371q0ucAAzMtUbskR50r2kQX2Le7ie2kO2GOVb6Gqes6jHO3NzZU+tZ20rRn4zykHP0ohbX1xOmJHyoH3p3vWC7TzABFZsrxC8AUseTpmidt0HQUJtMkDJ8h5UTSRYovEbbFUXyhj75JqF8lrbkDqR50ryTGQmRjnyr9qOom6uDhsgV3pds+oXQjAPIpGaJLLwMmX9J0QXkZu5kB8s+Vfb23EUoCrgCm+2tVt7YQKo6b4FAdWg5WPWiquBBbsnM60eTDBD3FGyncDFLemycki7d6aoxzID5irkZErnBlRou4FRtCenWr7R+lRMnYDaqFZ7MomHO+K48IDarxj865MeNumaoUkZlIxb4x3r8Ye2KueHX7w+1UKSMxZ12yAUyD67Vn3EN/wC7qQXxitQ10qICnesV498RY5OTrUoNhyZdDkTHOIJGYHl3+tIGsrlWyTjNO2ryB2bBJ8qTtVXmBwNqS7PGADOLDZOYk30MjtyopJPlRrgrSY3vVN18GSNwvMaoakzeJyoceuaLcKX6Q3SJk5yAWNbuodjpyBHNAFNwJnoW1VbXh9YrbJATDMcZ6VlPEcjCd2ztnbtWhWOrxtpXhAE/DsSev2rNeJZJJp5HxgAkivnqA98cz6Xpz/rEVdQnLOcjfG+O9UcwPCcq2d8sT/Kp7iZ+c5Gx2ofcl8YVMDtmtitfCSzYle5lDSiO3BCd6rXcHxDxJWHffp+VTyJJCAzHBPTArh44lx4z/Ge7Dm/Sm0OBxE35PM70uzsmkUSzzbnBdcCnfTLCyjdBHd3iuDuFRVH5tn9KXtLhtHTFzqCAdeWRRGCP+fSmC1fT0jMllfWoXG+T4g+nTrS95ZjxmWQhOI12up2NnGI4zG7Njn55PD6eeBlj9SBV5NVu4/DcxycrnIdvhGPIFvm+w70l3MtzHJ4okblC/OCFH6DIr7p+uW0Ya2vbu7JkUqTFCABntzMCx+gFItTnkxoEER+hu58ZhvdSiCAhgbhIebsdhnlHT5mWpBe6hpa+8WGoXckuHkVprvnCEgA8ojU53zvt/Wlqxt9SVhLFJY2tupXlXARs9uY8u3r/ADFTrC2r+JzalbC0wWmco8cSYOCBjLOfRDkn86XKkHGflLLg9BD1txAyGJ9X4lvIjn4lW5S0ib/MZmZ8eixZ9c0w2vtB4YzHZNxPbeOhIMdlHc3jHsAFCnmbG+7fas8e04ahhaOygjMkgHMzxyM7467hG5B5AsT51d03RJ25xb39ypeEkRWtuUfOejybBV9FBJob4I9rP7RkImcnibZomvMxaFotVtYEbDtqE8Vryg9OWPJdf94LRyPUuGJj4cpSVGbI5JBc8pwfifw2YL9XZc1hnC2gafYSc9tpr3d0nNzGVnWON++yhmB7/MrHzFMtpq+oWaxWcWkXbyDmAULywxqc7hFOM75JPM3+IUEgLwokd0rHg8zWrrXOH4GFraT8r8gHvDwuMgdFy2FGOvf618t+IXuoAmlW8d2ZCCsqlQpwCMg5yR2zg7+dZjpLe62sjwW8fiOxiV5okkDN0+FFMnM3f4xjpsKIafe2KtHNeWM91HEQvjaleKFLY6IsYWIbdMdP0qhtI5z8pI0y9OT6/SaFdRXsaQm6lhtrkHmSJQMg9CxDEFiM7EDOT2GKE3tjBZTw6ZaQ+ITEzyzyFcjA2UZICDIyx+xx0I2FrdoPe1J00Xp5o4rbYgKc7ugCnz+KQnoOWvt7qml28MsVtbTXFlOB71yL4jzjfCsdyqZ35C3M2csUUgV4HfweJ4VlOBzA+oWyRWP7Publx7y0e6gfvScvkkjHJj5M7EczkYC5wTX7gNe+8afJcRxXLvPmTPxKX22O+Tjm3OcYJxnbbeKBeR6ZJf6yZLSKZGlMUr5ceIAAGc4yxUjIUYAKLkbhcejtyl7aSWt9HC45lLSTBUVQc8kYxknruOvWmqCF5h68tGHg2Oe90KW3h0vUoluVYO/irMFB2ywkUklhnIXIHY9aQeLLNp9VaO8V4fAQJzSFhlk2GMjPQAYPlWqaNpM93ELoQNfSPEPEuJr1jEwxspAUsT16D70mcU6I4jZltyy8/wARlfnZcbbNnmb6Yq1FmLCw8Z6xQQVgLTfd44obhBIGbOMfCrr0xn+L+eBTJwNKougRCrcpMSxP8wxuWP5Uow6n4NuLCRTJC2eVeUqynG+M9jtRLQb2W28S4VlJc5Ujrkin9vnK0+0wAno+x4zjt4xaqxUsijIOcnPUmjcPFGs6jzL4irFy8nLnHw9xmvP+lcQTFldz8XfO1aXw5xGrxDnfGOxoD6lwdoOBNQdnLWm7bkzS1k97tua5lwpUkldj/wA7Ut3rtKT+9HMMFSD2qR9fj91AVzysNwBuaVl1hlumtyCF/Dmpu1AKBSYfRaVskiMsUphCXBIyrb5NWzxmlhhWnRC3QMwBP2pZ1zU5NO0G41URhjCnwqfxOdlH50h8BcE6zxdrQ1LVrmWQyyZZiSeXPQAdhS6q9nFUcPdVgvd0E9OcGaudanjjmJ8JwQcNgnbselatoltpcEyWtpAsbKOUCSPdzjfJANLPs+0q14fsLeGN4UUAHw2XJJ9V8zWilHnhjm5VyDgMVWEj0+lbGn7NIQFuWnBdp9prfcQnCyaKEwSCRWQDGBHsW26HGObH2qbU9QvfdmUNaqwwFMikkfTmxn86FzajaxI0kkVysiYBJJbI/wAJ70M1GwsdehkbTxdJMw3Ml3Oo+8e6n60PVhkUrX1iNGHYM/T4f3KmvaZdSqz2q2b3SgsI2gkJx/uknr3pd4b0PWBdk6rb+A/Nlo4+ZkdT3OSD57A9eopg07hu70+BI7iXwyuSXQfCV752yPsKl/bWmaMFimaCWRuiQMzux+jdT/KsH8IzsHcbR7//ACav4nYprT2oz6XoBtJlvkb3U8xGEURnB9FHTbz39ab7Z3FsWilECYyZJHCg79Wbf/4Rk9qSNN1PUr1fd4dJuLUybh57qGMjyJXmL/6+VMelcN3kirJqGqNNIm+VJUKvko/DXUaCoU8Ipx8v3nP6xjYMuRDweVLfEDoGYf39yAqn/JGfiP1I+wpe1Dh6zmuDe67q11dSsN84gBHlzSZbH0UUXvPd9LtC6RzPsA3JNyn7kDJ+gpP1biu/tQTo1va2j9A/hc8uf87ZNdGrIEw/ymIVctlYattJsogH0jRYdv8AtfdXuG/+OUqn5Cl7jzwl09jqmp3GAp/d+MFH5JgD86WdT1zibUlZtR1C6kPfMpI/LpWd8Y6klvbuHy7YycnekNZr6q6yqp9o3ptI72As3MzPjzW4H1N4LAcsWT9f5mhVieZPEbqRvQTVbvx9SZw3RquRaisUIXmHN6muHc5YmdbgKoUSxqF74WwYZFL17roVSQwyO1Vtb1dVlIzvSVqWrszOA+R0wDUJWXMIq4Eua7rjSoyq+Tg7Uj3d1I7nqfvUt3fZd8OfKhU0wkOVbb18q1aK9nEBY+cgTo3bI2ST1q9p1/IJR+8I6d6AyzDnHN0yNqsWl9HC4YsObPc09tBWJ5YNzNN0W/c4BbrjG9M0F54hC5Oeu5rL7PXVj5SCAQMbd6OWnEjLh0fGDvkUg6MsdHtCPylucOGx3NNOi68bJViMuMCsvi4mVhjxd+mx2orp2qLOUwcj60M5zzIKHwm22fFcnghVk3+tT/t6Vv7w5z6UiaLMzBSQd8U26XYS30ygAkdacpsA4BiVqeJk11cNcOqgAAn70X0/ZVyCNqsNw0UUSyI23eogogcR+WBT5z1MzlIzxDVo222ap61qojX3eNtzsd6in1FLS3Ls2NqVp9RNxK0rtk9RRU6cywG44hSJnlZUQZdzgVoPDmmrY2ys6/ER3pS4Q0w3L++TptnYEU+xvjAGwoicnMixvAS6hzQ3VoA2SB1q9HJviuL1PEizjO1HEFnEVov3c3XptTbpriWAUqXKeHNkDGaO6HdfFyE1ceUqxwYYKZqNlqwR6VwQMV7E9uErlN64KZ/rVggYx2rnHXNRiRmV+U42zXxlABPlU/Lg1T1CZYYjk4r22ezF/WpfEyqmsz4r05rkNzL+lP17KXkJU996HXGknUCCF270JlzDVEDrPI2qOzFsHv5Ur37BgR2J6dqYNRfZmIyMmlq+YBcDGCO1J6QcCcOhyuTFvVYnycY39a+cN3L2d4hZOffoNq+anM+SeY9MUKt7+SGYN4mN63WrNlJXzjWlsFbhp6D0a7W503PhBMjbPU0k8UMElYAn6elU+GeILuUKoeRsjA2q/r6q6F2XLtn864a/THT34M+k6HUDUUgiJdxMqHpk52qCXDAZySegru7idX5sZwc7mqUviMQzE9flFOoAYRjz0ks9u0mGaRV5TsCcmq8yyLlVhZtvm6VLBhWLSx82K7lvkj+S3RYwd+dzk0cEjiBIB5Mm0y2F0MKkSuvUBOY/mabrWze3tlJYkgdFEeB/Wg2jXAnKmFbcNy4BKk/lTNbJc2oaSa28Rj0YoMD8jSl784MlEA9oSsbKRo/EW3lEbYGUP/E4+1DrbTjJKzR3qQSKxOZJQkm2/XB3opcXksxKvCDgdM8o/Mb1Bdyalaw+JHaGHb4XDgqPuwzQwrEcQofZObrSLshV8aRnILgeNI5Ge7HGB9K70ZNSFwJYb9UeAlgwAJ8sjmK4+u/0oAOI7yJ2W4vrpVU55bdgSx8uvLv9KatI4vSSD3E2CR9CXkxM69jjISNP1+tQ1TY5hVsPQCSalxxxVBI8b6jeTRqwVWjueRVPmAg3P3qnp+t6/fP4mn3d8hRjzTPcsAhPmxK5+7ECj0mlWV/aGQ3rT7q4DILg5OfJuRPz+1EbDh3VIoQkFlBDHjmMs0qoVDdDhsHPfYYHpQMVqMAAGXDjGWgpodeMIXW9et5beF+ZYRclhzt5GJWHnvnPrRzRpILFkjL3li0i83iQ28SBk77yMGkHlg586X9bgjtTJcXt9e3KR7eLFeh41A22OGx06LvQm241e2ijtInWdMkOUWYuy/4mZh1Pp9qEaWtX2YzXYomkanrySgOoLqHCLJPd+K7Jk7lHGEz5DI8gaKQT8STSR6peyCwtlXlhQRWyvyBSBgkgKO5OSNxWWaMZ9RunFjaxPISSI5FwIF7lm2C9hkknyNOLcPajpKxTa1a2FtJNGZYnjIVpMEYCLIXO2xyA3+Wl30+Osu1ygbQI5aBfabB4+uTabqesLG4/fzWczRhttg37tJCMnYOsYUfKaPahxFqctqkl7YQ2Vqsoks7SdVhid+qu0Yy8p/EclEGfuc7h4gt7k20Uc8lzexOW8W9VpeRxkgQwNs7joHkVI03Y9KgvdVjnvZ79J73UNQEXJc3Ac3Mat5LKwCYXvygLnOA3Wq91gcD175QnJyfXwnfEvF9zxTqlxJq2pLKrN4j3TxGRZZFB5VCjI5UwSFXKg4JzjNVOF7W4t1Fxam5uJLuMKAytCJBnbJQMyIT1zu3elWeaBJLi1s9O8Z5W5WlkmLZJ3K4B3z1PQehpx4XnhtYJr+4vZYRE4jaPx/hyAfhPKArnf5c4Gd8UVkYDIhmsVFwBHfw7G20t7y5ligdAsbR2vM7PKdhhWH16ClK70SXUJJmlswgVBH4gaMvnqQSCFUjbIBz260xGJ57SB4biGKK4VwnKh5+Yr8TBUAQeuSfuat2+lXiQiBtNhvZGiDL7tHytEvQsu3KufMn6VSpD/wAYs1wQHJmI8ZcLahAkrG2kXkYKvNszbbbAkHpSja315pMkMWowuI1OM43Feqbfh1rqOH3e1PhRrmRQysyAjo7HYZI7tk74GKpt7HdM1SaZ7mT4ccwUjYHp2HnW5RXZjYVyImdagbfnBEwaXifTrS3NxaO9y5X4YlU7n18qWn9pntFtbrxrU20UQPwxGMEAV6Xm9gFj7qDBjmMmWblweXy3pA4r9jV7pcskscYeFMDYb/Xp0o66VKsl0z8ZpDtJtThFsx8JJ7O/adLxNp7ftKH3W8gPLLGDlTtsy+lNbziS7inXowxtWRaHpcuja08IjKCRQAc7N3rSRNOllHc7/u8bYrE1dQDMqDidRoLAFUseehmmy6NHr/CF1aoQZIwkwA78pyR+VHfZtpFhAyc1tCytj4mYAA/Q7Zpa4R1qNdPdjNhTGep65FMfs0umN7IJxDyhjylgG29VPX7U92W+xQrDmYnbRZK3APHWbpoks+lxeFLYIsRGxWPnyPMEnamC1iilZZbe4tLlmG8VzG2fsR/WlWxuWEcQaa4jJ6SwEPFg+YO4ovG15by8/vkMatsGbmBYehG29bzMMcdB69ZE4DknPjCWvz3FpAk4tJbXAwPdXIwPMEj9KXZ77VY1SYTT3ManaWV8P6AlOU4+tX77TIbqJJGPhuGwrtIHXHkOYg1PY2htCPfJ5YVXo8aZjx5n4jWbqQ9zccD18BG6Sla56n18YFi1vWll5Q2oCBmwzxxtIq/RmUkfnRey02K8UzJqNw/inmKTXPUf5VQbfei/unDxtnaCdI2k+Z7dwu+epGdqHSz3NuRb6dFeT5Ozx+Hgfm5J/KgfgnT2nORCHUq/CDEYdLs5LeGNFnjgABBdjJISp6kDI3+uRRWyv5bq6Ww0/UDI4OWMkeXA6dEBA/Wgel2d7dukl3C0A+Zm8AO4wOvVh17Baa7FrxBym9uZkK4AMTwjGN9hsfyrZ09GFB9fvMu+zJMtXXDur3qEXF/ZogHxPIxx+WM0BuuGtCtsifiWEsDv4Fs8n6nFSaxb6hdKDBpN0VP43flH1AOKEXkd5FA3jGGMAb88yf0Na6hNvKmZ2WzjdKerHgWyhYveXl2++fFjwv8A8KsP1Jrz37W+KrNVkt9OkIiIxypCsY/TJ/WnjjjWorNZF8eMk/wtnevOXHGstd3MgL9/+RXJdq6/e3dKAJ0PZukwe8Y5itcXv7xpecnBPU1Wk1dmXIbOPXvQrULkpzfFuc7UJ95ZDlnYA9PSscV7psZ5kuu6jKxL+JjyFJ93qbkkc23p50X1abnT4Tk0DW08eTlYN9qepQKOZRiegg65upXyRn6dqqtcytt3z5daYJtIzty7mqq6GyyBQOo600rqIPumPMBTeMdwSMHJqGOK4ZgBnenG34bEvKStHNO4PjbGYwR0r34tU4nhp93Jippthdug+BthRN7K7iTk5DjrvWiWHDttDGFCdB1H0rq60NH6KBt+tKnVhj0jArAGJm9t72j8uCd6c+G1unkTIO/60RsuFUd8hN/5058P8KiMofD7+WKWtuLcCNB0QYMO8NWM7xrzL1xW6+zrh+1RFkuIUctgnmFIOgaSkMaqRggU7aRxTHohWOeCXA/FHg/oaZ0BUP8A7Ji68tYhFc03VeFNIuLAtEghcr+HYflWLcR2DaJds0sytDnZgenpitAl49s9Rs3W1n+MD5SCrfka83+3T2kTaNASvOS7YOOmM10dlddigp9Jz9ffVkh4Y1viFZmMUUuQvzYr5w7BNq94sSrlEbf1rz5pftQuNS1GO1t3/vDjfevUXANrDBpUU4IZ3UHPnnvQbEKeyYxVcCDjrH3To47WBIYxjAonFJ3oNBKD1NEIpOmTUiVJhKN871Mf3iEGqUTdKtRuc486KGlCfCBdQhIJO+aj024MUq7nrRPUovgLCgKsUlznHpVy2BmQTmPMT88YbPavpI60O0e7E0HKTkiiBI771YNmUDT4a5PpX3m+lc5qQZOZ8JwCT2pe1u66qDnFHLqURwsc4pL1S5MkrHOQagtxPA5MqkCR/qaYtHsVMJcrnI70CsIDNMo7E4pytoxDCqgY2ry8mELeE/nrfspBJ9d6XNQfALUbunyxGOhpf1Fs82ciktLxicSvIi/f5YEDJxQiO3UTc0oBGemaJXrMCcEdKEO8pk+E/eukQZTAjKYBBMedBuHkC2tvyqM9hj9abrrTZVtudiucdc5rPuF7hop1aZs7961C4nFxpoQOoyK43tio02DE73sPUG9cHwmb6uAkjIDnzoTEC7nDADPWjWtW0nikKNj19aHwWZAwygDuzEACh1EbZsWA7p8aNXBAkzk9v5VUm0+4uZ+WPwyAfxEVeupLaKIosjNj/wBGuR+ZqhbXKCbEen85z80su35DFGrz1EBaRjBjRoNjJbxqTEiSE7O7DNN2nWrwtmK3naWTG7DKetBdCv0s0WR7q1tQ3ZEU/wBM0zRS2t/ID41xOzjZ2PKp+1I3tluZKgyZ7W18Flmmiidhh+TILemd6CXWj2U8ryQX86ZYKefLA+mOhNGZ2t7LCv7tlduVcOc+oGSapyTXDEk+Lvj5oFUEHuM9P0qtZPhJII5MW73RbGOIq0ky7YUtbCIfY7Z+9BJtLtbTlkiu023Abmcg/TYdfWtBs7mBrnwze29ryD94GUb/AHGf51di0qwLPODczrISOeGzVifoXZi32AFF3t1EqLQv5pnljr6WH7ySzlkmYcru94yEj05QeUeWN6MR8fxJM6R6RGyuBzN4XMijHnMSznbvgd8U3z8PwTRzS3s11ZBFAAme3UvtkDlUEk+nQd6T77hK1uJnUOGDNzArEm3nliRgZ8vyqnsk5YfXMMLFfgTrUeNbPWVhH+ydvBOmyPHF4jKuABypzKg9CFz3zRPhzg+5hh9+ghuY7ggu8boyHz3LsB/P+lWNA4QGlzQ3SM7Z+Lne0mC+uW+FCNtsZpm5Uihkm/a2us8wO8IEKOOu7qMkfTyoZwTheBJN23gfzAkckunH3bUL/wAd1JdYoYSzK2Ns77b9xv5UK1GS/vNSkLXErOyEyiQqZZNvlAGWxg98Ad270O4gSKKYPZ3dzEcEcjS88knYg4+I/epNBtrvS4lnnJLurckAYrIOmNgCB9cMfVaqEGMw6Pjkw7dT6jp9jy+P7tFP+792Eixcw/hJYA8o+2T50Ml8SFHRtQM8jSc006TFkjXuAq46dMbb1ajbUbi8N9expJNAv7oPdciW5IwSQSzZI35mbOOmxxXF/o8Ecfiard2rT5BjhgchgMbEEqAO/Qee3eoVVBxPb2Jyeso2+niVFNn4s0SPzPLyqI1XP8KjI36jOfPuaatKuNLuSiTyyCJDli68pXG+wXPMTg7ZG350ipKryskFxEkMYOWkkHKzD+FRkE/y7ntUtlrkKyLa+MbhT8DlnYAE4+FB3Pmd/rvipesuuJG4AD3zW4dTtp7UXUAmRJWWOEzTCIO3cZAblG++Cx7Uc0C7s5LmK1v7+MxXJb9xbs7CaRCcBjs0mD+H88b1mF5faq1rFb6TbwRJaR8kchIbkdu5J6HGcKPqeld+ziyvbrXHe5uvF8OPwwzOXabfJVQOiA9hgMetW02EbJgL6yyHE9GQy206M02ps8URDtAGCIuP4iNuvXc+Q6Ve0u/N1PzW1siQhQ/Kq8pOdgST09O57Ui2d3ZwQM91cu7WxYBS4EcLjHNkZwSNvvkDpTFoutW2oatDYwlPCVsRpEebnkGCWY+g3ydhW6j5YGYjKQI/s8aLGmOYKAdwNz2GT+e1V7zQLbWBcxzRKylvidBsfMn+QqF7aO6m5ZwknhqWjCtkKM7Z/nRqzv4raRIY1/doCA7HY7btjufWm94bh+kECU5XrMW9oHsSuW8PVtGgUGPJKKCGJG+32pDYXMdvLZXULRyICpLjl3r2HYXVi0Y94eNEQNNIWOSVIyM58+tZ3x/wfw/rVgl/YxpHOR4jyhdyXORn0ApLUdnqT3qfKb3Z3bboRVcOPOeb+HOJZhFJYxyZkVvDK9O+K3PgCKHSrAT311HmT5vxYbuDnoawFNKbROPbrT71QRMC8JDfCSpwcgfatv0qZ9Tjt5nuIxNHCpYICodcd/Xbr9qSorCsT4iana9xvUAdDzNY0y/eOPxbK9jaJ+b4Y26ffqp+xFXU1OcBpFupsKoOBKrE/UEbGkyxihktRaMDHFIxBDPjDeQJ6H9KPWTJaxC2aV1f/wBYh5wR3B3Box3dB0nMFVBhi34qmAEEN+UAJBFxDkH0JUEEfamO0u5J7UpA8VsZN+azf4GPfboD9qS5ZbGK5Ep5SzDmI5BjH8XL/UUx2ur6VFb8lusDM+Ph5DH4n3OB+Zr1W7cdx6evWJD42jaPXrzhOytbx5cy38sqISPEilBZfIbb/mtOFlGksEaTz+8lV35+Rj9diD+YpJhvXlH/AEUxQxlSWU/GB9UOfzBq7axzXMym5hZolXBms3yv/wALbj7Gm69qdOYu+W90dGX3RWlhs7ViT+K2YNjH1GTUtktzMrOsrwhhzcqfCNvLeq2nm7W3SPTtWhnjxjErNHID5EY5f1qzMhi3ltjEx7dc+oPQ/lWnWmcEev1iDtjgyjc27szSG4kbzy2aUuKdXWyt5FaRgANviNMms3sdrbsfGPQ9sVhHtA4p5nkhDE7+dLdpawaavAPMLo9Ob390R+POJzPPIAxwDjrmsi1q9MhZ3wTnz6Uza7dtNIzM22TSLq1ygyNun1rijlyWM6tFCDasX9QufiPO23lQe7vlUbMPzrrUrkFywP0pfvpjkgHenaU55kPxLjT+K+5JxRO1RVTmIXzpds5lGxzuaLwXakBM70WxSOk9WRnmMENukqiTYnG5NTLp0fzFMY+2ai02bnUBvtRgeHKB8PTfHpSpYjrDHpmV7a1jDqOUHfv2o1AqxMMDlDYxvVGMIFwMZB2xUkcpIxknBx1oL5PSWzmHIZd/gI6VaRUYfEAewNB7eUxbFtz5VYGoKAAXGOuDtQ9rHpPbgOIcsWijkwANumKbtFnUOMgAenaszXUgJQVY56bUz6PqkoIxjf1q4GIF13HImq2l+sa5OBttir9hImoXQRzkUhLrSogUtimbhS9E19Hv3B61NTkGBasFSZqOm8Ew3EHiNHnI2JH9axn27+zxI9MuJGt8qwO5Ga9T8HRLc2SBlztSf7atDtrnh67V1GPDbauw0i5ryJzdjlbcGfzV0Xg+ex1opG5Z1PMABvXqP2UcQm4sTpl18FxAQpUn02x9ayH2daab/jK8jnIaO0coCejDOT/KnzV424Z4jt9btRywSERzAdMZ2NRcd43iCVQCQOom528oIFEYJPOlnR9QS+tYrlHBDrnY0cglP+tLBscS5MLxPnGe1XI3HWhcMo2yauRyetXDShMtTjxEI60s3kfJMwxvTIrgjGaE6pCc+Iv50QNuGJQNgz5ot6YZghbZjTTz7A5pCEjRSArsRTVpV6tzbgk7iqK+3iUY4OYSLVyWqPnyetcSyiNCxIxiiCyeziDtcvBFEUDYzSfKxeTqOvarut6iJpyAcjNUbSMyuPWoD5MupwMw9oVuCwcjYUxFsYGaHaZD4EA3Aq08nrRFfE9u5n88bvlZSwO/TpS5qDHBJxt1NF57gFSC350FvskFtiPQUHTLgiciuYBvGAyAaEucP170WvRnIxQZjyyHO5zXQ1fljC8w9o6OxDO2OXpT5pF/EYREH5yBjJO1ZpZyzlsAkDypz4ftpZmRy4yMHJOAKxe1aDYpLGb/AGTqRS+EHMs66cHKn8qA+IiozSbbflTzrdrbLp4ZFDuBnYdKzfUWKyHAx2rndOd3sidzYcKGlC8lV2KhyST3qTTY1MyggEk/mPKq6QCRy0pz54onp7tG5S0dIf4mxljWgeFwIgMk5jnplqbeNWSCNWxkFkBxV651K8S1ISblYnLu+FP2x0oRooiOMtLO47u2AKKaqIvdlZbQyMAe+AKzX5eMV9IuX3EN7lueeRyfxK5x98AZ/OhZm1C6IZGKAH4ctjH571+uYRcTkSJCf8IkJP6V9ttJtJXVZVWMNnOGJ/mabRQo8pDnxIzLFpE8EwmvGup8bBEcRoG7dck0wrxNLaJmKEWiEYYNcN8Rx3Ee52/iP2qtpuhx+AEtdPlhjY/PJKTn1x5UXtOF9LYF/e3mfugOB9sVV3XPWB4zyJTh4xWB/eI7QyynotrH4Jb0aRyz4+iivo9pmv2rl7azgtHXIQRrzyD/AH5CxHqcA+lEptKihh+DngA+VBgEjucf8aow2Fuz+ILZ5QNiWJAB+g3NCIU9RCjAg88e8UXV2t6lrJLKrZeaS4lYt9W5lwPyFTPqnEuucrXkl5cLkZHMfAQeWDyqfzemu04U1GeNZb4BIiMqryLCDn0O5FFF0iO2QCOKVlUElogI1Hll2Bb8lFECbuggjcq+EUbbQ7uIGd5okcj5UPxD6kgKo+lHtM0tpITHzzmKQ8zyqfgcfw8xxkfc/er0NvcL8NklrbnJP7uNnJPq7jP5VfsrC9vLtLUpfalfyYWOGFmZj2+VAXP0BH2ob0npKjVHqZWSytNOiXwbWBHDA4SJnZd/mz2Oc75HTGaXtdK30bXE8scgjJMhmcEuTnGy7em+T9q0O60Ow0lVteJtXEEvNyrpelwrc3hb+E4Yoh7fG3N/hqhDa6i942n8NaPp/Dxb4i9xIuoarINzks/7u3GM/LGmPOh9wa/zH+fXxhU1Ibpz69dMzPOH9Mnv5JYpbW5VnChQi8qQoTsQoAMjnbbZRnc5pisvZzBa6hDJNhJW+ZZCfgOO+B1+mQPU7U06ToN7ost3eSXKrLKonkeViZXAO2ZH35fUbeXrHqmsm3hN7GnhyApK91N+9eQY+FI1bYEnPKN/MgbUKwsRxDrYc5WEl4e0WK0FpDaQuI0EbmOAlQoAJRQc/ET8zHJ6DfpUF1xVpHC7m20K3IvZMIDEAfCAGMs3cjJ2HT60N0K4uNQu3utTvZuWBWjFoHOYubJzITspJySzYJxsABUt1a2msuP2HbyNbqxRJkTEbtn5xkZZF65OxJAAxk1dENYBP9wbf7DgnP7SeWK51WxUXUhdmRWh022UgRo5z4sx33PZdzuB1OzdwNBqekyQx+ArG5J5kRCZNt+Useg8+31oRoqWWk2cMKyzqrsC55g0k7jOSWHlvkj6DAFF9J4jimv2SK6fwwDCkKLyrnzZupA8h69aeqZQQVMVtBKlcevX/sfdNvnaaS51a7t44oT8KwxZw+cYJJzI2+PKrN/xXYxzzW8yKZ/D5IrcNl8ZG8hGygDr9aUFjlmgMtnl+bBgycDAJAYD1OT/AOFRWHDFrb3DuGMs7AGaZyTzyE55cZ+Ik+e22aOLmHGIIVKTkmaFJO2o27eDcSLHdtyE/wCDHyj/AF9araldvBpahlUqow6g/MgPl3wBj70JtzdPFLLazk8reBEWORjOWJ7Zz/Squv6rZ2dzBZz5RVTkV8fCGLdCPpg/ejG8kHEmur2gJmftFe0tNWhmdwZVyZPD6kkAgDzB2zvV3hviV7vTEKyESAtFGdjlOY/1B/OljWL03E9vbv8AvGiBVnI+Y5H67/rRK0sVjVRD8KxqAWI2we/61mM4UzowgNQB8JrOh8RSvaxQXoEiSAeE+QcMFB5SO4IOPOmTSeJLdXUSBltjkcqksIz3G/QDb1waxlH1K302S1ErgK8Tq/XlcDZh6bAH60w6ZqOpFTbSxtzkMDn8Q7EE7E7sPVTR1vAxkzJu0oOSJsVzeWhZHRwYw3K6O2wJ6bnb6dDV9r62iiU28yglc+HKvIQB1wcYOO+23faseX9r3dskMd+YrmAIsbk83OgJIRweu22/kKMaIOI0uFjZ2MfwNyjflA6lc+X8qKNQhPA6xJtMVHJ6TaNMlt9Q/dm2WK5UAoWXOR5hgcZ+mMimTTNMkcrK0EqSx5BMbFX27j+Ieh3/AJ0r8M6dNyRSoApU8yHHw47oR5dx/StK0uJWC8ylWAxvufp6+h61rUU95gmZVtm3gS1YKyf3/LJ/jZeV/uw6/evt/KLaFnt5yqns2CCf5H74q64KRmTk58DcdCaROMuJILK3kw4XbdTtmn7HXTVEmKKrXOAInce8UrbxyqSqsM/Lt+leb+KeKDNdP+9Ocmmfj/i8zyyhHBGSBk9qx7VLo3ErOWz5EVwer1B1VhJ6Tq9JpxQnPWfNW1l2VviztjY4xSVqF88jMD1+tEr98qwBB7jel+5Dbk9s9KEq4jggy7lPMebpQu5K5ONsjHnVu/dx+E47iqMmGUDG4x1pyscSjAmRoVTDHPpvV6BwWUgjr+ZoZzgNyk+mK7S5IPLnGO2aOVLdII8R2sJyig9MfnRiK4ViACcEb9qQ7PUZM8pc4/lTFp2oI6hGOBikrKinMMtgbgxhaXkHMpGDtUUdypbJYA/Wqr3arGRgVQ97VZBhtj59aqF3CTu8YyteGKPHNknvmhr38hflL+pqs12pjCg+owapS3XK55j+nSrKvGBB7jmMlpOZCCW3z501aVc8qqN9sb1nljqEZYZYZ7U3aPdhlXPf1pexCIcMDGdrx2ZeXO/6VoHs+Z3uY2J3zWe2wWQg464rSeBY+W4jI8xS4YhgJFmNpnqHgN8WoJ7LSv7b9SgtOGL6SRsKsTHr6UxcHsINMDnuKwz+1lxYNO4OuraNjzXP7lQDjc13GjHd6Uu3lOQu9vUYnnr2SQsffNWYfFNK7D6FjWja7YR6vpMtuy5ypIpJ9nEXufD8Mb4DtT3ZT8ylXx6g+VIUW5JQycf8pD7LtdnMEmiXr/vrVihz1IHQ1p0Eo23NYjf83DfFdvrEDcsNyRHLjz7GtcsL0TwpMrAhwDtVXO0yDwcCMUMu25q3FMNsUFiuOgztVyKbJqu+UIhiOUedfLhFmjOetU45ttj+tTeMCKsLcHMGRAd3GY2O+KsaTqJtplVm2JqTUIwwyO4oHLIYW6kYOc161sjcs9jcMGaCk6uvMD1oNr2qrBEY1YAmgNvxla2cLRTSjmA7mgV7rZ1GZmVjy9vpQe/BHEqoLHEsPKZ5u53o9o9rzMHI6UB0+BpHGx6042USwQgY3oqvgQjHHEvhgihR2rhpB1JqFpD51CZcdDVu+lQOZ/O2aT+XShtw4YkButXJW+I56fyobdEjJ2p3Te+cuoyMQdeAEHI7daDPy+KQ5IANF7lzjPl/Kg9wDzfDvvW9WMLCD3QnZXdtERjLH6036JqwYKiqo7jtikK0Kg4ZT17Cm3QuZnXlQgbZ7k0jrqEZCWj+k1NiONk0PkiutNYsjF8bE9KzPX7FxOx8PAz3rWtD09rq2wxCkr+LuKWeK9IjhYjkzjy3zXEpYtV5UT6NTm3TgvMzSNiQrD4V7dqM6dbk4jggC+pqvcWkiyEpFnfoBRHTve4xlkES/qRWmX3LmLAYMN20ctsokldFC7DbfP0qLUruOZWaUSSAjbxG2H2FWovC5PFlhLAb5Y/yFDdRvWmUi3hVAepxuPvSY6w1YBPMB3SyT/BECi5+Y4UCimiaVZKFa41Jh5pF3Pq1CDFavMFur1nOd0jHMT6elMtlFaQLm1ihtcjGZAWdv9KOSVGJDDJhq0E6stvFe2dmhAYeKDIxA6bA7/ei8AluJRDJrM9w2NvCt1iBz/8AMaFabo7SMLiSRIbfGTLKMc3oBkZ/Oi3jWtrIYdNuoYYiPiEKZeT6v/QYFLswJysHg+MlutHtkjPjyyKwY57s31J2H6n0od7pMic1i8MIP4uctKfuen2Aq/PDcXKiRoTyD5VdsBT5+v5VLo/C2u6zK62tn4iQDxJpHIjhhX+J3YhUHqxHpmvLuc9ZYsqjLSvpPu9pMjXmoozZyzNJlifrn+tN2kWk+tvJHozTXSRb3Bt1AigH8Usz4SMf5mHpQt7Tg3QQrS3EGs3OCeQs1vp6HzJHLNcD0HhJ6sKJXFlq+oWFrqHGuvjSNH+awt3tgiFe3udhGF5v+8IVfOQ07SOcNz68T0H198S1Db+QMevAdYWMPB+mYjvb6fWJiOXwNPcpAD5NcsMv/wD2kPo9XLwalaWLWWrXMPCumTjP7K0uMpdXK9vEBPiEH+Kd8eSmgK8UHTpPA4N0mSxOMPqV7Ksl+48kIHLAD5RgHzY0DleZJXaeReZ2LMWyzsT/ADPqd6OXC8J6/Xr9osKyeW+sMT3ZUNpvDmn2+l2zjlfwpC1zIvfxJtiB5hAq0w6fcaNw3pQiRUjjcmWQhFAdhtzux3YDG3McDypRtbw2/KI+T4tifDCjPmSdzijAkuVmhmtbJr2/lKm2M0bSsx/D4UXds9GI+gGM0nzuyYwMEY9GR69qpms01XUbaDTbGSTxBNcHaZv4sY5pXwBgAYUeVc2GlwnT14jv7K4soZYzcW0k7gX88WDmSNTlbWELk+K2XIJK8xOxe74bj4Y1U6vx3cw8QcdFOe30uU+PZ6FFjmElyB8LzY3EQyBtnmJGRk9rqF/eSTXk0+rX+oSKZTeuWyQeYc4OwAI5mUZ+VV8sRYq1nkc/t8f46/tDVsSMKePXT3e/ofDzgS00yXXriK41O0MeltKUtdPiLRxuvquScNjdmJdurHfFOWp39jZyRW2ockK22Gmithyo6jogHUjYDl6bb5O1Q3N0ml2n7Wu7gzXCEKocDCIMqAoGyk4JPkNztjNG00ue4ZpNUAh1C5Vrsgjeztyo5XYHpKVYci/gUqd3cYDyxhgcjPh4evvGexjj1zTJb97Y2ARHUcxwYYhjHidhgZPIO+M9MUB0nS3vNUACPFZqTyuzbsqnDE+bHcHsAT3po0/TPd9JkknItLOJliRCcsxG4UebZG57tgfhqpGbD3xoWDLzqAyq2whBAEfkAd8n65zmrEgkSqZGQP8AyF5OJIo2As4VlaQEGUqOSNBtlR9gAfLOKvmWaVSlsh57ZeZnB+e4dep/yr/MCqdsluFa8Kq8dzIiI+MfAiliR6eQ8qvLPbafp0c7kKnLJIxJ6nbOfXcmjo7PwZQoqngevXEvTXtrpMc0Em6xzKCpGwwAc/nn7ikDirU5tS1NI7KYlVlivEKjI8Nhy4P+6ebH/Cvuq6vdatrt7FakhIbjkYZzzHm2H025gfI1xo2jXUF3a2XMqgoW3GAuCVC+ucgfRDVzYMbRCVJt9owTpGnM05kmthzSShkLKds/EfsAV/IUww6awxaPEeV5DEMdV7dR1+IjcefpR6y0e3nmZYpPFiUtlEHzIwHKRn0DfnRaO1DraXACmB8hmAAw75wR5DHWgYz1jPfeUFaVobMiBwpLKSqnfcfMB3674wdqZNN4ZsS6yRwCCZxuOc4kH2O/23FSWsRke0DRRsswZHBzs6HBAO2+RkfU46Ypy0i0tXXwiodWw/KT8StjqD3/AONErrVjiKai5lGYN0/hyz3d4vizhyTkj79qa9H4eicoUVW5em2D/wCNSHTxlJkBblIXLADfyz16etMGjJDEwDNjH4G6/nWhRQqtgiZVtzMOsP8AD+kQpGABjYZ/1pjtYTGqxvyhj07ZqpZPCyjkOHHRsdat3V5DFHzzFV2zkjY/8a3aVCiZlhJM41C/hhgcmQqy59CDXm72w8XrG0kavlhnfvWr8a8QQQ2788vMFBIcHBrx17XuLhLeSQpMWBYisDtvV717lTNfsnS7n3kRY1rV5b25ctJkc2etC5PEaPckDHnQW21VZpWZjn61budSURMGPriudSvaJvOxPAlO8mUMyjoBjehLlZGJB7+XSuLq8eaUgH4R5d6jjYkAZGQdye9XIl1OOsp6pbgKWH/hS7LIUkGDtmm68QTQlRv3zSnfxcrk8pxnFHobMhwSOJSnkPPsOu2a+wESE5PSoplIUsM1Elx4QwCD9qeVcjiJuxU8wojCIg5K+dErK9AwA5GOlLE2oSY5QNq+xXzLjDEHsKh6Sw5lUuGcR3bUAyYEmw7VRn1BAxbn/Wl39oyHY59aryvcSklQelCXT46wjOW/LGiPW+X4S21dNqIfbn6bUqJbX2c4OPOrMaXi7lTUmtR0MgBz4RntL4RuMuAe1Nujav8AEqZU79jWZwC758rkedMej+9F1Xfy6UvcFAyYREduAJs2h3vjFVB3PQYrZ/Z1pk00scrD4OuayL2Z8OXmpTRPJEeXI3Ir07oGjDSbBMR45RvtvS+jpGpt46CU11v4VNp6mN0nEEOk6Z8ThFRa8Y/2h/aCOL+IbfQbZ+aKKUM++RmtK9uvtFudE0mW0sJuWRwR81eVNEuptY4iF1PIXIOSSckkmuluu21GsdJyxIX2vEzaNDcWtpDCuxVADimW0usOvUA0lWtzggg+go5a3Z5Rv0rn0t2PmMgZXAhfiW0j1HSpY2+ZVypHXI6UU9nmtveaUIJpcyQfA2/ltQu3uVmhAcjcYNBeHbr9h8UzWnPiG6PMoJ71pOe8XiCmyQXO2xq7Fc79f1pahu9v+NXIbs+dZ3feEk8xjS5H8VTrcjzpfjvBjrVhLsdjUG/EoRDDzBxynfal3WyVjPw7dsVe96yOvWhWuXyQWztIwGQetFp1AztMqRjmYrx1r13pd6JxKQvNggmjfBHFH7RCc8mTsOtKfGcaa1fGMKW+LAHb0o5wZw7JZIgBwBvR7KEVRZVKspJys3fQ40aFZj5UZ8cH0pP4e1QRxi2c7jaj/vA8/wAqRbU7pEutPnpmojNv1qqZ/WuGm6elV/ESwE/n/Odycbn0oZdnPNk9d8UTkywIIz/Khd1lSeXp610+n4M5cDiDLg4ycULmJD82aKXRBUkD70HnJ5yTW7T0lwJZtJeV90JFNeh6jyyhVQnsSaUbcBjjfB60z6DB+8VgT/SgawL3ZLQ+lNhsAWbDwhLNdJy8oGPxVzxdpyBDLJIDtvVrg4IIFAxgDsNqI8QQW11AecnA2Ar5pqbcaklRPp+hQrQA0xe5aCKUsAceQ71wt+Y8sI1x5kdKJ8SWkds7CJQcH70mXjS8xPMfzrZoYWLxB2LtMYBrDnBluFUdcLihV1fSTylY0LLndupNCQ3hkmWR/PA3rn3qZ/hh5lAz96YFQByIDvCOIZSRY4+bCKT26Gr+lySSSbPHAOzPuTS9BdNCQSVAzuWHMauDVjtywkkdsYqGQkYEJ3gPWNkbRF/39693PzbSSH4EHoDsKtWerXkt9DaaRHJe3c7eFBbwRl3lf+FVUEsfoNqBWmnXWsWCaxrV9Ho+iBjGLloi7XEi/NHbxAhriQd8EIv43TuRs9Zvrll4V9n2hXllHqH7hvCBn1LUfNJJEGeT/wBTEFjH4ufHNUdzgZeULDogjy2raVw3huIP/wAqako+LTbG4BigYdri6BI5s9Y4eY9i6HarUd/xZx3p/vt9PYaPw5YzY52Y22n2r+QwD4kv+FQ8p7560ow6fovCMnJr8sfEOsIQq6RZzf8AQrU9hdXEZ/eMO8MBx2aQbrXWuXfEXEdxb3GtSEiBfCtYVRYoLRP4IYUASNfRRv3yd68QE4PHuH3MoFDcj5+H6D1+sdbPUOH9DIueE7EXV3Gc/tvVbdSyN521sxKx+jyc7+QSq9/f+/ySXeo381xdSsHluJHLO57lnOWNLejaBeyyKryOzEkhQDn0pni0GO1OZ/3kjDlEaktv/iNUZy5x4eQlSip06yvb3SG3LWBcKMhpTtzeeCdzUsVncOPGfPO3youc+n9KL6Posl7fQ2FuXnnkPJDbwplifIfbqTsBuaddC0cW14tjw+3verPIIJdQhTxUtnYbQ2o2Ek2A37zIAAYgqoL0xWhfiLWOE+MA6Vwvc2s62t1ZpdasQpFm4LR2YbAD3JAJ5idlhGWY7YJ+GnmaaH2axT2mkzC84wuFJvL+cqTpqnqMDKrJvgRrkJtks3y/td1/TPZdaNw9w5JFNxKQxubuN/FTTWYYYI+P3tywJDSn5QcKFGxze1nluWaSYth388s7HsPMn+ZJPlRLmGmBVPzft/f7fHoOtTf7T/l/f+v3+HWfT4Ql1JeO5ZI3MryStzPLJzZB36/H8bMepX0GKuq8RyadYMNOlKSyMw8TI+BD1Zm/i2GT2ozfafFbA2MnKPCAWUj5UYZzGPp0J8yakl0G300Qs9hHcXpKe6WcicwV2OVklU/MxLZWM9SQW2AU5R3DgTRTaxDGBNLWWysItc12L99BEsllZSAEQpy595lUjALAxiKMjLFw7gKVUtmi2jmNItWHiSsxvbtmbmM8pJIUsdyASCc7liKg1HSI0vFs5Zvev2fzXOoXBbma6ut2Ylu45y35fSiem20kk6xTLlH/AH0rdPhT5APqd/tVzYA20+jPEAjIlfiDUZ7dLGzuAsk904jjVTgI8gJZsdsJjH+Y+dWxwvBa3V8HDE28hj6fNyDlI+pfOf8AKKjsbJtY4i4ctZAA15qUUj+YDuEUZ8sBDTXxDLFbS3GoAYS6mneMDufHbOPvmh7e8UufXH9iXL92VQdf7/owfDChEFs5H7mNyeU4A5l3oLxDM81o1vG3wIwaRfONshh9vhP0NXPf447+K2ibeSFRkA4PNGoH/wAxoSOa6kLgZEhVznfCgnI/KjqcCUHXM+6HZKRLIwBkmYHK9SeXGR5bA7/ejMqCCCWZnBfkOAuwEKg//UdvuK50OzJbmRdy5C5HoBn9KuXZjZJWj+IHCKT0wOp/PFVZxLDlpd0C3NpiNDmQrChY9AQAf6Uxafpsa3Xu8S8sNzHzcg6cyjH23UUL0kYmMjqcnmk/ViP6UctiyRxL8QZHXkbuB1oyYIGYCxjk4kVmIowWKkwy4aUZ2R+hb03BP/hTpo8EU2BMc7Eg43B7/wBD5eVJCk+KkwA5ZGYMOuzYP8xTbw/O4twjgkqdiPIdqLpWG7BgdSDtyI8waesiYf5sYLDckdfv9KgaOS0lMRzNH25CSR9Aev061d0V43jWJ3w2Mgf1B7ihnEl6bOUcyyHP4lPz48v8X/O9bFgVU3zMTJbbC9tq5sYlmDs9uT8TKCeU/wCJeqmrl7r0E9oWScEPsQxBFIEfER5155C/MPhnUbsvkw71LPMvhNNEypkZ+A7fkaAdcApCwv4c55EWfajr8VnpsoEiggE7bCvG/GOovf3kjkk5Y7mtu9s/FIjWSzD5J64NeddUvmmJIGBnpXO22HUWlvKb+lr7msDzlKK5aFiObcetWWlkkXuD0oVAyeKMtROGeNhhdyKsy4ELwTzODCTjLb96jPwuAvTvVgN8XMdh9KpythiegzQwMy3STg5UjfHSgWoQDDk469aOQOCCCOhz0qrfQKw3x9M1KHa0v1EUGid2KAdTXS6VI+Sq5+1GobGPxSx2+tFYbSNExyA04b9o4i5qBPMUotElkPKVzV+34ZJ/CTkU3WlkgYFl361dW2hQggb7EfSgPq2PAhK9Mo5xFi24RaYqvLv6CmbSPZyZCvNGDnvimHR7aOR1OBgkHpWiaDawDlYrjH86z7dVY3AhyErGQIg2vssSRQngHf0qw3slABIgwO21bdp9lbsg2XcbbUUFlblPlU/avIlp5ZoBtWM4E82Xfsya3I5Yjg9cLRzhX2dF7iMyREjNbRNoEN0/92vXyo/oXC0ULhzHg/SvANb7BMsdV3awh7N+C4LCCPEWMDyp84gia1091jIU8uM180CAWyqAMY9Kj41vYE02RmlA5Vz1rf0GnWhPZnN625rny08Q/wBojUbpdUa1abIJJIzSFwFaYL3mM5/KrPtj4ij1jiy6WEkrG5TJ774olwjZiDSYyB8/XtVdSdtOPOIkf7MRmt5mODnGCKNWUxGMd+tBoYzgE0TtFJIAzjH5VksOIwoxDdpdGMsrAYxkVV11BIINRtx++gcE/SpRExTIGScA19jPMTbTIcNkU7pbcgAwDjacxt0bUBdWUUytnK+dFop+2aTuGue1drJwcDJXI7UzqDSuqr7p/cZYZhVJ+nepo7jcb4oUsjdqkSYg4zikGfE9C6XJPelbi/VCsZiUg0TmvPChZ2OwFZrxFq8l7ee7xsdz59qqrmQ05s7Nbq794Zd89KebW1ENupxgAYpc4ctOe4Ub/DuacpyvgiNegGKLXrzSNhg9uORKSXZt5VeNtwabdP1H3mBW5s7Ugzycj8rEjNEdE1EQTchbCtS2pbYd69DIY85jwJx/pXLTCqKzgqGU5zXxps9DSK6oy/SeFpmwSRt5mqNww36/lViWT4T/ADofPLjKnP2r6Vp1yeZyyDEpXPT+npQe4zzY2z6UWuHBHQ49aFTgs+ACc7VuVfllhO7diCBn0xTbw/byuyuzcqnH3pXs40jIkkAPlmmCxvnZwsfNjzoGsBasgRnSHbYCZsvDt7awW4RWHNgZH+tErq5SYY3IxjOKSuFlZ41Lu2evWmy5dY4QV2z51811tQW4gT6fonNlKkjETuJ7QfGyLg5JJFIt1aJklkOfrWi6nykMWbrvik7UoXLkhcDPendIxAxL2qGgH3FZM4GAB3qFtPl5uWJAAfKiwjKkrnrtgVe02wuL+9isLGB7m6mJWOGIDJxud+gAAJLEgAAkkAZrQDnPESIA/NAdvpLA/HDknb6k9P12xTP+wdP4aAPENml9qg/u9FBISE9mvWUgg/8A8uhDH/tGQfCxe0kt9HuI7DhWY32uysI/2jbKZBExyPDshjLP2M+M9fDCj42u22k6FwYS2qRW+sayhJNlz89naN/69lP7+Tv4ankB+dm3Wrgkc+P0EEX8B/Z/ge+ULThPWOJ3TizjHVBZac6iGO6kiGZETpBZ26coZV6BUCRJ3Ydy9xdtY2UmkcNWn7D0+4TwrmRpufUL9D2mmXHKh/8AQxhU8+c71QvNXvtWv31TU76S6uXAQyvj4VGwVQAAijoFUAAdBVqExcjTPEcY2LdWoD3Nn2fn4/1LogIG7p5eH9yKy0iCC3WOygWMLvzEdMd80QkutKsIEa4mkuLgnr5nyHlQO91S4RGijVghOyk9RVGGDUdRuFEQbmBznHSqLWTy0s7eUdtP11Iwo5Pd1P4c/Ef9aI6dNq/EN+ul6Pa+JPcMVjjzyjAGSzE7AAZJYnAAJNBOH+E9Q1e9hsLdJJ7iY8oVDu3cksdgoGST0ABJrRtH0lJnfgrg64t3E0Ly6zrMz+HD7vHvIS7Y8O0j6ljgyHBO3KKYrTcePXuEVd9njz65lnhzTLi5lk4X4Qm8cOvLqutqoXx13LRQc2OWHY7kjnwXfCDFNnEHEWm+zKyfhrhmVf260Rhur5QT7gjY5oYQRnxG2LuQG2BbGFjjj1viWw4B0eHh7hLxEvJo1kE0sfJOiMAwuZVIykj7NFEd0Xlkcc/hpHll3HaYMl1OecnmPxEknvlj1Jp53/DrtX837e4fzE1Tv+X/AC/v7z/E4VBOxDRPgtzYLZLb7kn17nrTdodvDo2mtxTdgeO7vBpUbDYyLtJOR/DHnA83I/hNL/D1vDrN60TXJs9PtImu7+7Iz7tapjnfHdiSqIvVnZR3qzrHEGpajqBu7S0XT3RVgsrXPMul2yj92h7NNg8x8mZmOWI5U+g3GNH2jtHr1+36QvCy6XIks7c9+uHjjYcwth2dwer7/Ch6E8zb4FX9KMqRycQXEp54pGit2Y8zPdOCWfPfw0Oc/wAbL5Ur6dAscgRpi7tl5ZD8R9T6nfYdSSB3o1qGvWkd5HpVmo8LTP8Ao+FOV8XOZN+/xDlz35M96XyMZHQQ3d4IB6w9OtlbWvu6jHivhwDk8qAMfzwFH1J719ubl7O2ikcZMsKS7HqWLgAegCAUAj1RLgoQ5cxruR05mOTj/wCUfaj2rmOO00hnKgPpFo2Ce/NLQWKkFvKWCFcA+Ms+ztHl4w0J5UUk6laqBj/0eZXP0+BRUgaTW+DjcOc3GjXiXJHc2t0Ap/8AhmVP/wDJRj2YW0DcaaCpIykVzdY8i1vK2f8A4QlDuFLi0066ifUv+r7u3NnfgDf3eRQGb6qeVx6oKYQKtahuASw+i4+uIJss7EeAB+rfuIGltpozp92qEsLWDt1KOwP/ANFXhp62zyQKCQHKLjyyDt9sUZ1HSZdLC6feY8eynntHZd1bdXDA+TK/MPQ1y8aERTnGGXB8yy/D/LH50ByQSD1h1IIGOnrE+WNt7vbkgAE5Ofr1NfZ7QACMqRyKAwx3O5/pVtp4oFVpAORMEjHzN2X+p9PrXActErtu0hLfUmgk54l1GOZNYZQ+I22QUH3G/wClGxI3w8rdY2GfJuoNBRNHyrGDkgbY9DVw6iiLCwO5JJBPUY3/AJ5pqt+MGLWKSeBCsECy/Ay4J3wPXf8A5+lGLO49xUoHAMnwqWOAG7fTfI9M0tPqASGGSMjnQYO/zAf+NXdQ1KO4sYbtMfvAVcA9+oJ/1o6MqZYdYFkZsA9I22XFds5EEoeGaLBIxl4W/iA/EvmK71LVDdA+K6spAIZfiQ+vp/zmkNg946XsLHxEVckdc0a05mkwrOVJ3HkaJ+MdxtaU/DKORDFra21zluVRjfboTQzi7WLfRNLkIdQcHbNE55YtLtWkJHQn6Vg/tX4ud45Ykm8x1rO1N21cKOY1pqu8cZPEy72h8SPq2pyOJAyg4H51m2p3mTyrk98/6V1r+sye9vzOTn1oO92JV5s5+te09ZVBmPWEZ4kkckrMeUjJ3PpRXT42YAEDA60CguVjfbuQBTHaSqsIZOh9aK+QMTy4PWTTlgCB1+naqXNIcAgjOc/SrLTo7lc4BOME/pXzkUgcx69QKByOstjMrRXXJIQdt+lSXEoI5jg52obdOUJPQioDfmQNzHf0q/dZOZAbBhCPBffbBohEDynfoe3nQiznaTlwc5NFoWfY9qhgRxJHWE7V1BAI6irXMCRjciqEbiNiSOg/Ku2uVU+Y9TS2MmMbsQ5p9yYWXB6U46Nrgj5eY4BPn0rMkvCGBydj2NEbTVgCMP12xmoNWeYB3BGJt+n8RDlBEg/OjVrrbSuBzjpWK2PEQAGZNgabtD1vndOZxg+vWhvvxiLhQBmbJo5WZlZsZO1PmkwRGMbA1lXD2qx/Dlh6Vo+h6iJAoBp/SIqxDUs0YWcWiF+bGKyD2vcXyWek3TQSfEFON/StL1vVI0hMRkVWYELnbJxXkf27cbR2sk1hz/vVYpICCOUgkEf0rpdJpRYNp4zMnUWkLkdZgF3M+qcQO53Z5izfnWwaVaiC0hi5flQZHlWfcGyWd5rjXEkSLErjNalaxhzzIOYHcEGs7tOhqWCGK02i1iZPBAWA+H60VtYMEYG9R2sBI6Y2z1orb22OijFZYXMdU8y1a2wZSD5eVVrq0e2n8cHYn7UVtkAwPyqzc2K3MJXHbaj117TKPzIrWITJHdRqA6bmj8CiWJZAOo8qWdOn92mNrI/Q4/40zWAKnkwcNvTdtIvq94g1O3rPzRcvYZqIjcelEJItqpTDkDNnYb1jWac4hgYB4q1VbCxYeJylh51nmmFrq7e6f8J2q5xxrYuL73RCCAcECvvD9jmSKAKTnBag9yUXJlRgmPPDdv4MHjMNz0oq75OwqGBFghWJdgoAr6WBGM1gagndukMOIL1VDkup+m+KqWtwQ436HrRS7j8SMrjNASPBuCvbOKLVYbEKGLtxHrTLzxoAOYZAqy0nrS9otxh8Z2NG2ORt3rLuzW3Esh45nhp5Cc7jP0qlOd8jv0qXxMA4ONx3zVeYgjY/WvslC4M5xVwMSnMSevT+dUXYCTJq5OSBv0odMdzitavO2T0MtREM25oxp7AMBG29LsTktgk0b01yrAjNB1Iyhh9OfbGJp3DjiGAOWy31zRe4vHdcs+KUNFvuUKM5x6elHmk8ZAQo8t6+fatCtpLT6VoLF7oBZHdSo/MOfm+/QUDumjyyncZ6D/Wr90rRqRnGe5FULO1N5cSyvMsVvbKJLq6kBKQITgEgblidlQbsdh3ItSuTxCs4UZaR2ek3GrXLWtlCicqGWaaV+SKCIdZJG/CoyPMkkAAkgEvY6bLfwXmj8K4tdKjVTrGs32YVlTO3incxw5GUt1y7kAsGOAtxUs30yC41YXWk8OM3jWtrHy/tDWJFyPG3+FV6gSN+7jBIjDtzEjtX1661qOOzWCGx060Ym0062yIISRu5J+KSQ/ikfLH0GANFR3Y9r1685nszWNgdPXzPu8JK3EOlaJDJp3Ccc6eKpjudUnXku7sHqqAE+7wn+BTzMPnY/KB0aXN5gLJHDGBjAGMCqvgxZ588zenSo55XX8e3kKoxLdIRVCjPjDttp6RYma4Uld8YzVoSpzeJPcKsXkdz9qVhfXky+DFzKg7jarFuXlcCRyxwdjvVSpB6ywGekZIIbO8mWQMTGfPv9KN2Mc8t9Do+haY011ct4ccKY53b1z0Hck4AAJJwDS/pcF5Lcw2WmW0tzeXTrFDHGuXdz0VR5/oBuaZluZbCccDcHt+09c1Tmt9Rv4ZByuACz20EhwEgQKWlnJAYKxJEa73RM8n1/cFYxPA59dYz2SXd5MOAuCDHqGo36tHqOoRSBYnVfieONzgR20YHM8pwH5ST8IALD+1NM4K4dgg050vjfyLc2Qli21iaNiE1CdG3FjC4Pu0Df30gMrghcUHS90LgnhW5tI2S70zxPdtUnUtE3Ed6gD/s6I7PHYxZR522ZgUU4eQLHmGqcY6nr2sXGr6pePPd3b5llVQi9AFRFGyIqgKqjZVUAbCmS3cAf9v29fX4fmAtXenHh+/rw8vj+VuvNckeaee5uZLu+uWaSaRzztJIxyzMx6knJJ86GGd7kL7xkEsFCoOYknooHck7ADuRQR9Za2j8NSG5+3Uk0y8K3rcOaVd+0C7I9/tZ20/QEYAquolQ0k+Oje7Rsr+QlkhHUNhdTvPJwPOMGvYvI58BGvU72x4TshwRZvG2oRTJca5cghgl2oPJbKfxeACc9hKXPVVIWTqkCIVgyEQklj3ali2kMKeGec82SSzczEnuT3J3JJq9DJPF/wBNlBVYdreMDJaT+LH+HqP8WPWg26jeeOnhGKtLsHPWNMF9+yop9RZghsuQAdS963N4KfSIBpWH8SKD2ofpYubhUgRBHCq4GepH18/WuNaRdLW30dsNLYK3jAHJe7kwZST35cJFn/1Z86pR308ERijkC83znHSlXtzwIylIxn17o3jUbDToUUEEr0z3PpUnE2p3mvarwjplvIVF3w/pzEqfhjV3mDN+QP5Vm9/fTySx21sDJNL8IJ/CPOtSg0wWen8PXOf3lrwfZQBx1Mjy3Ea/cKzn7VdcLWSYNkwwj97Grpr32grfyAoJIbxoVz8sfhFVHphSBS+b1mSK3B3OA2PIUW9jNyG9oum2kQwvgXSE+Z8Bjj9KXcKskjd1YqB570O1ydMhP/Zv2WVrrA1DD3L+7R/9/HEHCbcgL6noIjeXHWexAKCT1MPMqt/g5D+E0GsbwSRStLljAfFVQcZ7Nv5D4fyqHhe71Gw1uGfTrjwLiSKSGJ8BgJGXKAg7MpYKpU7EEg9av3Om2t3arxPw7b+Dp8h5b6xBJOnSSDBTfcwNk+G3b5G3AJl2N6i0dRwf5/bPz8TiAi0sUPQ8j+Pd7vlxxmlLey3sy83ypsqgYA7/APHzopPKYCqk/wB0ir98b/qTVOytFg5pXHww5Y+pHT8zXU5Z0DE5LKh/Sh1KSCxlrCucCdXFy0U648ga+zzSie2KZKBt/QEYqq48a6DnJXGPrUvh5j8OTOIzgEdR/qKJzKHEL80vMsbkKdgM0U061le2ltcgggMAD5VQtxNNEhkCyHGxbo33pj0pIWkSMwNFKV6MaarQExOxiBKmnWs1rcht8dwB2pmiWyhjNwGwOpHrVN41t5f368vL0PnSxxbxhBYQukbDlYHpQLbRT7MlK2uIIkfHnFkMML+DLtjzrzfxlrwvJZC0hJz+VGeNeMveXdEmPxds1lerXdxcMxzsfzNKVg3NuaaKVilMRX4juH8YuucZ61UtLrxUwWBPlmrOqpJNEwxvQOwlaGUxt2NbVSgpxFnbD5hZiysCM/SjelXnNF4ZO9BWxIMqR619s7lrefJUivFdwxPA45jIX5XHMfyqx43MvOD3oW1wJF51b5q7huGIVCMAnelynGYQNg8TrUYmKFx070CQsLgqc5pmdfHhKsf0pdvEaO4LbbVek8Yg7PZ5MK2A5B2HrReCdQCM+opetLocgyRnHarcNwSR8RwD+lUdMk5kCzPSHI7jm3HQ/wA6hkmHLkNv61FDNhDnJ71BPMG5sfbegqnJxCd4ccT7JfMNi+T1z6VHHqzxt8R+2e1UbhixJ/LNUX5s/EelMqgxFmsJEaLfWyDs3xDpTjw1rLyyqBJnfoayeKRw4U05cG+93F2kUCMzZBAFAvqAXMtXYTxPR3CZluEQjPb7VsHDllLFb+K/l0rOfZzod1Fbxy3qcuRnFaVfaxZ6VYGd5FCRjDb9KY7N0rWsMTP1t2wFZnXt11jUIuFdQTR5mW9SF5I+UkHAG+CO+OleN+MOIrz2h6evEk9wguriV1vEXqJ1Ay2DvhgQ31LDtW4+0TjSbVdZmtoXjkhWTlCvEHG3TY/WvMNzrGnRcQzT6MJYkkuHjngZQOb4mAI+wH0Nb+nfcTX4DB+ExC+/BHh9cxj4H0i9aMSI0hyc7DqK3LTYAkaIBgKoApI4R09NIhtbj3iKdHUboCCrHqrDsR0269ehFaJaRcj8qrtnYnypXtitlu9qA0bh8/GErSL4RhSAOoonBH06ZG1VbVQAB0xsTRW3jBXOAT13rLRPGaAMkt4wfL/SikMQKYqvBGM4x+dEYV26Y27UYLJi1rlibSZb5F2U4bFGtJukmjXEnxAbf0q5e2iXNu0bKPiFKlncSaZftZyKQASVOOo7/lTlXBGZUjxjvzB03O42xS/xRqSabp8kjNhsHFFreZXjD5A8/wDWsn9p3EL3F0um202DncCh3afBJxxJDZEXbLn1fVHvJASmS2++9P8Aw1ZhCbh+o6UscPaX4FsiYPM5yc09QILaFYl2OMn61lapNiEecuPdCImyBXBl7bYqoJ8HrXzxst1P5VzGoTwnmPjLeQTnfHlQrU4OVvEGwJojEQ22a5v4/Et+2R5UnS22wRazPWV9Om5CDk7EGmeFxLEGBBFJlpKqPjp5edM+mTiSIqSMio11fGZVW5nhsnY469TUbsemfSuwT/iHcVG474FfYKxMACVphzdvWh8ynmyPvV99gcflVOc8uc1orwMS2MjmcwqM77UVtHCkAAk0Kikx1A9au2snlQb1LCFpIQxv0dyxUb/lTR4pWEYIyBtSVpM7Iy4ODTpomjahr0rrZmJIrdBLd3lw3JbWcROPElf8IydgMsx2UEmuM7QobvZ3XZl6mnOekgs9Mu9XuTCkjBAQZH8Nn8ME4ACr8Tux2VF+Jm2Hci3q9zo/DYSwnsob28tnLW+luyy29rLjBnvWX4bi4P8A6JT4cY+Ek4KmXiHjGx0u1OgcCieO1TmWbVJk8O7vGIwzqB/cKw2Cg83L8JIBIKIcR9+XHQDpipqArHmfpGiGtO48D6y/e6pe6ndzalrF3JcXc55pJZGyzY2H0AGwAwANgMVQe7JYANhOuBXDMZTlsfSopSY8scUVBk5Mqwx06CX7e4Eg5VYqPPvV2GOFgA+DigNtdKWClsD6URivVlkWCEd+vl61LJ5Sqv4wgVMjeHFgDGwAxVm3snSVIUiknnlYRxxRqWaRycKqgbkkkYAqSytPiDHJ5iAM7k/Ybn6U233JwBDLFGw/2lmiZZZT/wDwqJl3RT2uGU/E3/ZqeUfESRVUyYNr9pxIJY7nhpX4Z0NXveJNSYWV9LaDxGh8QhfcLYr8zsSFkdfmP7tTyhiWbQNHsuGdPvrSPUYbdLeLm4j1yBVnEcauB7nafhlUShY17XFyB/2Fu5apwtw1qmlXkHDmnRsvFurQlbhwQjaFYOmXTmO0dzJGfjY/3MTYJDO/JU4w1exvvduGOGxGug6W3NHIgKpeXCrye8FevIq5SFT8qZY/HK+TqO7HeN6938/LrBly/wDrXx6n7/x8/eVfibXbzirURcyWwsrG1QW2nafHIZEs7YMWEfOd3cszPJIfikkd3PXAFi3aMh16/hHlRg2HKfFZgqgY371OlsQonUAMB8Ofw+tIuXY7jNCsovAEraHoGo6xrNnoulqJdW1GdbeAucJCW/ET2wAWZuiqrHr0O8T3WmapeW2ncPM50LQoP2bpTMOUyxhi0lyw/jnlLyn0ZF6KKJ6Bpw4e4Vu9f5iNQ4hE2lae3Qw2YwL2cer5W3U+Rn8qXr2PwUCQ9AN9tqhgwUJ58/p4fz8p5HUvu8Bx+v8AXT5yCS4itB4cI537uR027Uc4ef3YvxDeohTTESVFfcSTk4gTHf48uf8ADG9ALW2SaQzOf3aZOCMZ9aYNUiktbW00uRSvIBf3i/8ArZFHhIf8kJX/AHpZKCQFjOS3HnKhkUr73cyEs5J5nOSxJ3J8yT3qjPdNOcRjCDJA/wBalMMsoNxMmFJwoPaoUUXMwtYU2ZhzNjc+lBAAPEP4cwhw9p3vN17y3xBcHPn6CtW1xPdtG4bgRh40uiWcr4/CqmZUH/zSH7ik7RrMoI7O2j+Jiqg+bE4H609a7ZoLvTXjz4UGh6dGgPfEWc/fOfvVSxZHx7hBORvXd7zL/saPge0vhx3GFa/W3Ynb+8Vo/wD9cUPkt2j1Oa3dT+4nlB+ocj+lWNCuv2Lqun6kp5ZbW7guM9N1kVv6Uw8QaI1lxrrenyKOaPUrg/7jSFl+3KwoqUtZpwnkx+oH/wAYu9wS8t5gfQn/AOUFwWs6hJYiUl5g6H+EjcH7GmGO4m0TVm1PTCsXvCGVUZA0bxS7vE6nZk5uZSp/h88VDFBzvkfKoAFS/Ddxy2gOZbQNPER1aPGZUHqMc4+j+dMVU7OV6+EWstDHn9YQOlWmtWjvw5EY52+OXTC5Z1x18BjvKnX4fnH+Ib0Fe1fwApDc6xgMCNwRkbjtVywCyKrLgZwy47Y6Yow+qvdMkWuWSahsU8cuYrlR2/egfF/vhqaFSWDPQ/T+vh0+EBvdDjqPr/f7/GLFrbMyeISBg96M2OkrOA3iYDbE46eRorZ6Vo10HFvqbR46rdwEMh8i0eVYfYf0ozo2ioEMMs9oebdXiuMgjPkQKldKQeRn17pVtRxmD9M0VYuaENGwZsPC4IGfQ9vrRmW193to5EU5iGDzdQM7dOuM9asyaT4EizyXEYXHI5GTgjpkY22pc4s4ot9GieB5W8RRgHsape6aes54g6w1zDHMFce8VDTtLMviqSg2/iBrz5xLxvLqKyOzEKO2aIe0bjb3xGQMABts2dvtWNX+t8+QHz9qw60bUWF26ToK61pr98s6prHiyknOTtjzoVLeyHHh5xVW8nL7hSAR96hinGeXIJXYVppVtHEWd8mfZTytiT8R3FBdStvBkE0WQD1x2o3IonBVyAeg33qpJF4iGJtx09aYQ7DmDYZEp2c3MAG7mrlxETGHQgHtVaG3MMmMbGicLJInIVGcbGrswByJVV4wZWtLghfDcmr0Moyu58tqr+68jcyHqfKrUcICjBPTYiqMwPSSExCEFwnhnffpQXVObmOAN+h61e+TJI2AqtKqysSf171FZCnMFYCeILhd0+EE7d/KiloxIxn8jUJtVGcDGKsWqBScADPpRLHBEoilTzLyTMq45vvXMsy8mebBOahlYRAso6dKFXF8Q2Mn6UJU3HiS/s9ZdnlUts1Q86uQoznpsKHG5kdgAOpxTjwPwtPruowIsZIdgKm1loXc5nqazc21Jb4J9nuucXXccVjaPyEjmcjYV6m4B9hcXDtrFPdRgvy5ZiO9P3sf9m9lo+lwn3eMEKPw7miPtf4ysuB9AaaUOEPw5QZx9aFoq/xrhrOngILV3fhx3df6mJV9rNtoLzQJIuI/4W6fase4u9pVxc6jc6feTFLd0YwherOo5sY75xVfXfaLa3+mSz2wEtzOxIPQkVk3EGpXk1xb6nPFhbaUOwGc4Ox/Q10uiYaPUrnpOZ1NhvDID1E0Pjq1WDUbW7VOSPULSK5QgYB5hn88EVgfHfD19a8Q3erWMJMNxiZ2TA8NwAG/M7575NegtYuZuJeA9I1VLPCaPO9pPKB1VwPDP02xWYcYRqqSqUBVkOQT2xUaus6LXsi9PD4HmC0p7yvJ9GNHAtxea5wzBb3V1LNeLbx30CyuWZbd2dAMntzxP023Hen7RJ2vLUNIPjiIQnHUds1lnsw1e5Ww05pwWj0PVrXQjMF+GO0vIpiUY9h7zDA656NM2PnxWie8fsHiBLcH9xeNzEHbY9R9qa7TqFy785yAYLTNsYjHT+Y52iDbG+aLQRjzwAao2sZBGF+tErdWyMiueVZqCXYIx+dXokOPr61VhH4s5FXoem9GVcCWBnap2Pel7inSDJF77BhZIviyKZkA7jNUddgebTZQjEMFJ8s0VBziQTM6uuO4NL09lkcCXHylsgHypF00rxNrJvi6tzMTgHO1IHtR1q5stUljWX4WJUqDTh7EbW7voBNOxwSGBH8q1Ni2U8xM5rsJmt6bpscWJgvQDbyq1PJg753/AFqZTyoV7L+pqncMckZztXMa8DJEeQ+cjaQ8xyfy6V9STJIyarO/pXcRHUHrXL6keM83MK2x23NTTnmiYdjVWBgBuR9asOwaP6jzrLK+3mBcZEAF2jkzt1xR7Q5+ZioOR60v3hIdiNgDt60Q0ObllUFu3nT96d5VmAXrPG3Pk9c718Z/h75rj8Rr6v4q+sV8cTEzkyGUZNUJ+tEZOp+lDbj5qbQy5Wcod8HpVuGUJg7bVRTv9auWX9/H/wB4v86tjIlTwY98NcNmZLPUNeee0trzeytYsC81D1iDbRxbHM8nwgAlQ+Dhh13i06lZQ8N6PHBaaJZSeKsFtzCO4nxjxWLfFJgHCs+ScltubAg4v/8AzicU/wDu6b/9AtLlt8o+orA7SrAPHE6PsZyevhn+JYucsMBfrgVRljbHMWIzRLy+tVLzofrWEvBwJ1WSesoB/DB5AOlVp2lkPX9KsSdD9qi/7FvrTKmCK+EooJGlMcJ3HzMelXYLqK1Usp2xks3Q4/pVeP8AuH+rVZsf/L7L/wBoi/8ArFMDmKtxmPtjqz8DWUOpXYH+0l5GJbKBxk6ZCw+G4kB6TsDmND8innO5XF/h2+j4b023441d4n1C8LyaBbXADh2ViH1GYN1ijcMIwdpJVLHKRNzJftH/APP7iD/3lP8A/VRzjr/zk0f/APp/Q/8A7OKiBR8vWYHoAfP1iPtxeTcFcNSaVLNIeIeLY1vNWklYmaCwc88cDk/F4s5JmlzvyGNTuzilYahGrjI53OenRase0v8A/OVxN/70u/8A9I1AbH+8X70OxBnHlxJr5AfxMO2VlNe3GWTKAZO+1GtM4ZvNf1az0HTmSNrqURCR/kQHdpG8lRQzE+SmudE/uP8AdNNPBP8A1hqP/ufUP/t3odSCxwD0l7GKDIgrjDWrG91QJpUbrptlClhpkR6raxZCEj+JyWkb/FI1KzwzXE5Dt8P4sfyq/J/5efof5VxB87f896E/tEmFQbABCGj2Vl70jX0PPZWytczp/HHGASv++3LH9Xr4FvNX1CS4vDzyTyNNO2Ni7Hmbf6np5YqxZf8AkV//ANzD/wDp0q5o/wA4+ppWxABiNK5MGa5CEwiqFAGBtXGg6S/Nzcm56k9hVriD+/H+Y0Z0f+8/3KC1YAxDCwlSYZ0mxWzzdg/FDHzg/wCM7L+pz/u0ya2sS3drAo2ttK06Pc9MWkR/rQa2/wCrJfqn8molxF/5XP8A+zWv/wBtFTFNSis/p94B3Lvn14QTFMLm4kkZiUhPXO2RWvcZQrd6vNxAD8UrvZzHylixyn/eiaM/Y1jGif8AVU/+c/zrYtZ/6q1T/wB5Q/8A29N0KO7cfA/v/MVvOXVvj9oFe4hghHLKoB7k4qo8rWY978QxMGDxyg9GByCD060IvP8Aqxfr/WrVx/5rXn/d/wBa8y+XhLLwYek1HT7eCK+gCRRMypLGo2hkboMdkbfl7dV7b2LW8t72c3CHMSY5gDujf6GkzTv+pp//AHM//wBxFV/hLref+z//AKwq5XDSCvX3HEeIWXT9SjvFIaOT4WOdiPI0ws8Omuk0ak2l0c5XB8N/5Z9O4pa03/yU/wCQf/VRkf8AUcn+ZKG7mtSw8IMIHIBlviTXo9L0551nhd+TALE7ivNXH3tGnvZZVkUIucNg4zWs8c/9WH7f1rzhxl/et/mrE1DG6z2jxNXRVKi9OYrcQ6oZoXlSUsp3xikmeVzEZMYNMurf3H2pWuPkf6U9plCrxL2k5nyO8mli+P8AD1+lfUlR3DAjPeoovlb71An96ftTqqImxIMIXEzNupG/866tp1BPiHJNVp/w/SuU/vhUBQRiWzgwoYfFIwM+or8ieG4yTyg1btf7pPpVV/mb/N/WlwctiHxwDLgjVhkE9M7dKh5niYqAcdasQ/KKjn+aqg84niPGffEMi8hxkDNRNDJnIXr51+i6n6/0qwen5fyqc7ekoRk4lcNgnmU5/PFfF2OVzjrUsnX7ioj1+9WBzKEZODIrgsyYzQmaJi+SM70Yk+Y/eqj9qJW2II156ybRdHe7nVQpOTnavVHsF9msk88N21sSqkdutYFwb/5dH9v6V7k9hn/VkP0FZWoc6i9am6R/aNNQXTrNg0DRFsrNIhFj4cb1g/8Aa80iSX2eaqY4y7RwlwM43Br0lbfIKwn+1N/5iav/ANw1bWnqFdyKvmJz17F6nLeRnkD2W8GLLpK3t/K3MFyVJ6UR4l0XT5bSey5ABIpHMB37UX4C/wCoZP8AKKEcQ/j/AM1Oaok3sSZm7EVBgSL2W3lzq2m6nwZcPyi5iMTek0blo2+4GPvSbxhZvyMsifGFKMue+4Ipn9kn/nnN/wC0R/zNDvab/wBZ33/tD/zrY7T/ANtNGob8xGD9IlpkFdroOnWKXs9u7ez4q0vTrqeWPT+JJVtdSiDHlmSNGOD6grGwPUMqsOlbLxVYy3mke/uhF1Z/vG2wQw+cGsI4c/8AODhT/wB4zf8A6M16S1v5tV/7yT+VeJL6VGPgWH6dZCgLqCB5A/XEscE6qus6LFKZQ8kY5H339D+VNttH8O/Ssx9k3y3H2/nWpwfh+1YbDa5AjlZ4lqBBsD+tX40+AE9aqQf0q7H0+9WAl8yRQMZ/nQ3iOZbfSpnY4+A53xRROn3pe42/6kn/AMp/kauBIPAzPJnHOhy61qUt3GC55yGAFat7HNOWz0wI2RkbH0NKUP8Afzf5/wChp/8AZ/8A3X2FN1sSoEFYPGOkhC5UHJ60OupcE71dl+Y/U0Ouu1YvaACsYwvIxKryEE71LFISd8j0xVY/MPqf5VLB0+9c1qFAlgMnEJQvnGM471cDEpvvQ+DoKvx/3YrKskMOIF1HCynlzvviv2ly8kiEnvvXWof3o+n9KrWP98f8wp1BvqwYoODif//Z"
+    },
+    "type": "object",
+    "properties": {
+      "filename": {
+        "description": "",
+        "example": "cat",
+        "type": "string"
+      },
+      "image": {
+        "description": "",
+        "example": "/9j/4AAQSkZJRgABAQEBLAEsAAD/4QDiRXhpZgAATU0AKgAAAAgABAEPAAIAAAASAAAAPgEQAAIAAAAMAAAAUIKaAAUAAAABAAAAXIdpAAQAAAABAAAAZAAAAABOSUtPTiBDT1JQT1JBVElPTgBOSUtPTiBEMzIwMAAAAAAKAAAfQAAGgpoABQAAAAEAAACugp0ABQAAAAEAAAC2iCcAAwAAAAIBkAAAkAMAAgAAABQAAAC+kgkAAwAAAAIAEAAAkgoABQAAAAEAAADSAAAACgAAH0AAAAAmAAAACjIwMTU6MTE6MTUgMTE6NTQ6MzcAAAADUgAAAAr/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAGpAoADASIAAhEBAxEB/8QAHQAAAgMBAQEBAQAAAAAAAAAABQYDBAcCCAEACf/EAFYQAAIBAwIEAwYDBQUEBQoBDQECAwAEEQUhBhIxQRNRYQcUIjJxgUKRoRUjUrHBCDNictEWguHwJDVDc/E0NlNjdHWSorK0FyU3s8ImREVkdoOTo9L/xAAbAQACAwEBAQAAAAAAAAAAAAADBAECBQYAB//EADkRAAICAQMBBQYGAgMAAQUBAAECAAMRBBIhMQUTQVHwImFxkaHBFDKBsdHhBiNCUvHSFSQzQ2Jy/9oADAMBAAIRAxEAPwDyHfw/EzHJxk70qaxj4snO9PWrQiNGGxPcedI+r9SN9+9KaI5MY1gwIqTr8X1rhB5CppwQxx1FRID16VrY5mU3EmjHxZ38qvwABftVGMHG9XoTgYxt9KIvETt5k6dcYzjar1uB1O5qimdv+f1q/bg9hnO9X5ziJ2cCFbMZOMfemCwUEigVnjmB86YNP2wcdNq9Mu08ZjLppCYOd6NWp5yM9f0pftnAAUDbqfrTBpzcxz16AUjqeOYpQCXxC1pCxIBOcf8AO1MVjbqeUgHJwfKhNmFBXG2cHGOn+tMNiMgYGP61y+sJJnZdnoBiEraBQOma+XbLGu1WogBHnA32odqEgLkDpWI6EmdRQfZlYHnbI2qZSBgnzqCJh9Tn86lQ57iqNXiO189ZbQBsZH1xV+3yBjoMd6p2ihsHHQ4q2rhDnPSqBPCNgGQ3L/vcVXmPMvzA57etc3EvNIWByetRtJzKMAen1ond+UsvBn6IlcY3+1WUG+wH3qqpOcAmrlspO/YVOzMZUeM5e6mtZ1mt5eR1OVIGfqCDsR6HY1O8UOoW8l5p0IjljBee0GTyr3kj7lPNeq+o3FKfPOR96+QyS28qTwSvFLG3Ojo2CrDuDRBXgbTJPPIlaVvjBB29K7t5GLdaJm1t9fPNZRpb6oc89qoCx3J84uyyecfQ/h3+Gh0EbKxDKQwJUgjBBHUEdj6UwKyolQwYyC7mIbGeu1D7tQwBA2O/1q9dDmP3qnKg8P6URR0kEQJyF5Sd/vROy+Fc4PWq3hHxc4Iz5USjhAgx023o88BK16BIec/bFDZIjy82djRB258qfw9qhkhyMDqaLWBBPnMrWwLBlxt51ZFm9xLBaQL8bsF/XrXNrEVVmYYPNtTJodqscvvswHMwxGD/ADpTW6gaZCR1Mb09PedeghBNLEECWCMCkRy7D8R9aYrLmghRYUCnG5I6CqVlEj4ZjklizZphsFEi8zJ16LisOgGxi7dTG3O1cSzp8cwCygAnu7HYfQUXSK55chvFPkp2qG3V0T4VVcdNs1agS6l+ExFx2IbFala+Ez3OTPqe8KMPZnY9MZx+VWLaSNTmNGI8jGRXx9O1s4a1m5R1+FgCPrX2ObiSwk5LjT5JQe4IYGruSg5B+UmtQ/Qj5yzKtvKnOsMZPfBww/1r6LYhOdEZlPk+cfnViGbT74ATWbJL3DLXL2GnwEsJJ7cn8SHmX7is6+vvOVx+00Km2eyc5gDU7QM6yKT16E012+nJqPCFzAVXJiZd9+opa1VAilkmEnqBimHhN5p9Lnhd8jlo/Yrd3fgyO1kNukzPGmpeLba7f2EijMUrAY9DXVu2MH/hTTx/DY23GN9aJajn8Rg7KNs5paWLkdl2yD1862NfVsfJ8Zz+jt3JAHtBYx6C0g25DnPnTDwLrknEHBOn3cq5kgXw2IPbp/QUue0ZC3DcoQYzt9KGf2fNUubjTtR0GZt4mMiqT5+X5UxpEF2htr8Rg/KB1L7NWjeYx95qPiHGFBzWCf2hOGOJb/iHT9bg1e4vLS6jMcVrMzeFYmCNSSNyCCCSBy5zkb5Fb+ID2xikf2kTNpuu8C6hHOivDxAhSNlJSQ4QrzenOseaW7GJGtStTgMcH18ZbtHb+HY4zjkSh7GNY1O94fv9M1PRLWxuNJv/AHad4rFbV3uDEplhkUDPNCy8m/cnpnFPlzzvbSBVDHlJCnv6UQm0mHTJ5rK2aN0jnlPPGgUSuzlmk27sxLE9SSa493+EjHzDv5UtrdQb9S1jcHP7cfaF0yrXp1XrxLnBmkSycMXlvHJzSeDzlebPnkY9KW9UcW9lNK2RyoTTf7OmFndTWbOS7u7OCflJ6Y26bUo8bgafp18JlwVZlx5Vr9rhbBReP+S4+UT0VhrNtZPQ/vMV0oftXjMEY/vcn862F0yN1xsMbVlPsttHvOJ57rlBC5PTpWxmBgckYwPzrN1jAMB5R3TtjJgt0z1AFBNQtgbsFhtynf8AlTU1v2GT26UJ1K1Pjr8O+Pz2qmlsHerDW2ZWXhCsuluCQBynB8sb1mWrBbvViudo8DI/OtTQvHokxcYAT8tqydZOaSads/ETWlqlAsz7orp7PZIkun2Jub0Y3GenpTesQjQIMYG1UOGbMEGds53NGmiwM9/Ss66wM2I/R7IlFkyc527V9jgLSqPMb471YMWOvbvmpEjAZTynfpQa2w4jFrZrIgmaBY7gsmBnvTJHEDEhOMctCrq2w4ZATjrtRyxX/ocfN9SftTWrya8iJ0NhsThYdtu/TNDtXYonhqPvijRAVObuKXtWkJkIJ8+9ZyElsRtzxzF+7CqDk/Nt9K/afaGV1OO9dyKJnwDRnSbIcwYjYetNs+xeYEc8y5DbCOEAAH1qxHCSdqlYZBwO2MeVSwoeYbd6AGMswA5n1LcbA/SuBByzMoBIbYURjjHYZ+lfpoOV1k64IPpRq7drgmK2rkQDcQe73AbcA/yotymSBTndNutR6pBmJXRejE/arOm/v4uVh1Falw31mIqdrSo6NjYEVwVZTnYd6uSRkHlJ74x1r54O/mc461iMQBGwcmZhrceebGxOw2pC1lSCwO5PTG9aHrRHxZ6b49Kz7W1GWB23/Suq0B6Cc7rfy8xVuvnOd8+lRKvTapbgnnIGNqiAwc5rZMxzwJLHkHFW4ziq0Qyc/wBKsx4xgjeiCLPzLkYJ3FXYN2xiqduSQAOtX7YHmBqwHjEbTCtnvjIO9MFlsB2yN6BWYOwPSjURwoGN6mZduScQ3ZnmYbE0x6cDsSN+lLOm5YjApq09eUjAORSOq4EHp1BeMlkuFXOObp0pgsFJ6g77/egWnDmUEHbAP/IpjsY+UDbt9a5m9cnBnY6FMgYhDn5Yjt2oVdPkmrc8hUcuNhQ+XOcEnH0pE15nR6dMT7D06ZzUiD4sHtn71CmU2Odv1qxCAWGT3ob1ZmjUuDL9rgAd8V1ePyD4SB518jAUAj61FcNzg4AzQRVzmN4lTmLZJ69dq/RvzY8qjyQCuf8AjX2MfFjc/wA6MKxiWAlkL3Aq/AoSEt6VWiUHl7+lWHcRpgHpXlryIbmU5mw9cK3cdMYr9K2fvUJz065o4rzKzsBXJz9qPRzR67CsWoypHqQAEV3IeVbjySY9ObsJD9G8wChXmZcdKtzryxcvmMGr4xxPbM8yheQTwTy29zC0UsTFHjcYZWHUEdqoyjGQtMUU667CmnXjhb6JRHaXDnHiAbLBIf0Rj0PwnYjAGeNklaKRWV1YoysMFWGxBHYg9qsK8dJ5OTgyosWTzY2q9yYgJK9v1qOGPJCnG/r3qzcqEi5N96uEzCbcQLJHiXJBNSBSqr3IBzX6RM+WPOrNpC0sioULMSOnff8A4V6xhSpLSFq7w4n7TNPe+kZDsi/FIf6UaWIF4+TcfKoB6CoGVNMRo48lpCecD+VWdJiPNk52OT9+1cpqdQb33HpNeuoVr7MZNOtyeUnHkBTDbRyKBy4H2oRZBgAFTHqaLxy8pBa4Cgdd9qPUwURS0EmErVLlhhQQD5rV62hvI3w8iEYzgrgUHbUrSJQZr1EUeZODX1Nbs3UFLkt/uNg08lkVNTHoIzwpMuOWfkxuQDmiVnqKRjkn1CD6bb0nwXtpMCqqST35sfoTV5IrWQhmtFbH8LAkUytzKMiD/DgnDRziuVnA/c20mPwl9z96/SJpM4KtB7u56Enal23S1VQkFvMmO6kgCrPvdug8OYkqO/MSa93gsHtASwq2H2SYL161mszvZxyxk7OpJGKOcIWzNbyFUCc69B0oZNesJfDjUOjfXpTNw+T4b8oC/BS2nVU1K7Y1qmY6Ugzy37Y9IfSeMry6EyYmcN0/OlE24kZZUGzAE0/e3TTJH4vmuzIHTlHw56Gk7RIPerUofmhbGPStrtAmyrI6icnpm7s7Yoe0KELw3KCAfQ9RST7OIZeHeJdP1UE+BqLeC+PX/jWke06yKaAU5fmPc0unRprf2fxavBD4ktnKsoOOgByf5UDszUCplV+jNtPwIxLaw7gWHgM/Kay1qFkK+R27VmPt3vP2NacKaonK0lrrLzRwhyryMsDYAPYZIBPbIxWqaZP+09LsdTC7XNuj5Hc4FYx/anuzZ6Twqvgx5/aVxMsnWRGWEAADPQlt/UCltADp+1EQ/wDFpa9xbpz4gibXeWVlFcsmnQGK0CoYY8Y5VKKcY+pNVzbb9Om4rrh24Oo8I8MagZBP7xoVgWnBz4zrEEdz6l0bPqDV4wnOSOtJ9pf6tZdWPBm/eXoszUpz4CArO7utF18SwJ8E3K7HyIIH5bmgHt9vYbJJBspvh4i+RJ7inDWLNLe2XVprmOBIcliwzt9Kx3X+IIPbBqVrokVzFC9lN4bFBnIz1AJ+ldHo0bXdmL/2RuPgZn23d3qvcRz7sdJY9jmhGOwl1Fo/7w4B/wBK0V7TrjO350Q0nhEcL2MWlrhiiA8wXqKsNaY2wa5jU6gvaZpK/GQYDe0J3Yd8/eqN1Y80ycq7ZyKZ3tCcnl3qCWyPOsrKAE3Joen1GLVnns45i3qVs0GjNCoAZ1wAemO9ZW1n/wBJ8JAfnIx960fV9ejF8bZ0BUEp1/X60vaPpfvmsy/BlRJsa6ntMitFtHlEtHc2WJEK6Rp5t7JF5cZHYVYe2AGw3o2bPkQR42G1V5bcgk43Ncv+IyczWSyBWgKkEfau44cMpwAAc4q9Jb77qd658IKw7cpzRK7ssIzvDqRK11ZkjIBGN+mau2cJS0zjOD+RogbUSKGU8pIz0rtbYx2rYAGDvitrUJmkmJVW4sAge+lMUbbdQdqUNRuvjYjfHrvTHrk/KpGfTekyZ2nmIGcc24rPqXJyY6zZMuWERkcEqCScU12tv4EIUDc7nNCdGtgzKT2/nTAwCr9BiqWvkyymVsjPfGNqmgI5hg9/KoHZc7etdxMFYHJ8sUIGQ7ZhaHmBGRsOlSTAsmAPzqGBsjbv1yKnzgY26dv1qwJEAeesruiz27IeqjequlOUZou6nzq0OaKTlO4Y+VDnJtb/ADy4Vz2862dO+5OYjYu0wncxnxObfc9qjHKqsxxvvV2KP3iAMNiNx3qG8gWOJsY361l6isq5WMK+RMm1hwS5zjOcelIessSG696dNWckkjY0j6u5y2DkV1OimBrSMRWudpPLtXCb9OvSurn5+tcIcdP51siY7HykqEj4e3lVqLruc1VXJPT/AMatwDfGc1cQD9JehBBzsM0Stx0ND4BuBjftRO0GdiNxRF64mbeeYUtAFAJotAxY8pIOOgoXb5UYzjuMURtW5mG/oak++ZrZ6w7pyHmGd803acucDPXelawX5T16bHypu0tchQRkdqTvyRBUHNsZNKT5VYD+tMlunJHjyzQTS0w6nl2zjyo65Kx4x18q569eTO57MUFeJUmfLffpmomwVORjFSSDJ6CozkHAxvSjIB0nT6dATIiD1BwfKrNuCe2agTJO4zVmE8m+NzVSuRNEV4loPhCSKg5uYYz+lcTylF5cmoEkHN9aH3cKFn11+PfO9TRxjIONqgLEPnHpU0MnMME+vSrbfGWCkwhbqAM1DeSgNgnGBUsLYUdT22qjeSFmJ5sAHy71UJC7eJy79/SoGYMxVSfPavwbKYJzg1yNm5jTCriSExyZdtwOYDO+M1PeyfAF2O3WoLbPKCSAB51xcy+JmNWHlUbfOW2cSm0vNzIdwdvtV25mGsW7XTEnULRA0573EQ25/wDOvRvMYPUGh0nw74696ktZJLe5juLZuWSNuZSdx9/Q9CPWiDA6yoTxEntV58NnPepruIsiqBnOOlFbPRXmYXFpCRBOOeNf4PNPsf0xRyz4UeQpJOuB6ilrtVXpxljChN3SIw01pDyhDg9NqM2OmrYKlzIvTp6+tF9YS007lgiALnY4obqdw6QxRnfG7bdK53U9pNrCVH5RG00/cgHxMF6hBI17I6sGy22OlFdLtjEi8x+o9aGQy+NI0gA5c77d6N2BU4Oc0jnJjRUhcQ7awZGARnG9Xo9MeYAs5UDpgdap2sjKPhHQZwKuw3UnKPGmVQ3YHemksUeESZW8JJHoOl5zLeuWzkgb0Qg0jRAOVpCceZHWhUl+wk8C3Gw/ExNfHv7yCETOyRN+At/9X08qartA8JQ12NxujGtjYWQUCLHfdtxXwX9tBkQHwuX+FAT+ppTW6iuGAk1aSZz2QttXydbOEE++uDtkCQ4x61J1JPTiGTR4/OST8IwXetw+IA91cTt3B+DFdwamjLzx6c+R3b4qXYNR0sOI7efxZQewL4oxBc6jMR4EaNt0xiiV8nJP3l2rC8Y+0P6fq1zdTLC0EIXyA3py06MCKTBIylKfDdpeSv4l1Zxqc+VPOmQpzMj4GVO1Er3nULzEdYUFZCzzX7TrNrjiG+LHm5HyoP0pL4Zg8DXGilziVenatj9pOmwx8QTtGn96oYn9KzG8tJ7K7S7SIt4L52/hrXU5sek+M5BjtAYeEV/a5EkdtDZqoyzj+flRjTOGhd+z57LABmtz26HGaX+M9Qh4m1yzitFVlVsMQ2cGtb0rTxFpMNqVwPC5Dj6VmXK1RCjqDmHzlj8pnvsdupdW4IjgmlV5NMnktWx1AViB/Kse/thQG3veEZlgkB8O8Afmypw0Z5ceY659cVrvsbsk0viTjDh0y/u470zwqxHNhxnp9c1nn9q/Tje8eeznTBA6G8nMAmJyp57mNSvL6Zz961b0C9rLcOjDd81zEqW/+12nw4+Rx9poHsLvI9V9kHDRjbLWMc9i8fXw2WUyde+fF5vQkjtTyLb/AA0j/wBmnSBp3Ams8O3EExvND1ya0upHmBRbjncOiJj5eVEbOdy5rVvcQegrK/yCrZrncdGCsP1AP8wumf8A17fLP7zMvafoc+o8LXkcF89u5jK7bDGK8p+zrROJrDjOK+sOd1hl/vBkd/MV6r9vuppoPBNzMTglCo3wcnbalv8As76faXmiQvfWY8WRTICy9ab7Guup0drg9OkrcRwSPGahZC7uLG3kvSTN4YByc1I9pncr0ox7n2xj7V8a18hXIXXtY5c9TCBtowPCA3tM9qC8TTiy09z0+HPlmnI2u/y9KW+L7CC5sWgkXd1Ir1DlrQsh7Mjmea9Y4kmbXPd1kxzPsc1rvBGmI1oLllHORnNZ6PZ4bjiAyiInfIIHbNbLwjojWNoImJwg2Ga6ztrUCvTpXnwg6hgjE/TWmMgLVKa1O4VcUzz2g8qpS2xJ6etcmt2Y+rxaktSTjGfoKhktyFJHnk5o9La/4elVpbbmUjB37UZbscwytmcWhjeJC+xI2qxJCGtZAuebl2+1CreQxzrA+dtt/LNW9X1GOyZeQ7NtnPbvXYaewaikDzidrd0czPNdlkeVowNwcfehVtZvz+O/Y0yX1tDfXLXEPQsc4rmHS/HvIrWHBXP6Uu9RoXa3WO13bukv6Pp7Lb+Jy9atSROOwyM5o5HppihSLGCBuAKil0+QjoMGk2rYnkQvexbkDqd+g3rhHIYAg47UZm0l2PynJ/SoxocrEZB/LrXhUc5xPG4dTP1u4IB8x1FW13OM9Tv9a7i0eRACWNWhpbA/1zUip5XvB4GUpE5uV8Daq2q2JeJZ0PT0o7HprsMEZI2ruXTWktTGynan9ICvsmLWnPSVOHmWaEISMDapdXteVWUDfG1UtMjaxuREWIGds+VMF3bG6hUrjPQkd6ZtoNg3eUEtm04nnHVJOYtlsUm6sd29KZtRlyWJ6DO1K+oDnDZ61r6QbRMnVcxbuB8RJ89qhB3/AJVPefCarg43FaucTKYZ4llBkbAVag67Ej61UhOTjH0q1CQrVfHHEBZxCMAAG2+KJ2gAfr12NC7c9OmKKW+AOYfzoq4mVfCanYDbIPaiNl8w2xn1oXCxJGeporZAB68c4iLrxmNGlrnHTfrTZpiZHKNx2pV0obj4fKm/Sxhthn7UrbFaD/sjXpyZRSO2OlFJWypGKG6eQFwRtjcgdNqsGYEelYWoXJ4nedlvgTmTKk7feo3I5+uxrovnO+49apySkdT09aVwek7LSL5S3Ge/c1cUARgnf+lDIpAxI89queKFj5SwyPzr22aeyR3L5IwetVg4ICnz339ailmJzk53qLxR3/8AGvbMDMlU5l9mBAOd67hbBx64qkkxIwTnOwqS3m+ME4wO9e2QoQCGixEZwRiqLtzBt96/PcgRkDoexqt4wwd8kdKptMttwJ1GxViu24r8rAnHc7586rSTcrHfoa68Yk82TjtV9vjLAZhGNk8Pr8386rzZU8/3r48nLBzk+g2r5AWI+LcE7VU8CWInc1nLJFzKM8u236V3ptnLNIv7skZANMOgWfiusT45XHemvT+GYLfmm5Ad81hW9rCljWYYUcZEKcOR2EGnqkgUNjmAx3xQXiLiNLOJxCQNjjBr9qSXEEReAleXoR2pYuonvrwwunOsyk48vP8AWucvvfUtGKqlT2j0kNs8uo3bXswPhgfDv1NR3QErSu2d9sE+VTypJZJHaQ746jvVC8lC/AWwTgEHsTualf8AWuwSwHevuH6SFIhGEhTZc8xOdzR+0Aj2UdBjNA7H95OAw9Bmjkau8ykHbOOUV4+1xDWDHWE7cN8xY7j1rv8A6ZkfPy5+HB/pUMXheMAjZJ2I3o1bJC7KqLyMBnmPRQOpNFTYDiKN7PM5gt5FUytA8ijblJzzHy9B51ZTSfHk94urRA79idhUg1OEsEV15FXCDfJ/413Hdyq/7kIpPYg5pkWJ+VYIbx7Um/YzmLl5Uiz05RvUD6BpSkRzQC4kPzF/9O9Q397cqfhueUgdW6Chja00ALS6xliegP8ApR6+T0ngLD0MZrdNE0oYtLeBcDcFQN6rXWvSxuIbRFRGO5RcCgMutPcKGWXlHZipJNT2CatcyK3iYh/xjc0wbMcAy6afHtWfWPvDlxM6B5JSc05aShnnxv0pP0WIwooC4OKa9BuWF0fICraNWbUKW6RDWsvdtsiL7TtLMeoCXlG6gVjvtAtr1dFnlsWKOIzgg9TW3e0q9ae9Eajt5Vnuq20b2Eolj5hjoac11wq1BZPCcinPBnmf2KarJqnEdzp93FiWGb94WODnO21epY7cKqrjsK8vW9uNB9rTSWcfhC7+ZV6H1/OvUmkye+WME3cqBTfaTi9UuAxkCBoygKE9DEXRuGI9M9sF1f8AIqrrFkOXBwGeMnOfXDfoay7+0fZtP7bPZRp0UCLO98v7wyZwBcxnBT7Eg98+lb5xbo3iwW2swc63WlzLPGydSB1U+hGaxb2op+2v7W/s1to0WRbax98YqnxD52yx7jYY+9Oov4rS16odawVb4YOD9cQAPdu9X/Y5H6/2DD3C0R4U/tL8UcIW2fcuLdMbiJYmfA94wqtyD8R5kc/Q1sS2w7gVjP8AaU00aBxP7O/ajbWc5k0zV/2ZeTQk5S2k/eLnywyPg/4sVu6JFOq3EDh45AJEYbBlIyD+RpDXV9/pKL/EZQ/pyPofpC1ttdl/X7faebf7ULHUH0jhSJyGv7gAjGfhUZNNPs04bk4cn0yydQSLRVIHmd6BavZ/7cf2jINMliZrbRrPnbfKh3P+grR71jpvEtt4agqX5FGOnaq6FtgFR6HJk3r088Z+caWtAN+X0qI2vp1o0Yeb4sbsM1E0GO1c5ZpwpIkE5gdrTbYYzWfe0C+WwRgc5xgGtTkhCoSR0FefPbTrxtrtbZXySRt51bSaYG9cSp6gQ9wPbWupO1w8XxDYU8izjgXCKMUp+yqJm0mKV48FxzfnT/NBgbVPbTFnA8pCfmOYDmgHkKoSwjfpR2eAZORQ+aAntWGMiNI/EDTRA9qqyRddu9FZovixVZ4c52oy5jKNF3V9O54TPEeV13GO9IHE2rXksPhgt4kOds9R3rVdUVVtSDsSKyfXLSVryQINySB3Fdb2G2TtbpK2DcJBoOtwzWEr3Lcsw/CO9O3AOlSSRPqE6ks5yM4z6Vm2kaLdRXrtI/OC3NgjYVsnBkEnunMdlG2K0dc4aziVqJXiFWt/TcdxUZtu53JogU3yAa6EWT0260uo84wxg4WIbqv1rpdPUYJWisUOeoqc24Izy/8AGibYPd4QP7oOnLXSWh5sY2ombfG+KlSAeVeAzJzKcFkDg4BqSWzCLnl26HFEoIcYBFWHgDoVOMGj1Lg8SjGZdxPG9ldpLE5UHbFFeGtUS8cRzONuufSpOKbNTIYmTOO6n9azuLXJNP1VUAI3I61rphELRYjLYEx/UXIkb1/Sl+5fBbINH9at5YZd0JDfIw3DfSly+OAw3BHap0rBolqkPWAr44cj171VVqtTxNPkxnLA7L5/SqGSjEMCCD0NaQIJxM3HEuwNv3q9Cc9KGRtuKvQSZIJ29KIDFrBCdscY3x5bURhk6b9aEwyAEHfrV2KTcbmiiZtq5hm1YDb9KN2WSRjIx1pdt3zj02o9YNkjvVjzELRgRs0lgCMjypz01sqDjIA/OknSmAKj7dacdMfCjJyAM7UtcQBE9PnfgRmS4CKoAz2+1SeNzJkYHcY/lQkXIz5jOD6CpDeKYzliO+3esm1QZ2fZrHcJca65R82POqU1yBLjzqpPeYBPNuOvrVGa9DYIxkHzpXbg5nf6H2hD9rOMbE58qnkugq7Z3FAIL0cuM9a6mv8AsG6V4rnpNULiXpJyD12IPrURn3xkdaGy3oK8wbpUPvw2+LrUqPCQRg5hqK5AIyasx3A5jv13pcF4OYNk1cju8quGOTtVNuDCgZGYWmvd+XNQ++Z7/rVa4s7xEE/hsUJxnFTafp11eXkcCxn46g4HJkbhJHkZyuBjJxVmNZCoXB22p20/2W3V3GJCSF7UXi4AFtMhmUHkOD6ik7NZUnAMkHPSJdhpFzfQhVRsEYO3eimm6DdLGY7iA/CcAkVplnpunWMKqI02HlVPU54GDpbKvNjIx1rH1fagGVEMiM55i3bwHT41k7xnP2oonE6JFzMwKEbgVFJau9ms8wPI5KNt0oENDZ1aGIsyK2x7b1yGotNrkmaddakYMn1/itYbVxGuQwyD50P4Cvf2ktxfsd0kYLt8uR0rq54Wee28N2YI3wk826kGiXDWippdvc2gULIfjyBgMRvn71fTWqpyZ7UKndFVgybM+pPLgnqdq5n04Nes0ikocOc+YFFWshDfMpPwyAMp+tdmBZ0SRQTjZjjPoatZd1Mog24xA/uKwyGdF+UZq/BMqhSyYx8Rx22q+NPRxylt2AxtXEFgFguGYb8+PtQ1sLHAlywI5kVrcLGDPMQibkE9ftVy81ePTbfNwMtKgllBGCq9VT69z9vKuY9N8SSOaZMx26h+XszE/Cv3O59AarXejvqUgeXLeI/xlvxep+9OVlKwCep/aAbDtg9BObfXjKVkFqADsuTnbzqHVuJri2QrZlpJmBARRgk0Yi0UpMfDhVEUbd67sNAtRM91LF4jnp6CjLaCBiSDWDkiZ9PHxlrUijwpYUc7Bjgfl1o/pfCElqqtd3w8TYEH4m/0FODWwVliiiVR1P8ApXQ08FSQFWRzjIHSjCzAlm1RI2qMCV7O3tLdVxb/AC7c7/z3o/aiE8ojwSe9ApLKN5OQtIxXfbYZonZA2/72X4UHQUzRaMe1FLRu6GPGjWpkQDB3ohGW0u7VQuz0M4W1VZZVGAFz0NOV7pKahEk8IGV3rWGLqc1fmEyW/wBduLehmc8cAy3McvL82RmkjXR4emSnzUitR4x0xxahmT4k3rNOIrHUJrApa2M8nMcZEZC/mdv1rMvZ3fBHJmDqqhVacdJiF9w6t7xLa6kFOY+ZeYfpW0cEuz2LQFs+G21AeH+F5JvGNzNZxsvxqHuo2YfZCx/Sj/C0NnYam9q2qI3Pn4I4JCPzYKK0q99qPUfDkTPJAKnznz2oW+uSezziBOGw37SNhN7vynB5+U4wfOvGP9mD2i3L+2m21z2g6hfalINPfTbdnjM00bEjlVd9uhHev6CvbadJC0MhuZA4KkciKMH7mvInE3s99l/sX/tD8HXuhWOrgapcSySwvfp4UTu3LzAGMsRl+nMMVo9g3qLW0tg3B/DzIB4MBqvy94DjH8zZf7RujjXPY1q00d01uLB7fUSxyC0ccg51OPNGYU4cN3MY4G0y9WN4QunRnklzlCFxg59AKM8TaRba7w7qejPbB47y0kh5HPNzEqcfrisbteP30n+zjqfF99qbTz2qXCP48PK0cw28PlG+zDFRQDf2bdWvVGVsfHKn7SzD/avv4+eMfeA/7NH/AO1HHPG/G8igrLqD20JB5lKR/CCDWgcbxG21WKdPhKSg/bIoP/ZM4Vn4e9klhdXkbR3GqFruUFcYLkt/Wm32iWoP70r5EEVnhtt6hfA4h3bfaT+ny4jVaL4tnFIDnKCvrx4qDhiZbjRbdxk4QA/XFEXjxk4pXVJi1h74uDxgwNqmILKRzt8JryP7VWm1Xi+G3jJKGQD9a9U8a3gs9KlyRuK89z6E1/xTb3TKWUuG6VOjISzeZI49qavwDpos9LtYeXGIx/Km6aHPf9KGcOQhBHGOiqB0phmh26fpS2tr7w5lRgGApoe2CcelUJ4d8Y3o/NB12qjPb1lmj3QyGL88J7CqjR8p5umKNTw5oZqIEMBJ22q1enJbEZVjiKWv3ZDMiHpttSvd6eTaSalykFNxmmK8i95m5e5O9fNRtDcJDo8KgtL83pmt2snSoGHWFBgTg7Qxq1nPezqQxJK+op24YRYUe1KjmXPfc11p+lrolsloi4Veu1fHAsb9ZwSI5NjWtt3AN5wY4OYSdOUkEb19jCnscGrDxrKiyrg5G9QiMrsB/wCFCA28RjORJogPLIqyoDDONxVaPIqwpIO3eiAEyhnfhKdwK6VB1xUibjzrrkq209ZGZ9RcYOa6lYFGy3KMZrgsEU5oZqd/4UBVSMtsKMkqeYA1cLJLJ8WVGSP9KyPVLKefiDmjTmAc/DjrWu6lEP2dlY/3jmqWi8M293LHeSRYZOp9aaRifYlWwvMZ5f7JvBs5kl0TjF4pX3Mc37yMHywd6z/i3+xNxtePI2jXWmX0J3jnt5OSVR5FG2cffNaTot3qF7HjSuI1laMASc0R/dnzL/KcUy6PrPFdjOrRcQwTxLuTE2ACPPO35Vy636mpw6FvoZv2aaplKOB+08FccewT2ocAXjR8TcL30NozELdxwtJEy9jzLnl+hxSLd6ddRTNY6lAyTKAY58bMD0z6etf1lt/aNcS2pi1nTY7hVGGeIBlcHzG9BNY9nvsS9omnNpuqcM2duznP7pBE6Me4I3Faa9vXIwFoB+HB9efgZlN2LSQdhI+PI+H8eIn8pjHLBKUmjKlTircZ5GAHfcV7t4u/sC6Tq0Er8H8VKGIJhiugCV8l5h1Hr1rzbxn/AGePab7NnmsuKeErySyRyEvLdPFjx55XpW1pu29PcOfZPkePl4fpMPV9i3Vk7eR5j7/zMwjc8obtVyFiMHcA9PWrA4du4WMUscoRt45CuBnyPka5hhMMgs7xSEc5jkx8prYXUI59k5mDdpLU/MMS7av03o9YyDbG3nS3GktvKYZRhlOCKPWOTF8IJKbnHlRwwxmZF1ZBIIjfpUu4GfvTRZ3XINzvSXpUh/TvTDbTM+FRSSfLzoNx4iFSHvOIwG9BHMew8+9cG9PKW5z8Q3yKEh5QpXJx2zULzyRZL5286zHIHSdj2bWcgmEmundiBnGMGqkkkqsVfof5VxDdPaSpcSLmFjyt5AUYvtFuzaS3EY5lgAdCN+ZDWdbqFQjPjPoHZ1bbc4gmK+OOvTauJNQbrkYPrVO5SazJlYE28+CG8j5VWWGWVZYhklPjXA6iih1IzNF2OYSN4dirfCRneohdHmAznPSrNjoNxNbxScpbnk5QB6im7h/2UapfTLJMpVFfI+lDbUInJM91islpfSoJYoXKnqcdKa+EeFNQ1uZR4RCA55sVtOkezbT49KSOSNedRg+tSm303hi3ZYI1Vxkbbb1mWdqqFO3rCqGPAhDSeDdJbSktruFT8GDkDrX5eEtG0qX3mNEGO9AtP4lvrx2VX5R1A9KnvtUnmiZJHPKFxnyrCs1thzgw6acDho6Wmo24iCxBSPSqepvM3xBSQw2YDvSfoOrtAJLeSQuVwR51BqnHv7OcpcHAU5ANKPZk8mFWls4UQvrBv7XTpL3flAyMVnNlxi/7VQysQnPgnPStPj1my1zQ2liIdJkJGCMA46V5z4xmXTtWeOGRovjJBI2A7g0EqHOBGtKN+VcT0Kyz31k0NtIgjlXxEPqKH2N09tcJzJyt8vKejeY/Kkng/jqMWFsktwcxAdNyp8/pTpa3mj67MpS8ASfBABwx37HsQaWNO45lCWqyrDiS6hqIs52tW5HiY8yt0OD/AKVVubwRvHNDk4XLY7r3qG88drhdMuYkuJbaRvCnG3Ov8J+o2+tcFUiRL22fxbWQFCCcmNx8ynyOKVarDErCLtxzJo7lJ5YkcklGwrf4e35VYtZo4U8HAzHkP+dVbe2S3vBZqGkjuAZreQdAuMMp/nUsEJllWGMKGMbCVenMuKqynPM8ADwJdvSsFzAUf4XwR32rgXSKjkZyXIwe1C724mjt1ifIe0AIPmudjVzh1YrjUJLib4olBuGyNsAZx9zgfevKpztXxk93tQs3hDFyViW3tiBzR/FMP8bD+gwPzr7Gojt4uX4SxJ6UMs2upL24tbv4peZmJPc5z/Wr6FmXLZ5o3AIz2NestJOR08PhBirZxCEMGYZCZOZj69akizGzKAAQN6+oEjQxq2DtgVWCymeVycJkYPnV1sKYMHszmXGtoXlMznZVyNuhr7M0dpEJuX59l+tfI1Dx85z8W2Ks+AvhI0+AEY4JO2f60yljMcQLDHWVbuQwonhj94wy2RuKozzMLY3U3MFXfHQD6k7D70WaLxQUCczO3MWkGwHbb/Wkfj6aeWHklnPhp8KIOhNOoQq88mWoU2OF6Rr0LiC2xzR3KkjtH8Q/Pp+Wa0zhfiwyFbYkkeprz/wjb3PhB2Y8qgH6mtd4MtwZFlentG9otBTiT2jTSqnPM07XLOO+0xpYzhgvUda86e0GN438GZmc5Pzkt/OvREt2I9NYBtuWsK9olg9zMZ1XON/tmne1XRbUHj1nHvp3srNg8IG4FtQI3fHwnbFVtSP7J1qOXpl+XNHuELcRWOemaq8bWIaMXAXcYIPqKS0l+zUgnoeJj3DC/DmN9qwmhjlXcMOteRf7a2o/sTjbgjVoIwksEkrmTGxClGwfyr1ZwvcePpEJJBZRg151/tb8KjjLjDgbh25/dQXtzcQideqOYvh+xx+lPaCz8J2kjH/iSfkDB24dCp6HH1InovgzXbfifhbSuIrZlMd/axzgg7bivEHt5460iC/4g9lnCPEUl9b61xMs1zDETyxl2XxYsnY/Ge30869L/wBnLXNQi0jUPZpqsAM/Bvh2LSr0cb4/MYP3rx3/AGlOBL72c+3a/wBb0jQL2w0u7uYtRtLhoi8JmY5cq3yj48/CfOt/TIml7RspB9mweyf/AOWIYfSUpYugc5JXB/UcH6z+iXDmifsDh3S9JEPhC3tI0CZBxt6fSgfHdsHtSxHVapew3WdW4k9mukcQa1qHvd1exF3bwgnLv0AFHOMbbx7HA7gj9KxL0SjVMlZJUHgnrPVlsAv1kHAziTRUTO6HBpgZRj7UpezxitnNas393IevXem+Y8sTH0qNWM2kyTwSJmPtLvGIS1XfnYAigFjogSSK68MYwDVvjCZrrX44VOQGNMx08Q6TG4XfApcAqVAl24RR5z5w9/eqMYHemmSLIz2pX0MkTr23pxKfAPPFFuTPWUPWCpoObOKoywgdh6Uaki36VTmjFLGjxll4gGeEk9KVuIJgMRggYp1vVEUbufKs/wBYfxZWyTk7UzRQB7RjNfMGW0Y/eTOM8gzRLhfTDc3kmqzIMZ+EYqCO2Myx2sWeZj8QFOVlZJZ2qQoMADf61babXz4CF8YO1e3HJ4ijGetBpk8W3ZCAWTemq8jEkJBpaZeSUhj12rVoG5dplj0zJ9JufGg5HAyNqulATjY+VA7OT3S+aPm+Fv1pgTJAPn0xUsvMushVOVgSOtTLjrXYjHavqrirAT0ljHapcDuKjQDrX2WVY0ZyelTgESMSjfThW5Ac49aWbu694vggA5U361f1K75Y5JCT0OKXoZmZi2N2NeU7RmSFOIcs4jfyFQvwrt9aZNOsVs42hIG+/SqXDdkEVWZfvR67jCqHQAYo1Jx7Uo3PEy7k4lvrWO81LV9QhtmXnAnkEcS+QCjGT6D86JQ6m8UHPbTC7jtwFkmlZxGCRsoHc/SkloNU1O8hgv70z3MuORGfIiB/E/8ACMb4/M9q0P8AauicKSWui2nialdwKFgs7XA5Xb5priRvhQt15RkgYHpXOjTls4OJ19loQAYz7hLNhY6/Oh1O7itNLtgoZZbx2T4exCDBxTFomq6NdviTX1uvC6yWNrIFX6ux3oLfX4uljuL7SPeJGPMgNzyR+peSQZPoFFTnRbm6hjm1XiOPS7TYrEkXhod+isd2+wFebTbTgc+v0i/fixfb4+Hon9o+6frpjnHuutahN4ZyFMZO3ptTHae1FDcHTNXhS6iIAdHTfB81YVlkHDGoEBdCv9QKNuHt5ssw8yGxgfapJNL1azEaXvFNzDInwqtwnO2fLON6XdLFGFGPXvlVWlj+b+fpNE4n9lPsV9oMLe86LbWssyjEkA8Ng3ntWF8df2JJWglfhLVo723ALKkh5ZAd8FT51oCa80McUE+uK7g7GMhOfHnzUZ0zje7gm93AY4GcKTz49MZBqBfZS2aiVPu6fLpKvpQ6bXAYe8TxvqvsO4v0iF4OIdHlivLJsLJ4ZxNF6+ZHmKEabwjc2ty3iRP4LqVIx0/1r+h1jxhomsKtjrOni5yNvFiGR+dC9S9lPs4166d9PUW0xJbwyByk/etOrtjWqpGAwPlxj9PrMW7sHRWMDypHn4+un9zxVa8D3Lwq1uxLDyHWmvRvZxqs6xTQwtlfmBHzDzFenj7E7Wyw9pE0q82eZUVh+QNW4tAg0sCMW6Bl2wRyMfs2P0od3+RapF2suICn/EdGXDq2Zhl57IJbjTfeIFKyhRtik6b2bao5eCaAh91BxtntXqYT28JMEsRQjYhhg/kapy2WnPzMEXmNYw7cuGRmdMnY2nQhtv8Ac876D7Pbi4t5NL1O2wAeXmI/WnfhX2fvFay6bekvyoYeY9x2z9tq0xbXTxHI/IocDPTyqgNVtrWY4APMMnekNT2q9nU9ZpU6YIMIOkyX/wDC03SXGkSwfBztyHGB6Va0f2LNG6+8qcR8yEkfhPStctNTsbj4QqKxzv3zRi3urd7dWJViNmHnTNXalhX80iyrB5Ez+z9mujWKxL4S5Ug4x3Hejl3bDT+VbWNcbDamK505ZZR4R/vBlcn0pY1ma40ySMyk8r7fcCq2ayxvzGerrVjx1l2zmvZoU5VIG4IoZrWmQXAHjDd85zV3TOILOCOOdyApIU58zVrVoLa/5nt7hQoORvtmvCzIzIIKNg8RS/2fFtaNdWTh3Q4x6VUeBrUc9wQ6z7FemMiurtr+zWSCCZmLczcvcEDpS5FxD+0rUC5Z4yxbnB6jlONqG1pI4jaIeueJdja3F61ikgWTk5gc52AoZxbw5LqoMHMFklh/dn/EBnFU+DLa71biFr6OYMis0LAjbB+U006nLHPr9tbKrMVUSEN2YbH9aCSwbMZ4rYKsVfZ3d6joYj0i/jm8KZ2RyRnkcDJFJvtd0u6sLs6hAviJyF3B3V164+uK2u3Nrb6m9peRFJ7qPxYSy4HiJ1GD3KmqXEPBw4l4emKQ+PMjKsQGMOpBAG9XSzawsPjBhx3pPTM81WHEcOn3sU0UrG2ZeflU83hg439V7HyrXrG6057a21HTrtYbe62SQnKxynof8uds1ko4Fu+HtX5bppYLET+FNk5eykzs234cfpW0cKcDQ32n3Ol3VtHBOsbsvhsVhlznEiDouTsw6DINM6gV8MktYTjLQxw1ezalK0GoxKt1C5SU82RzKdiD59P086bbixtbqIo6yILqPMsa/AVderg9j39aA8D8MTQSiK8jeS45FhuEOztyD4ZB5OowD5jHam4QNBNGom54pUZJVx8RBPXB/nSbYycRN29rjwgXStPHNZQCUORM4jdRnn26jy6bj60VXTgXUSxcklsTGSO6EjIP0NWJtLl0i+V7Zle2uLiOZGDAeG4IVvzBGR60a1C3h1Ex36ry++RlZ/D6FlGM/XYVHdZXPlKG7DZ8ItzaD78rocAvIYQ3bI7ffriotA0JrNLq2duVr1jHEWHURjmP5sVH+7TTe2/u1vpeqWj88Uq4lQDbIx8XoRXzUYVnmtHgPNc2ZVMY2Yn4/ts2/wBKgUBck9enz/rMn8QzAKOn8f3iCH04yXFteyKqOIgsmO5XFfJ7AwS3Ky7tyiVSBTE6JdRJCiktDK+eUfDtjf8AOoWhSYFpd2kXw1AOfi7j6UFqsDiWW4nrALZeS3mRfhxjI6H61Ys1NwpXGTzkAY3NEP2eYtOY8uDDjc7DB864tLYoUeIYVoyxY9Sf9KDsK+00uXBGFkaKsPhxtgt5dQD/AFqa6ieSNU5sn5iT2HlX6GNZZssu6oWGe5qbJbAI+YYBoitn4QLDmcqqxRFsks64xSXrmkjULhuZeYJuB6mnabkRHdTkgbelURZ45GdSNuZs9803U+OTPIShyICs7A2MCxhR8WCcdqedAukgVFGB2pav8/CYk6nYAVJZXcsBLOD8IpxNYKTmRZWblmk3mpc9mIUbtSZxAkLwN44zgHrVE8R3TOIwpxnFWtXgur3TuZB8RHTuTS1upbW3hhF7NN3GnYYg7QgggYRjbNfuI4BLpzNjJSvui2c9nAYp1wwq3fRiW0ljx1U152ats+U4W1CGwYE4Au2ktJbY9Y3OR96zT+0eYrXifgDU+c+JDrsaBM9Q6MDT5wazW2tXNux2fcUg/wBqFVY8ISRriePXrUo/8O5z+lbdjZ11Tjo2PqImT/qPu+xhG6mX2ef2gtMu7WXwdO4+sua+DnEYmt0C831Ksn5U3f2h9MXU/YrxhbNbrK66XNIoZc4dF5gR6ggYod7beHbnW/ZiNX06CN9T0DwtSt3bYiNCPGUHtmLmFNvv2mcd+zf9oW4E1jrekMQA2cq8ZU79/rTvejUdm1XjlqW2H4dUP7r+khT3WoKnoTn68/Xn9Yp/2Z9RGp+xnQJPDK+DF4R32bB6jFaBrsRexbAyRv0rE/7FN5eTeyA2VxJzxWF/Lb2753ZBjOfvn863i9j8S2kXHVdq92qQuvsI8Tn58yFUqNp8IkcFyNDrNzbMcc2Djp0z/wAKcdRbwrR2yBtSVpoFpxOhIxz5Gf8An6U18TTrb6dIzH8JqdUCdre6EYZbHnModBf8TZJyA+K0nULTk0eMKOi0i8LW3vWs+MFOGfP61qN9biSyMeDstLgHefdCW/mAHhETS5PDuuUgbGnqL44lI7is+YNbX5XtzbZp70yYT2aEGnGTMhl5zOnTrVOaPfeiEgx36+VVZRt9PtUCvzlgMRZ4im8KAxrjcdKQ7hBNcAEbd6a+IrkPMyhunr3oBaW5mlJ68xxRWXasZVdq5lzQ7DMhuXXoNtqPH0PWura0EFuoA3IzX51I3JqFr28SVHjIJMbg9cdKXtTh5GblHU5FMMuTjOPOhWqQgx+Iucij1+wQ0IBniLl7GGjWdPmjxnFGdJvEuYVKsDgb0KkYJzIw2cVW0i590v2t3GzE4px1B5HjLgY6xyUA+oNSeEDv5VHAQwBHQ1aAFBXpLESIJ1xQ3VrgInhA4Jos55cnOKVdUui9yzc2y71VjiSBmB9an2WBGY+eKj0i1Mky9Sg657GqlzO1xcFubvj7UxaDbBVXPU71B5wJLDjEa9LjEMIwMHtV6TlkiK4+lVIGCoBUvinGAcdqKrQW2eftCNxaMdb1a68IMPGigT5m/hcj6/KD5Z8qZuHQxBniWLT1nJW2e4Y82D80gAHNIx8wO/zd6UWvJrSOOXkWW6kkAjjK5CbDBI7ncURskvmDzTXkhupxh7gseZVHUA9h16eprHWzHWdbbUWBM0ePUNJ4fRpLHTZNa1eVCI57whVB6EknZUB/kfLNS2Wo3KoNf1rU7QXDYEcyR83OT+GEEFuXO3MB26ilPT3V5I4p7YfEvjtzL0hUfAgU9PPJ2GR3NF7z3lreC7u+eTUNRPiJBGpZ5VGyjzCL2GwJ7Yo//wCTpM9k2nBkur683K1pHqd/c3Dnn5pZeSJM9MICWbPYsWzRHh+LUNWdLW+uLy9tV2aG4t1MLH+EeJk/UjFftH0Rbd0sFs/edbu/3kuACsIPUu3oPz7bU2xRppUDQ+9JE3LytK+OZiew8h38z9KqaT4mUa9VG1RIrCw4X0mOVJNB93WMZaS2YLHgfwh8/pjPlVrSo9FvpTJojWcTYyqy5SXPqd0J+jflQo6dpMTIrq17eTfE7TNzHHYsM4VfIbn0qeSO+jBFxf21uqL4fvDAKkKnoFTz+pz6DpS71hDkgSVsLeJhnVbzUtNjiguYbhzI2I2kVVz9D3oeOL5bW5C363QWPvHIrcp88A1U0yw0jSnlVdb1e/muVzIsuGix/wByRyAepGaFnTvZvrF46Q8NXCSxHElxZzlYlb/ui2PrgrS7ozng49ef/kZqdF/MMjzmgaZ7VGtJAy3rPbscBs7j6inbTuO9P1U+HdQQzxOm3ONjWGi1srGSaTRNH0zVRApE3upLvEuOskR+MfXlI9apQ+0L9nWQMlmi2yE5aEhuX6YO2PKlmssqO1+fjDfh0tGap6CubHR72E+5TC3Un+5l+NPsD0+2KBajwXdypJJplyqELnlZ8oT5Buq/fI9aQeFuO11SMxe/xXMIwUkQ4dPRhTCvGt1o92sJlBhlPn+dI3V0WNllxCKdRScA5ibr+ra5oE5t9Vs57Zn2+IHBHmD0I9RS1FxFdXE04UHnjAJUnqp7it0u9U0LiuzfTdRtophjKqezY6qeqk+Y28wazK84EhstRmvLHEtpGDkEYkjU9VkHl0IYbH0O1Zup0gq9pTkTU0mvRwVdcN9JX0W/uZpEkBJQkHbyP/Gmy1nMUa2zyENIpIJ7n/WlnT0W1iyMjwjyOezqTkGic94nxKzkujKyN6d/0pBMq3ELa/eHAjnZ6iXWO3ckyJGCp8waF8QeBdB45m2wqqc9GJ3oDpWqXDXQkdnYJF8OD1Aq1qNxDNcwgEuOrJnrncGnms3piJrXssirq8UsMkEMTsqSk4H+Ne1BtL46FnrLaFdy5Z+Z4+Y9x1FNut24flZWPigs8W2zPg/DWGcSySRa+mruUR7ZmPr1AOfzo2nGTjM0kAvQgibnFqNrq1uWacRtzqM4w2cbH6E5pW4usF/2hU6fFm3XTJp2UDA8bBYA4oVwxr082lrfvb4gEqWrFtzzqOcH9CPvTJqeoxnTRcxrzGZn+IDBMTrsR6Y/lTe3EzcNXZgTngJl0+9lto0xF4S8zlf+1CKSfTcmj8KWWqcRXF6luSFIh3GFVS2SM+e29VdEsHHDUVzHEA11aGdnO7cxO39fyoToV3q1teX14WKWzXy2z7Z2BU//AKx/Kl7cbiIWsGwlgYy8QQnWLqyNqvh3BiZ4ip+JW5SAd+vn9M0T4FuH1Dhy6eZD4kDbqUwykHckeYOenlS3puoyx8Ranp12ymWwuY57Zuzwsd8eex6U4cGeAmrTzwBhazSeBPGg3UqDhgO3Mo6eanzqqMScGVvTYnHh/wCzPvaNp1mJP2k1oq3aQCK4VVGXjfcEjuQdwf8AjQHhTUb+NWiiu3QQKMkdIvKQD+HpzDyJp79sOnRQ38slwHXmspTFLGpAeJCGT6kfGMfSs34YWW4nh1K1lSX3cNHeRhs+LEQdwo6nGdvI+lWOVyDHKMWUbprejwzz3aXkkTQXdsQkka5BAGDkHoVGdvQ0cnFpqFxEGURy+I3L4fTnG+QP8Xl51WW0McUd5YyRsq28c8EhY4khbA5c/iBDDB9M1LrMduosb21ByhheYt869id+/n61DK6L7UztyO2Vkz3YS1u7W5HjEj3q3YoCCYwGwR57Gr10s8E0rW3wwTyHEabgPgOGH+dT+ZpW1C9ZoWCZd4hIM8uObAww+4bP50Z07U1urGPxHPiPCjRk9CBuvTyyB9qhLsqc+vWJD04wYQVZZfdbOMYilkdWQjHKHw4PpvkYqOB1jvLm7bm+OWOUHGPhbIH2AxVqOWT3szSFQ/hSXGf4eWMnP5jNV4VnmsgA3M7QBQSuF+EfCTRt2a8+OT9P/YADDevXhJtOX3ezaRubmZWcgH8bSD4f5GuLoLcMJLZgqRkzjbAGRvvXaR5t5gCQiRgIMdXA6/r+oqCzmeOyitnTmbwPjA8z0WhH2hg8CFUYJI6y5b2wuNNELluWTDOfTtgH7V8FrJGCkoHUBfUZ6V2L4K0viPkhQBj8I6E/nsPoasRxiX4C5XIGe5yOgAqrbW6T3IlGW08G7lLH4sFVz51C8UoUMF+EjbHlRO8VpZOaJMMRynO5HqT0FfikCx+FzDPIFz/CP6UPuwekncQILCsYmdxhcgflXJ57uJp2wkS7ZzucdhVu4jGAAP3a5xnufOqFxzzYhQnlUYCjYn7dqkNt4MsBunLGCXlETqCo75OP0qqyxt8HioN9yQ25/Kroto7cgSuFAGTio7gKcGKLHl50N8sOZdMA4E7tNMgVOeSWFj/vf/8ANFrN1U/E8TL23P8ApQ5JAkYRuuKnimfwwAux6V5GCHInnBbrDLWNrcoSoHN1yKB31o9uxVl2ozYF1wWJ+lTanaieDnC4+1Os/fLk9ZznaehDLvTrMqiQ6bxAJ3PKhbGKzj+1NczrZcNeBgodZtST5DmzmtY4r0prqMtBlZF7jqKwT246zNd3XDmh3WTMNSt3Hryk5P5VvdlivtChDn/ZSeR5rOQvU1hl8CPuJ6W06CHVOH47K6XniurUwSg9CrqVI/I1mf8AZk1MTcJapwXHLLLBwnqcukQrcAeIsauygMB2yDWk6I//AOS7VRt+6FZzwJpUXD3t747tjexwftu3tdUt7dX5RIjrh25e7eKjb+vrVexHF6arTH/khYfFCD+xP6Qeo4YOPPHz9CIf9i6/iWTjzh+1ikitrDW5vBR3zygyyKFx6BRXpqReeJl7EGvMH9mKS5Pth9qMgijtoLjWbstAMKQ63Ljp9AT9TXqMYx169Ka7XYrqUZv+SIfoPnCnBd/iZmeqO2ncRQuo+EuMj9KL8camV0pPDI+MAdaEcewSQ3QvYgFMJ5s5xtSvf8QfttYYIXLmM5YfXpR7QTUth6QqjNi/CN3s9s/Ek8f8P0rQJF5kZTjcUvcFWAtNOD8uC3nTExpSlgef1kZ3MWiBxHa+BeiYDG9GuGbvmi8FjUvElgLiItjpvS9o92bS6UOx2OMGtQcrmXIyI7SD/hQ3U5xBAzedEQ/iRh17jNLPE93yp4StgnarqkuozFLUJGnlbIO5zV7RLHnlBZcBdjVFFMkoXG/b0pv0mxFva82PiYVYjc3whm8p9lTAx5VTmXBxiiEwwCapTjO5qdskSjJtkg1UnUSKVPcVamAHeqkrAeua8B5QoWK9+hiLr2BzjHagl9IySLdLuVO5zTHrcXx+KuSDsaV7hmAeBj16HP5UWtsrtMIR4x60K8W7tUYHtRlW5R9aQ+E9ReJjbucgHam6W7Crtt3qrkDme254nzUbpYIHOcZ2BpI1S85Y3YDLSHberXEmuIX8FZdgeoNLazm7m52YmMbDJpcvuMMiEDMu6fB4jhnHenLSUUKDjYUu2KDChep6YpkgYwxAdDioLY4EjGYS8YKNjXwXJHXah5usbjpVd7wHo1eD4ntmZjWmxh3tzI/xvI2SewJ6/XbFMdqxm8eeGFSFHhWwY/CWJ5edv8I6/b1pOtLlrd3kIPwghTnqx2otba015JHayStBZxNzzcm2UQE4/kKy6xmdXfk9I9WNpHHLHFGyO8zIZp5RlmA+XI7IPnIPptRlNVGp3q/7MN4HvLG1j1K6HxuE2Zo0/hG4HYk5JrM9N127vA12yvFbDcKd3k5mAA+p/QUWtpNXmuV0LTnX32+ULd3sj4W1th8yoOwxsOm+TWlW/QLMi6rByx5jlNxLNDqD8LcAxGaeXL6pq9xIBHGg/CD+I9zjbz7CiIuE0/wWjafU9TuR4dvnPKB3kbO0aAfiO52xk7UDkuNC4b09YppEED5ZFzs6ocAkdSgPRfxMeneiv+0VtpdpFJqK+G9w4a1thvLI38UgHQZ2A9O9GCRNm/6iMSRWeiWxu7y4hkupCHY7hQe22SfoPuarxC2Wb3rUJv2hdg+NHbuvLDar/GwHf6nJ9KDxrFJE1/qErOLc8wSQ8qGUndm88HYDf71+Iu9Wj+IeHbu2IreNOVnP8UjfXoKVuGOBJQZ6mMU08OpwSLqZEFqRvyyCPxT9Bv8AzoebnSdGtmFlbQ4x+EZC56fD6+dfILC3kmjt7aNXuEATqDy47k9BjrXFxFpsE8qWV0re77TT4yiN+LB/G/8Az6VnWnPQRqvAOCYB1G5WGcTuDHd/OotY8zIex5xsh+9VJtXXWnNvr+irqS4Ie7S6WDUI/wDM4Xw5evSQE+TCqOtx61xIDa6BdNbQtk+GwxHP6lx8lUV4YbSohacQTPqJxsjDCR7fKpUfF9Tk0obAgwD+nWadag4z193hDI4B4ms2Gr8BXQ1q2VQZLY/ur+3H+KHJ5wP4o2YUQTUbnV4YFmZ4bkHeNzy/F3ANB+HL+bSrxJopGuIoieRY2IngH55bH5itDfXtJ1+ILxJZtOJAAt7EFW6Q9mYn4Zh/nw3+IUjdZXZx+U/T+v1+cZzYpy3tfv8A39JFol3d6fMlteSsebLROT8w/hPrRC61u5stRhfxss2RFKCN+zKR326g7GqGowyWWni7iuV1LTIwEF/B/wBi4+UTIfihY9Pi2PZjSZrPFCrJChJKBiwb+Fx1H32rPsSxTtbg+uRLIBadw6Rtvp4LyaS50cqsiK4uLJTnmA38SEdSB+JOqjcZXoHfXklAwWHMmRlth2P1pH/2glS7W+tLqWKVg9xE6vhopB3HkQRmivv41zTzrWm26e/2Lh9StoxyrJC/zXUSdhvl0Hy7svwkhbfh94yBz69f1GgO6xu6Rs0bVJmhke0mBe0Krj6vg/bGKKWGpxT3tzdzRjEXOFGdub5SPtSpbRyaXdGXxFEV2Y+Uj+Dm+b7ZNMUcTTWkJgiCtb300d3GNudhJjP3G/rXhUSIOxlU/GEbyG5uNPRjIRIjM2V3+EdceXbesZ4u01vf7tJZhlgIWB2wxkVSc+g3+9bVBGy6K0LZjk8EgyH+AuD+YBpL4z4afU4LiaCNo7hlkklCnoUlXxB91DMPpV0/1sDC6a0DIPSZroutppPDtxYzSO80V+skak9XTmVznvkHH3FarwFFBxDptlNduzT6UP3kYOzwyF0DEHsOYf8AIrKuJeFpbfStZu1LZ0/VIYQqZI5XmjyR9sD704+zLjCLQtX0y01F43zc3GlXW3/YF2IP1GWb/drQXFuGPiYPVJ7B7rr1m3w6X4unWEMQ8P3eSISqjbsrSOjflg0maVFJbxfsu5eTmuL65ZcAEuYpSrH6jbb60+6bdyRCWGaP99bz+A6g8ueQEE/fnVvXNJ+qWFzCkN/HE5m0fULt2UdVi543O/4iXLg/5/pS11aoYlpLGbIPrr94sapqkNrxAl6shM1p0LHKmM/hPmQozj0pw4F4jtryeLVLVy1t+0v2ffoDvGZF54nXsMnOPUEd6zeLVYdR1HiDSdRKo2l3yWgfmDeIhU+Dv54518zyAUp+zPi5OFPaBfcL3ryfs/XfEsmUk+GHQq0TAnuHIAPqahNOTnzHMfsAdMePr0J6R9q+kT6joTcjMJYwwDA5ENwnXb+Fxg15p4Q1G60niiGbT7j3ZXnF1biY7RNuHjbbdQ4YH03r1bo15FxVookkl5J5gYJSY/lmj3JI7kHOR5fWvOntA4dtOHOKL23vIWghgn8YSRkN4SyYZXzjBHMrDyPQ4ySIydxHnLdnuNjVHqJ6j4I/Zep6JZywQmKNGkEESnKwAkmSAg5A5WLAeQfbbFS3PDb+5zFyrSRMwBK5JjOeU+uQv5jNZ37LOIZIdKkspbgNNbTBXxlRNgMkcuNjzbNEwO4ZFzWy2mo203isvK5JAKAY+AjIP/8As/Wn6imor2v4fxMLVK+muJWYvxRZXukIpBYN/eSbk/GV5vyK/wBKF8PazM1rZRnYh1UAnflxj+la1xdoEdwJYrmMeHcxwc2X33Rht6fBg/UViq6dPolwYGDHw5WYty4C7tJt5jlK1iais0FkPnNvR2rqUGes0/TryOWyunz8Udq5B7hSVUD/AOb9KsaPycgRsswnDbnYAAj+p/KlLRtZ8O3ukK83OqRDJ2GCCf5D86ZNBuFYSeGA3LhQR0JHzH6Z2+1ErsztHrrF7qNgaGoZ1GnvMImIKgKCfIkZ+p3P2oT4JhuppEB5G+PONmP4QPqc/qaOM0c6eFCzIMgB/Id29Nts+VUbyONpFWIgQRIVQdC52HMB/wA5p2+slBjoP38fX8xOlhk++UIUW6kWKHlysgEjDBDyDfH+VQfzo5pvOwkneRVgViObG7bfmfU0FgBmC28KFYVYcxUY8Q9eX6dc+govayNchrK1MLCIkTTfgRv4R/E36D16Vn1jJjdkml93Q8yoxifdE5TzOfP6VwljcznEkAjkbcL/AADzY9B/Or9vELZgsUhmuW+EuQGbPkB0z+WKse4TcjQ3U7xK2T4SMcsT15m6k/kPrTArJ5xF94EC3K2sOBJKz422/oP6mq72dsm8EEjyMMgYwAPOj50x7cqngooPRTscds1Hcv7qGV5IouY7nqzfQda8a/FuJIf/AK8wH+ynkXxXwue53xVN7ZhJhVZiO56UdLSzIPCDIB3cb/8AjXM2nOwAcfEwyIwcBR5n1qpQN0lhZg8wJPaiI45wXPWpIIOTDk5ANEJtG5SZGUZxgCuBDHAg5yWPYY2FUNRBhO8yOJLaSKr5dxt0Ao5EI57cgYzil+KEbyhcD1FEdPmPOBz7eVGqJU8+MBaocYgLW9OaJnfkyN+vevDv9qHjG90bjrSTFYEG0kEwkxswz0+te/8AXYGkgLAZ2zXmb2xcF6Tr/EOmLqFkknLdAjK+YrU7EsGj7RU4yCD+047tXTbFYiaH7M+Jm4m4UsNTKlTJAhwevTNBOJZLfQfb3wDxExghi1exv9I1GWZMqbeJo5QAT8r4kfB/0pl4V0y10fRoLO1QKqrjHQfSl32ypcJw7o2t2+oQ2P7F4i069nnlTnAt/E5ZUwN/iDKtB7E1y/8A12t2GFZipHufK/eYt6E1EA84z8uZjX9nnWXuP7RPH63V9G9xPq+pZeM5SbluXGVxtgDH5V668QhSQelfz5/sz8SQj233uuWUDRafqWoXPhxyOHkj8ZpJI1J2yQoAJxjNe/VlBQHm2Izmtn/KAKPw5B/44+X9S+P9rCYP/aS4sm4b4dmuoJiknyjY75P+lAfYXqcfFEMEyM0gGPEY9zVz+1SLW64VurchWbGQMZ3qj/ZY0ybTtFjhZNnIIPnRKNZW3ZWLPPiFtXYoYcGem7OFLa3SFOgFTbHrUKtgAdcV0G64NZNOoGZ4LgTi7hE0LKR2pH1aye3nMiKdvKn3OetAtfsS0TSRjtW1pbgw2k9YRYN0jia3W3NtcvyuBtmg2q3S3szujBl7b1nPtI1q80GFruGTkKHJ8xQbgr2lDV51gdmJYgHNaKoyr7Xzl1Gw8zX9E05pp+dkOAc03FQkYVewqnw9FHJYrOCOYirsox1FeXiWB3cylOPKqM4ODkiiMozmh84xkedXHuhVg+bBHr5UPnzuBtRGcHfAxQ6frv2qjcQywXqUYmhYYGRuKTNS5owXIzy7Hzp2n64pW1a3Hisrr8D/AMqEH2nMMBniDbG5aGaOdCQO4zTHf62ItPMiNlsY60nSXJ04vHMMjfYmgDcRyvctDLLyxdOufoKl0LjaJAIDZMJXeoPNOZHYkE7CvsGoYYIPrQ1pYpctE4znYVNYxSPKB0JPSk2zWOesb4fpHHR7x2Ic5wPOjTalkEdqBWi+DCB026VK829Lm4sZPdiEJL/IOM/Sq/vhzs1UzN1PN6Vwzb9T+dWFh8ZYIJml6HQMowM7n0/0qhLqEtlYSxRgFpCVyT1HUk/kBiiF2/ibqBj1O1B7myWZgoHMcjrVkXibrcdYZ0i4unsrJrmXL3EpaKJTnJTpnyUbk+Zpms9ctrCe6e4uOTxY8OkRy7E9Sx7bDAA7nJpBGsvah0sVbMMDQRN36b8o7DJr9w9Z3Wr2/wCzI5PChV+WWZmwCDvIxbsNsff1ppAQciJWrnrH/hjVLrWb9uINRtB4VqBMEbdQi/3Nug6LuQzHr96btCsbvWtUk4gvGklZHPNIEGWONxFnZRnbm3+vahemW1pHYrKyk2iFUgjI5TOF+Y47A+Z7Udn4hgs9NFzfpFbRk4jgXbKjpkeQ8sfXyoxOFmbYdxwsN3N5DDNbclvBPKmWgtw2Yk2+Yt3x3b8qmiuIZue61HUiyuSXmzyoAPwRDoF9eprNjr1rqniXsa3TQBsLGr8glx5t2X6da4stJ17ibUop9euJI9MQg21jDnkOO7HuB19aSsPOWhFqA6Rxl12TXZJtJ0KcWemWxze3MWQWH/ow/c464zVWe8W/YafdaeP2TCo8OHcSPjoxI6D0P3qXVNRl0GyTTdH0t3QkAER/FKx/EcfKKgZLq4tjFc26XMsg5mjcGM/Zh09M1m2WA/ljtaY6w4hDoW0zUII4UQh0fAOfIMOw8qpxwWk0RgfxGkHx+IN1/wCH6UmapEZJImW31DRUhOFWRS8TeeOXf7nrRWDiS5lsoktHhvnjXlSWJwGI9RsdvKs+4blyPX6xqtCDxGH9m2ZtluzGlyYSHEikJIp77jcj60NvtQ/cM0dzkRnl+o8jQ8cSiPEyoEbdZlPQHG4INAZNajjll2ISRSJEYE4XOxHnWeUZjH61J6w1qHF2saHeQ6voV9LbSleUSRH5k7qykEOvYqwIIO4r9cPw77Q4RHbXVjwxrwQmSCRvC0u8JPLzRuc+5yZIOGzCfOOlOTU42aTTZkR5BIHR1YfGNunrjp51d022jtuKrSF51a2vbUrG+AVaQggAjybOCKe057te7cZHl/HkfRBlrUAXvF4bz/nzHoQZZaRxHpmo6nomraTeWuq6Q7NcWcyFXCnZwR5EbgjIIIIzT5oml/s7SLW+0u6zLPZyR212rcrRzRMXjJPZsEKR0I9CRTvwld2upXiaDxPZteQ2lqptpCQbyyt5DyNHGxOZIg43hY4GQUKnrUThbUOFhPpeout1pkkrvZalEQ0MinZZPMMhblkQgMAQSOhJbaOO8Tp+x9/2PT9gk2t3nu34P7/D+P36yfVra11vRdI1ywgjgEMlsb+zUY93S4Xcrj8HMSMdiCPLPxrvNsJy/JLGIWZSNzIrgM2MbEBv61Q4R1aexsrmzSIXF3o6PJJZPu1zZO+Hh9QCMqeoOAO1fOLfedG0Ky4ztdQOpabO6KzMFDXESPhHfHSTw28KQd2UN0NBdQx3LK1khhWf0/iFNV1OKydZgpaC2nkt5+boGDjl+xB/MGmaDQV1WBtTsHDtLlvDByHdQQyEdiw29ayPiPXJdOn1xXInilaOdMr/AHiqQGYY/wABQ7+daN7NeIRLPfWsBIhE5urblbIeKRQxI/xKxbbuCfKgVIGYBvGGuDLVvWI3E+kfsvhi8miVzBcraygv2y0a5b1BjA37k1ieja9fadxqIAiNKbhfDEzYV5lIZASegYqyZ/8AWGvYWt8N22r6dqfDaIhHhvLbqGxk8rGSPfqFkAcD1PlXl72xcET6de32sWVsqfs42886hDiTnRWIB7hUD5HoaZ067G2P0MYo1S3IR4/aek+BNX/bdvcRT8iXd1bzQj3gFXSSF+X4h1BCRrzd+9EeLkS54WuHtmW3l3Lj8Xhycjnf+IAj+fasT9gPGrawtrHfSZ1PTrpbV3Y5FyifAjsTvzNA4ic9ysRPU1s+vanYPpIkeEhZGiQgDm5GEhDEn/Izr/uCq6n2GIJ9dYilZWwYExTTITo/th440jU4FOnzyxqwOByYkDxTqe2wbBH8JHekviXSpdM1sahqUNx4Mmqm3IjUc8HOhZWX1JUEdjgjO9alb6fd617R+I7S6iEAg0OMDIyvNFciRAT9JJBk91pM173q+tJuDtQv8ara3i20My/LMvM6RlsbbeLGc9jv3q1bAsG9w+U0MnBHjNW9mnE95pbiK9kBE0sQuCjEBZ3HLHLjO6yE8pPYsme9W/anptjqWlz6lDGZLg2CSwsYx8aJIpMbj+IczDHXrWbcGadccR6DFeeK1tcJG1lfxOSTHHKDyORtkR3CcrZ7MKZI+Kr65s7rQdVldrlYGjjlU5OWVHXcfxBW3z8wNBtQAYHUQVQIu3qfjBvs64hfS9YW0u5CLSaFRFK5+J4ZYwU+L0KsP9zzr0xDIGht7iORlZoIbecA55JVPw7+vLjNeW9CjhvbzSLS9xbSFfc+byRmaW2f7N46Z/8AVnzrefZ3r3vNrELxy8c9uIGRtsSodjnsfhP3zQabCLCh8ekt2pUHAtTqOvr9M/KaneWA1SztrjlC+BEWcKOq55wfsQRj1rLuKNEElyPDOIpHdPl6qAg279OYema1jTJVit4AZvEQwgkdjGc7/wDPnQTWdJhvbOWFi6+Gyw8yjDMAQWH3Cr+dP6vTC9Qw6zF0epND+6efra9lja8hUYMUoiGT1IbDYPptTVol/gpp8bEeGAZmBznvy59e/oD50sa1BLZOUEPL4qNcMcYwvOWOPopX7sPKqOh67MJxEox4j5cnuSd8nsvTP0xXPVsVbM662oW1kibfYSeJComdAjKC2/bGcH/Sh+qXi+CZfE5U5CzyfiK9gPr5j7ZNCtG1GHU0cMS9rC4Vw55fHcjYHG+OmQOwxRTULc3koRecxxDmVgBjYfMB5noPTfyrZLm2rCznwnd2+1A1jfvq9w9pAZYYwP3zBsMN/lH8P8xsOvR204IkMccCxwxrhAY+uPJewPm25oXpuixaVbgO/L4jhyEGGYbnGT5+f1+tXXuwMhFSNEHKCSR9RnGw69PX1oVWnaoZfrLXXrYcJ0hmE2tqhEcI8iQdwfJew+u/3qz74tovNFbxRMRkkuXc/bv9TtSuvEMUJPJIkZycSEgBRjr5/wBaoXXF1tbkhcRo7D95IR4sxxtgHoPU4owdUHXEX7p3OAI3SyXd6zNNeS+G2yoh3P2XA/WqrR2sKk80a5B+IuOY/TG9LJ4jaWIMk8SxONuQkgnuS34v5VXl18DZLscx+bK5P3NK23pnnkxmvTWHgRkE7wuGihbl7F/h++9ULni/T7Cc2sVwtxcE/GwIwn3rOOJeJdZnR7eyui0b7cwwMD+ZpStLHWbg8lnbu7OCWc/KPXP9aWXUEnCTSr7OG3dacT0Pa8Q6TPH4HvEUkjDMhD5xXy6FuwD2wUY8z0HrWI6bPqGjOIoy7uT8UrfiPmB2Ap/0nUH1BPCV9+UZGepp8WbxgiKW6XuuVPEYvf1lLKm5GxIqzarJs4OKDwYthgBVx+tEbfUoyPDBqfjAEY6QlPdGSExk7gYrEva5HJY3VlqBU8qXEefoTj+ta2Zcy4zisn/tF+NBwnLdwZ5oWVy3kAQaa0Q3aqtj4H9+Jjdq6fvKWx5Rj06TmtIXzkFcih/HmnjV+Cdcsz4fOLGW4iZ1yqSwjxUYjfIDICRjcVDwbqMepcM6feggmSJSd/QUD9s/CnEnG3s81LSOEuKb/RNSiR7qJ7PPNdhI3zbNghgHzjY9cZyM1g7Rpu0wlrFAr9fLB6/pOXVdwBE8kf2drGNtNvuK7Ys82l8S6WJmRSVEEkU2AGwB85J89hXvmXUEh0v3nOAE/pX80vYxqs1rqllo1zb3NlY3Vx4iyJ4kXvEq/CFdR8EgjJ3zuufM4r3vxfr8NpwjbFJMGeFOnmQM/pX0L/LdEPwddqnJ3/IFQMe/lc+HWK0EvcFI65/fP3mWe0O3u+N9QWyjyYi55/LG2BT/AOzDToNFvU0y3TCQIqgeuKrcG6MX0d9XuI/3jAsCe3YfpRTgvbiCYfQ/euSTUbtMax0BjV3tEnwHAmoq5rsOKrBq7V8jFKVW8iW2yyrb18mRZYmBAO3eow2d6g1G7W2t2cntW1pLCSJ7Exj2r8Nx60Xto03OR9DWfcAez+bR79zIpKhjgkHOM9c1tV43vkzsyhiW770waVwrbva+OIwGIz9a6OnWZ9hukIeFAMGcPX8unKlvMCFOwBpmkkWRBIhyCO1LWoWrW8jRlTkDY1Po2qEH3Scjfp60fG048JXoYVkYDbNU59tx+dW5cZqjcNt1ryNzzCLKNx3Oenehk/nRCdqHXDKcjPWvOYdYNuTjOOtCNQg8ZScHIFFrg43xQq6kABGNyMEHtSdjYjCxF4kURr43MST1Hes41S6czfujjG5ycZp84ynYZiRjlduvWs4u7ocxSQEEnYg7U7pHD9espcpHSHdG1EyhYiN870/6RbBkWYgYIzWb6DZuXEnKQvnWnaROrWwRSOYDHSl9cvBIhKCehl/nx5fSuDIT39a4O2/X0r4G23z1rKGOsd4E65j1ziuWbbANclgMjIrkvjYt1qd/lPcTPL20nsZGWRSF+nWhzzM/NGowzDAJIGBWja/paXLSKycrDIG1Zxq2g3Vs7MzNy56Cm9Oyt7LdZrFw4DzmK2hSTkWWNmKlFwTgZ6nA3Jp10mCy03SVkmnW1jIzgqFLL6jruaQbCSK2l+NSigEnB+JvTNT3Ooalq8vheGVTICgLgAfenNuIlZlziM8/tBmjLw6F8MxyDcSLzci9MLVKB9S1a6HvDy3MwACrIdz6t/CPr+VVki07TIVe4lUzHBIYgBR9uv0oxpS3epwNJa2ssdgch3RcNIPLmOFX6k0FmI5kBUHSXrexis7gvqGpQ3ksYDeEPht4j2Lnvjy6elXrvim8tLWT9ll724Y8gcKeUnyAHRR5d6Bz6jw8ka2Gsahp1rFG21pp4a8lT1cp8HMfV6YNCh4VgiS40Kwu7qaQHme5vFtPsVjDN+TikrfN+nvl0A/4jn15wfo2r8UafcSapqGoSm6YhFgLZGfUdBjypz03jqWeMjUI4Sg2Y28oV+Yeamqkd7bXi+AuicOW9yTyp71bSXZz580rsPzFUbib2iaRN41hfW9rFG6gDTbKzjGM7/LECfpmkbWRzknHwH/kMBxtx8z/AADDMvFtjqAazhuoiB8LrJjnQdid/wBaEXUcNyfB06W0llB5SGZdu4JIOR9TRGX2jce27BLnim+AQbASmIsPquMH0oZbe1Tj+11RoX4u1Oe1mO7SSLKR6FXU/wA6UapCchj8h/MPVvHskD5n+JVF9w9dlrbU7wXGpWw5ZILNgOdfIyHr9QPvUMGr+APfNM0DTUtxh5BNEblxjZ8mTIB3B2A2zRPinibjiGWK+tLrSNQfH7yG80SwlJ+7wc2/TGfvRPh/VdO1WSKW54F4caSWLMkSW1xp8gbGHQrDKEP3Q+deCVkZVvmP4zDlmrGWGfgf/BAXDfF2rTavPoMupCxMDlrWaCFEjdOoQhVyNjsRnBHrT5qzavJo0kst7FOYP+kRTSWcM/hd1kAK5Kk9cb/MOuKW34c9nfELSRabLruganbDmUJcQ3otyD2SQQuQOm0hODvTrodjqMt34Gl61pGtXfg/vNPRjY3z7fPHDPy5Y43VGdW2NXOnZ1BQ5Pu/jrFbLk3Zxj9Pv0+sFy6qlw2m8WajottbX9g6CW5tJmiilWTlAkQjKFGIGQQCGAO2KdkvPGefWeH7KS+tZybXXdDkHK8oAPLOi5OJE5tnTOVbG6jFBtM0+0trybRbiw5BOrRTabe2zQv4bfMBBJsR6DbuOlGZOHpvd4TpTRm9tEaK2mnlws8GQRH4g3V15flkGdvhYjNEqZwMj5fuMfbxi12wkD1698VOPbC44Y1Kw450l3uNMdhaXF6BySW4woAlA+U7AMp2Iwyny709tFu9Om4U1C7hSy1sme3mIPhwXXxL4mDsgO6Sr9GHSrUPHE8NzdaPr2myTJPGIry0njDeNEdirD/tB1ww3U4IJzylP4ys04cu/etOnF5wtrsvvWl3rHmFrcLgS20hHQ7ZI2O+fPA7ApXvKuniPj9vLyPHkSxSGYiuzr4Hzx9x9RFPiie799jtL6EQanpsklhcxyNygE/uzGx7AjGG6fLvuDTT7KtSk0+9s0gibxYh4FxA5IPJg8pbfPLkMh8jg0rcXr+3kSeANJquk2xju4mOHvdPUcqyAfikiACnGSUVT+E1J7I9asdbvrzhy51RrXiHTz4mj3F2AI7uIsCbR5wcAsWUxs4XDHlLENsNaTYMrzjn1/E0bXC1Yb4H15faennsNVfUraaOdnR45bKUvnMqOPEt7pG6cwVnRvPHSkD2laOur6LqFwtuLmfVLJniCjlC3Mdu6Oh9MyN552HY1qXDfi3WiPZ3EMyGLkvIIzGVe3PMTLAyn4lIwxBXcZYdhkHrWn3V43gyqJIIiJSYmHxrzN4UqN0OchW7564zR9TWe5Dr16/z9/jMTS37LsHwnj3geCTQeLUsnUpBqDYjIzzBzG8edu+cH6qtehZNels+HodY1GF5Lp7+3EsYf4XLgkOuB0cSAj6is8u+Hrey4pS+v7cGCzeO4mYZXkty8Rdx5FfGikx5Bx2NaU2gRDhC40a5m5Al1cWbTeIMwR+I0tpcg5/7NnaMjyx2UVms/wCIAZus6PU92jhh0Pr1+kJ3mgXOn8Xajf2MytDqOgu5UD42kDRsmM/h+Bz6ZPnWTcacMft28kvrCSKG5gax585Bd2hLIVbO+Ao6jfJ8q3fRLv8AaE37UvQIZQIyrSAYiWSJ4ZV8+UP4gxvuFNImpQ5n0uRraYu1uLKfChRHd2jR+HnfqfjBP8OakHuznMSptbJB68evkInTyPpmu3HFOmRCaHVLdLqWOM4DLNyiRCvmJQxHng9xTB+z4BrGm68i4TULF9OuIcgqZ4izRuPIGN8gjuopdi0/VrKDTgLUCOJZXW4cnLOk5b5f4SVY7k7SNV3TjNJDDbXMk7SWEvghBnEfIeZCGAGSYTy5z1FMBgesGysOhk0trJZXtnHdQx+DBL7t7wAQQpk8WEkf4ZRMpPTE3rTnpXENpapYX3MBbySEMvdBJMwVvXlfP5iqWp2ok0hpoJQ5gu5LVgy4LhZwoOPNlVM+rVSms4le7W2ZRHDcXEELOxCjllEykjy5AcetKXIc5xLpYLBhumefv+83XhbidZrOa1ldidPPIebtzFT+Wc0zi6SWRg5UBXMh38u/5AbVh3CWrS2uo3DNGVhvrRmyBzKORDv6bqw/KtC/a5zNMHJCx5bfIbA6/fc03VcRXk+vXEzLqAtmB4+v3zET2o6QtvF7wypGs0axc+fkVgXkBH15Bt5+lZQbi5s702sZUSyqGzn4huMDHmAyj6kmvQXFsEXEVjp2nSRK4meGSbmOByjnJG/UZUViunaLearxTfX95HurpyIx5QAytjPbGQ7fYCsm7TkW4XoZ0nZ+rXuCH8PQmlcI20kGlwQwxhiEJA5sgM2OZmP0xv5CnUBDGj27K6ZPxuOuOrH08h9aUrbUrW0i9yhnjjRmxJIT0jTAJ9M4/XHU0L1/2jaFpNtNc3GopFBEmxZgOVAepHr2HVmO2y1saZVrUD16/qYlosvfIHWNera7BAeaab9ypJPMcGVh+JvJRg7d++w3z3jP2w6PoAZb28HvIbEcK5YljjquMsx8sbCsW439vGoXMck2kNJZWskjCO6kQmViPwQp1ZsY36DGf8VZnp2m8b8c3vh2Nrf2VpdMFluDmSebJ/FIPkBzkhcepNMjSW6k56L5+J+AjIXT6IZv5byH3PhNT4s/tGCxf3O61iz0xmKs0ZBmmBA2Zo1BA+jdKFaH7TrXiK6jXSuIm1e5uHGEdOUx/wATd+XApp4P/sXWeqWkE9wJR4twiyyk5JiJ3ZQNgR6k+tZ5x77NJf7N/t7sdFmmFxpOqIngXJHKJYZPlbl7MHBUitG3/HRVR3jo3xOOf0gtL/kFdl4pq2/AA5+f79J6y4M4L990lLqK7Lu6fG3MWLegHYfrRyXgHULt/CPJCgbcKhzjyJNKnAt3JFE9mk00EXNz4hZkYggZ+LOR36Vreg6jaarZxSW0qva8o8LlcupA26/i3HXzrntXoamI2jEMdZdWSSYA0/2Y2CqQ5LjPxnqD6Udj4FsoLRovgRGXGMg5/wCH6UzQyWsS8qydF5vWrUIsXjL3ADOVIIz09P8AhR9Po6q/DmZ9uuusOSZjnEHAy25eS0j5UYczvzDJH9aXtLtZtLmaVCXRfxZ/ma3e/wBA0+TIkjDPgFUclgoPcjpSpqXCloFIZHUZOXxhfsB0odmmZW3L0jdOuBXY0X9PddRXnljQAbdatx6XK0nPC6KnWqEc9pp10bK3Yksd8nJpjsRacoZZWJPXeqkZ6yzEjkdJSjiEdyok7Uh+3OCDUOFL62MZf90cb4Faq2nLITNGnwikXjzSv2hA8HKORgVOe9EUmpd48OZn6s+zMp9i2otccFwW0jfvLVjGe3Q/6Vo9jIXuIkDEczqoI7ZOM1k3s+hl0PinWdALqYiVnRfqMH+QrTbK58O4ik68kit+RFZf+Rjfq+/UcWAN8xORpXC7fIkfKeR/Y5wrw/rljc6xfq02p6ImoRaU/jkRi354Eebwu7mZ5/iPcg7kDGt8a3zyxaPw6jFg6pGCDuDsP0xWceyPTNPstU4y0ATOZuH9U1nTk2APu/ixSrnuRzr0O3cdTlo4WupeKPaDZRMh5LCP4lP12P619K/yBlfs224HxrP6bP5548YlpAReD5b/ALTdY7JbDhiKBBjCeX5UucHsBxFKAdxim/WTyaa0a/hXA/KkHhG7C8WSxE/FgV8z0rFqHAj5TCTWQ31qVCc7VAretSKcd6FSTmWxLK48+1LnE9/yJ4Knr1xRuWYRxlz5GkTWdQ94u3JbbOBW9ouAWkAZOJNo9s11eonUZya0SCNYYVjAxgUp8HWeFNw602c5rV0zZO7znjyYF1+xE0RlQYIFJE/PFLzA4ZT5VpM4Dgqeh2NJXEOnmCQzIuxrXqYONhkDmX9OvlvLcAt8a9d6jue4INL+mXxt7gYyAdqYJyJEDrvkVZh5yyDHEF3D9Rn0oZcycuRmidyvUmhF0OtDLRlIMvLgqD03oDqF4I43dtuXfFFr4ncYpP4muzBblQd2FK2EmNIIqazdm7ndiTtSte2ivMpKjlB3GKK3UwDFT0znrXOn25uZNwD60Spu6G6WwHJBhHQbYpHyjIwP0o/pt0IbgRscA9Qf51SgUWaBAMGoZJzHIJR069aK7d6MwZ9kRu8QfN2rkybHB2G9D7W7Elsrbbdal8c775I9ayHUoxBjIbIzLDv1wpG9cGQ5+mx9PSoPHGxY965aUcuS2+ajMnI6Q9FcR69CY3RUnhXbb5h5Ut6rarMWSWMhlyCp2qeOWSC+S5iuCnhtnr2700yWFtrdqb62iCygZZAN/v5U+aO9XvE6iJdndo9ye4uPs+Ex/U9OdAfCVIyN9lyaEiF1QtPdMoJwSuCx/XH6046/bPEzxuuPQdDSe9sTKWdS57DsPrTFdhYYYTbK+IMljm0+xlWddOhdkGUe5Pjux7Hl2UfkaG6pxLql7ODfTXlzynEcOPgUdgqj4V+wqW5gvJQSgK46bVGmm6xdoIjNHGo3GSQT9TVm2jqZVFJ6eEsaVxLbWTCXVNAg8KLfk5cM31Pc046V7QvZ5qUYN/pFzpjL8KyKQw+oxSM/CE90ytdX64I2BGVz5Y619ThKGO4w92rSdQmWT9CP60lalLc85/WFXeZtdvq/D3gRCz1j3mBjnEsecA+uail1Cxw81pqUeSTsNs1mKQzWEaQAzIrdWROZR/rV+zliupPDvWz15Z4QcbfxL/pWRdQM5EbRMdYz6xJdTxiO4sxIXTPNjmDfcfKaTNWnZXFnK0kTAZhm8j/CaNftS94dlgOphrvTpPjjdD8SDzU9D9K71yzsLuP9oWMiT28wzzx74P08+2KEilOsMrKDtl3hfUW4k0d9L1FjJcQqVAx8e3Q+v1Gav8KanLb3X7C1d/e7XmZVMspWa3kB25WzzcpGdhuPWkOyuDZ6pHDZTBJrggxqflc/4D1Vv8J2p6m4e4j1stc67wxcW2FDe930kdnG4H8ZmZD/ALy7/wA6Ia8NwOsizABUnEYOIIYJtUgfSb2JNYQCQ2GoqVF8qjZo5Vx8eBgkDfbINXbyztNesozc6HKVgfxXtjOqXllN2e3nHwlcE5G3qM0J05rG3todJ1r2g8MCCN/3dvf3pvAgxtyywIwBHb4gfWmHSJW04rcW3G3DF3bOBCjEXbo3+EzCAhs+UgY+tVCEf3FTnjjn15Rk4a4m4ttFh0LUtR07XuH5FCQQ34Et/bEnb4XP71fVCr7dQa07S2lm0/le1ltZLc8ySCaSeIjy5iPeISP4ZVkA/jxvWS23B+gXyytYz6C8krfvrbxnjRmbspKDwyfMcoPfNHdL4L1y1uYpbFtXsVaMIgmiWflx1CXEDEMmB+MN/u9a0KLn6OufXn698QvqTqpx69eEbtf0nTLq1b33R4ZJIBzcvglgEb8aFc/Ac4LJlR5Cse1vTLHh69uBaX0s3D946jUbCdw6xSHZJc9Y2Un4ZSCpBKscErWq23EvFWkN+ytSv7HWYAC/u96jrKgzswPz77DmGR03HSk/jmaz1RTcWczxTQjmW2mcNLCfxKp2LqRnbJ27GlNYqp7dfyx6B9cQ2hZt2x+nn69e+Yhxbot9o2oqujXpX3WRJNOuypJhfqscmeiuCR3VxsCey5oEsp1p+I9Ht47a+s4RcXNmSP3S7LKvKdnhYMd9xy8pztsy65etp9y1vD4U9hKTGbU5DQ5OSqg7YPXlBCnY4VgGrPRcXNhxFDqejXh8SItJD4hKucDMiA48shgeuQSOuRUNuUgTedCFBPP3nt3gTjttQ0nT9R1G2kjMxMPPzcxEoGAVY778hBU9HQjyJtaxDHpuq2V7ZMZdN1ZXPhxNlJH5TzoAB8J5Qwx/lH4VrLPYjxVb3dleaHqr8jqiTIqqBHPaSgeHKuNuZHUo2Nxyqe2+j3s8nhTaZzgWN8wZCf8A91vlYNHIP4fiwD2IYUZrC1Y3fP8Amc41QquIHof1KuuaXZ2+r2t5cpa3EF1JJYySgYY+JC2AwI+VimP9/HaqlvZLqWntZQzo9ssi2k/iAAxyIIwC2P8A0kTxPnpkvRbUZ7C9hhkaFohdOA8SkFreVXEiY/yuCPMh8b7ig+g30eo2l5pV4kUc4jZEmXYM8PMAh8xyMeU9gzDfAxnCvBwOI8tpKZPhLFjL7hZWUkiuC87WVzzrk+KgIbP+8it2ySfOutasbayePVI357Ce9kuEDDOGkjZvh9cNtntnuKn0+4a+067+BHV74zuhIDiVN8gDzDSrk+Y8q610XH7KeJDG8KiwvIJlA+I8xGcHqCCo9BIPI15qsAkzy2bmxmKU9odVXS7Jo5I5oVgAiU/CoZjC4Bz8QzHkelVuH7eF9QtooZZFt1RopEmOzgIcDH+EOQOnyEVJd+8aHa2MkihZtN1Wa0knB3e2KrPA4HcKOaM56co9antkgs9Mlht3kNyZHtpGUnDcrh1cfc/kx7VI4OTCtyMD9P5+8KXMDyaZLG8cUU1mwuWySBIG8ORTnzBjC/SqGpaFcPeXdtE8BBWeZRITnxS6NEPuh5Cem+aYjy3gtNQR43jlkSaNDkho+WRWU+YIGR/lrnUtLi07WUMjvKt1pjrbBgCQypkxn/EFwQf8JqHIbgylJKnj3ylaW4tJEsHyiva8glDZKtIrbHz6rn1ps0OSR9FFteKXRVZUlBYleXnVfrhkIP8Axpfhube/hs5onBEuQHCjDPEevXbKlM/5T503cP6fDaWclnIhHjS3HKSfh+NwSQex2Jx6tRaV3uAOhxA3sVX2uuYR0+2PuNvLJhnijYc2PlACtg9zu3as/wBWsY9Fe9u5VQRJIqDA+YhckD6szD6A1pNvzWluWln5kaNW3P4jlD+eFNZD7Wtag07TTIZ+WJXGOUZLyE7ADy3yTR9XWqVrt69J7QFrbdvgZmPtB9oo0BTahg87DmIB6fNgbd8kn7VjGvcS3P7qfXVN7qdxiSz01WIULjaSX+FcDYDcjYY3NVuMOJTJfzatNi4nmZobGJkyq4O8rDuq9Bn5ifIGueFOGp7vUjeXzu11MFkZ5UPO7HqSTkdPyxgbU1p6E0lYtsGT4TR1esFX+mng+JnHss9w9o2vW13f3slxdM/LJCYx/wBHRTuqqNlTodu3XeveXAvs/wBB4f08fu45AIy3OOVUQ4PyDbA265NeFPZ9pf8A+G2q8SWdjHGdWjimZ2clXubZxzRoF7Lseg6geVe2OCfaHpUnBFjxHMyXPv8Ap8U9uqJzF/EjBGe22d/oa7urR1dnqmssIZLF3KfAcdPX2nzi7X2a8tSPZdTg+/3+vvNx4cu7G2t44rVFzIytkNkev6E14B/ty8V6Rxn7YI34TmintdM1D9nWs8ZLBnj8MuVJG48ViB2yDWi+0v298Q2Okto2neHp9+4Pi6lbjkkkiIxyIo2Gd8sa8wcHafNxd7RNOskDSafohN3MXOxAbnOfMluRf/CidodrU67TbKvif4h+yezbNNqRY568D9fH19p6+4HjupFFiZ2jiP7qSUkGQseoUdzj7DvW16Daw28a2tiP3afACTnP/Pn+VYf7NLS31SR7icOwWTmIXaMt0UZHzHbOPStsjvVjhW2jlYkj5guwA7ADvXzWx0zjwE7jVA7seMYbaZ/eAFVfDj+J3bYVYbWtMS6ZLYqZVPxzFs8ufIdPsKTr7UI4bcrJPh+X+72L7dWbBP5b+WaC6brMN/dosMr+5g/G+MeI+dx9PPH0pazUFDtlKtLvUt5TUbbUZbxmleXliOCrSbc/ry/6mvl45uwInukA8hglj50Du1laJLiaZ7aHkPIObPMB1AXuf+c1Nw9dx3EqxQqGbP8ACOb79hTKWktsMXNPs7x4RZ4o01dOk/aMFmilT8T8u+KraVr1tOBkAM3fGK0zX9JbVLUQyxxEEZPxDY1ifE+g6lot48qXAKZJVVHT7UHU1mp8jpG9JYty7W6zS7XUUCYaRceVBuJo4pbVpV3PbbYUh6NqupXEwV3cjP0p9uEZ9KLSHHw/U14P3lZEDraO7U4nnaeKTTfavHcSuyxXsDRjtkjf/WntXKuVzuCRST7Uo57a6tdcslHi2M4br1Gf9KaI71J4obtWBWdA+QeuaT7RT8T2dTeOqZQ/uJx6psvZfPn1+omD6bf2PB3tx9q2nNp3iftC3k1e3n5d4ZXSOSRM5xyusjde6LRP+zIbjXtU1TiiZTyyOFQ42CgbUjf2gdYveF/aNq1xpqMkuuaZa5Y4xITHJGRn6RYH0rv+ydxzLFcPw3K0qGQAphth55Fdpfpjr+wUYPj/AFoTx1KZH1+0VH+q5lxyW+hAP26T11qjc1i49DWaaFJ4PGQ7Myj+daJey5s2Gd8Y+tZvZjl4thkGBnI69a4HQLmp/hNBlxNljYkAmplYVQilJQeoqcS4XmJFVrGTI2yrr9/7tZtytuRikOJ3vbtYwCSzf1ojxdqZL8gbIHUCo+DrVrq5Fw42HStkHu6wo6meA2jcZoOkwC1s0TGDjer3iZFVVcKOVegGK+l81qUYCgQOJI7evSh2pW63VuyHGcVdJ2qJ9x0rRrJE8BMy1NJLC7KsPhzTBpF0tzbBCd8VHxdpvOhmQfFvQjh68CzmEnONqfXD8y5GRkQ3cruR5UJulzmj10gYc46GhU8ec0CxSDiGTmLl3GN8is64um5pygOy1p2pARwSSHsNvrWU8QkvI+Op6UqwywEMDE66Yuxyd+m4o5w7adHI9M0Me2M1yqBc4OMU5abp/gWqgJ8Xehah9q4hk4GZS1FCGwADnv5UOc84Krvijd/AWTP8jQNgVfbpU6O3KlTBWnHSW9LnMZMbHp+VXmYhyF6ZwKFQqyS84OcedEWBZVfsR286rq8D2xK1Xc4zOjOQMkmuWlwM83SoiCWHnnyr5g9MbdOlJBxDh5Y1geBzTDYk7HyqjoHFd/od2c3bzW8h+Nc5JorxLHiFl9Cay7VLye3dhExBz0FbHZtngZzF5wwImocRXFrq1u19ajLAZIyM1mp1PF34Y5uuCPTNWOCuIZhfNZ3Kc6SjB2yaKcQaF7nqKXUCYD9jtVtQe5u2kdek6rsy86ijk9JCtwhtfEXqe+KDXWoDmI8fw8dzRO/cR25RUKv+IY2pQ1aXkU8y4J71BAYzSqYqIWtrqUTBxrR5j8uRsPX0pgtH1u45TDdWsq9SeUEsPvWSXN/JEcwE5Bzmrencc6pY4BVlVcZJUnaq2aR3GVnu/RD7U1lri5kQxchjMYIY7g/XuKpyLqltIt3B4nOhHLLCwJ+46Gl/TOKrnWB4ccvJIN89Vx6k9KP6dxDYWzOk8EUk2MFkz4P5dT/L61k2VPWTkRyuxWEN2Oo2+vWMlrd2RMZyZZA4SJGH4vi2B9F39KqaX+ydEE0djdy8Rgnm8FJDbxRj/Ev97JjzHJUcqNqRXUBLJNGg6xYLRfROmPoKpPZ2U863CXVpM0O6868sg+xGf1pcEQuMnrC1zxNxDJbleHLi30WFxnk04LbP6gygGRvUOxr9onEaXbC31jVrWW6I/c3QuEknGPwtk5YfcUU0rX9OtrZ1Md5BI4y8tvK6kHoTkqQfuamukvbvTx/s1xjZTsmSq6lB4m3Ug9MfUVUtuG1xx68gZQnacqIRgvVkCxXVhYTlgoEllciM56Z5WOD9MjFEY7WC0maVNMmtppAFWUgBebOwbALHP8QP2pb0/WuMDIqSRaGZo8E+B7vySL6JJzN/Km+x4j1z3dYr/RXXxQQ3i21usa77HA5QR9D5UHBB4IniQeMTu0udLin91u/GspuYSCa31ONHXfcgNEjKc9961vgniJwkllccQ6veW5ARnnhtLsMD0JlhaNh9dzWUaxfaPHbxzahZiAhctNbo2xB65duUD86p6dfcBXssaXGiwzKxyZ2ljDLnof3RVz9iaJTqXobgcfE4+ki7SrqE5+x/eemYW0nUbWOxu5475lDmIXgZwM9omlJI9VD49KVuM+C7aaxa3hNxJDGhBWQEmLfZQfmIHlvjzpE0XVOALGf3TSeKksLkqEktru8uAAx6fBK24PpmmmObiaBDe2s1rLCrcwlhuo5RsP4TyHp2y3TamrrV1KYZflzMxaH01mVOPjxPO/HWhe5SFo7lnYEqCvzMPItuGGexwayjU9QeIyRrK7XELLIhmUrKHXo38LHsT+IdR3r0h7T+H7K6WfVb7TTHPOoaRra3KnmAPxNj5e3Y1541mwkWQA2UcrpKWhbxjzSEbkA5wcj9TSejIDFW8J0m/vaQwmqex/iy0n8BbuM2avA8AwcoGfGcEjKgNgZ3wQofYhhsOoa89nbzTzlriLKW9yF7AEczFfQNn1U98bebvZ/puhywS6lpepeBeQyJL7vIzYI3BjyvwsrdASqspDK2+M6lacRCW4IvllKzwNF8Q/dzxlcHcbBgcffnwcNRrQASq8TKsry27rNJ126u9O12a+tpFNtfwePb4XmDTIpLKR3PKGOOp5cdRS9bcYafeaxFAwMJ1Eq0Ds+0Ejg5QkdV5lb1BGe+KqtqUd5wfEouFW4t5EMEoc4YhlGd91fIH+/jsSKynWNVvtBvGWAbrPb3dueXEYLZYrt5lCP/ABoG3efZk0oGGG6jibHo/EUtvPczxhld4veYgi5/6RGDHcW7fXwwV33L/wCKnVPdFtLnSHMMtvLao0RO5MAJcqhH8Pi86+mf4a8/W/GTLq117vJNFdQXTXEcBchZA6Bih+pQEf4ga1Ph3X5L8QW1vexD3aVbW2Zmx4clxGxhLEduZFTP+IZ+aibPBoOxSvI9eUNWFs2qQyLNyLdPJbTw5ccrs6lZAP8ACXRsf95v1r9apBY6dpFrDbB4733uD96TzgomShJ35uXYZ/h9KCx64Ybu3ujarEYZL0NE/wA0TLAJQnquM48jEwpqvrgeEZUiR2tAroyuCwmSQqJAvcMmx8wp86VKbDDFiwAPrw/uX9DWM2cWlvI8rpA7QOF3KZ50ZcbZzLjpjDkdqYNUs/gjuhyeLaSRtGAccwADjr02Ykdug9KU4WOlNa3txBKn7KljWVl3YwvEEEg6ZxybjvyetP1xHY6gzrb3MbySc0MlvGeXJK86lcj/ABbZ23G5BrzpuQt5Qedrg+cWbDR7OG5W0s71Y4be595tnZSVjUqOZD/h5WQd9gD2p30HT7gusbwqyvIHCZ5uSXl5HQ+hyMEbUnOEsr9w6h4Ut0XcchKAlV79eXK47cuK0vhi3PuNskLkgIgVmJLLy+eeuxwT3GPKi9lsrWFSIPtFWVQ+esWNQjfSNECJI8kdsEQFwSSvidDn8QB/T0rzF7dta5ltLaBiqI8qu+cMo7HHYA5375r2Xxho9rqVjJCsIJuVYSrn8WMfXIOOleIPaPoerQ8XS6FqlsjQXF6kUHI+c9cLt+LAPw/XrTV1YGoG7oohOzHC1tYPzTEND0u61fWZbtwq+KVSBZQSqKDhV+u+T6k1puiWr2ZZ76YQx20nJ8UmArE/KVOcjYHJ+1calwpLZypqMNqSiEyvleVw2NiADv06YqQGNrWMrIolLFlCIGySP4fL1Oe9Wst/FruWZ1r923WVOMdE1zU4rbjHga8t/wDaTTLdoFgYLItzC2eZBk4YjO23UjG1ffYrxhqVv7LLbR79ZBJpFxPYBJSqFCpz4bDqoAPQ1DeX9zbX00pCoLcq9uYHx8JXGVI38j9BSVqHEMmoaxeWWiQzXF5qc8k5WIZknlOAXIHbbdjsMdaaqt1VukXQMcqDuHu93w8fjEk0tBvbUePT4yXj3ieV5n/dh7mU+DGkYLFyx+FVzknJI29afPZTwTqfD2nNoHu3NrGpyLPqroctBHjKwg9dgSWI2yT5VX9mXst1CPUI9YlaG61mT92l0CHt9N7MYQSBNKBkc4yqnZcnJr03wjwfpOhxRgyoXIzJzHld27s/dj9sDtVtf2gtFf4bTnnxPl7hNrQaTuT+I1A5/wCK/c+UvcH6BFo+kwlGWC3UAIc5Lei9BjzI+5o5qnEX7E08v4YhUZIknjLEkDry4G3kMD7DqO1biGCyJlSe3t1jQg3IBaTlB3KjB5VHr8RPRaz2TXTxhcAQyuIUPMJ71m52VTu/IMgDOMZ6E9Mmuaazu+F5M0a6W1Ld5Z0lo/7T8SsRcXlwlq/xyo8oTKbk5C5JJz3PTyzWg8KabDpqLDP40jpjl+H4jg7DfZQPL88UO0e0FhYpJGZLaKOPxXkaLmklkz8+MbADpkHfoM4o3aRNe3MYurp4YEUSqjHlZ89ByZyfv+gGKiurJB6mXv1IYbBwsdYWi1BS0lrFEhTCSMTIc58xsfzxUlnayW55IJ48qOZ2XHTywO9V7S7s0jCXEs8jKMEREuQfInOOb07VzcaqkN5+y7S5mUOcvBEy84J7MQK0Nqg7jMwMx9lYftY75lDJyNE3R/XvtQ7U+FoL53e5UyZz0G2aNWdhdGFQ+I1A3APf69TV2NZljEPKFX6U4agQAwifelGJUzL5uGGtpm5bfkRTkH0qW/mji09oVYE8pHWnrWbFpYGVvhB8utJV5p8UMbqNwN8mgNSE4WMC03qQ0xHjHTJtRgurYRbMpIPrQD2fXvvHDUlldXWbzTZWidSRnlB2/Q/pTxxZKIrh08UAeQrFml/2N9oQvwXay1wiCRc7B8HB/Pb70HsxBb33Z5//AGDj/wD0On0nN6te6YW/9Tz8D/eIi/2jVs0470zUZ1JcaQEiDEFTJ4/wkjrgK0g8t6YP7OXs/wBFg5uKwhNxgKCHyMZ6YpO/tTXCH2k6LpsYKrY6QjSNn/0khIz+VaX/AGfbq3HDUghcsQRkHtW9rVs0/wDjKVngggH4ZJxFBg6zjy+wm1Xdxi1Y53xSBFIDxRbOCPmI+1Nd3d4tHIONqRYJ1PFFsQQMEjGetcf2cmUf4TQcTY4ZhyqM9q6u7tYLdnJwMVQhnBAOe1CeKNVS2s2UyYJFRp6y7gCeK5ivrF811fFVbOW6VoXCVkLOxU43I/Wsw4cjfUtWGQSoPNj77frWx2UYggSMdhWiP9l2B0EpYMACXgcD712Mmol3xUqDsK1qVxBYnXTvXJya6A7V+IxmtFFkbfKDtUtFubZkYdtqzvwTp2p8oyMmtRdAVI86RuJbMxXJlVehz0p2oeEsB4Q1Bie2GCDt1qjcRDJqbQJS9uqHdgMVYu4cM2Ns1e9Ohl6x4RN4kIS1ZcjJFZZq0fM7Mex7itP4nYMCPvSFf2/isRjOTikCOYyBxiBtB0r3u75zHkCnF7DlTAXoKtcN6QIrcy+Hgtv0onPa9cL9M70lcCxlwcRVnsucHbr6UralYtFKcH16VpElnnOR+VAte0vnj8QJvjrS1RNb7vCCsijaI0yhG7ZztRW3tyyMhHbPSq8EBhlzRq0h5wGPU9qevHepkRQZByIKNqfLevhtDjfajz2RD/Lv1rj3Eb/Dn61i5IMZU5g/iNAVYHpjfasi4kYrI4RcHvjtWw8RDdsnNZHxPyI7kDJwTW32YczBu90pcG3tta6zHJOcKD/FjatO4hniuVgukVWhHVgcisHWd0vlcvyID2O9bRot5p2scM+6wXP7yNOnNk/Wmu2KDXsvHhNfsC8MTV0zJr3Q4dStg9q2Dy7d6SdX4dvYcqYw/wBRvR3S+Mhpdx+z78ZRSRkCjt7cWeoIrwkSKwyO+PyoQsXaGE3lLI2xpkE2i3hm/dohGc1NDoqiUC7Ux5OxRTt9T2FNes2ywMcLjuBQZLe7umxb7MNs5qjXEjJOI2tankCX7LTpJAsMZtJUQ7eG/hMv1z1+tT6jomoRJiE+MG6cjAkfcV9tNNaEE30oCj5iV/0qxJPpMMfhWeoi3mwQCSQP9Kz3tJbiMCsCL8ScR2EnPasUkB5gHPhP/oRRmHWJGZTqfD0lxLJ/eFFDAnucDI/Wq1xNNO3Nc20N6mMB492+xzUEEGmvP/0e81GA9o8MB+lVOH6iW27OI46ZpNzcTJc2+gB4cjleG78J07bo5AH60aPAcLye96lomjozkOEkm8V3HY/MoJ/Ogmg32s2ye7aNp+olsjJS3MjP6jBPL9cUettKlY+Jr4e0dPmjmmLuwPblVwf/AIjj0pNiwPB9fOVOesuWy2dlImn2trHzy7BY5xECR/hiOaLW/CmhXXM2o6XYmQDJws0xQjoMrIcnJ6Ej1rnSvdrbMNjodxZRHdWULuuOpUcpb6seXfqaZoRxTPbibTLc2sYUiOfUYUOfUR8y/mWIoe5vOCZgDwZFo2n6vpspj0W2LQ/IRzXUYCDf4hK/Km9HrGz0ucCXiLhvRElKkSOlxHI7DtkKy4+uTQhJdRSJkbjHTmKkBuVpIpHc9SPAk2I+oqxHd663LLFeam8KgK1y95NDChB3JJR3Y/U96uhzyTBszHn69DGaw0XhW5hMWkS/s2ddkjj1YiOX/CVlLpv3+DrRWLhcyMbiwsZrWd9zJaS2zYx2YwSISPqm++9J0Wrx3Msdn/tFOxRWzBNbxzq++zAyKr4HmrD86Lw6/o0MY8aTUofEXAKePJCxHcBiwX6nNNo6cAj7RZ0tHQn9cmXNa0eYRtJq9nJKwO11EskUm3U5UdfqrD1rEeNPZ1YancyXenxqHOfi3CTEndXVdkbycAb9VFaXqPHkdnzrLpPEHJFs15YQLcxxD+J4g78o+nL54pd1b2m8PRtzT3FneRtgrMyeFIreXLklR92Ge3aqWJk7lHr7xjTG1OkxvSuCrzTeIJbW3lZbvJPhS4UTpjDRk7BiPhIYbggZGMEaZZWNvqOjSK0RZA+ZoCPitpcckhUdviCsR5nyIqjfa3wzxAiXEMq3FuqvNzcyiaDA+LcEZZdj6j9L+j6lFDcS3NtKks8kKtMwJZZznlDEdiRlTjzwQCBUbyTh+sParEZHWc8PwyQWt3YXtuZrS5WYXMIzkFowCynyIwwI3DKrdzSzxlpC3yRxeJzSrboRKT87eISB9QSfsPWn/To7eeEyQAtbqTAGbZlQFsAnODgM6k+npVObh+31FvdcFZYky7dcER8zZPkOYfc1OQBkQAsxYc8TGNftnbVbZowAiIsbfhdl+IhfTlZW++aZ+D+ILj321uoZnDosaXSjBDxr8SHGeocgfUCofaloUdoyXcCnMcjhgoxh1YjA9CzN+dKXDNxdTXF6sEoRGtJEjCsMg4C83pkqDijAAp8IcNuXjxnpnQr+y4jX9rpb83v5ljmCDlLSyR4QgHcEsrKe2Jc9qIWzoNPtZYHcX9vctNChAT3m393DFmHb5myB0JNZnwRfahLaTz2RYTyRWk8Q6eGwZsvjyBMh+grSLG7ntJbAiVZo9PNxKC0YZvikB5MDqu4xv+Nh0xSrICcLBZK+vdHrTLK11nS5NNmuf3NxBm2mjAZ7aPnccyjG/IXXI/wtjrTCbXk06YmCKC7iMT5hl5QAzcrRhj+AnDIfwnKnYilzg2z03UuFbHw57iIpzQCSKMq8alyObA7AKNx5AmnCwhgvbTMNwlzLbz8zpEVAkhJHMyjm5SvNuV28sKRVVrFqdM+v3HWDdjXZ+vr5ytrOj3LXDh0aEyNEfEROYE9yR2UnB8hk+dE+AuIzZ8tlq4KSQEcrD4Tyf5e+DkY7fQirDPaWsQtiJQk0gAMWcoT3IO6Y65HwlSOu9Qz6BCWS6hSXlLvFIrqPhB3yDtlc/cbHzpIltNd3lfURobb6u7s6R21I20li0tvKvLMOeLBB3H5jPmP5dK8le2XTL/UrtLzQIPer7TpZru6tDB4khiRQpkUr8rBm2PzHqK9Az6rGlu0MjcizgcyfKwYjBYjsemfP86Rbm+fSuJbfVYL9rOYxGJwrArKwyUJGN8nlA32z0rRXtGt9QpK/39oOjSNVU49089aNx5oWuwL+2PDDKedrhVw8WwHxRjBfc7kYPfFLnFtrZW8s1noNxJdSlTG0dlE7Agt1bAwAOxNbCLTQNEhvLu1tLZWiRp7iQKnNz55tjnphsYz3+tBtH4gtNVvDbmGeEuWCStF+7YkZILK2B/vYoBtr0rF6umTx16Rheyl1fL5wPXvmTaP7MuOuK0jku7hLK3h2MwXmmVcDbJ2GM9gfKn/hP2RcNcNK4Lvcu7f9KRCPElIJ5fELnmdQcHlJVemBWj2MtrlPGgg5YgVjLqMEnsT2+9cX73wVYw9wiE5ARl3Hpk9PWl7e1rrhtHA93H9xins6jTN7A/U8n18JPp40q0SOG1s4o0ADYGDIfIEdR9BtUuo8cQ6dbzWlhHLdyhSWiiAUZ8mx1PoTgdSDS5rGoambBobaWG3DKR4gfLsPJiOn69KH6TaXFwrRP4i2y45rrky0gBwVihUZ2Yj4nJyQcLtSZO7npGO6Vvac5lzVH1DWpIzrN8lvzlAbaPDvgbqpOct/lHKoG5B6A3wwunaasjWWn3NzcFlQPyrsSSFCA432PxHAG5HnQ630OC0jlmaCWGzlwoxIvjyjpl5TsoJJ2X174pgstQtFRBZ6eBDbsD4caFRIxHygblzj9Ou1QpUNnMs7MybQOPdwJPqusXumaY2qMiLzyjlKH4R3CpnZifPfOOpqtwzxJdpHJfzXCRyuSxL5O38IJ36eQJ8qu3fDHFnF19FcyiG2i5S/PJIqrAp2zznJZvMqNzsMACmnh/2OQLJ415czzxsApeRPDMhHUgtg8voNqPXTda3+scRZrtNRXiwjPu5/SLV5xlqmoyPZaXBK6qAsksahREB/iJ2/OtB9lWgTSAXcoWNhvy/Ox9TjYfejdn7OuHIAokDzSD4mji6DzPwnCj6YPqaedCgsNPiS2tbdCO6qMKv5bVraLs63vBZaZk6ztKrujXSMSreTXRfw4FXAOC30qSOToiqQf4qocQcWw2EjQRG254zuFOcf0FAo+Nonk5ZLiMtjZV3NOX3ojlQYhVQ9i7sRqu3VgfEyxx0xSVxHNFbQyMY8ZBwOpNNNnqCX0QcIM46mg/EsEcsfhrEOZu5qBWLRkSVY1E5mC6vpF/rl+zQRkJnriher+ybUdStFkNqzmFg6465B869AaHw3A7BnRevlTtZaFZBAhjX8qHpuzlW4W7uQciI2nIORnM/nT7YPYvxhxTr2ocVvpzqrWNvbBMEsBG5JP61a9h/Dt7w9pV5ZXUbI/OHZWUjl3IH6Yr+h15wTp17CUaFWU5ztWc8Q+yXTY5JZLW0ROY5PKMZroO0NK+s0TV5zkgxNTXvBxgzz1qF34VnIc7gVn8F+p4ntiCBgkGvUR9ldoyFXt1PN12qhJ7GtFllWVtPi506Ny71g6Dse6pGHGTDW21gdYmQXWYwzHtSNxzq4kk91R/i6da1LizhFdBtHngdl5R8hORXnrijUwb8O7czFgo37k4oOn7Lu0znevTpCVur4KniaZ7NLLmj98cZ5t9/IdK0yJ87UmcErHHpETRgYdR+VNsMucdx6UOjTsp9rrIPtHMIRnNTruKpxuT2q3G29a9VWIMiSgbCvpG1fVH6195c9qdRJGJEy57dKXuJrMuniKu+PKmXk8qoavbCW2ZcbimVGJIEVtAcI3JtRrUsLF4nYigVmvu91y4wM0V1S5BsSo6gUawbkzLAe1xETWz4kjdh0oHBp7XV0qKnU7mj96hdie/Sr3Duk8z+My/Q0gy+cP05k9vYiC3Vcb43qKS1z9Btij0lsANqqyW2dwOnnS7pmSD4QJJab9Pzqje6essLKU3FMb2xBwO1Qvbg9qTeuUPPEy66sDDcMMHbPaiGnwnAycY8qLa9pfhzeIF6/rVW0QjAI7/nR6faXBgCueku+6c8eQK4FmB0WitlECnKe9TNakMF5aR1NG1siFryZnWvEFWOelZJxOAZCWHXOa1PiCUcrkbnf+VZVxQ3OGddx32p7s1SCJztxGIiXiq0pRQfX0p99mSxWszJPcYR1wRzCs51GVkc4bl3q3oeoe7yiQ3DE/XArotZQ1+nKg9Z7QagU3BiPtG/jW1aPUZJLZGMZbIOKF6TxBqGlt8UjsOgGdqbtKEHENm0apzSoOuck0patA9ndNH4AJBwDXL1k0nuWHSd7VYmpUWKesNjiCfUMCSFZObbOOlErCCOaNizCFsZ5Q21K+nRvNhjbsQO+TtRlLUyoea1lYnurb0vc3OJoUqZde1gTmHvM84HzIOmKHPaxvn3CymXB3aVM4+mRioi0S3IVjdQAkA5bBP3zVu41O0tysUOqysM4dVxj7sc1VczxweTP1raXGCkl7HCQduSPB9PPNGNKn0+2cE3t00hOB4rsoz5BQN/yodpl0b9/3F4rRofwxBz+eMmj1u18mY7W6uZmTflVFRQfVmx+poNpBODJXIHEP218dSmNvaWl/ceDhfDSVgCPQJ2+ozRq20sQvHJPpwsV2KW7/DLIx3zg5cD1Kr6ZoLpup3kbqtxxDMHcgGG2YJGfJXkHX6AH0pht9c4f0VxPd3k1xeROWWCzRY1Vu3M53P1Y9s7Ur4wLhh0h6x07UVRbiKyewf5mMao7H/EzzcxUeuAdtsdahvL+1RwjKt0ytgKshAUgdZZpDue+FX6E0IueLb/UrGVtavrbSNNUZ/eSyTzyKd883MqjP1/Os/4t9r2laDb+6aBbW0bw4DThSoU9twAzsfIY9c1dK2sbbWM/CDSvA3WHEfNQ4h1pFU2Oo3EUikt7w07rH13/ABHAx0LlfROlIHEXtp0jSZWaea1v59+Yq6tluxJCKAdzkYrD+NPaTr/EjCK+1Se4LOWSJn+BSe5Ubfbp9etLyWh8MSXLNJIxzk7n7eVbVHY2AG1B6+A/mK29qV1kpQuSPE9PlNUuv7Qt/wAzG2snLEZyb2dlLfxcuQOmw7UqX/td4qupmeLUL+35yciC4ZBv6ZpXjsec87AjG+4FXIrNWGTGjkfEN/mrTXQ6SrkJn4zObtPVueGx8AJePtG4nlBV9V1gqx3zekc36b0Pn4nuJGJujd7nfNwDv96K+xzQ9K4r47tOGeI7yW3024eR3EZHO7LuI1Y/LzdMjcdt69r8O8F8N6Xrur8PLw1po0poLJktXsUaFEMRVgQQc7xZOSSTknvW7pux1cByFUHge/5THu7btXI3MSPCeGrDi68sJRJbajMjDB5ZRjcdDkbfnTpontf1DTJPfJDmTlYMuwjIK4JAG3YZpw/tK8Aey/Stdij9nWlrZXiQudSgtZCbNJeYcoRTnlJXJIUgZxtWIro0kauELEAbgdMd6ytVpNPvNb4yPKaGl7TvKBx0PnPUfBPtFs9b0h2luB4ck6MwO2cEgnHbYtnzBBrV9Mtkvbh5S5MLjll5duY4zkH1+H9K8F6Vrdzp0wjt52XlYZUMRuOn1r1X7KfaTa31nBp6yKJ2Q+IPiLIgVAzH6gYGOhWsHV6M6Y7hys2a711SZX80a/aPpAvuG79IXVbhImnLg7krIpA/Pf1rANOjuNMuJPBixPIbiAgnLEBgyH03BX6CvS+umxl0m8tXdAvKpkCjBwrq3KPMY5s1g3gxPxJeW/MIml5pio3WJXJYkHscjp2zSqPyRG6F/wBfM0Pg25NqxhacyBBJDNNJnAiZ+RVC/XP2XPetQj0dGsG/Z5lUiMNHyt1BOH+pwg+mayThO7SLVoY5oZ/FiCyeAX+FGY5XmPohXz7nrWw2d282k3MCSo0sCyMJElVGZN+ZgWOMZO1A70BsGetrYYIjRwFqV7a3k+nNrdxbiOOBY4Qpl/7MFn5VCsCCBupwBjzrR5+eaaGc2UBuIXDpduwgkJJ3VlLEjO3zdR2rG+GDdQSzXnK93JC+FVYOVkGQCMk/Ec4I7bA+lanoVxHFbJaLMq+PmXxkhUsw/hJXbbc/XagUPyVA9frxIvrxhvX8/OElkcgWdxJDGplPhh3JKD+EMoIx9MdK6STUtPdrW4jyknyvhmDpnIO2wwc4PrUU8/uSQ8lqrCQ4BKoCmwyX68x2PTz9Kln1ARxCS4jMfirmPDY3I7LnA386rcrHOTzLVHjgcStrmjJqh8WF5I3HyuHBOMjb1ORnB6ZrIOIrfWNL1FoNQDyrbsTGwzjDHIJHUbBsj09K1+wvOXxbK4jkaZ3DifGeV8ZA2JHTOdvOqOvadFrljcWqvFHd+EVhfIPNzDJI+v8Az0rKsTLbh1mrp7jV7LciedLqC/uNZuGtOX3O5UNJJ4oeQZIU80ZXD4GRvtgjNV7fhN0kZBapAiKAskEjK2zbYX5cY3x0HSmnWdKvdAuB7wVe5CqGSQEtjoBkdslMef16XNM1G0Fw0AhnsTHtIFlbDjGOZRISPXpSrXN0M2hhV3Vxe0/QpMiObUkijDhR4zKHO/qRv9KZp7OxslWM2/vcrYBdpeWMY81BGcd9znypkjt9L1OJPD1eBJSAJBcScjqQMANhSN/sDQa84f1C2YQxQwXKk8rEtjnXG3L8IB+wb86NXYfAZmba3eN7RxFr3zlvlXwormUnmQLkBCD1wqkk+ijOw3AyaIgMlusVyrCWVT46nl/dL2DkbA4wOXJ64wTk0Uj0fUrK8NxqGmJY8q4jijlYZ26MScjPoCT6VZuWhtxHLL4Vs0jZgCW/NyP35FYgs47sQoFW9o9ZTegICj1+kgtNNu7pRczcyRQgYe6TkBbbpH1GAP1Ge1OXD+jaWJY47i2dxIAVWUnnmzgnmCj5TgYRdio3yKAQRI4SRro+DbOshlnTxJC+TgKD8AOc4LKcbtud6bhdR6ZavaWyFtRnTxTHHG09wUPxfG7/AAx5/jkYHHRdhTWmpDNuPhEtVccYEabVXeVIUtbSFBvNO48SVttgu/mMALyqAOtGg6yxS+7tDEXXEspjWSQdvmOI4+vRQx/nWZWOpail+09xJFcuoIYiNnjh22VScKcdc/Ec5PKOtfuIfaTovDlkl3d3kkkszcluG5mknYD/ALOPv6k8qjb0req1NQTn1690w7dNYzgLzNEWWHTo3jbUYWXIzLM/MgHoAAM/XFV9S4wit7V7PRwt7O23KoxkY6tn5R9aw1OP+L+LLpLeygNlaRnlDzP4s2/foET7ZNaXp2lrplisUcMsskwy55z8TeZJqadW+pJSoYA8Ze7RLpQGt5Pl/MDaraarqJebU9SSFfmKQgKiKOwpet9XWG6930yNpMHDTnfP0px1LhrVtTtzHPFKEYY8GIlFx6nqfzqpLwjLparb2ttGDyjOO39TS2o0pXLL184zp9WGGG6eUbOEtWIt1EhBPU0Q1C6W7uAM9KTbDxdNHLNJjlG9fl4liWVmMoxnzo9LlKgG6xPUANYSs0fTWijQbgUZgvo0GzCshm49t7f4TOB96ks+P0nOElBo1esqq/MeYA6aywZAm1wasiLuw6VQ1PU7d1IIU5rPYuK3kX+82I86rXfETt0fr61pDtRNmBEzoju5jVcapbx/KF6UMl1uNGY+GhA9KTr/AFpkBZpCPvS1d8UFXKiY5+tKp2kwbKy7aFXEN8eX1rfWUqRthiMcp715r17gK4uLz3ogqokL5xtW4NfxXpAlPMTviq2o2Nv4JIA/0pwao2HJgxpxSuBFbg26kS0FrKMeEAg36042zEkHGNqRluYtP1IogwM4A7U2WF0sqBlI375oHdDdme/KIchc5q9CaFwSZA9avwP2J+lNIsqeYQTHl+tShAarxuewqyhzjNMKJTE/Fc7A1HcQ+JEwA7VZVc9TX5kHKc7VfEtiZ/qaizlaQ7EUJi1lLmfwy4IO3WrvH90LSGVlzkAmsi0LiYy6m0OSW5sUdPaHMsB0mlvbeNOIoxnem7TdO91tV23I60M4Rszct7xMBv0+nnTe8IUAKNu1JsvMuW3cQPJbgdAetVngNGJYcZ2qu8GdsUArmezA7W5B6VEYMn5aLPD12qIwelDZAZBMXNW05biHLDcUsR25ik5WG4NaLJbBwVYZBGCKVdSsPAueYL1Pl3oSrtaeIzOLJCME0U8HxEDYP1qhaKSQMfajdmnOvL1xV7q96yFGDMC16bAbGTnPXoazHiOT5/Udq0TiEsckZG5GxrL+I5GZmG/rXuzQDOWZ+Ij6o5LnBqlp8wNwqvzYJq3fKXcjI9aJcK6baS3sRniV/i/KutytdXMUrVnfAmp+zfT28BpoyyDl/hOMUP4kgU30g5FYk55sVqljb2NjwoPdIsHkGNtzWY37mW6Z2jYknvXAau/vdSzAT6R2XpzVpwDBCxTRxbuyjrgYxXQurhF5ku2BXy7VJeakIHxNEzAYHy7UMuNWE8nLyBUPVQKGqFvCa27HGZcae2uV5764Tbc5Usf9KtwDhy4Phx28l0wHNhV5VHp9aHWNlc6jIy2dthAN2cDApjs4rbT4/DkuFeRz8UcYAwfU9Kq5C8AyFBbr0lmy0u2eMFLFoiT8uQfpsKuwJBHDJGkMbMg3jEeM488nP51Wm1i5hj8T3a2RFG2X+Egd/rS3e8ZqwdGZIkXfw4ByIf8AMRu35igCt7DxL5AOBGWTiD3IeJDG0COeVHji3Pnyk9x0zQm/4sFk5XTbB5Lldkur3LmLO/wIcjPrjPpShecbX11KIbSedEb4FSAdv6D6VNa2t3eXEfjycniMPhkYgn6dz9f0ppNNsGXEEW3dJHqF9rOq3xk1C7eW4JzzSS5b8t+Wqk3CF9fwSXMg5goyA22x7jI2rQdA4VuJ5UtLdi7BiXWGLEceP4pj1PXIGSemK0NOERaabJJHZ3N082AOSIBvIjDYKqPoOlHr1PdkbBF7K1cbXnknXOHX02e3vVhPhswRvLJ6USv4TyKY0ZQem2/rWz8U+zy4ureXT7+1aOO4XmX4cEE77fTbfpWWy6DdwO+k6tG8d5AMAN0lUdHUnse/ka1vxItCsT0mPbpDUTjxlKxthzy8uAU2QMM82CAfyzRePSVNnDIkTNlsMWPoTsPt9aDi5ki1MShOVGYc22wPfb9frTIb1TCgdIpIoj8EiKVw52Pw99ulWsGeYquegmba4L/hbXEexupbO5jPjwzQScrL5YYdDtXqbQvbLqPGHDdpdRaYYLuTSYbO4lW4OZZ1Zz4wDZxnn6E+ZzWDcRWNjxKpgkK29win3eY7gkZ2OPOmrgiIWXDdpbeOIZ4IQs5zj95uTjzwO9MajtW0aQVIcHPI/Tr9pnNoQtneMOPXELcXxpBAk0iM3OrACaTmycD4gfLrsPSktY1W1mEkLMuARvyqfr570y69f2lyIo5dTupQg5VDfGFGM9e22+BSpqF7aQ2gildppZSQiKASD22O4H+tI0qe7wRzDAbnGDFG6a1ayvAbeFp3vYXSUt8aKBJzKozupyuTjso7008I6/c6Q6XLOyFRg9sjrvVzTOCLaKL33VIxLNLylEPyJ5f8mqF1pdvLbzGxWdmSUIcAY9OXG5NO3WV21BT0mnpqrdPYXPU+E2/Q/aZFxDpru1xICNyhbCyAnff7H7H8lO31oSa1eX9zFPJLccvMoCgmMAfCfqQc+lZ3p93PpAFphUbxQrKANzuN9+xOfrTdwutwtyZUaNZHlLB23xvy4yfUb1zz6UUMzDpOkSwWoB4+M1fhicXytK9sSt7KY0uNmxhyS+O+QR9eUVq3C+pWSiQKJvDkhUCWZFJiVg0eOUnpy5z1zvtWCw6mLK2a1hSSErHKpXm5QwyAvKB1JGT960fgC5v7W0EkF7HLBBEyNDP8RVm+JQW3z1+nQVmtWwbcIZwGSaal9FZRqvvcNxzOP3kYJXwyQAyDG3TJHXbHatA0C4Sa5kl00iNo5WjT8SkhQSOXp1yR9ayTS2trG5tI7Jz4E5RolJ5kOSQcj8JBI/M0+6HqFtZySTRGTxd5HOccxYDmIA2yMZH3q1NJJ3HiLXNxgc+vKas8NneafJCickzcryDqRsAd+m+TkUH1hbgMiBxJLKFh5unIMZyoA79DU1vIWsRHZRchZGlQFjzF/IZ7Hc1VbUbi8uo7NZiHRQrM2VOBjIxnfbNNaqrjb0iunY5zF7UrpraBb+aPxJeZMFyeUE9cYO2PTerrT+/Wy28jtB8JaOSPLAMPLO4orNImoGWzv4o2hUOYQm6qSQcY7VFb6fKJXcxlUQAYBIAGPXtWDqtKUOVOfXM2Kbwy+0MGAr+1h1Im5vbNI7pFHJJjLNKFAU+WAu4/zUgapw17rcvOjNLcLzLI7AIvzHO5AJ9MHOPrWpuIHna3d05YzzRsy5yCR5bnbA+gqhq+jXUkKyzXsbQAAxotsZJn7HJY8qD0AJ260myB1zGqrjS/EUNCvtRtkIjKtyn4TJHkKD3+IZxt2Y0YvdSjuLc2rzwIwbIEQ5FJP4lxhyfocVTudOsLTwhp1ldhhj92shKSHvlFOxJz6VNCk9lmG3AilkxyiZQrqeuyBiSO3XahBSnEvYUsO7Emfh7UwyPDBDyy4OHuAjMCPnfJYsCO2/0qePSyt1/0026xBgSgdXEm5zzF0ARMAAKFJJ7d6507T7dLiS69wtpJmcI0py7SNk8wJXfy70Yt7a3lk99eysYZQpKRHxE8Mj8T/wAOO2GyfTenKiDyfX0iVuRwPX1kqWlvcRwvOyRQRjKkjEvIu58NcpFAN8s7DJPY9KGnR4by7lSzt7qSHr4CNJLzg7lstjxDjHxNyKB2Owo1a6PrmqXTzTXkc8JBjCxxkAbZAjVgST58vTq2avT2TojLDbOJCoZ7iZWbG2xO45u2B3PatWpDZjAmZZb3WeYr65qNtp1uLDTY7iEyY5kRPFkOCcggDI6EE5A7AdSFma6h13VDaWnDJuZlAjaa7VOUZ6gIme/mx6dKc73R5GgaFZrtELZklunCzMD25V2QdNl39R0qbh7SoNHjU2yBCBjndcu30G+BTA0dmofDdPXSLfjEoXKjLS/wvwlHp0CTXFpAZQeZFW3WNIz5KBR+5vYLLEtwltER3kbLH7VDbNeToqRSMUO7EnlAqnqyaXFjNu09ydlVVLsx+wJrVNFdFWKREO9e+zNphmz1hb08pv2YDYHlwPtVDXHFsjSxF5Cd+Y1TsHu4V5zBFGR0jTt/mb+g/Oh3Ed1NJblpJCoA+VNqGXJq9ocydoD8HiJHFnEb2MUnNJhjnOKzubjVl5lExz9are0fWyJmgSTvg1nlo9zdXDAE4NZpJM2KalxkxsuuLLu7uORHOM+dNnDWszKqtI5x60l6borJ+8dTkedFRexadHgtjypFqwzZjzWIte0CarbcQEgfvBRGHUvF35sn61jtpxOssgRXxv51ofD7vcxK4O9TY5XCiZ/cj8xljXtQdEJ5jSxaWWoalcl91Qb5p3udDW8XL9aN6Fw9BHEByjNP6Ok2NzKW2LUnHWKVroVxEFYlzjzo1FoclwAHUmnE6TbqnLgZq9Y6dEmOYDFNFdlmB0i27emYl23s9iuWEhtgSf8ADRVPZ+Y4sJZ9P8NaRpos4VAZelG4bmwYBQyg+tb2nrV1mBqLnRziYNf8PTaefldcfhYVVhYq3K2xBrctdsbO6gbxIo3BHkKyjiHRUsZWntgTHndfL1+lEek18jpL06gWcEcylE3r6VchI2zQ2BugHSiMGCBtVVh8cy9EoxjvXN26wwMzEZxUkRAXmO3nQLXdQDt4KHI86J4SMZOJnPtDllmtZ2RSSQQKyngjQrl9YMzrkc2elbFxPavcweAqcxfbpXHDvCyWHLI0YDMc9KuvHAhTgDEcuF7ApbJhMDG9HZIh22rjRI1S38MDcbbVeeLqcVRkgw0GPF12qB4cnbPpRN4vTNRNEM+tCKyMwW8G2SN/KozBnfFEmhOcAD8s1yYfShlZG7iDDbnPShOtaaZIy4Xcb00GDfptUU9oJYipWhsmRPbsRAgjKNylf0oxbDkXmPlXy6sTBMTjvUc1x4EJHeiVru4lifETzxxC2RIMjJNZbxGMMw671pfEMikELncedZpr3xeIeu/lS3Zo5E48vnmId7zlyIyQaKcJ2l2uoxubhFyRsTv18qH3sTGTbAzV3QVVLqJ/eGyW3UGupsP+qRpwTYJ6gtIscJKok5zyZ3A8ulZlqRMMzPzZc52NaVo/hScIRFAw/d4wTv09azTXFiS5kDqWJ67182fJvafTtEf9IIi5qLNL8c1wFGNgGoUqLPKBGPhHViR/WptRGXKhjgdjQ9niDjnUkA7g9K0q14jDPnmGhqNppQH71nZzjPPnH07VBd6jEzc4fGSNzsd6CzTpLPzgJydgxqpqVy/hkRhFHQ43oiacMcwbX4En1TXmJ8OGQkDplsj7UJt2uNSnEOWbmOw+VR9WNUAJriTlQDPmBTFoFoVkX3hUUd/EyPyAyTThrWlc+MTW1rW90PcNcGNcyc8t+i8uPhiiaRmIOceWPqRWvaBwjGMRpAlu6rkv4CvNJ6cozgfUgUv8OyTRQq+jac7kLhmIWJBnyLEjPrTZo54gZmuJtQjiRl5XaGMzHy3woXPrvmsTUOzn2ukb37RgR30jS9O01FZJA5hJLTHYA4+WPlIHP6jOO5olNHLPGHsLqO1g5s3Ba3EhaM7kgk7HzY7Z86AaZqWl2pS6M8V00agePqNw9zMe3wRrhFHoD9avnV7+9liS2LzczhhJI9vEFPXYOSowP8JPrQA5UgiBGTyfrCw4R0q5sLgPLN4TOrxxPDGNgMfA7Nkk9frSNxT7NdNucx6npT+EFM0M8cymeLH4xy9Bjz69CO1P8V7rkbr73EWQfGZ7iZS2B+IEYH0xgVJZwx3ry+LbNOzsX5FjLJgjqXOBzeufPFFXVvURx698PWoYHceJ5l1z2IavcGSfh3U7bUUyTySEQykjzB2O46gj6Ul6rwZx3owMWrcN6lFGOkiW7OpA2+ZQRXtW54R4e1WHIjlSYbL4UwZk/wA7A8mPQMaFjgi5RFNhrmoRwITkcvwxgdWZ3KjfAxhT12zua0au1UH5lI+HP8GLWdnVWco2Pjx/M8VppuoOsSwaFqbOTyhEtJSSf/hx9KYrDhzi1po5X4fubKE4SSW8It0j9SzkHz/0r1bPwTf3qrbf7WXs3iEsrxyEHl26YAGOu4P38419kXCKxi61iCbU7skyLFduZhkbLlAR3OcE423J3FebtPTk5Ck/T7mDPZfGHsGPd/4J5qsuBtX12eS10xpdWaIrzSW8TG2TJ25pCBkdflz67U3aX7IppvAFxaoWmCmSWRQhVVAbKqOijOPLv3r0ZDZaJpFssFrokcURcSTeGgBLH8WFABLNk8oAAAG21DNf1ezhhubC2iYzhlErIqgRKMZX6hQM/ljqKU1Xaltg2r7I938x3RaKjTtlFyfMzCOMuF4rOC502ydHcuWMjSAlVxjJI6Ejoo6ZHrSI3DMbaNd3k6SYjIjgESsjMmMjYdQBgk7dj61sF9pFyLy4vprJQqxPcPC/WPPR5PI7g8uepGd+mc3k91dX7adHCYUOVLnBUSH4iz9jgAnHy5wOlC0177eDNW6pLGGZmz6VfXutq17DNKLiQt7wIzh5Bg8qsNi22CD18+9NcWbHTpJUSMM8rvFz9QTKCQft/Wjen6XPo6M7Xht7O9lJjjvboILsL8JJ6cjjORjYc25BxkTxt4sVwtulrIJJHPijIJbAAb77ZPqSe9OG7v2C+ES7kUAkQlFqi3E9tbNbzyeFIC5hOHOcFgPtWi8AapdzQ3GmlUktovhWa4fldPjPKGddi3bp0rIdOurpJ0mikcSxRNMkkTchDAbn69ad/ZvMzX8oE0aGSPkIkOCS3RkxtkEjr1FBsqhVbcs3a0tXupIbi0IW3aVZIkGPhJOTnvjrTtoumXVlNEy3KwzAkqnKSArEjGT3G+1LfBdmVRA1xI0efCLcvyg9Tv03GBT9CJYURnIyJy5YjqoHUj0o2l0ws9tvGKX2FTsWHrWeOGS297mZkPVwx5VBO2fLfau7ZojKwCOJNublP4d9ie9LV7ObRobjxlRIhyhlYnKMfiDDv2qlqPEcNoJlhvHIni2DDcPn9KetpQjLDp/EpTp7H/J4zRYbmyaZvEifMfwn4scy9gf9aYbD3a9jeOOJAW2JB/CRjB9awex4xv53ME0hPYEbU48M8SXEXIZZNyfiOetId7S7AEcGOv2dai9Y8a3oMkNu8sWC6kAEDcr2FQaNNbXdv+zruV4rhl8NRhDjHQ75qccQWt5G1tdTDDQseYHocHG4pG4U96ur3mEZlLEA8o+UDpsNztvWVq6VotBqGQeJCK5Qi04I5hziHRQlw8Elg5ul+IzQKuG8iwB8u/TeqTaStvbFFuIZGcZkJgYDftn5mP5D61pB0eLV7FG1FGtWtgViLHZ1I7kEYobNw7PakvDMkOcFgob49ux7fXNK26Ihs44Pr184JNWCu3PT174kppDw45BKYx23Vd+wQAkk+tWrLTH8U3VxNGVTJSMjCJ5BwB8R/wANda5JrkCOmn2EMc0iKjSOHk+E5B+I7j7daraD/tIZYP2jPFgHlCouCq9iCPl+nXrQVREYAZP6ev2hyzshYkQ/bXs8FwA3LzkBEBldJGOdiYVPTOcc5PXJ86OwaQk0TMr5WNj4p5uZi/XdurHPU9B0APUBNMt4jlFUQSFyFHiM8khzuSDvnfocmn3ReHL/AN0ZJrRrMk5AlIB+uDv065710PZam59uMzD7QbulzmJVzo0DS86oYgD8TPjmb6CprXTBzFbCy8Qj5pD8v3J2H3p5m4f0iyOb9pr1ycBII8Lnyydv51JJbahDbLde6aPolmN0nvn8Z/8AcToT/lXNdVToVHX6TnbNSYq2WjXkzgwWstyVG628ZZfu5+AfbNWG0K/u3Nu8trbkLvBC3iOB/i5c/qQK/X3EGieKffb/AFriKRekbObS2P8AuqeYj7j6UP1DiXia7szaaTo8Wn2Q3EVpFhR9SAB9yam1aEHtHPuHX6Znke5jxx8f7lPWbDStFjLT3skrgfJDyqB9WO35ZrJuNuK0EUsFuVjTyDEk/U96m4w124tpHF5dKZO6mQM36bCsv1a/e+kbDcwrldbqwX2VrgTf0unPDOcxQ11JNTvmf4iM0U0LQo48MQMjFWI7NUkOQN/zq2LuO3BX/npWazYmnuJ4WdX7R2cGQRtWa8T69IzsiNjG21M3EWsBYmXm3IJyTWV6xf8AiSM2Qck0aiveeZBbC5h/QNWkN0vNISM+dbxwbrMYtkDtg7E43ry/p2peA6sCBk7b096BxrJbKqK/kOte1GlZjlRJW3cu0z06mrwBNpFqzb8VQw/AsgxWDWvGs0q4Mmx9ambia7I5hKw/rRKAyRexFPUz0PY8RQzMCZB+dMdjqUbgYYGvM+lcY3EMil52A747VqPDXFSTxpzOCSPOmAfayYFkKjiabearJbwl4gCaU7v2h6vYzlUso5Vz3fFWpdVimt9viyPOlPVD4rM6r371q0ucAAzMtUbskR50r2kQX2Le7ie2kO2GOVb6Gqes6jHO3NzZU+tZ20rRn4zykHP0ohbX1xOmJHyoH3p3vWC7TzABFZsrxC8AUseTpmidt0HQUJtMkDJ8h5UTSRYovEbbFUXyhj75JqF8lrbkDqR50ryTGQmRjnyr9qOom6uDhsgV3pds+oXQjAPIpGaJLLwMmX9J0QXkZu5kB8s+Vfb23EUoCrgCm+2tVt7YQKo6b4FAdWg5WPWiquBBbsnM60eTDBD3FGyncDFLemycki7d6aoxzID5irkZErnBlRou4FRtCenWr7R+lRMnYDaqFZ7MomHO+K48IDarxj865MeNumaoUkZlIxb4x3r8Ye2KueHX7w+1UKSMxZ12yAUyD67Vn3EN/wC7qQXxitQ10qICnesV498RY5OTrUoNhyZdDkTHOIJGYHl3+tIGsrlWyTjNO2ryB2bBJ8qTtVXmBwNqS7PGADOLDZOYk30MjtyopJPlRrgrSY3vVN18GSNwvMaoakzeJyoceuaLcKX6Q3SJk5yAWNbuodjpyBHNAFNwJnoW1VbXh9YrbJATDMcZ6VlPEcjCd2ztnbtWhWOrxtpXhAE/DsSev2rNeJZJJp5HxgAkivnqA98cz6Xpz/rEVdQnLOcjfG+O9UcwPCcq2d8sT/Kp7iZ+c5Gx2ofcl8YVMDtmtitfCSzYle5lDSiO3BCd6rXcHxDxJWHffp+VTyJJCAzHBPTArh44lx4z/Ge7Dm/Sm0OBxE35PM70uzsmkUSzzbnBdcCnfTLCyjdBHd3iuDuFRVH5tn9KXtLhtHTFzqCAdeWRRGCP+fSmC1fT0jMllfWoXG+T4g+nTrS95ZjxmWQhOI12up2NnGI4zG7Njn55PD6eeBlj9SBV5NVu4/DcxycrnIdvhGPIFvm+w70l3MtzHJ4okblC/OCFH6DIr7p+uW0Ya2vbu7JkUqTFCABntzMCx+gFItTnkxoEER+hu58ZhvdSiCAhgbhIebsdhnlHT5mWpBe6hpa+8WGoXckuHkVprvnCEgA8ojU53zvt/Wlqxt9SVhLFJY2tupXlXARs9uY8u3r/ADFTrC2r+JzalbC0wWmco8cSYOCBjLOfRDkn86XKkHGflLLg9BD1txAyGJ9X4lvIjn4lW5S0ib/MZmZ8eixZ9c0w2vtB4YzHZNxPbeOhIMdlHc3jHsAFCnmbG+7fas8e04ahhaOygjMkgHMzxyM7467hG5B5AsT51d03RJ25xb39ypeEkRWtuUfOejybBV9FBJob4I9rP7RkImcnibZomvMxaFotVtYEbDtqE8Vryg9OWPJdf94LRyPUuGJj4cpSVGbI5JBc8pwfifw2YL9XZc1hnC2gafYSc9tpr3d0nNzGVnWON++yhmB7/MrHzFMtpq+oWaxWcWkXbyDmAULywxqc7hFOM75JPM3+IUEgLwokd0rHg8zWrrXOH4GFraT8r8gHvDwuMgdFy2FGOvf618t+IXuoAmlW8d2ZCCsqlQpwCMg5yR2zg7+dZjpLe62sjwW8fiOxiV5okkDN0+FFMnM3f4xjpsKIafe2KtHNeWM91HEQvjaleKFLY6IsYWIbdMdP0qhtI5z8pI0y9OT6/SaFdRXsaQm6lhtrkHmSJQMg9CxDEFiM7EDOT2GKE3tjBZTw6ZaQ+ITEzyzyFcjA2UZICDIyx+xx0I2FrdoPe1J00Xp5o4rbYgKc7ugCnz+KQnoOWvt7qml28MsVtbTXFlOB71yL4jzjfCsdyqZ35C3M2csUUgV4HfweJ4VlOBzA+oWyRWP7Publx7y0e6gfvScvkkjHJj5M7EczkYC5wTX7gNe+8afJcRxXLvPmTPxKX22O+Tjm3OcYJxnbbeKBeR6ZJf6yZLSKZGlMUr5ceIAAGc4yxUjIUYAKLkbhcejtyl7aSWt9HC45lLSTBUVQc8kYxknruOvWmqCF5h68tGHg2Oe90KW3h0vUoluVYO/irMFB2ywkUklhnIXIHY9aQeLLNp9VaO8V4fAQJzSFhlk2GMjPQAYPlWqaNpM93ELoQNfSPEPEuJr1jEwxspAUsT16D70mcU6I4jZltyy8/wARlfnZcbbNnmb6Yq1FmLCw8Z6xQQVgLTfd44obhBIGbOMfCrr0xn+L+eBTJwNKougRCrcpMSxP8wxuWP5Uow6n4NuLCRTJC2eVeUqynG+M9jtRLQb2W28S4VlJc5Ujrkin9vnK0+0wAno+x4zjt4xaqxUsijIOcnPUmjcPFGs6jzL4irFy8nLnHw9xmvP+lcQTFldz8XfO1aXw5xGrxDnfGOxoD6lwdoOBNQdnLWm7bkzS1k97tua5lwpUkldj/wA7Ut3rtKT+9HMMFSD2qR9fj91AVzysNwBuaVl1hlumtyCF/Dmpu1AKBSYfRaVskiMsUphCXBIyrb5NWzxmlhhWnRC3QMwBP2pZ1zU5NO0G41URhjCnwqfxOdlH50h8BcE6zxdrQ1LVrmWQyyZZiSeXPQAdhS6q9nFUcPdVgvd0E9OcGaudanjjmJ8JwQcNgnbselatoltpcEyWtpAsbKOUCSPdzjfJANLPs+0q14fsLeGN4UUAHw2XJJ9V8zWilHnhjm5VyDgMVWEj0+lbGn7NIQFuWnBdp9prfcQnCyaKEwSCRWQDGBHsW26HGObH2qbU9QvfdmUNaqwwFMikkfTmxn86FzajaxI0kkVysiYBJJbI/wAJ70M1GwsdehkbTxdJMw3Ml3Oo+8e6n60PVhkUrX1iNGHYM/T4f3KmvaZdSqz2q2b3SgsI2gkJx/uknr3pd4b0PWBdk6rb+A/Nlo4+ZkdT3OSD57A9eopg07hu70+BI7iXwyuSXQfCV752yPsKl/bWmaMFimaCWRuiQMzux+jdT/KsH8IzsHcbR7//ACav4nYprT2oz6XoBtJlvkb3U8xGEURnB9FHTbz39ab7Z3FsWilECYyZJHCg79Wbf/4Rk9qSNN1PUr1fd4dJuLUybh57qGMjyJXmL/6+VMelcN3kirJqGqNNIm+VJUKvko/DXUaCoU8Ipx8v3nP6xjYMuRDweVLfEDoGYf39yAqn/JGfiP1I+wpe1Dh6zmuDe67q11dSsN84gBHlzSZbH0UUXvPd9LtC6RzPsA3JNyn7kDJ+gpP1biu/tQTo1va2j9A/hc8uf87ZNdGrIEw/ymIVctlYattJsogH0jRYdv8AtfdXuG/+OUqn5Cl7jzwl09jqmp3GAp/d+MFH5JgD86WdT1zibUlZtR1C6kPfMpI/LpWd8Y6klvbuHy7YycnekNZr6q6yqp9o3ptI72As3MzPjzW4H1N4LAcsWT9f5mhVieZPEbqRvQTVbvx9SZw3RquRaisUIXmHN6muHc5YmdbgKoUSxqF74WwYZFL17roVSQwyO1Vtb1dVlIzvSVqWrszOA+R0wDUJWXMIq4Eua7rjSoyq+Tg7Uj3d1I7nqfvUt3fZd8OfKhU0wkOVbb18q1aK9nEBY+cgTo3bI2ST1q9p1/IJR+8I6d6AyzDnHN0yNqsWl9HC4YsObPc09tBWJ5YNzNN0W/c4BbrjG9M0F54hC5Oeu5rL7PXVj5SCAQMbd6OWnEjLh0fGDvkUg6MsdHtCPylucOGx3NNOi68bJViMuMCsvi4mVhjxd+mx2orp2qLOUwcj60M5zzIKHwm22fFcnghVk3+tT/t6Vv7w5z6UiaLMzBSQd8U26XYS30ygAkdacpsA4BiVqeJk11cNcOqgAAn70X0/ZVyCNqsNw0UUSyI23eogogcR+WBT5z1MzlIzxDVo222ap61qojX3eNtzsd6in1FLS3Ls2NqVp9RNxK0rtk9RRU6cywG44hSJnlZUQZdzgVoPDmmrY2ys6/ER3pS4Q0w3L++TptnYEU+xvjAGwoicnMixvAS6hzQ3VoA2SB1q9HJviuL1PEizjO1HEFnEVov3c3XptTbpriWAUqXKeHNkDGaO6HdfFyE1ceUqxwYYKZqNlqwR6VwQMV7E9uErlN64KZ/rVggYx2rnHXNRiRmV+U42zXxlABPlU/Lg1T1CZYYjk4r22ezF/WpfEyqmsz4r05rkNzL+lP17KXkJU996HXGknUCCF270JlzDVEDrPI2qOzFsHv5Ur37BgR2J6dqYNRfZmIyMmlq+YBcDGCO1J6QcCcOhyuTFvVYnycY39a+cN3L2d4hZOffoNq+anM+SeY9MUKt7+SGYN4mN63WrNlJXzjWlsFbhp6D0a7W503PhBMjbPU0k8UMElYAn6elU+GeILuUKoeRsjA2q/r6q6F2XLtn864a/THT34M+k6HUDUUgiJdxMqHpk52qCXDAZySegru7idX5sZwc7mqUviMQzE9flFOoAYRjz0ks9u0mGaRV5TsCcmq8yyLlVhZtvm6VLBhWLSx82K7lvkj+S3RYwd+dzk0cEjiBIB5Mm0y2F0MKkSuvUBOY/mabrWze3tlJYkgdFEeB/Wg2jXAnKmFbcNy4BKk/lTNbJc2oaSa28Rj0YoMD8jSl784MlEA9oSsbKRo/EW3lEbYGUP/E4+1DrbTjJKzR3qQSKxOZJQkm2/XB3opcXksxKvCDgdM8o/Mb1Bdyalaw+JHaGHb4XDgqPuwzQwrEcQofZObrSLshV8aRnILgeNI5Ge7HGB9K70ZNSFwJYb9UeAlgwAJ8sjmK4+u/0oAOI7yJ2W4vrpVU55bdgSx8uvLv9KatI4vSSD3E2CR9CXkxM69jjISNP1+tQ1TY5hVsPQCSalxxxVBI8b6jeTRqwVWjueRVPmAg3P3qnp+t6/fP4mn3d8hRjzTPcsAhPmxK5+7ECj0mlWV/aGQ3rT7q4DILg5OfJuRPz+1EbDh3VIoQkFlBDHjmMs0qoVDdDhsHPfYYHpQMVqMAAGXDjGWgpodeMIXW9et5beF+ZYRclhzt5GJWHnvnPrRzRpILFkjL3li0i83iQ28SBk77yMGkHlg586X9bgjtTJcXt9e3KR7eLFeh41A22OGx06LvQm241e2ijtInWdMkOUWYuy/4mZh1Pp9qEaWtX2YzXYomkanrySgOoLqHCLJPd+K7Jk7lHGEz5DI8gaKQT8STSR6peyCwtlXlhQRWyvyBSBgkgKO5OSNxWWaMZ9RunFjaxPISSI5FwIF7lm2C9hkknyNOLcPajpKxTa1a2FtJNGZYnjIVpMEYCLIXO2xyA3+Wl30+Osu1ygbQI5aBfabB4+uTabqesLG4/fzWczRhttg37tJCMnYOsYUfKaPahxFqctqkl7YQ2Vqsoks7SdVhid+qu0Yy8p/EclEGfuc7h4gt7k20Uc8lzexOW8W9VpeRxkgQwNs7joHkVI03Y9KgvdVjnvZ79J73UNQEXJc3Ac3Mat5LKwCYXvygLnOA3Wq91gcD175QnJyfXwnfEvF9zxTqlxJq2pLKrN4j3TxGRZZFB5VCjI5UwSFXKg4JzjNVOF7W4t1Fxam5uJLuMKAytCJBnbJQMyIT1zu3elWeaBJLi1s9O8Z5W5WlkmLZJ3K4B3z1PQehpx4XnhtYJr+4vZYRE4jaPx/hyAfhPKArnf5c4Gd8UVkYDIhmsVFwBHfw7G20t7y5ligdAsbR2vM7PKdhhWH16ClK70SXUJJmlswgVBH4gaMvnqQSCFUjbIBz260xGJ57SB4biGKK4VwnKh5+Yr8TBUAQeuSfuat2+lXiQiBtNhvZGiDL7tHytEvQsu3KufMn6VSpD/wAYs1wQHJmI8ZcLahAkrG2kXkYKvNszbbbAkHpSja315pMkMWowuI1OM43Feqbfh1rqOH3e1PhRrmRQysyAjo7HYZI7tk74GKpt7HdM1SaZ7mT4ccwUjYHp2HnW5RXZjYVyImdagbfnBEwaXifTrS3NxaO9y5X4YlU7n18qWn9pntFtbrxrU20UQPwxGMEAV6Xm9gFj7qDBjmMmWblweXy3pA4r9jV7pcskscYeFMDYb/Xp0o66VKsl0z8ZpDtJtThFsx8JJ7O/adLxNp7ftKH3W8gPLLGDlTtsy+lNbziS7inXowxtWRaHpcuja08IjKCRQAc7N3rSRNOllHc7/u8bYrE1dQDMqDidRoLAFUseehmmy6NHr/CF1aoQZIwkwA78pyR+VHfZtpFhAyc1tCytj4mYAA/Q7Zpa4R1qNdPdjNhTGep65FMfs0umN7IJxDyhjylgG29VPX7U92W+xQrDmYnbRZK3APHWbpoks+lxeFLYIsRGxWPnyPMEnamC1iilZZbe4tLlmG8VzG2fsR/WlWxuWEcQaa4jJ6SwEPFg+YO4ovG15by8/vkMatsGbmBYehG29bzMMcdB69ZE4DknPjCWvz3FpAk4tJbXAwPdXIwPMEj9KXZ77VY1SYTT3ManaWV8P6AlOU4+tX77TIbqJJGPhuGwrtIHXHkOYg1PY2htCPfJ5YVXo8aZjx5n4jWbqQ9zccD18BG6Sla56n18YFi1vWll5Q2oCBmwzxxtIq/RmUkfnRey02K8UzJqNw/inmKTXPUf5VQbfei/unDxtnaCdI2k+Z7dwu+epGdqHSz3NuRb6dFeT5Ozx+Hgfm5J/KgfgnT2nORCHUq/CDEYdLs5LeGNFnjgABBdjJISp6kDI3+uRRWyv5bq6Ww0/UDI4OWMkeXA6dEBA/Wgel2d7dukl3C0A+Zm8AO4wOvVh17Baa7FrxBym9uZkK4AMTwjGN9hsfyrZ09GFB9fvMu+zJMtXXDur3qEXF/ZogHxPIxx+WM0BuuGtCtsifiWEsDv4Fs8n6nFSaxb6hdKDBpN0VP43flH1AOKEXkd5FA3jGGMAb88yf0Na6hNvKmZ2WzjdKerHgWyhYveXl2++fFjwv8A8KsP1Jrz37W+KrNVkt9OkIiIxypCsY/TJ/WnjjjWorNZF8eMk/wtnevOXHGstd3MgL9/+RXJdq6/e3dKAJ0PZukwe8Y5itcXv7xpecnBPU1Wk1dmXIbOPXvQrULkpzfFuc7UJ95ZDlnYA9PSscV7psZ5kuu6jKxL+JjyFJ93qbkkc23p50X1abnT4Tk0DW08eTlYN9qepQKOZRiegg65upXyRn6dqqtcytt3z5daYJtIzty7mqq6GyyBQOo600rqIPumPMBTeMdwSMHJqGOK4ZgBnenG34bEvKStHNO4PjbGYwR0r34tU4nhp93Jippthdug+BthRN7K7iTk5DjrvWiWHDttDGFCdB1H0rq60NH6KBt+tKnVhj0jArAGJm9t72j8uCd6c+G1unkTIO/60RsuFUd8hN/5058P8KiMofD7+WKWtuLcCNB0QYMO8NWM7xrzL1xW6+zrh+1RFkuIUctgnmFIOgaSkMaqRggU7aRxTHohWOeCXA/FHg/oaZ0BUP8A7Ji68tYhFc03VeFNIuLAtEghcr+HYflWLcR2DaJds0sytDnZgenpitAl49s9Rs3W1n+MD5SCrfka83+3T2kTaNASvOS7YOOmM10dlddigp9Jz9ffVkh4Y1viFZmMUUuQvzYr5w7BNq94sSrlEbf1rz5pftQuNS1GO1t3/vDjfevUXANrDBpUU4IZ3UHPnnvQbEKeyYxVcCDjrH3To47WBIYxjAonFJ3oNBKD1NEIpOmTUiVJhKN871Mf3iEGqUTdKtRuc486KGlCfCBdQhIJO+aj024MUq7nrRPUovgLCgKsUlznHpVy2BmQTmPMT88YbPavpI60O0e7E0HKTkiiBI771YNmUDT4a5PpX3m+lc5qQZOZ8JwCT2pe1u66qDnFHLqURwsc4pL1S5MkrHOQagtxPA5MqkCR/qaYtHsVMJcrnI70CsIDNMo7E4pytoxDCqgY2ry8mELeE/nrfspBJ9d6XNQfALUbunyxGOhpf1Fs82ciktLxicSvIi/f5YEDJxQiO3UTc0oBGemaJXrMCcEdKEO8pk+E/eukQZTAjKYBBMedBuHkC2tvyqM9hj9abrrTZVtudiucdc5rPuF7hop1aZs7961C4nFxpoQOoyK43tio02DE73sPUG9cHwmb6uAkjIDnzoTEC7nDADPWjWtW0nikKNj19aHwWZAwygDuzEACh1EbZsWA7p8aNXBAkzk9v5VUm0+4uZ+WPwyAfxEVeupLaKIosjNj/wBGuR+ZqhbXKCbEen85z80su35DFGrz1EBaRjBjRoNjJbxqTEiSE7O7DNN2nWrwtmK3naWTG7DKetBdCv0s0WR7q1tQ3ZEU/wBM0zRS2t/ID41xOzjZ2PKp+1I3tluZKgyZ7W18Flmmiidhh+TILemd6CXWj2U8ryQX86ZYKefLA+mOhNGZ2t7LCv7tlduVcOc+oGSapyTXDEk+Lvj5oFUEHuM9P0qtZPhJII5MW73RbGOIq0ky7YUtbCIfY7Z+9BJtLtbTlkiu023Abmcg/TYdfWtBs7mBrnwze29ryD94GUb/AHGf51di0qwLPODczrISOeGzVifoXZi32AFF3t1EqLQv5pnljr6WH7ySzlkmYcru94yEj05QeUeWN6MR8fxJM6R6RGyuBzN4XMijHnMSznbvgd8U3z8PwTRzS3s11ZBFAAme3UvtkDlUEk+nQd6T77hK1uJnUOGDNzArEm3nliRgZ8vyqnsk5YfXMMLFfgTrUeNbPWVhH+ydvBOmyPHF4jKuABypzKg9CFz3zRPhzg+5hh9+ghuY7ggu8boyHz3LsB/P+lWNA4QGlzQ3SM7Z+Lne0mC+uW+FCNtsZpm5Uihkm/a2us8wO8IEKOOu7qMkfTyoZwTheBJN23gfzAkckunH3bUL/wAd1JdYoYSzK2Ns77b9xv5UK1GS/vNSkLXErOyEyiQqZZNvlAGWxg98Ad270O4gSKKYPZ3dzEcEcjS88knYg4+I/epNBtrvS4lnnJLurckAYrIOmNgCB9cMfVaqEGMw6Pjkw7dT6jp9jy+P7tFP+792Eixcw/hJYA8o+2T50Ml8SFHRtQM8jSc006TFkjXuAq46dMbb1ajbUbi8N9expJNAv7oPdciW5IwSQSzZI35mbOOmxxXF/o8Ecfiard2rT5BjhgchgMbEEqAO/Qee3eoVVBxPb2Jyeso2+niVFNn4s0SPzPLyqI1XP8KjI36jOfPuaatKuNLuSiTyyCJDli68pXG+wXPMTg7ZG350ipKryskFxEkMYOWkkHKzD+FRkE/y7ntUtlrkKyLa+MbhT8DlnYAE4+FB3Pmd/rvipesuuJG4AD3zW4dTtp7UXUAmRJWWOEzTCIO3cZAblG++Cx7Uc0C7s5LmK1v7+MxXJb9xbs7CaRCcBjs0mD+H88b1mF5faq1rFb6TbwRJaR8kchIbkdu5J6HGcKPqeld+ziyvbrXHe5uvF8OPwwzOXabfJVQOiA9hgMetW02EbJgL6yyHE9GQy206M02ps8URDtAGCIuP4iNuvXc+Q6Ve0u/N1PzW1siQhQ/Kq8pOdgST09O57Ui2d3ZwQM91cu7WxYBS4EcLjHNkZwSNvvkDpTFoutW2oatDYwlPCVsRpEebnkGCWY+g3ydhW6j5YGYjKQI/s8aLGmOYKAdwNz2GT+e1V7zQLbWBcxzRKylvidBsfMn+QqF7aO6m5ZwknhqWjCtkKM7Z/nRqzv4raRIY1/doCA7HY7btjufWm94bh+kECU5XrMW9oHsSuW8PVtGgUGPJKKCGJG+32pDYXMdvLZXULRyICpLjl3r2HYXVi0Y94eNEQNNIWOSVIyM58+tZ3x/wfw/rVgl/YxpHOR4jyhdyXORn0ApLUdnqT3qfKb3Z3bboRVcOPOeb+HOJZhFJYxyZkVvDK9O+K3PgCKHSrAT311HmT5vxYbuDnoawFNKbROPbrT71QRMC8JDfCSpwcgfatv0qZ9Tjt5nuIxNHCpYICodcd/Xbr9qSorCsT4iana9xvUAdDzNY0y/eOPxbK9jaJ+b4Y26ffqp+xFXU1OcBpFupsKoOBKrE/UEbGkyxihktRaMDHFIxBDPjDeQJ6H9KPWTJaxC2aV1f/wBYh5wR3B3Box3dB0nMFVBhi34qmAEEN+UAJBFxDkH0JUEEfamO0u5J7UpA8VsZN+azf4GPfboD9qS5ZbGK5Ep5SzDmI5BjH8XL/UUx2ur6VFb8lusDM+Ph5DH4n3OB+Zr1W7cdx6evWJD42jaPXrzhOytbx5cy38sqISPEilBZfIbb/mtOFlGksEaTz+8lV35+Rj9diD+YpJhvXlH/AEUxQxlSWU/GB9UOfzBq7axzXMym5hZolXBms3yv/wALbj7Gm69qdOYu+W90dGX3RWlhs7ViT+K2YNjH1GTUtktzMrOsrwhhzcqfCNvLeq2nm7W3SPTtWhnjxjErNHID5EY5f1qzMhi3ltjEx7dc+oPQ/lWnWmcEev1iDtjgyjc27szSG4kbzy2aUuKdXWyt5FaRgANviNMms3sdrbsfGPQ9sVhHtA4p5nkhDE7+dLdpawaavAPMLo9Ob390R+POJzPPIAxwDjrmsi1q9MhZ3wTnz6Uza7dtNIzM22TSLq1ygyNun1rijlyWM6tFCDasX9QufiPO23lQe7vlUbMPzrrUrkFywP0pfvpjkgHenaU55kPxLjT+K+5JxRO1RVTmIXzpds5lGxzuaLwXakBM70WxSOk9WRnmMENukqiTYnG5NTLp0fzFMY+2ai02bnUBvtRgeHKB8PTfHpSpYjrDHpmV7a1jDqOUHfv2o1AqxMMDlDYxvVGMIFwMZB2xUkcpIxknBx1oL5PSWzmHIZd/gI6VaRUYfEAewNB7eUxbFtz5VYGoKAAXGOuDtQ9rHpPbgOIcsWijkwANumKbtFnUOMgAenaszXUgJQVY56bUz6PqkoIxjf1q4GIF13HImq2l+sa5OBttir9hImoXQRzkUhLrSogUtimbhS9E19Hv3B61NTkGBasFSZqOm8Ew3EHiNHnI2JH9axn27+zxI9MuJGt8qwO5Ga9T8HRLc2SBlztSf7atDtrnh67V1GPDbauw0i5ryJzdjlbcGfzV0Xg+ex1opG5Z1PMABvXqP2UcQm4sTpl18FxAQpUn02x9ayH2daab/jK8jnIaO0coCejDOT/KnzV424Z4jt9btRywSERzAdMZ2NRcd43iCVQCQOom528oIFEYJPOlnR9QS+tYrlHBDrnY0cglP+tLBscS5MLxPnGe1XI3HWhcMo2yauRyetXDShMtTjxEI60s3kfJMwxvTIrgjGaE6pCc+Iv50QNuGJQNgz5ot6YZghbZjTTz7A5pCEjRSArsRTVpV6tzbgk7iqK+3iUY4OYSLVyWqPnyetcSyiNCxIxiiCyeziDtcvBFEUDYzSfKxeTqOvarut6iJpyAcjNUbSMyuPWoD5MupwMw9oVuCwcjYUxFsYGaHaZD4EA3Aq08nrRFfE9u5n88bvlZSwO/TpS5qDHBJxt1NF57gFSC350FvskFtiPQUHTLgiciuYBvGAyAaEucP170WvRnIxQZjyyHO5zXQ1fljC8w9o6OxDO2OXpT5pF/EYREH5yBjJO1ZpZyzlsAkDypz4ftpZmRy4yMHJOAKxe1aDYpLGb/AGTqRS+EHMs66cHKn8qA+IiozSbbflTzrdrbLp4ZFDuBnYdKzfUWKyHAx2rndOd3sidzYcKGlC8lV2KhyST3qTTY1MyggEk/mPKq6QCRy0pz54onp7tG5S0dIf4mxljWgeFwIgMk5jnplqbeNWSCNWxkFkBxV651K8S1ISblYnLu+FP2x0oRooiOMtLO47u2AKKaqIvdlZbQyMAe+AKzX5eMV9IuX3EN7lueeRyfxK5x98AZ/OhZm1C6IZGKAH4ctjH571+uYRcTkSJCf8IkJP6V9ttJtJXVZVWMNnOGJ/mabRQo8pDnxIzLFpE8EwmvGup8bBEcRoG7dck0wrxNLaJmKEWiEYYNcN8Rx3Ee52/iP2qtpuhx+AEtdPlhjY/PJKTn1x5UXtOF9LYF/e3mfugOB9sVV3XPWB4zyJTh4xWB/eI7QyynotrH4Jb0aRyz4+iivo9pmv2rl7azgtHXIQRrzyD/AH5CxHqcA+lEptKihh+DngA+VBgEjucf8aow2Fuz+ILZ5QNiWJAB+g3NCIU9RCjAg88e8UXV2t6lrJLKrZeaS4lYt9W5lwPyFTPqnEuucrXkl5cLkZHMfAQeWDyqfzemu04U1GeNZb4BIiMqryLCDn0O5FFF0iO2QCOKVlUElogI1Hll2Bb8lFECbuggjcq+EUbbQ7uIGd5okcj5UPxD6kgKo+lHtM0tpITHzzmKQ8zyqfgcfw8xxkfc/er0NvcL8NklrbnJP7uNnJPq7jP5VfsrC9vLtLUpfalfyYWOGFmZj2+VAXP0BH2ob0npKjVHqZWSytNOiXwbWBHDA4SJnZd/mz2Oc75HTGaXtdK30bXE8scgjJMhmcEuTnGy7em+T9q0O60Ow0lVteJtXEEvNyrpelwrc3hb+E4Yoh7fG3N/hqhDa6i942n8NaPp/Dxb4i9xIuoarINzks/7u3GM/LGmPOh9wa/zH+fXxhU1Ibpz69dMzPOH9Mnv5JYpbW5VnChQi8qQoTsQoAMjnbbZRnc5pisvZzBa6hDJNhJW+ZZCfgOO+B1+mQPU7U06ToN7ost3eSXKrLKonkeViZXAO2ZH35fUbeXrHqmsm3hN7GnhyApK91N+9eQY+FI1bYEnPKN/MgbUKwsRxDrYc5WEl4e0WK0FpDaQuI0EbmOAlQoAJRQc/ET8zHJ6DfpUF1xVpHC7m20K3IvZMIDEAfCAGMs3cjJ2HT60N0K4uNQu3utTvZuWBWjFoHOYubJzITspJySzYJxsABUt1a2msuP2HbyNbqxRJkTEbtn5xkZZF65OxJAAxk1dENYBP9wbf7DgnP7SeWK51WxUXUhdmRWh022UgRo5z4sx33PZdzuB1OzdwNBqekyQx+ArG5J5kRCZNt+Useg8+31oRoqWWk2cMKyzqrsC55g0k7jOSWHlvkj6DAFF9J4jimv2SK6fwwDCkKLyrnzZupA8h69aeqZQQVMVtBKlcevX/sfdNvnaaS51a7t44oT8KwxZw+cYJJzI2+PKrN/xXYxzzW8yKZ/D5IrcNl8ZG8hGygDr9aUFjlmgMtnl+bBgycDAJAYD1OT/AOFRWHDFrb3DuGMs7AGaZyTzyE55cZ+Ik+e22aOLmHGIIVKTkmaFJO2o27eDcSLHdtyE/wCDHyj/AF9araldvBpahlUqow6g/MgPl3wBj70JtzdPFLLazk8reBEWORjOWJ7Zz/Squv6rZ2dzBZz5RVTkV8fCGLdCPpg/ejG8kHEmur2gJmftFe0tNWhmdwZVyZPD6kkAgDzB2zvV3hviV7vTEKyESAtFGdjlOY/1B/OljWL03E9vbv8AvGiBVnI+Y5H67/rRK0sVjVRD8KxqAWI2we/61mM4UzowgNQB8JrOh8RSvaxQXoEiSAeE+QcMFB5SO4IOPOmTSeJLdXUSBltjkcqksIz3G/QDb1waxlH1K302S1ErgK8Tq/XlcDZh6bAH60w6ZqOpFTbSxtzkMDn8Q7EE7E7sPVTR1vAxkzJu0oOSJsVzeWhZHRwYw3K6O2wJ6bnb6dDV9r62iiU28yglc+HKvIQB1wcYOO+23faseX9r3dskMd+YrmAIsbk83OgJIRweu22/kKMaIOI0uFjZ2MfwNyjflA6lc+X8qKNQhPA6xJtMVHJ6TaNMlt9Q/dm2WK5UAoWXOR5hgcZ+mMimTTNMkcrK0EqSx5BMbFX27j+Ieh3/AJ0r8M6dNyRSoApU8yHHw47oR5dx/StK0uJWC8ylWAxvufp6+h61rUU95gmZVtm3gS1YKyf3/LJ/jZeV/uw6/evt/KLaFnt5yqns2CCf5H74q64KRmTk58DcdCaROMuJILK3kw4XbdTtmn7HXTVEmKKrXOAInce8UrbxyqSqsM/Lt+leb+KeKDNdP+9Ocmmfj/i8zyyhHBGSBk9qx7VLo3ErOWz5EVwer1B1VhJ6Tq9JpxQnPWfNW1l2VviztjY4xSVqF88jMD1+tEr98qwBB7jel+5Dbk9s9KEq4jggy7lPMebpQu5K5ONsjHnVu/dx+E47iqMmGUDG4x1pyscSjAmRoVTDHPpvV6BwWUgjr+ZoZzgNyk+mK7S5IPLnGO2aOVLdII8R2sJyig9MfnRiK4ViACcEb9qQ7PUZM8pc4/lTFp2oI6hGOBikrKinMMtgbgxhaXkHMpGDtUUdypbJYA/Wqr3arGRgVQ97VZBhtj59aqF3CTu8YyteGKPHNknvmhr38hflL+pqs12pjCg+owapS3XK55j+nSrKvGBB7jmMlpOZCCW3z501aVc8qqN9sb1nljqEZYZYZ7U3aPdhlXPf1pexCIcMDGdrx2ZeXO/6VoHs+Z3uY2J3zWe2wWQg464rSeBY+W4jI8xS4YhgJFmNpnqHgN8WoJ7LSv7b9SgtOGL6SRsKsTHr6UxcHsINMDnuKwz+1lxYNO4OuraNjzXP7lQDjc13GjHd6Uu3lOQu9vUYnnr2SQsffNWYfFNK7D6FjWja7YR6vpMtuy5ypIpJ9nEXufD8Mb4DtT3ZT8ylXx6g+VIUW5JQycf8pD7LtdnMEmiXr/vrVihz1IHQ1p0Eo23NYjf83DfFdvrEDcsNyRHLjz7GtcsL0TwpMrAhwDtVXO0yDwcCMUMu25q3FMNsUFiuOgztVyKbJqu+UIhiOUedfLhFmjOetU45ttj+tTeMCKsLcHMGRAd3GY2O+KsaTqJtplVm2JqTUIwwyO4oHLIYW6kYOc161sjcs9jcMGaCk6uvMD1oNr2qrBEY1YAmgNvxla2cLRTSjmA7mgV7rZ1GZmVjy9vpQe/BHEqoLHEsPKZ5u53o9o9rzMHI6UB0+BpHGx6042USwQgY3oqvgQjHHEvhgihR2rhpB1JqFpD51CZcdDVu+lQOZ/O2aT+XShtw4YkButXJW+I56fyobdEjJ2p3Te+cuoyMQdeAEHI7daDPy+KQ5IANF7lzjPl/Kg9wDzfDvvW9WMLCD3QnZXdtERjLH6036JqwYKiqo7jtikK0Kg4ZT17Cm3QuZnXlQgbZ7k0jrqEZCWj+k1NiONk0PkiutNYsjF8bE9KzPX7FxOx8PAz3rWtD09rq2wxCkr+LuKWeK9IjhYjkzjy3zXEpYtV5UT6NTm3TgvMzSNiQrD4V7dqM6dbk4jggC+pqvcWkiyEpFnfoBRHTve4xlkES/qRWmX3LmLAYMN20ctsokldFC7DbfP0qLUruOZWaUSSAjbxG2H2FWovC5PFlhLAb5Y/yFDdRvWmUi3hVAepxuPvSY6w1YBPMB3SyT/BECi5+Y4UCimiaVZKFa41Jh5pF3Pq1CDFavMFur1nOd0jHMT6elMtlFaQLm1ihtcjGZAWdv9KOSVGJDDJhq0E6stvFe2dmhAYeKDIxA6bA7/ei8AluJRDJrM9w2NvCt1iBz/8AMaFabo7SMLiSRIbfGTLKMc3oBkZ/Oi3jWtrIYdNuoYYiPiEKZeT6v/QYFLswJysHg+MlutHtkjPjyyKwY57s31J2H6n0od7pMic1i8MIP4uctKfuen2Aq/PDcXKiRoTyD5VdsBT5+v5VLo/C2u6zK62tn4iQDxJpHIjhhX+J3YhUHqxHpmvLuc9ZYsqjLSvpPu9pMjXmoozZyzNJlifrn+tN2kWk+tvJHozTXSRb3Bt1AigH8Usz4SMf5mHpQt7Tg3QQrS3EGs3OCeQs1vp6HzJHLNcD0HhJ6sKJXFlq+oWFrqHGuvjSNH+awt3tgiFe3udhGF5v+8IVfOQ07SOcNz68T0H198S1Db+QMevAdYWMPB+mYjvb6fWJiOXwNPcpAD5NcsMv/wD2kPo9XLwalaWLWWrXMPCumTjP7K0uMpdXK9vEBPiEH+Kd8eSmgK8UHTpPA4N0mSxOMPqV7Ksl+48kIHLAD5RgHzY0DleZJXaeReZ2LMWyzsT/ADPqd6OXC8J6/Xr9osKyeW+sMT3ZUNpvDmn2+l2zjlfwpC1zIvfxJtiB5hAq0w6fcaNw3pQiRUjjcmWQhFAdhtzux3YDG3McDypRtbw2/KI+T4tifDCjPmSdzijAkuVmhmtbJr2/lKm2M0bSsx/D4UXds9GI+gGM0nzuyYwMEY9GR69qpms01XUbaDTbGSTxBNcHaZv4sY5pXwBgAYUeVc2GlwnT14jv7K4soZYzcW0k7gX88WDmSNTlbWELk+K2XIJK8xOxe74bj4Y1U6vx3cw8QcdFOe30uU+PZ6FFjmElyB8LzY3EQyBtnmJGRk9rqF/eSTXk0+rX+oSKZTeuWyQeYc4OwAI5mUZ+VV8sRYq1nkc/t8f46/tDVsSMKePXT3e/ofDzgS00yXXriK41O0MeltKUtdPiLRxuvquScNjdmJdurHfFOWp39jZyRW2ockK22Gmithyo6jogHUjYDl6bb5O1Q3N0ml2n7Wu7gzXCEKocDCIMqAoGyk4JPkNztjNG00ue4ZpNUAh1C5Vrsgjeztyo5XYHpKVYci/gUqd3cYDyxhgcjPh4evvGexjj1zTJb97Y2ARHUcxwYYhjHidhgZPIO+M9MUB0nS3vNUACPFZqTyuzbsqnDE+bHcHsAT3po0/TPd9JkknItLOJliRCcsxG4UebZG57tgfhqpGbD3xoWDLzqAyq2whBAEfkAd8n65zmrEgkSqZGQP8AyF5OJIo2As4VlaQEGUqOSNBtlR9gAfLOKvmWaVSlsh57ZeZnB+e4dep/yr/MCqdsluFa8Kq8dzIiI+MfAiliR6eQ8qvLPbafp0c7kKnLJIxJ6nbOfXcmjo7PwZQoqngevXEvTXtrpMc0Em6xzKCpGwwAc/nn7ikDirU5tS1NI7KYlVlivEKjI8Nhy4P+6ebH/Cvuq6vdatrt7FakhIbjkYZzzHm2H025gfI1xo2jXUF3a2XMqgoW3GAuCVC+ucgfRDVzYMbRCVJt9owTpGnM05kmthzSShkLKds/EfsAV/IUww6awxaPEeV5DEMdV7dR1+IjcefpR6y0e3nmZYpPFiUtlEHzIwHKRn0DfnRaO1DraXACmB8hmAAw75wR5DHWgYz1jPfeUFaVobMiBwpLKSqnfcfMB3674wdqZNN4ZsS6yRwCCZxuOc4kH2O/23FSWsRke0DRRsswZHBzs6HBAO2+RkfU46Ypy0i0tXXwiodWw/KT8StjqD3/AONErrVjiKai5lGYN0/hyz3d4vizhyTkj79qa9H4eicoUVW5em2D/wCNSHTxlJkBblIXLADfyz16etMGjJDEwDNjH4G6/nWhRQqtgiZVtzMOsP8AD+kQpGABjYZ/1pjtYTGqxvyhj07ZqpZPCyjkOHHRsdat3V5DFHzzFV2zkjY/8a3aVCiZlhJM41C/hhgcmQqy59CDXm72w8XrG0kavlhnfvWr8a8QQQ2788vMFBIcHBrx17XuLhLeSQpMWBYisDtvV717lTNfsnS7n3kRY1rV5b25ctJkc2etC5PEaPckDHnQW21VZpWZjn61budSURMGPriudSvaJvOxPAlO8mUMyjoBjehLlZGJB7+XSuLq8eaUgH4R5d6jjYkAZGQdye9XIl1OOsp6pbgKWH/hS7LIUkGDtmm68QTQlRv3zSnfxcrk8pxnFHobMhwSOJSnkPPsOu2a+wESE5PSoplIUsM1Elx4QwCD9qeVcjiJuxU8wojCIg5K+dErK9AwA5GOlLE2oSY5QNq+xXzLjDEHsKh6Sw5lUuGcR3bUAyYEmw7VRn1BAxbn/Wl39oyHY59aryvcSklQelCXT46wjOW/LGiPW+X4S21dNqIfbn6bUqJbX2c4OPOrMaXi7lTUmtR0MgBz4RntL4RuMuAe1Nujav8AEqZU79jWZwC758rkedMej+9F1Xfy6UvcFAyYREduAJs2h3vjFVB3PQYrZ/Z1pk00scrD4OuayL2Z8OXmpTRPJEeXI3Ir07oGjDSbBMR45RvtvS+jpGpt46CU11v4VNp6mN0nEEOk6Z8ThFRa8Y/2h/aCOL+IbfQbZ+aKKUM++RmtK9uvtFudE0mW0sJuWRwR81eVNEuptY4iF1PIXIOSSckkmuluu21GsdJyxIX2vEzaNDcWtpDCuxVADimW0usOvUA0lWtzggg+go5a3Z5Rv0rn0t2PmMgZXAhfiW0j1HSpY2+ZVypHXI6UU9nmtveaUIJpcyQfA2/ltQu3uVmhAcjcYNBeHbr9h8UzWnPiG6PMoJ71pOe8XiCmyQXO2xq7Fc79f1pahu9v+NXIbs+dZ3feEk8xjS5H8VTrcjzpfjvBjrVhLsdjUG/EoRDDzBxynfal3WyVjPw7dsVe96yOvWhWuXyQWztIwGQetFp1AztMqRjmYrx1r13pd6JxKQvNggmjfBHFH7RCc8mTsOtKfGcaa1fGMKW+LAHb0o5wZw7JZIgBwBvR7KEVRZVKspJys3fQ40aFZj5UZ8cH0pP4e1QRxi2c7jaj/vA8/wAqRbU7pEutPnpmojNv1qqZ/WuGm6elV/ESwE/n/Odycbn0oZdnPNk9d8UTkywIIz/Khd1lSeXp610+n4M5cDiDLg4ycULmJD82aKXRBUkD70HnJ5yTW7T0lwJZtJeV90JFNeh6jyyhVQnsSaUbcBjjfB60z6DB+8VgT/SgawL3ZLQ+lNhsAWbDwhLNdJy8oGPxVzxdpyBDLJIDtvVrg4IIFAxgDsNqI8QQW11AecnA2Ar5pqbcaklRPp+hQrQA0xe5aCKUsAceQ71wt+Y8sI1x5kdKJ8SWkds7CJQcH70mXjS8xPMfzrZoYWLxB2LtMYBrDnBluFUdcLihV1fSTylY0LLndupNCQ3hkmWR/PA3rn3qZ/hh5lAz96YFQByIDvCOIZSRY4+bCKT26Gr+lySSSbPHAOzPuTS9BdNCQSVAzuWHMauDVjtywkkdsYqGQkYEJ3gPWNkbRF/39693PzbSSH4EHoDsKtWerXkt9DaaRHJe3c7eFBbwRl3lf+FVUEsfoNqBWmnXWsWCaxrV9Ho+iBjGLloi7XEi/NHbxAhriQd8EIv43TuRs9Zvrll4V9n2hXllHqH7hvCBn1LUfNJJEGeT/wBTEFjH4ufHNUdzgZeULDogjy2raVw3huIP/wAqako+LTbG4BigYdri6BI5s9Y4eY9i6HarUd/xZx3p/vt9PYaPw5YzY52Y22n2r+QwD4kv+FQ8p7560ow6fovCMnJr8sfEOsIQq6RZzf8AQrU9hdXEZ/eMO8MBx2aQbrXWuXfEXEdxb3GtSEiBfCtYVRYoLRP4IYUASNfRRv3yd68QE4PHuH3MoFDcj5+H6D1+sdbPUOH9DIueE7EXV3Gc/tvVbdSyN521sxKx+jyc7+QSq9/f+/ySXeo381xdSsHluJHLO57lnOWNLejaBeyyKryOzEkhQDn0pni0GO1OZ/3kjDlEaktv/iNUZy5x4eQlSip06yvb3SG3LWBcKMhpTtzeeCdzUsVncOPGfPO3youc+n9KL6Posl7fQ2FuXnnkPJDbwplifIfbqTsBuaddC0cW14tjw+3verPIIJdQhTxUtnYbQ2o2Ek2A37zIAAYgqoL0xWhfiLWOE+MA6Vwvc2s62t1ZpdasQpFm4LR2YbAD3JAJ5idlhGWY7YJ+GnmaaH2axT2mkzC84wuFJvL+cqTpqnqMDKrJvgRrkJtks3y/td1/TPZdaNw9w5JFNxKQxubuN/FTTWYYYI+P3tywJDSn5QcKFGxze1nluWaSYth388s7HsPMn+ZJPlRLmGmBVPzft/f7fHoOtTf7T/l/f+v3+HWfT4Ql1JeO5ZI3MryStzPLJzZB36/H8bMepX0GKuq8RyadYMNOlKSyMw8TI+BD1Zm/i2GT2ozfafFbA2MnKPCAWUj5UYZzGPp0J8yakl0G300Qs9hHcXpKe6WcicwV2OVklU/MxLZWM9SQW2AU5R3DgTRTaxDGBNLWWysItc12L99BEsllZSAEQpy595lUjALAxiKMjLFw7gKVUtmi2jmNItWHiSsxvbtmbmM8pJIUsdyASCc7liKg1HSI0vFs5Zvev2fzXOoXBbma6ut2Ylu45y35fSiem20kk6xTLlH/AH0rdPhT5APqd/tVzYA20+jPEAjIlfiDUZ7dLGzuAsk904jjVTgI8gJZsdsJjH+Y+dWxwvBa3V8HDE28hj6fNyDlI+pfOf8AKKjsbJtY4i4ctZAA15qUUj+YDuEUZ8sBDTXxDLFbS3GoAYS6mneMDufHbOPvmh7e8UufXH9iXL92VQdf7/owfDChEFs5H7mNyeU4A5l3oLxDM81o1vG3wIwaRfONshh9vhP0NXPf447+K2ibeSFRkA4PNGoH/wAxoSOa6kLgZEhVznfCgnI/KjqcCUHXM+6HZKRLIwBkmYHK9SeXGR5bA7/ejMqCCCWZnBfkOAuwEKg//UdvuK50OzJbmRdy5C5HoBn9KuXZjZJWj+IHCKT0wOp/PFVZxLDlpd0C3NpiNDmQrChY9AQAf6Uxafpsa3Xu8S8sNzHzcg6cyjH23UUL0kYmMjqcnmk/ViP6UctiyRxL8QZHXkbuB1oyYIGYCxjk4kVmIowWKkwy4aUZ2R+hb03BP/hTpo8EU2BMc7Eg43B7/wBD5eVJCk+KkwA5ZGYMOuzYP8xTbw/O4twjgkqdiPIdqLpWG7BgdSDtyI8waesiYf5sYLDckdfv9KgaOS0lMRzNH25CSR9Aev061d0V43jWJ3w2Mgf1B7ihnEl6bOUcyyHP4lPz48v8X/O9bFgVU3zMTJbbC9tq5sYlmDs9uT8TKCeU/wCJeqmrl7r0E9oWScEPsQxBFIEfER5155C/MPhnUbsvkw71LPMvhNNEypkZ+A7fkaAdcApCwv4c55EWfajr8VnpsoEiggE7bCvG/GOovf3kjkk5Y7mtu9s/FIjWSzD5J64NeddUvmmJIGBnpXO22HUWlvKb+lr7msDzlKK5aFiObcetWWlkkXuD0oVAyeKMtROGeNhhdyKsy4ELwTzODCTjLb96jPwuAvTvVgN8XMdh9KpythiegzQwMy3STg5UjfHSgWoQDDk469aOQOCCCOhz0qrfQKw3x9M1KHa0v1EUGid2KAdTXS6VI+Sq5+1GobGPxSx2+tFYbSNExyA04b9o4i5qBPMUotElkPKVzV+34ZJ/CTkU3WlkgYFl361dW2hQggb7EfSgPq2PAhK9Mo5xFi24RaYqvLv6CmbSPZyZCvNGDnvimHR7aOR1OBgkHpWiaDawDlYrjH86z7dVY3AhyErGQIg2vssSRQngHf0qw3slABIgwO21bdp9lbsg2XcbbUUFlblPlU/avIlp5ZoBtWM4E82Xfsya3I5Yjg9cLRzhX2dF7iMyREjNbRNoEN0/92vXyo/oXC0ULhzHg/SvANb7BMsdV3awh7N+C4LCCPEWMDyp84gia1091jIU8uM180CAWyqAMY9Kj41vYE02RmlA5Vz1rf0GnWhPZnN625rny08Q/wBojUbpdUa1abIJJIzSFwFaYL3mM5/KrPtj4ij1jiy6WEkrG5TJ774olwjZiDSYyB8/XtVdSdtOPOIkf7MRmt5mODnGCKNWUxGMd+tBoYzgE0TtFJIAzjH5VksOIwoxDdpdGMsrAYxkVV11BIINRtx++gcE/SpRExTIGScA19jPMTbTIcNkU7pbcgAwDjacxt0bUBdWUUytnK+dFop+2aTuGue1drJwcDJXI7UzqDSuqr7p/cZYZhVJ+nepo7jcb4oUsjdqkSYg4zikGfE9C6XJPelbi/VCsZiUg0TmvPChZ2OwFZrxFq8l7ee7xsdz59qqrmQ05s7Nbq794Zd89KebW1ENupxgAYpc4ctOe4Ub/DuacpyvgiNegGKLXrzSNhg9uORKSXZt5VeNtwabdP1H3mBW5s7Ugzycj8rEjNEdE1EQTchbCtS2pbYd69DIY85jwJx/pXLTCqKzgqGU5zXxps9DSK6oy/SeFpmwSRt5mqNww36/lViWT4T/ADofPLjKnP2r6Vp1yeZyyDEpXPT+npQe4zzY2z6UWuHBHQ49aFTgs+ACc7VuVfllhO7diCBn0xTbw/byuyuzcqnH3pXs40jIkkAPlmmCxvnZwsfNjzoGsBasgRnSHbYCZsvDt7awW4RWHNgZH+tErq5SYY3IxjOKSuFlZ41Lu2evWmy5dY4QV2z51811tQW4gT6fonNlKkjETuJ7QfGyLg5JJFIt1aJklkOfrWi6nykMWbrvik7UoXLkhcDPendIxAxL2qGgH3FZM4GAB3qFtPl5uWJAAfKiwjKkrnrtgVe02wuL+9isLGB7m6mJWOGIDJxud+gAAJLEgAAkkAZrQDnPESIA/NAdvpLA/HDknb6k9P12xTP+wdP4aAPENml9qg/u9FBISE9mvWUgg/8A8uhDH/tGQfCxe0kt9HuI7DhWY32uysI/2jbKZBExyPDshjLP2M+M9fDCj42u22k6FwYS2qRW+sayhJNlz89naN/69lP7+Tv4ankB+dm3Wrgkc+P0EEX8B/Z/ge+ULThPWOJ3TizjHVBZac6iGO6kiGZETpBZ26coZV6BUCRJ3Ydy9xdtY2UmkcNWn7D0+4TwrmRpufUL9D2mmXHKh/8AQxhU8+c71QvNXvtWv31TU76S6uXAQyvj4VGwVQAAijoFUAAdBVqExcjTPEcY2LdWoD3Nn2fn4/1LogIG7p5eH9yKy0iCC3WOygWMLvzEdMd80QkutKsIEa4mkuLgnr5nyHlQO91S4RGijVghOyk9RVGGDUdRuFEQbmBznHSqLWTy0s7eUdtP11Iwo5Pd1P4c/Ef9aI6dNq/EN+ul6Pa+JPcMVjjzyjAGSzE7AAZJYnAAJNBOH+E9Q1e9hsLdJJ7iY8oVDu3cksdgoGST0ABJrRtH0lJnfgrg64t3E0Ly6zrMz+HD7vHvIS7Y8O0j6ljgyHBO3KKYrTcePXuEVd9njz65lnhzTLi5lk4X4Qm8cOvLqutqoXx13LRQc2OWHY7kjnwXfCDFNnEHEWm+zKyfhrhmVf260Rhur5QT7gjY5oYQRnxG2LuQG2BbGFjjj1viWw4B0eHh7hLxEvJo1kE0sfJOiMAwuZVIykj7NFEd0Xlkcc/hpHll3HaYMl1OecnmPxEknvlj1Jp53/DrtX837e4fzE1Tv+X/AC/v7z/E4VBOxDRPgtzYLZLb7kn17nrTdodvDo2mtxTdgeO7vBpUbDYyLtJOR/DHnA83I/hNL/D1vDrN60TXJs9PtImu7+7Iz7tapjnfHdiSqIvVnZR3qzrHEGpajqBu7S0XT3RVgsrXPMul2yj92h7NNg8x8mZmOWI5U+g3GNH2jtHr1+36QvCy6XIks7c9+uHjjYcwth2dwer7/Ch6E8zb4FX9KMqRycQXEp54pGit2Y8zPdOCWfPfw0Oc/wAbL5Ur6dAscgRpi7tl5ZD8R9T6nfYdSSB3o1qGvWkd5HpVmo8LTP8Ao+FOV8XOZN+/xDlz35M96XyMZHQQ3d4IB6w9OtlbWvu6jHivhwDk8qAMfzwFH1J719ubl7O2ikcZMsKS7HqWLgAegCAUAj1RLgoQ5cxruR05mOTj/wCUfaj2rmOO00hnKgPpFo2Ce/NLQWKkFvKWCFcA+Ms+ztHl4w0J5UUk6laqBj/0eZXP0+BRUgaTW+DjcOc3GjXiXJHc2t0Ap/8AhmVP/wDJRj2YW0DcaaCpIykVzdY8i1vK2f8A4QlDuFLi0066ifUv+r7u3NnfgDf3eRQGb6qeVx6oKYQKtahuASw+i4+uIJss7EeAB+rfuIGltpozp92qEsLWDt1KOwP/ANFXhp62zyQKCQHKLjyyDt9sUZ1HSZdLC6feY8eynntHZd1bdXDA+TK/MPQ1y8aERTnGGXB8yy/D/LH50ByQSD1h1IIGOnrE+WNt7vbkgAE5Ofr1NfZ7QACMqRyKAwx3O5/pVtp4oFVpAORMEjHzN2X+p9PrXActErtu0hLfUmgk54l1GOZNYZQ+I22QUH3G/wClGxI3w8rdY2GfJuoNBRNHyrGDkgbY9DVw6iiLCwO5JJBPUY3/AJ5pqt+MGLWKSeBCsECy/Ay4J3wPXf8A5+lGLO49xUoHAMnwqWOAG7fTfI9M0tPqASGGSMjnQYO/zAf+NXdQ1KO4sYbtMfvAVcA9+oJ/1o6MqZYdYFkZsA9I22XFds5EEoeGaLBIxl4W/iA/EvmK71LVDdA+K6spAIZfiQ+vp/zmkNg946XsLHxEVckdc0a05mkwrOVJ3HkaJ+MdxtaU/DKORDFra21zluVRjfboTQzi7WLfRNLkIdQcHbNE55YtLtWkJHQn6Vg/tX4ud45Ykm8x1rO1N21cKOY1pqu8cZPEy72h8SPq2pyOJAyg4H51m2p3mTyrk98/6V1r+sye9vzOTn1oO92JV5s5+te09ZVBmPWEZ4kkckrMeUjJ3PpRXT42YAEDA60CguVjfbuQBTHaSqsIZOh9aK+QMTy4PWTTlgCB1+naqXNIcAgjOc/SrLTo7lc4BOME/pXzkUgcx69QKByOstjMrRXXJIQdt+lSXEoI5jg52obdOUJPQioDfmQNzHf0q/dZOZAbBhCPBffbBohEDynfoe3nQiznaTlwc5NFoWfY9qhgRxJHWE7V1BAI6irXMCRjciqEbiNiSOg/Ku2uVU+Y9TS2MmMbsQ5p9yYWXB6U46Nrgj5eY4BPn0rMkvCGBydj2NEbTVgCMP12xmoNWeYB3BGJt+n8RDlBEg/OjVrrbSuBzjpWK2PEQAGZNgabtD1vndOZxg+vWhvvxiLhQBmbJo5WZlZsZO1PmkwRGMbA1lXD2qx/Dlh6Vo+h6iJAoBp/SIqxDUs0YWcWiF+bGKyD2vcXyWek3TQSfEFON/StL1vVI0hMRkVWYELnbJxXkf27cbR2sk1hz/vVYpICCOUgkEf0rpdJpRYNp4zMnUWkLkdZgF3M+qcQO53Z5izfnWwaVaiC0hi5flQZHlWfcGyWd5rjXEkSLErjNalaxhzzIOYHcEGs7tOhqWCGK02i1iZPBAWA+H60VtYMEYG9R2sBI6Y2z1orb22OijFZYXMdU8y1a2wZSD5eVVrq0e2n8cHYn7UVtkAwPyqzc2K3MJXHbaj117TKPzIrWITJHdRqA6bmj8CiWJZAOo8qWdOn92mNrI/Q4/40zWAKnkwcNvTdtIvq94g1O3rPzRcvYZqIjcelEJItqpTDkDNnYb1jWac4hgYB4q1VbCxYeJylh51nmmFrq7e6f8J2q5xxrYuL73RCCAcECvvD9jmSKAKTnBag9yUXJlRgmPPDdv4MHjMNz0oq75OwqGBFghWJdgoAr6WBGM1gagndukMOIL1VDkup+m+KqWtwQ436HrRS7j8SMrjNASPBuCvbOKLVYbEKGLtxHrTLzxoAOYZAqy0nrS9otxh8Z2NG2ORt3rLuzW3Esh45nhp5Cc7jP0qlOd8jv0qXxMA4ONx3zVeYgjY/WvslC4M5xVwMSnMSevT+dUXYCTJq5OSBv0odMdzitavO2T0MtREM25oxp7AMBG29LsTktgk0b01yrAjNB1Iyhh9OfbGJp3DjiGAOWy31zRe4vHdcs+KUNFvuUKM5x6elHmk8ZAQo8t6+fatCtpLT6VoLF7oBZHdSo/MOfm+/QUDumjyyncZ6D/Wr90rRqRnGe5FULO1N5cSyvMsVvbKJLq6kBKQITgEgblidlQbsdh3ItSuTxCs4UZaR2ek3GrXLWtlCicqGWaaV+SKCIdZJG/CoyPMkkAAkgEvY6bLfwXmj8K4tdKjVTrGs32YVlTO3incxw5GUt1y7kAsGOAtxUs30yC41YXWk8OM3jWtrHy/tDWJFyPG3+FV6gSN+7jBIjDtzEjtX1661qOOzWCGx060Ym0062yIISRu5J+KSQ/ikfLH0GANFR3Y9r1685nszWNgdPXzPu8JK3EOlaJDJp3Ccc6eKpjudUnXku7sHqqAE+7wn+BTzMPnY/KB0aXN5gLJHDGBjAGMCqvgxZ588zenSo55XX8e3kKoxLdIRVCjPjDttp6RYma4Uld8YzVoSpzeJPcKsXkdz9qVhfXky+DFzKg7jarFuXlcCRyxwdjvVSpB6ywGekZIIbO8mWQMTGfPv9KN2Mc8t9Do+haY011ct4ccKY53b1z0Hck4AAJJwDS/pcF5Lcw2WmW0tzeXTrFDHGuXdz0VR5/oBuaZluZbCccDcHt+09c1Tmt9Rv4ZByuACz20EhwEgQKWlnJAYKxJEa73RM8n1/cFYxPA59dYz2SXd5MOAuCDHqGo36tHqOoRSBYnVfieONzgR20YHM8pwH5ST8IALD+1NM4K4dgg050vjfyLc2Qli21iaNiE1CdG3FjC4Pu0Df30gMrghcUHS90LgnhW5tI2S70zxPdtUnUtE3Ed6gD/s6I7PHYxZR522ZgUU4eQLHmGqcY6nr2sXGr6pePPd3b5llVQi9AFRFGyIqgKqjZVUAbCmS3cAf9v29fX4fmAtXenHh+/rw8vj+VuvNckeaee5uZLu+uWaSaRzztJIxyzMx6knJJ86GGd7kL7xkEsFCoOYknooHck7ADuRQR9Za2j8NSG5+3Uk0y8K3rcOaVd+0C7I9/tZ20/QEYAquolQ0k+Oje7Rsr+QlkhHUNhdTvPJwPOMGvYvI58BGvU72x4TshwRZvG2oRTJca5cghgl2oPJbKfxeACc9hKXPVVIWTqkCIVgyEQklj3ali2kMKeGec82SSzczEnuT3J3JJq9DJPF/wBNlBVYdreMDJaT+LH+HqP8WPWg26jeeOnhGKtLsHPWNMF9+yop9RZghsuQAdS963N4KfSIBpWH8SKD2ofpYubhUgRBHCq4GepH18/WuNaRdLW30dsNLYK3jAHJe7kwZST35cJFn/1Z86pR308ERijkC83znHSlXtzwIylIxn17o3jUbDToUUEEr0z3PpUnE2p3mvarwjplvIVF3w/pzEqfhjV3mDN+QP5Vm9/fTySx21sDJNL8IJ/CPOtSg0wWen8PXOf3lrwfZQBx1Mjy3Ea/cKzn7VdcLWSYNkwwj97Grpr32grfyAoJIbxoVz8sfhFVHphSBS+b1mSK3B3OA2PIUW9jNyG9oum2kQwvgXSE+Z8Bjj9KXcKskjd1YqB570O1ydMhP/Zv2WVrrA1DD3L+7R/9/HEHCbcgL6noIjeXHWexAKCT1MPMqt/g5D+E0GsbwSRStLljAfFVQcZ7Nv5D4fyqHhe71Gw1uGfTrjwLiSKSGJ8BgJGXKAg7MpYKpU7EEg9av3Om2t3arxPw7b+Dp8h5b6xBJOnSSDBTfcwNk+G3b5G3AJl2N6i0dRwf5/bPz8TiAi0sUPQ8j+Pd7vlxxmlLey3sy83ypsqgYA7/APHzopPKYCqk/wB0ir98b/qTVOytFg5pXHww5Y+pHT8zXU5Z0DE5LKh/Sh1KSCxlrCucCdXFy0U648ga+zzSie2KZKBt/QEYqq48a6DnJXGPrUvh5j8OTOIzgEdR/qKJzKHEL80vMsbkKdgM0U061le2ltcgggMAD5VQtxNNEhkCyHGxbo33pj0pIWkSMwNFKV6MaarQExOxiBKmnWs1rcht8dwB2pmiWyhjNwGwOpHrVN41t5f368vL0PnSxxbxhBYQukbDlYHpQLbRT7MlK2uIIkfHnFkMML+DLtjzrzfxlrwvJZC0hJz+VGeNeMveXdEmPxds1lerXdxcMxzsfzNKVg3NuaaKVilMRX4juH8YuucZ61UtLrxUwWBPlmrOqpJNEwxvQOwlaGUxt2NbVSgpxFnbD5hZiysCM/SjelXnNF4ZO9BWxIMqR619s7lrefJUivFdwxPA45jIX5XHMfyqx43MvOD3oW1wJF51b5q7huGIVCMAnelynGYQNg8TrUYmKFx070CQsLgqc5pmdfHhKsf0pdvEaO4LbbVek8Yg7PZ5MK2A5B2HrReCdQCM+opetLocgyRnHarcNwSR8RwD+lUdMk5kCzPSHI7jm3HQ/wA6hkmHLkNv61FDNhDnJ71BPMG5sfbegqnJxCd4ccT7JfMNi+T1z6VHHqzxt8R+2e1UbhixJ/LNUX5s/EelMqgxFmsJEaLfWyDs3xDpTjw1rLyyqBJnfoayeKRw4U05cG+93F2kUCMzZBAFAvqAXMtXYTxPR3CZluEQjPb7VsHDllLFb+K/l0rOfZzod1Fbxy3qcuRnFaVfaxZ6VYGd5FCRjDb9KY7N0rWsMTP1t2wFZnXt11jUIuFdQTR5mW9SF5I+UkHAG+CO+OleN+MOIrz2h6evEk9wguriV1vEXqJ1Ay2DvhgQ31LDtW4+0TjSbVdZmtoXjkhWTlCvEHG3TY/WvMNzrGnRcQzT6MJYkkuHjngZQOb4mAI+wH0Nb+nfcTX4DB+ExC+/BHh9cxj4H0i9aMSI0hyc7DqK3LTYAkaIBgKoApI4R09NIhtbj3iKdHUboCCrHqrDsR0269ehFaJaRcj8qrtnYnypXtitlu9qA0bh8/GErSL4RhSAOoonBH06ZG1VbVQAB0xsTRW3jBXOAT13rLRPGaAMkt4wfL/SikMQKYqvBGM4x+dEYV26Y27UYLJi1rlibSZb5F2U4bFGtJukmjXEnxAbf0q5e2iXNu0bKPiFKlncSaZftZyKQASVOOo7/lTlXBGZUjxjvzB03O42xS/xRqSabp8kjNhsHFFreZXjD5A8/wDWsn9p3EL3F0um202DncCh3afBJxxJDZEXbLn1fVHvJASmS2++9P8Aw1ZhCbh+o6UscPaX4FsiYPM5yc09QILaFYl2OMn61lapNiEecuPdCImyBXBl7bYqoJ8HrXzxst1P5VzGoTwnmPjLeQTnfHlQrU4OVvEGwJojEQ22a5v4/Et+2R5UnS22wRazPWV9Om5CDk7EGmeFxLEGBBFJlpKqPjp5edM+mTiSIqSMio11fGZVW5nhsnY469TUbsemfSuwT/iHcVG474FfYKxMACVphzdvWh8ynmyPvV99gcflVOc8uc1orwMS2MjmcwqM77UVtHCkAAk0Kikx1A9au2snlQb1LCFpIQxv0dyxUb/lTR4pWEYIyBtSVpM7Iy4ODTpomjahr0rrZmJIrdBLd3lw3JbWcROPElf8IydgMsx2UEmuM7QobvZ3XZl6mnOekgs9Mu9XuTCkjBAQZH8Nn8ME4ACr8Tux2VF+Jm2Hci3q9zo/DYSwnsob28tnLW+luyy29rLjBnvWX4bi4P8A6JT4cY+Ek4KmXiHjGx0u1OgcCieO1TmWbVJk8O7vGIwzqB/cKw2Cg83L8JIBIKIcR9+XHQDpipqArHmfpGiGtO48D6y/e6pe6ndzalrF3JcXc55pJZGyzY2H0AGwAwANgMVQe7JYANhOuBXDMZTlsfSopSY8scUVBk5Mqwx06CX7e4Eg5VYqPPvV2GOFgA+DigNtdKWClsD6URivVlkWCEd+vl61LJ5Sqv4wgVMjeHFgDGwAxVm3snSVIUiknnlYRxxRqWaRycKqgbkkkYAqSytPiDHJ5iAM7k/Ybn6U233JwBDLFGw/2lmiZZZT/wDwqJl3RT2uGU/E3/ZqeUfESRVUyYNr9pxIJY7nhpX4Z0NXveJNSYWV9LaDxGh8QhfcLYr8zsSFkdfmP7tTyhiWbQNHsuGdPvrSPUYbdLeLm4j1yBVnEcauB7nafhlUShY17XFyB/2Fu5apwtw1qmlXkHDmnRsvFurQlbhwQjaFYOmXTmO0dzJGfjY/3MTYJDO/JU4w1exvvduGOGxGug6W3NHIgKpeXCrye8FevIq5SFT8qZY/HK+TqO7HeN6938/LrBly/wDrXx6n7/x8/eVfibXbzirURcyWwsrG1QW2nafHIZEs7YMWEfOd3cszPJIfikkd3PXAFi3aMh16/hHlRg2HKfFZgqgY371OlsQonUAMB8Ofw+tIuXY7jNCsovAEraHoGo6xrNnoulqJdW1GdbeAucJCW/ET2wAWZuiqrHr0O8T3WmapeW2ncPM50LQoP2bpTMOUyxhi0lyw/jnlLyn0ZF6KKJ6Bpw4e4Vu9f5iNQ4hE2lae3Qw2YwL2cer5W3U+Rn8qXr2PwUCQ9AN9tqhgwUJ58/p4fz8p5HUvu8Bx+v8AXT5yCS4itB4cI537uR027Uc4ef3YvxDeohTTESVFfcSTk4gTHf48uf8ADG9ALW2SaQzOf3aZOCMZ9aYNUiktbW00uRSvIBf3i/8ArZFHhIf8kJX/AHpZKCQFjOS3HnKhkUr73cyEs5J5nOSxJ3J8yT3qjPdNOcRjCDJA/wBalMMsoNxMmFJwoPaoUUXMwtYU2ZhzNjc+lBAAPEP4cwhw9p3vN17y3xBcHPn6CtW1xPdtG4bgRh40uiWcr4/CqmZUH/zSH7ik7RrMoI7O2j+Jiqg+bE4H609a7ZoLvTXjz4UGh6dGgPfEWc/fOfvVSxZHx7hBORvXd7zL/saPge0vhx3GFa/W3Ynb+8Vo/wD9cUPkt2j1Oa3dT+4nlB+ocj+lWNCuv2Lqun6kp5ZbW7guM9N1kVv6Uw8QaI1lxrrenyKOaPUrg/7jSFl+3KwoqUtZpwnkx+oH/wAYu9wS8t5gfQn/AOUFwWs6hJYiUl5g6H+EjcH7GmGO4m0TVm1PTCsXvCGVUZA0bxS7vE6nZk5uZSp/h88VDFBzvkfKoAFS/Ddxy2gOZbQNPER1aPGZUHqMc4+j+dMVU7OV6+EWstDHn9YQOlWmtWjvw5EY52+OXTC5Z1x18BjvKnX4fnH+Ib0Fe1fwApDc6xgMCNwRkbjtVywCyKrLgZwy47Y6Yow+qvdMkWuWSahsU8cuYrlR2/egfF/vhqaFSWDPQ/T+vh0+EBvdDjqPr/f7/GLFrbMyeISBg96M2OkrOA3iYDbE46eRorZ6Vo10HFvqbR46rdwEMh8i0eVYfYf0ozo2ioEMMs9oebdXiuMgjPkQKldKQeRn17pVtRxmD9M0VYuaENGwZsPC4IGfQ9vrRmW193to5EU5iGDzdQM7dOuM9asyaT4EizyXEYXHI5GTgjpkY22pc4s4ot9GieB5W8RRgHsape6aes54g6w1zDHMFce8VDTtLMviqSg2/iBrz5xLxvLqKyOzEKO2aIe0bjb3xGQMABts2dvtWNX+t8+QHz9qw60bUWF26ToK61pr98s6prHiyknOTtjzoVLeyHHh5xVW8nL7hSAR96hinGeXIJXYVppVtHEWd8mfZTytiT8R3FBdStvBkE0WQD1x2o3IonBVyAeg33qpJF4iGJtx09aYQ7DmDYZEp2c3MAG7mrlxETGHQgHtVaG3MMmMbGicLJInIVGcbGrswByJVV4wZWtLghfDcmr0Moyu58tqr+68jcyHqfKrUcICjBPTYiqMwPSSExCEFwnhnffpQXVObmOAN+h61e+TJI2AqtKqysSf171FZCnMFYCeILhd0+EE7d/KiloxIxn8jUJtVGcDGKsWqBScADPpRLHBEoilTzLyTMq45vvXMsy8mebBOahlYRAso6dKFXF8Q2Mn6UJU3HiS/s9ZdnlUts1Q86uQoznpsKHG5kdgAOpxTjwPwtPruowIsZIdgKm1loXc5nqazc21Jb4J9nuucXXccVjaPyEjmcjYV6m4B9hcXDtrFPdRgvy5ZiO9P3sf9m9lo+lwn3eMEKPw7miPtf4ysuB9AaaUOEPw5QZx9aFoq/xrhrOngILV3fhx3df6mJV9rNtoLzQJIuI/4W6fase4u9pVxc6jc6feTFLd0YwherOo5sY75xVfXfaLa3+mSz2wEtzOxIPQkVk3EGpXk1xb6nPFhbaUOwGc4Ox/Q10uiYaPUrnpOZ1NhvDID1E0Pjq1WDUbW7VOSPULSK5QgYB5hn88EVgfHfD19a8Q3erWMJMNxiZ2TA8NwAG/M7575NegtYuZuJeA9I1VLPCaPO9pPKB1VwPDP02xWYcYRqqSqUBVkOQT2xUaus6LXsi9PD4HmC0p7yvJ9GNHAtxea5wzBb3V1LNeLbx30CyuWZbd2dAMntzxP023Hen7RJ2vLUNIPjiIQnHUds1lnsw1e5Ww05pwWj0PVrXQjMF+GO0vIpiUY9h7zDA656NM2PnxWie8fsHiBLcH9xeNzEHbY9R9qa7TqFy785yAYLTNsYjHT+Y52iDbG+aLQRjzwAao2sZBGF+tErdWyMiueVZqCXYIx+dXokOPr61VhH4s5FXoem9GVcCWBnap2Pel7inSDJF77BhZIviyKZkA7jNUddgebTZQjEMFJ8s0VBziQTM6uuO4NL09lkcCXHylsgHypF00rxNrJvi6tzMTgHO1IHtR1q5stUljWX4WJUqDTh7EbW7voBNOxwSGBH8q1Ni2U8xM5rsJmt6bpscWJgvQDbyq1PJg753/AFqZTyoV7L+pqncMckZztXMa8DJEeQ+cjaQ8xyfy6V9STJIyarO/pXcRHUHrXL6keM83MK2x23NTTnmiYdjVWBgBuR9asOwaP6jzrLK+3mBcZEAF2jkzt1xR7Q5+ZioOR60v3hIdiNgDt60Q0ObllUFu3nT96d5VmAXrPG3Pk9c718Z/h75rj8Rr6v4q+sV8cTEzkyGUZNUJ+tEZOp+lDbj5qbQy5Wcod8HpVuGUJg7bVRTv9auWX9/H/wB4v86tjIlTwY98NcNmZLPUNeee0trzeytYsC81D1iDbRxbHM8nwgAlQ+Dhh13i06lZQ8N6PHBaaJZSeKsFtzCO4nxjxWLfFJgHCs+ScltubAg4v/8AzicU/wDu6b/9AtLlt8o+orA7SrAPHE6PsZyevhn+JYucsMBfrgVRljbHMWIzRLy+tVLzofrWEvBwJ1WSesoB/DB5AOlVp2lkPX9KsSdD9qi/7FvrTKmCK+EooJGlMcJ3HzMelXYLqK1Usp2xks3Q4/pVeP8AuH+rVZsf/L7L/wBoi/8ArFMDmKtxmPtjqz8DWUOpXYH+0l5GJbKBxk6ZCw+G4kB6TsDmND8innO5XF/h2+j4b023441d4n1C8LyaBbXADh2ViH1GYN1ijcMIwdpJVLHKRNzJftH/APP7iD/3lP8A/VRzjr/zk0f/APp/Q/8A7OKiBR8vWYHoAfP1iPtxeTcFcNSaVLNIeIeLY1vNWklYmaCwc88cDk/F4s5JmlzvyGNTuzilYahGrjI53OenRase0v8A/OVxN/70u/8A9I1AbH+8X70OxBnHlxJr5AfxMO2VlNe3GWTKAZO+1GtM4ZvNf1az0HTmSNrqURCR/kQHdpG8lRQzE+SmudE/uP8AdNNPBP8A1hqP/ufUP/t3odSCxwD0l7GKDIgrjDWrG91QJpUbrptlClhpkR6raxZCEj+JyWkb/FI1KzwzXE5Dt8P4sfyq/J/5efof5VxB87f896E/tEmFQbABCGj2Vl70jX0PPZWytczp/HHGASv++3LH9Xr4FvNX1CS4vDzyTyNNO2Ni7Hmbf6np5YqxZf8AkV//ANzD/wDp0q5o/wA4+ppWxABiNK5MGa5CEwiqFAGBtXGg6S/Nzcm56k9hVriD+/H+Y0Z0f+8/3KC1YAxDCwlSYZ0mxWzzdg/FDHzg/wCM7L+pz/u0ya2sS3drAo2ttK06Pc9MWkR/rQa2/wCrJfqn8molxF/5XP8A+zWv/wBtFTFNSis/p94B3Lvn14QTFMLm4kkZiUhPXO2RWvcZQrd6vNxAD8UrvZzHylixyn/eiaM/Y1jGif8AVU/+c/zrYtZ/6q1T/wB5Q/8A29N0KO7cfA/v/MVvOXVvj9oFe4hghHLKoB7k4qo8rWY978QxMGDxyg9GByCD060IvP8Aqxfr/WrVx/5rXn/d/wBa8y+XhLLwYek1HT7eCK+gCRRMypLGo2hkboMdkbfl7dV7b2LW8t72c3CHMSY5gDujf6GkzTv+pp//AHM//wBxFV/hLref+z//AKwq5XDSCvX3HEeIWXT9SjvFIaOT4WOdiPI0ws8Omuk0ak2l0c5XB8N/5Z9O4pa03/yU/wCQf/VRkf8AUcn+ZKG7mtSw8IMIHIBlviTXo9L0551nhd+TALE7ivNXH3tGnvZZVkUIucNg4zWs8c/9WH7f1rzhxl/et/mrE1DG6z2jxNXRVKi9OYrcQ6oZoXlSUsp3xikmeVzEZMYNMurf3H2pWuPkf6U9plCrxL2k5nyO8mli+P8AD1+lfUlR3DAjPeoovlb71An96ftTqqImxIMIXEzNupG/866tp1BPiHJNVp/w/SuU/vhUBQRiWzgwoYfFIwM+or8ieG4yTyg1btf7pPpVV/mb/N/WlwctiHxwDLgjVhkE9M7dKh5niYqAcdasQ/KKjn+aqg84niPGffEMi8hxkDNRNDJnIXr51+i6n6/0qwen5fyqc7ekoRk4lcNgnmU5/PFfF2OVzjrUsnX7ioj1+9WBzKEZODIrgsyYzQmaJi+SM70Yk+Y/eqj9qJW2II156ybRdHe7nVQpOTnavVHsF9msk88N21sSqkdutYFwb/5dH9v6V7k9hn/VkP0FZWoc6i9am6R/aNNQXTrNg0DRFsrNIhFj4cb1g/8Aa80iSX2eaqY4y7RwlwM43Br0lbfIKwn+1N/5iav/ANw1bWnqFdyKvmJz17F6nLeRnkD2W8GLLpK3t/K3MFyVJ6UR4l0XT5bSey5ABIpHMB37UX4C/wCoZP8AKKEcQ/j/AM1Oaok3sSZm7EVBgSL2W3lzq2m6nwZcPyi5iMTek0blo2+4GPvSbxhZvyMsifGFKMue+4Ipn9kn/nnN/wC0R/zNDvab/wBZ33/tD/zrY7T/ANtNGob8xGD9IlpkFdroOnWKXs9u7ez4q0vTrqeWPT+JJVtdSiDHlmSNGOD6grGwPUMqsOlbLxVYy3mke/uhF1Z/vG2wQw+cGsI4c/8AODhT/wB4zf8A6M16S1v5tV/7yT+VeJL6VGPgWH6dZCgLqCB5A/XEscE6qus6LFKZQ8kY5H339D+VNttH8O/Ssx9k3y3H2/nWpwfh+1YbDa5AjlZ4lqBBsD+tX40+AE9aqQf0q7H0+9WAl8yRQMZ/nQ3iOZbfSpnY4+A53xRROn3pe42/6kn/AMp/kauBIPAzPJnHOhy61qUt3GC55yGAFat7HNOWz0wI2RkbH0NKUP8Afzf5/wChp/8AZ/8A3X2FN1sSoEFYPGOkhC5UHJ60OupcE71dl+Y/U0Ouu1YvaACsYwvIxKryEE71LFISd8j0xVY/MPqf5VLB0+9c1qFAlgMnEJQvnGM471cDEpvvQ+DoKvx/3YrKskMOIF1HCynlzvviv2ly8kiEnvvXWof3o+n9KrWP98f8wp1BvqwYoODif//Z",
+        "type": "string"
+      }
+    },
+    "required": [
+      "filename",
+      "image"
+    ]
+  },
+  "SetTheAvatarrequest": {
+    "title": "Set the avatarRequest",
+    "example": {
+      "avatar": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wgARCAEVAOwDASIAAhEBAxEB/8QAHAAAAQUBAQEAAAAAAAAAAAAABQABAgQGBwMI/8QAGgEAAwEBAQEAAAAAAAAAAAAAAAECAwQFBv/aAAwDAQACEAMQAAAB6kyQJJhZ8LmmL7CkiUkkJ0gSXmA314zqx9LToTJMCZMCZmaUVEHjGLU7Y+2HukppoyQceCdao8+2r9QhRT7pLpzTsgfEbfyH8+agxUx06khRImbO20NF2E0XixoSgDQlBpW6dsVlJTajKvLHVvXx+e7vJ/NubXRWc1off4fR2ftxTPXli66b5v0Gn4vnR73zh33OL1Z27sIxeLIwlBqMXiDXKV0VtnabVax45sP4+vj856Hinjz6ImH8uiNs9az9L5yp3PGGAZm+a9Fmdoa9/Adc7ZhBj6Tz4RlDeIwn5tRi8RRu0bwXGdptoTQAa9yh816MefdCxekaXEdDr5WaOZTT+pz+iS9HmzfmQHfN+i1W1WwsC4bd9uOY6Tmim0lYSj7XFDznBqMJDoq3fHELi8ztNpnYBgk8B8HuaEvHz9/RqNC0bPZcr0TplHy+j83zAXKnj9kYvHyOl4xrJ2nzxPadnGna+n8xq7ZvaC9ECHx13xwYSIIp2sZnQeec0w3g3DQIP5HXlaW8G9mLl/Kx2ZUM/qeT+ljsat6PJpeb0h8z6HkE0NnScZqlD0+c6GmG9jlMhA4vZT3kSET5FRJVSUSWejJ2BV/cCw3LJewaLGc+7TbzMcN1pnPdXz/eUe5TlvU4Cr5AOl0aIrlAdBD7TjlvU6SNUWb2ea1DXpD3rxHgXDFxF07Z6qpVgyVQNgtTWeGpCsHlNDyBvpoLonOYLhElzJoj0iOTSuc72mM2fcuD9fxmb3HPCOmRTwG8zVBelcx4ur+Hn6551DAcwIrjdlnODrsc+K2uhZvclMf05WL1LWyCMHLe6A+lkunQwOnE83qC/md1jXrlhHSc75h0TjHZdDj3aOeEgyfTsvaTFaTHaIQjZ47SqUXElpi+G0Vfg6shrZ+uiWD3lLpz55sMAT2YHpWe8CQeztD/AC+nP7eta6spXrz3HItZ7cz3e4F9G4kLr3J+sYpPb8/KGkrfLdZsQqqxXiKhUUVcmGSz1TJAoyQZbn/R8Ju+g8nO6ERrF+RGXa3WV1cCSaV4cf7JidH4RyvQLMj0DDggo9Fxu9C0RFFs48K9iuKoVFFXJdJZ6skgSSDI+XhrNTlHUOS9gp88B7bn1HXzdS3ziZJJZHXYiiziNmF1ejx92+jM6vPm2Fyw0lnNetZqk1Swks5Ls7Z6pJAkoAEqjKeyD7qjjGdJ5P2DkJXYyA4jikkkNzg7S0IH6gseW2oTQNZXVZDeNvdoX85r1bdVzTLCyrksybPVJnBxpEczK5zY4DoWxyHROcquu8Z7VxCTuNoeQxSSrhjbWI6XsAR3hoRg9HntvByrqHI+oWIvUt5z4VrVdzTKDyQiLPGNHSYJY3Y4Sw9zrSibejxWvxg+r8a6TkcNN6fyGozVgGYxe+XP+1YTRaGB6zyvqo+a6TM6qDOaDHdFAn5vGZ8q9jwarEx5Fzei8J0d4oJVLEkeQLRQy0wZu0Ti8z56t08+UvNtkqt1rkAA2mS8nt8N2GN+lzZrNdDGxoP04C64vQo2N8Z+Pp5NeREaTc3oJTaSQeApJHrZSC7JIGdJjRSAXZSQvZJFhJNskgZkmoxSCEUmo3kg/8QALRAAAQQBAgUDBAIDAQAAAAAABAECAwUABhEQEhMUICEyMxUjMDUiMSQ0QSb/2gAIAQEAAQUC8Lew7KOpuJCCfwHHwhoGZEWzz3zfN83XN1zmXGrunhfk9cjTDEfY+b3IxtiSpBWk0c6T8sXt4uTdLYN4rg51GKjcj2eWp3yNhcm6afL7Yr8sPt8LcNpaQhDwJHMrMjkR/lIxsjb+v5XB1G2Rz8qNcjk/HD7eK+iPXdXcGuVqwyc7fGV/O7g1ytWKVJE8F8ofbxm9GLi8Yn8rmO5m8Z12i8GuVqxP6jeK+UHs4zex3iLJsvEr4v8AmLxifyORd0/BB7OMvsdwX+8le2OMQqMhsD+dnCVN4/EsuIVAZ2vZ+Af2cV9UdwdkJ0jTTY+sLUSuaeI/Z/F6cr+BEnShrTpJVu4Fkg09O5zY3czPJcH9nhN6O4TVDnGYkUaSMXZY3czOBbdnrwnjSaEEAiOwxrWtwR/ri+HUVku++DezwKT18gnbt4Et5ovKJ/8ANF3ThI9sbIJ1mx72vli33F+PwJTeN39493I1hcDsKsoYkgY5rB5OSTdN0lYr5Z53yL6LwVcQiJUMso4kHj6bBpN2775JNFG2GHv3XJzocpUl7lcE+Pwcm7XpsvA6viLwOqjgkZE+TIRkYttIREPWXXVmMvIm5WGqY3gqb4ZWQkYJUshkjidIrI0jbKwVxP04VMuLFw61gvdzL6J67B/H4yj8y9tJnavxA8dJE2Vz5o8MKiEiBn7sU+GUCwOBS0Fratg6q1yZ64jHLjRpFwh8IznqR2s9lDELfc615ExLg64Jxk3JyO/pHYH8Xi+WNjkVF4LIxFte3aQBaIZYaiA6kOnzu3I1LAkgGnie4AAZyxp6+F42J0QJjSSdRw9OQxqmVmnX/fVWQ41vI1cdgXxeG+2EDR2C2EbQ82htQIpJBS9ojRDIJK82tKacHajdmdM59jRUxfaGkK7pnRvr6ajNmmMsWP7EYyZC54WywivUQ+7hSeuoJ+qDZIgNpLs/FxcXAfh4zzshRg6vlONHr46Ul5x9DzD2OpReQjTJm7NRh9cTTDZ2yapg3j0z+tJrutbBioMyxm71RJuiX6OQuNYSa6buAdRi9Eynm7usDIfXm6hRJQaAvdP+LjsA+Hh3bXyxBRMfZXjI8YyUwmrrIwVs/wDCu7IZCgBpnDkMc2aIo8isyTlNqqt5OBiQgxWtym2lmorrCBRy6efuK7U43IRpgrZ90P3AAMwUDtQh9KenRC6oiGWvLFnaTA7HYB8Krsls4maaQscQawtZinV9bIY97hKeEGzmIO1LDzg0JHXBvA+3O00T1BdVxfbppCeyc4augs7OQt9fXTGqGNCGzU4u8enzOgUeK0sZjnCFwytnhsIuws5WMNDpJu0JtBELH09KrXux2AfC7ZEk257ZnMOBRsjz7smTK0G9vUSCcqNCA6UrtDbwfuAKwrtjUVJi7G3iGSaaWeWsplfhBcQiLbyLaTRtIgIhePPWkd0HqMXpE6ZI5o9UQbpp2fqB6iaqWFKapUNmLKNMM57xn4D8MkfUyVn3Sw5So4Wv5M1VDvFZlIVSUc/XrreHo2FJP1668CUUuDd45FdLIXXVsITSVlLwUSEZt9FyS6cN642phfTT5iQz2o3dBAEqEVK2M4KlHIjsTRmFj9uTAc1i8rsdgPw42NEcjER/A2FCBZB3Mo9KT7S6oH9NLEfdvo3qKyZI0mf2rUZIa9E2TLoTuIQCVDLekZQxMTxSaoruwtSCNik0yVult1o4qEyWdeRrXLjsdgPw+K/0UxGgUW6WtzH1a0Gfty1OGnVldHBZ2aL3HGVMtxOgVpg3mZqgXdmmyFiNtIGzhQyvFIOlmlBqdvpq4uOx2A/D5WLV5akBxEl0cWwvtGfQNLNRSiJ0XVFon+Vxf6MuE55aOeMewOKEMY6meJA2YmwJu42xE++npv1a4uOx2A/F5akIdCFpfb6dqD9qPs+t0si98rlbclxdQzwvsth4RqvT6b2uoZelW6ch5itQptYiO309TJtVrjsdjsB+Hy1OxZMHiYMMdIppo0fbh6bZhq/58S8zfCwk31Bqh+1fpYdHSajJRxemm7janbsfWt6mnqj9YuOx2PwH4fIjaW01BP0q+ig61jfz9GuqI0jrrVOWxC9ReK4S5s1/ZRfVLCV0VXXnDP7PTibVeqf9ulby1Vdv2a4uOx2A/D4ucjW0c3cWGqnfd04P0hbsp5JAHoFb/sgf9XjdudI+7Z2odMB9PgIniNbdr0ajT/6rVC7nApyg1knVBXHY7HYF8XjYNfIINGwC31G7ezsZ3g1N09ryxU2gsF57CL+LOJb0TUFbM6xL1EanSLj7QHVfpNQsVlZev6lov2g6Vd6tcXHY5MC+LxPKYJAEM8oq0n61jZx9aptBOzNb7GfcNWaNk/CRy5aSN7moh6FeDD3t7Ysc+51WnMSzlggZzGWFu7krQI+kCuLi47A/i8bJkZVtbEdpX0ELJrHUj5WBXir1xXc457WsOfHHKu/CVz4IhUUgslqOFoye2OdGjprKRSdQXpCwg6bbGuM6rrFeC4uOwT4/EGZHXOpZUeNpdu52odupYAzMnBNiYGYN3J1T8mb+mo5ukBpWJFl1BO6GuoBuudDkUv8A6W5jSeupY5Gkyj9WffFxcXFwT418ZR4ZsbGxiGh+sYMs80oUsrvp0ufTyMEHIgf99can8ZBB5cmGaPlmx5UGn2NHdF6R3A8KxtlVzqr34vBcXFwX4183+wPm22XNs2zbF4leo6uysa5vB0aOySvHfkYD4HbF5yELjGq1q4uLgqfbVM2zbOXJoGys+nK1WBytztEXEYiZtm2bZtjmI5Eromr270xw3OkcMcabZtnLnLnLnJnTzpZ0s6GIOm7U2T//xAAnEQACAgEEAgEDBQAAAAAAAAABAgARAxASITEgMBMEIlEUQEFCYf/aAAgBAwEBPwHTrj3qhfmPjK6g1FTdGQr36ByYolTNj2HQCzUAriVMuLbyPNe4NHAYbYRRqJwRq1VzHXafNORMobjbGx2wafULRvRDuFw9TGC6U8yYqTVULdeGA2um4DmZV3pp9P1WthvtjrtNaYn2G477zeuBwvc+VPzGfFe6PnZtMT7W/wAlxyn9p8yoKxwknuVCfcYfUIPAwTEgfuZsWw8StQCYTAL78TDpjybZkfcb8MFA3MigNxrWvXnXvv3j98qluoMLt/Ey4/jO3wEqvPG5Q3HbY5KT9Tk/Mdy5s6YVXIn3TKAGpZhyqnYmZ/kbd7LPn//EACoRAAEDAwMEAQQDAQAAAAAAAAEAAgMEERIhIjEQEyAyQQUUQlEwQFJx/9oACAECAQE/Af6M1U2JQ1TJdBz4STMi9io6iOX1P8Dzi0lSuusrG4VHU95tjz0e7FpcnvLzcoOI1Co6vu7Xc+couwqTlFU7nxnuDhNcHC4UzcoyEekWeYw5UEvdbfznGLrKjdEMhL8qGp7cboyOV9OlyZj0qGdt5am2yF1UPZBOHwqmqw6c/APWSQR+yvfjr9QZjJfo2CRxxAVHJ2pen1JlnByKsTwu26ICR2n6UMncYHBAKpp+8yyhh7TMetdA6UXavtJv8qKnrC3t3sFBQMi15KYL7VVwiSI25TmkKETtN4rplBNO7OpKiYG7Qg35KJv42RbgnDGzgnjUOCcLFYXF01mSYMgvxuna69D0t+02O+rloSQE3eyyaSRihubZav0CZYEtUWjrIbHpvJCA/HoVU1DoLFqoqgSsydyss1wQ5ej1IRG/VBmepRfjtYtWG5UotuCfubknatDkf9o/tFVFMJeFTxdpmCabG6c3bonbmXX1BznMACgfI6IZq/wgM2WUe5uJUZttK9btVy3TyYdCm7G6rGxsjwOkbrFO2vunDI3Cdrqjz5cMUmgCGrij0Zym+hJXqxH1CPPkG7gEdz/+KP2KPRgsudPhONwnegR58Rymeyjso/k9XCzVxYI+oT/gI8+Lf2m+l0HNYAXGy+5ij1c5RS95uSaLmyfq6yl50XyESL6ec0YkbZRt7kQEuq+zhP4pkbYxi3pUzSU82w8qJ7pGBz+VNE6Th1lBGY2Yn+T58//EADwQAAEDAQUHAgMGBQMFAAAAAAEAAgMRBBIhIjETIDJBUWFxEEIjUoEUMDNicqFAQ5GxwQVjgjRTktHh/9oACAEBAAY/AtwXcZHIQz0zaEfcjanMdAFeiOmo6fd6rVa71W8IwCBd7RUfcFzsAE+Q8zgpn+2lP4IjqgH4g8KZK32lNeNHCu/HdrszxIFBrvw34H+DjBddurJGCepVPb0WG8WvaHNPIqH7LFgcKNCvWl2PytQB0Cw/hKhd97t64Lv/AAtdw7tR/C0PP7uo+9O6578GhXoXVC7+rt5u1rm6IFpq13P707l8zF0RNC0qWMakYJrLobUXSFTruEer34YdUGz3c1bpCbI1t7Z6jspQdAfufrun1vscBETXuPQyBjb55+gPqD19Xxu0cKJm0BuR+70ytA8KnXeLXmo5LBfXdrvlvqe2/gq+pdI4Nb1KLrt2P2k+7unUe19MMOS7L67vj1JK/FaOxVGHaScgFV7qvOJQ74KiLQ4Fw1CLAzYx/O7nu1EjP6q7ERJKdAEK8Z4j3V3osEXPkaANcVJJbWOug0jYcBRfZYMoAxP+ECxhdHo70PndI3LxyyfMEJHuvuGiyhXnYuQNkbefXHDkhFNE0SO0c3mU6N8EoeNQn3wA5p/b1xV4fDf1CD3uvkaDksP6rBGGSO69wwOl7wvwGrZQkXyMT0TnzVcwanqUBE3DtosdUfO9VpXJcli5GJodta3Q52l5QOLWhukgHJX5nUH902WoF7pyTvmDr7XdVDaRSOYtx8KS48vkoMeRWIK0WDSuiuyX3OpXAaKsj9m+IF2T39E2WtXPGVvUqN5we1wOHJNns8z9kcHj5SjeqI/c5Ms8DA1gFSen/wBVBp6HzvUe9rT3KwI9KF7a9Kr7Q99AQBVramqkjbgxzcoehaGVL2cXhbGQ/Ck/YoyUzRlXHcUeVOLuIOLa9t1sjnN+HrzwUEEZfRjCLzvcobQ3wnXBi9lQpYHirXt0KELAG/KF1PM+p87wvUdG11cOa29la2/GM7PmanOs5LXEcjoUHmt+N2KxFY5Gq7U1aatcg/no4J7G8PE1fD4y3H6Jpd+G7K5bKCm0l59O6uxyuvs9y2domc4OGCl2L3NeBUEFRPkle4B2NSpI6cQomF38t9CnkYlucINrmjNFDaW4NfxKORuN03gdw+dwXzicAOZW1tBvEcLeTUcBfOIY1WkT47WP+inh6cuqbaGjLJr5RsrtRi1bVo+JFj9E43D9nfz7qKce3KV/zKkis5BaccPauJz3kULnK0WaLFsTLxPdRSdHLsVLGfa5QydsVtQMsuP1Vx2Lm5CuwN146hRyNxANQjZnnuzcPn1MUGd/MjRq2svxJhjfdyRjsmZ/zcgqCr5HlBxdemIoTyUNp9j9VIwdLzUyUYFpQdq1wTrGxraDgf2RJ0fHVOisxPxcDRG75c4p0NlPmRWmvQBSxEaHBRO5gXSmzjSTA+U+zE8WZqePc3MFFBZiL0gxIX2hoyP17FOhlxAN1Dq01aeqbIzn6nyqqIWY/A99DQovoGge0alUBMcfyhCrSyHm5Ua3Ofq4qziaJrGuvAISc2OTWnjjylOLR8OTMEYHcUenhQzAYg3SooGwO1/EdoAvaxv91dbli5N6qvBF8xWyi11PUptpaMW4O8LZOPw5MPqnRO56HoUHaPjcmyMxa4I3NA6+1UPDI1S2SfKScPKLf5jcWlSwOr19T5WKdd0VaVQfbHB35VSMCKIaHmUNrV8craVcrLahxNfRSM5Pas/A/K5OLcXszBRv9taO8J4nAMf8uuiMcNHyDDsFekcXvKElsF1vydVca0vdTCOMYqKZ7NnGMtOycw4teE5h4mFRyc6UPlCdoyya+VJZz7cwUU45ZSnRE4xn9lfpQObqjHJ+Kz9wn2yzvpXUDko3Si68jEeh8oVKLWIMicGPa4OxQ2xDn9h6RTD24FQO9166VGTxNylTNphWoUdcS3KVk/DkxaotqKSUxV2BtQ7E9leOaXm4rZWc3IvdL/gL4TceZ5lMoD7gti8/Ej/cJtpYNMHLYv4JNPKkj92rfKEtNMHBEDFkjcE/27PB9eadG/6HotlFXbN0uoGXj59PU+fQu5ou6+skR9wQrqZaqWHqLwUdoH6SpYDzzBNmiaDJC6/io9u9plk5NW3IOXkPcmPkDo4B/LOrvKw9JANeIJko0GvhEaxyNT4jxNKY/wBwwd5TZ2DB+B8p9ncfzMRtFmdR7BmFNQpIpST7g5EgZjz3D53jRRsOoP8A7qobp5qZuppVRSN5HFOhjdtCRjRWeKpeXNLsVYT/ALu4D0UwAw4x4KNlecW4tTLS3UZXLZE5JP7qVjulR5UcmNRipnAXWllVZy0AZd0+d9jrpNyv1FMUZ7PLcZG7KSMVJAJsg6BYRi/sq1UhPtaoae3Iv9PH+7uFWdtPi7NzvPZMfLg3SvRGxslD5JNLvJOtDps8YvCijjllcbxTWN5MXmFWfxunzvhjNZMPoj+sqb6KOnOL/Cl6Bv8AlXnnETKyO+RxO7Z2x/iuko08wpy1jakUrTUqHtVOA1ebqkfyY2i/4hV6RkKz+N0+d+ytbqXUCawUDWjFOf8AOaNCYxx4G4lWqUDBz8FM7/cUbuo3bEz5UG/M9STmtWZQmRVyRYnyppD7nph6sTm9Q5Wevy7p879mZ/2gXlFoOaTKmV4WZlJjRz8FAG8xVWkfnKg/QN2z7F1+5xuCjhikGyjbVzhyRLRlYMO5TbY9158j8yZ3cVD+hQjqKplRTUfvunzvFztArVKdXaeFA2ugqjM/WTTwnGp2OjQoB+QK0/rKg/QNyzWRhptXZqdFFBY23do67l1KeZXC+7E9lappDWzwC6zu7qrHBpUCqi+qaOjFAPyKN3n++6fO8+OPiflUFnYa3o6OPUp/YAKzRN1eKEoNiAEbGBoAUQ/KFP3emDsBuNe85IY7x7J1oeKRRYRjv1X2SJ3xXHEDorLYAM8zgXlWdvRqivc6lTdsq/TH/hQV6bp87xkf9B1TbfaKNPsYFK9vWgXxBR9AfBVytWmhBQp0Qvml6TFRxOOLuH1ozjKkbHjjmd8xUQ5kXipXudVsbr3lWD5MSrMOZFE0cmNWXEvfVT920CgZ0bunzvWazycIBcQnujArwjsgJReAFfqgI6XHGjioQSCWxNUTurQp2twaHlWJ1avZQtPb1tVpcMaZR2CjbdJvOxopG4tF0hN5tfkKjcdWYpkdKhjg1ODTQyZVJc/HHNw5dk+z2otezijqKbx871qfaiGubgy90UTYjezVNMU91NGKybRx2Zdi1OrmrioWONHNbQhSyjLG7+qoTW62g9WxD+YdVNL0F1OuavN1BzuGLMnPrW8U9zm0q4hSD3NzBMlbUH5OblDK52MWIG8fO9WWJrqdQqMaAOiMsRofy4Lbvdt7mjHlX3TAOPtu6LCSP+i4ov3RdSN2HVcMY+qzYr4kTXeUXQi40n2YJoMjspUxfeMhw05IVwW3uAStPENVe2lVI467/wBfuCieX3D1RPLmltfTELGMeRgibPaXtB5OF5fiw/8Ags07R+lioXF3c7n13brifpgslrtLf+VV/wBbOf6L4kkj/JWG7R2IXw3zM8PWFok/ZUkke4eVkaBvarVarVarEqgX/8QAKBABAAIBAwMEAwEBAQEAAAAAAQARITFBURBhcSCBobGRwdHw4TDx/9oACAEBAAE/IVmZmZlTJoL2OYTD7NT/AONmL3Exvb3GvoXLZbLeZbmK5YrljzJ3n5gbqle+haFdCAt7CVoFy5f/AAe4Hasfa/wCbJB93ofQx6MYx/Kb9Qd0FMZIUqNyPpTk7k0WQPWXUI4c7XA3Rl8q9kdn/wAGPR6M+2PosUlmjUg48s2U2FPwgeeePVq1gDWAusF7yYaT8DyyrdhVy/O/UxjGMZ9voVi7R7/QGBd7j0rRbpFs9kZcv7pnEDqeoxlxjNfz6FZ3jzNMWXEuIBDeHW++3V16AdSDZvudHqejGM1PMepz8zVGOvXhL7Q66vmX6R7CGeg9WMYxjNbz6MvH0vUVCjazFoamiShdmHrXu026PVVeSilzZU7oYxjGMZq+Y9TS5h1IzEULaiIkcD5o7RXH20rXEF23ZkDjrS522Y9GEyGNnvFZS9A0/ULc2vKpoMlK0GVzuYYxjGMejXh9ApxZ+pnIrv8ABPEFmxJMzQNTJA5s61DoOh6MCPgtO2E2qXLELW2lX0M9DGMbLHPZKZKasPopPKOvocQcztpnrjmuR1ZeOjCLLRqAY3jGHEeqURInbWsH0IgOZLxrqnUh9GQjDpPQRB8K3SklM7Y0d92XpF7N9pd3SG8Zq5ozTNSM+p0re0IbDjrRa6GZ8GLG+CWQD3ljugPJA2NRftAAUJ2ZqnLRqW6Hk1G9HQnbhFMJl2rzNPboj6O9B1lL1i3sxr5myxqqCMfK6QslWnBFh5WpUJgIQV2GXWnS0Zj3gUH4TeMIpodZi3suHyS7PboqKGcb8JXMl1eZuX46eTmOiuM76zz3I1/sqBmEfYicI8UaEujHl61sAZ2Ylt+UH1p7xHT9iWTpGbF1UO8keOidr+4kPsBquxHoVbHwPeICv5AXFJELTDHgek8BH6M+InJ+Jq49prIHuxu/Y8NLh9iBYO7+k4jm6f5Q5nYdxI92efnf9mNjLnn7XzDwbI/7Uo0kRT5n1CnDQquasq4elBj3kdouCaDeHQmADPE1jORcOeUfXDWfySiioj2dZQUarubQvgGBxMBSJ2ldj8TMca4lvy9Q2XYh2m6P2Q0mdZ3MkErCF31moxL0rJb2pZmGYy7c8j0qfO+lGpCJTDBV4an5hWODs2/ccbosDxspUYh+SVNFlXmJAFbbmzEOFjt3ecilvZlweoPLqJbCsL+/aXJZGWh3gDawF85YpZXN3I/dbwxDEopeVKYKeMCz+gYBtEiLtrDxtBztYnzAVYCLccej5+T+vQ/DZyzggDap/wAL3hIN3weWUm4FbA2+YM/wb7D/ACFtEwJ7r37m5P6SG6F+up20lc9Xt7QBa7XBxpHc7u6La3NPUIW0bQ3tqLfjGLaqXxL7C+5hYUIYDlJ2JhmgL4jWVa0G/wAYjBzahEroU7JNZ4uz5I6Ot8j+uqEksCzd2Aswf03EYcaS/g5gd88X7YrBYDo7E+EP8MzFuT32mua6fZANVv7Mb1mpraLN+mc1MKOFTTv2hniuXyvmO7C/hGTK0SmwL7HSF+ywQR+LDwgY6/I3hnF/H6/EYxzRdtbxOBctuq3gakBn2lM0jjk4eOr8z+oTLQmxsOSZ/k4JAMkV1jhNfLGndqfULOSaA9y8QuiIHKwKrVeziefCcbR94R77ywN77dQ3UFOzKEmWH/tZZHwjLiZE9D7QxWnUtfEMjSLH8k/x0QYg5Dg7bGYtdX4CXA1Y8axviy/pHoqF4I208jxOQynSn9lJK9xcQHw6Th0er8j+okOmJtg9oSq0Sje4hhew6e8LnGBS/AbS0RBvaL/0mJEWGlTUwmvxKcVe1vMrxsffmNd0vdJgvKupz79I0jfkmP8Ak5JQ3+UOgOoAeNo6sWXd7sovpb7Mt/Nb9MG/zo9msP8ARCzG237brFF4y/qZhsbyhoICuSRQLPX5pmxuJn+pnph0HzP6h5ADY3gADEFhHtgefjUdOVS7zpODqPCEt9Ye4TQ4vbMsz+lf8jyuRo2dyBl6qXmONepcOAaKuy8cTJNtLWv85lCEWrnyMxaA5PP8gcMS/ZluWaPjZjtqTLicaWD2kvNW3Y7kVnLLjiHhxO1xKCi8vv5hVybLd38RlI0KGh6/zP66Dwyho16hx1a7Mqxlo7GJY7j3gmANP+coUMfe3gElA4bzADQNguUidquyHap5u/zz2doAAANjowAqX9zaWSCY87ooa+IZhJw36YN3i9pCbj0m3KJp/gfkhEuYLH9yME3MNOSAi0U709F+Z/XqKlg1iYT0Xe+LIsOijySniik8TaUfs3gHaQZhZzE4qq9E0qZyV9AW3/4iO1P8XZnc6F1NyUANA54jKkNV8JQxuHYRRgepyQYjoO1S24BujV9I/M+vMSvQMJueI/b+SSOoABxXiYgh6DLvNvgQgAsAXlJ5Kvr0NSFoaS6Cm0aEJoVQW/nMTItYXmBdKgdyV6dsMAeIZuBmDb/+Ez837fSvzv69b40t3c3QYJmGFnC+JxeAQbnIw+sZj7zhL4b0qisCB7qQJC61knv4+ImjFCf0QZck2JNRqN3vz6R+Z/UfVqxcXdgo6LfLB+Z8M0IF2FaeIC0Fd9pTwk/M7LD+T03Tob92FdZD4my0HbOstOorN9kcRnX9p2iPuOTqIgTff16Q+Z/UfUNeU7jYmKpKeN5ZRu/1K8LA18wtKpfllIbQzH+K9CoVwRTZ01Aa7zPRDt5OnmHAKA3k+zHjocS0cuf7O8vrc/KJaYQOwq9K/M/RH0shRWsRveg4tiC6siIoavjZqgHCQ3/MH+IxFcTD/Bj0PT3xTC6vXTY5lyivhJLhABsxDH1YDwRX5ftOyjOwh+pbZThXhdQQw/m/qPp4UI8csbFYV5BiG2iCW1eIbzZwopi/3Ox5fEsXL9wmxBPx6BBko/JIZfxC2Cb6j3mcEieY+CWdvxOyzBsiDGXaH1Qj9Vvt9KB+bH0rjbpvKYxx2BywC5XvKlRToKFTdcbiKt0GvxAEqZPGZiXfg11FVboXod5c5Jn6/wAu0FsD3SymzVWcHBBVClHkzKU1fyl36e+1EGG+C3/ILrr5LEunCNnf1ML6WS1ba9o2NgPugK0COlJ5sixxUr7D137x78zviYSxHaaIMTemermSS4NCXUZoF4vMsHkQ2xNLWe5lwwuNUPnEQyEA7ZYTJFbNeZUaBC3KgqIcas80b9D6N87H0govaBaDcL7Sil4VPvESVi+/eItFpG17SmFlHRl4Vd5IKNWpNiDTMGsyHShToE1NpD3liaJfsy4QZl7u0KrbB2JUUxFmHBqfaP1Yqhg/RFpJEZrfLFb+gnomrpcuXGRXoh2wOMRLVxZCZm1REz2YsyxaEXAxIzvLJRokJwTShy2z36mIUQt8Yjl1zZqqbmPagxHg02vmVwhiXD/qWCPDiEACulF2J63dw3nKBfUaeg6kavRekzx0z4abl5Cno8wjfrYas8adD4RcAs5XYywTGWrKvpirJapnyPia6ADCJbnlH7if/Ld4Tbnl9Aa/eLJ5zznlERo7u0zHbKfYimfI/wCJZw3FB8QAMA0Cec8+u/IUyMdPbWr5mMU+4v1B5FjC/wASsePMzznnPKeU843h/wAEf8kf9kRX8xBtSAOAJ//aAAwDAQACAAMAAAAQABcE2CCHyOCJydpKKEu2uG64WbtSUBqCzcuqAmKZrtN6XGbCk0g9MQjTklPzW5E7DkvkgWUKYUlWGi8JQx+HaZHDjWm6IczL6B+WR+Nzo+iAbuCkA6P5NtduyG2hqLpDNZSn7vTwkOjs11DDpjOvkPxmq5/WJdvas9ESiee6pP1wFToqIRqCS6W5W/Ad1hC2ksBWCWd35d9zSBhOd1O6KnrLTkm3S2W1222Qe1ImdfcivqW3UgS6/dDkZ1oqAyxcc/hDghh9CiB8g8//xAAhEQEAAgMBAQADAAMAAAAAAAABABEQITFBIFFhcTCBsf/aAAgBAwEBPxDCdPmg193mgjbprNi4mwaZxn+A0EoCbFM2hxxUQZpEJTEfh8MMOizmEth2xmXSK1+4EOQWeY9fmH4Gm4tkTbwxyGqlZ+eK2A2rsXdool2kYy5OjcpGnOs/ECJrMvK7htlCWHZeRv8AMZVAn6Mx9KsqotMo8ThrYbRojGC4A8YwpkaaiNrbNO4DvzVTzHkvdSrhPLi9wNufZyUsORal1tlHbNGcYdleQVO5eFtQgFphTREgtQ6wlOjbFVmVKolR2XB7N9w0xb3/AKybpAblhamJHlxVzZvA1Fhbh348rDkduCexMMYd+L8lHk7HBPIMeRjD4/MFEI4MGGMMv7hzUMOPcEuMYdzVykiFC5rhf8m5NtQIYFjFDZUY/NZRlFfyVzbO2WzUBp/kf8IDVsNRyJKlZGX8XPK/hz//xAAnEQEAAgIBAwQCAwEBAAAAAAABABEhMUEQUXEgYYGRocHR4fEwsf/aAAgBAgEBPxD11666XMFtmTK7H0Gfg5mIzduf+HsiRmrBlsIPEN9CY4LjhssVspIB4v59L0oPsxRgw2LRpePEJ6mMHyMUWIUb4VDHV5PfodHollSwXEw+oYX9e8O3g49mXz2Z6eyz+Iwmtl+JXNVDRrn/ANI7V2PvCEpnRavt5gBas62HdTEvBLA78QDzZr7/AL6CDyU/roMwXAQNn5Vt8QOZTkdTaqdnb5hVFepkbSWNW+pQ3kvHxbK9/oPBBCjMJDhn6i1IkOlb2188QFg9v8wQUGjUpy3UuR11C8s4MRDe5ywQDko9HeDQ6IgUmA7S1HIYxHFhNOgCG4BB0hWPiDJ2RmSF9jGzjIIF3OLxRlwoYCL2TTU0l4DPDvzHpYNf5FPPHEsI1PrYOUF69/EdaCHgTH5pcJEITDNkK0JVw5mkcKArl5qNe7sr4JfYxV9kP6733x2/mHbzXy9vxF1TULuCIaVxna+7C7JHXoDM7iaBdzKHbrGlgCBb63G1fMwUI69CgBtmLdynhRaO3QXCrmIfZNuboR16M14lrjUNUZs9MDuxyo2IlvvFhmyEddb0rcyttDPmJb3mOmDKuETy4hTHyxYJlXFahHXXG+wlRWzCoW7yygD7h0dW14lR3Rp9sZ70UAdR7tf6hCOvQgTTwnDKafKP94/zK20SiZJNL75hw0twTNALIwhH0c+kDLqQ6M//xAAnEAEAAgIBAwQCAwEBAAAAAAABABEhMUFRYXEQgZGxofAgweHR8f/aAAgBAQABPxBro1L6mX1MvqYlxknUtqZgKA2AunrzLerLerLerLerLerBerLest6/mbwhHZdexETpVht3ILxZFesV6/Et1Z3GPWfmd58x5F8z/hmf66UD7IyQBMHC3cyDTpxzHb6kyoLXoRzA/YNvzFognejHsv8AA/gjMrlAEcCGB0cATJcct7Tj4hr0d+rmOphFLzH6FEv5R29XdpCHRKimfSup56MZIKi/OfEX22Dslw16mvV3QhYHcdNzZULUj4VZuoBTk06jGPoxiizFzHFi3U2+X9QZ9H0fOyuxXYdGDyJkR/mIFYKAVTtB73D2Q16noPKKuCNdNAi1i9OcytjUjZgJ9IN7aCsygc1rkjGMY6mHoUR/ct7RRZ+Udx9B0IXFCd5iscxYIWk3mBggSoGIeoJgGWPLYNCPPeNvMMVD8zgMA+I8xjibYi5iuOVRVcXSZ+b9Ed+q90D0itShZtD61mJPgfDNJz6UBtoe8uwYuYqRMJHRoPz2h0lEqyPoeZp6Vm0c2lXyfog9bu0Iqh2vpXC7xu7jCubfSNPQhVDgs2RauPmG47hlMcnWauSMef4Zbs9DxPzv0R3EjB41p194vScUpjrLW5b1HaIbIpizxY6lnMU9MU25Hkl4Ra3MyGo4uEJ3Daxt9oA4Vlp/dR6fwTjGMCWRpmXk/R6GMOkuiSoDY5nlLV8JDqhdRJD22y0ODoZlBQR0aIVyk6Ki/JZ+YJ4FXvxDXoAR04jJ6Sp3x3mKtl7qLwrpCf0BtedJyi6e0YwURTccdNwnwrZSCmvi/eZhgKz0vETdMeGNAxF0n5D6PUyphesqSjEt2ZYXnmfUWg5zMVsBghxWooyKSqQ9iABxm8+lY7SvWgvcjyJFMQzW9L0+zGVAqWJdPO9Qyz/7AqBQIXVqUWOBT5JT1M+YkdXUtRC6sl4iCgnaK8/L6PQ7iTiVFo1BTO83HeSGo6DK7cy2nLpfR9cKXKcjHNRYjYF46TmPvKcVvVwnE0CAY69ObLNcSsrAGlp+AczCTFFV0ekG6KZXmO/P+j+Co6gtVzI7y6JccndBa9g6xClcWd6I5iBRmUsaPcgUkjdHs6AMSv1pYO/SVWYbPE354d+U4mALnLlItY5YiO1V9SXF0sAsoFPQ6w0uJef+kovBnWwK17RXi1ndla96iJ6rV1lzE47Igj4qOBKqLT0ozfaU87KFqV1lesFoZIYRjoY3G0BTweq20iqhVMHYmdnX9EEqJFndYImTrUcbhIoNNl8SqiHC+DmMjReeuFOWMBkunEPeC4B5EWXzQCZaoxOxpQhoeF1LmosIDv07wnIAfPl1erLyxieeIdVnQuJIaKr/ANp5iy6QVnhTmNEmyahiVTN+sSh/TeByA4HSHGhB2eC5z5gukBbYsUHVGbDsGdwnnvGDaVkHiaPh01cW7q+iPqlyq8RyEpe7OWPENlu9wldUp1KqOIKcNWtE51MB8N20xWqfpUH5+u6bYrLwhplRdFnDmLXIcYCrfYkWp1ZrZsOTYyzkZiAc/wCkpZ29iWv7UQp6Ajvj+omaGOm20d7p4iYIDVXqw4x8kd1NoSgGnJbmAfoTbCnjLAawHgSsqs2D3jdJdxfQtrrxDzEd40BX5ETQMACbIxzf+BHn+FQpv2B7V7h68+pallYT5h9IFKLe25Tzxu0idKmLeIazTQWva2u5R0sivXBoTtxBdAoVh9eDqNVOWN1D+5SVLX1TL4sgG0q0zPjUQpmWOQnUj5EPA51UNFxbtxAXGpPFSOVppNQ81Sq4brJxTWbwRRLtDG2DgoSoSi//AIlPyRC5A5ypEef+S8+dPfk8m3tMzbLe32+OAi44myMdX+BH0qVCLI6rUPucwMph4yuMTOWQpk4DplcMaQzIB3x3m+4hVaaS+sFp+VDAL+R+oY1HXL/BIuizt2gnRjW0I6DMHs4hwyfYU/I1cRURc4FoXlHKFXlpS9qcdWNdCzJYuOkpapaKa+OajK1FBbKvcj/o0kbSJ4isrxR1MP1AyaRN0P0IwsqCOQynuLMIQp3fKhP1qOBun7lMX3KAU1U+E+IaxHHVwWf2qHn0uAmCA2vQQ7VrUJ7fkS/jAQLbo0d4kANUZKgHaEZVRbpmx1gNVQp08+5Ki+Utv5Rz7ws8sNGV09t+zEyVowNCHPSNZqihyyn3lTFm+DCXSM5YaKdGVy0D0DAOA6TYMEQLi3YGZE23c0/hjZiO31B/sMpC/F4lkbNWRZPchDSdq4xfPDAsddyHJ8fUW9ghwNPubhHhdze99RHFta0fq/MdpuzcCj2jo3Hev/KGXUe1OcVPm7EUBYGyno0CGEinWnPc/EuDmtqdegEa8dDgU/sjCCgK/p03K4cVZxLp5lrIXYaT8jKyTV4Q1+WZoHEc6zGrNQgNRFpmx3EgQWTWd835VZMSNLCIyq43iMjLHpu3/cwObnmxtbfeM4uisXWj5/EVjpa5MP1U4FEn7WTrDreGh5MytCbQtHg/WoEwSohtm83ZUO5SUHB9MIMMvKUh4WJYhB6Lv3MM5epy8694HM5T9d0hQaK1l0QtDqZDdNdkO9FAwjABy95glNkTz1vEZIm6azpfbFs9ecFGLUXHzECwyhHVB7wiXMkMmZDRimZajb4+o34ZA4Fr859472rZlWPhxH+WquNh+YC2N9BLdhvsTAPW0FzLQZVY2umxSDnr8alaKKwHYeX8Qs9xN8NpZMuVm1s8MVWGWj8ZemXNoVthtB1tOVaqHuXD+GI98J32SyyuWLbdfcrGd9rpYncYD0p8dYqvspGC4XkGQb8X7haRSOJoqEzeYQtjA/2qFIAmbhD8WDhUa5GgxzmA+QW4XeW17RnXCij4x5gPfuiFD0DgOsUK48BXyvVq5jTaJndiImIycTQvDB3SHcBgeSPahE8rT8NPtBLYqhxZI9erluZambqumuhMKEhSt8A48EVuChvgvwdo16zQQbRodWXQPL7TlOW8xiUdWRDD9MwNoNNNh21KYnKWsAYVGinwbPkplyKAebMPA595f9tEaHK8Xj3msBCueL4Y6EkcaTnqYlEHts8PkafaMCq80c9i7iZR0FJ7cdan5T9t0hwbaSEgAwG7alsKSKb2HzBIKG0eoPo4OlycGS+R+ZxFqtrD8kq4pu86S/aMDZu9l+7jFw2/K6F/CK6Umc/9VxCnXeQDb3lJL4IxzfacaAM8joRoTCYi/IX4RyVg9+0ywQIFFhBonTImQoSxnkd618TjYK3LZ4ce8MmNY44vnUE4+OMmPOYer6nLx5CoVW+fJLXskUABRGlaB1vZCxoUVvCP7goFW5Q2X6iD7cjXya65lm1Ve83zP23T0X8lu3NeJePVScQ+PQ3SASaMj8xtVLGwWLfqx8aH8SrLsk4Nr+pREAHsxT2r4msaklRPbkfaDKnZmxR2OViV8IBYUnk8kISy21wgND5cwohUBQHQJWKdSgaNbNVPuCYqgDz6P7xMKJh6hh9vuMq0Q4suw/EfJan02Pvv3ivHCUCWe4/JOsejmuL7ij6h/Um/IMUnitRLldHUIYYSsVNF9O0G5amO3vP0XT1X6tQKhdGtx4ANXXGOtDftKo2N7bj3I9BmA5V4jH0uHfi3amKD6XQQp0uri9iwZntBBqwxtc4HUrL5hLpghFsidVuXkkKaUz+nMQCTvyf0u/CwiYpzg7e0EHR26O3xZBbKN+jIG/x7wHrwUJNIdnJBcnktVbL7zgIJijCvVxPbOc7sR9p+i6EvNfwuJY+KlxIckcB0OSdyB6KZSmTDHaGH/AzWb8xO7T7JLWwyM8LWtXLgt5cIU+YVEyivEG2LOYY9lFywWMgNlL77W/acFRYNMLocQUCYdTkUYDEyQnZDVmAiUKpMrTxAQlte7VmW2HujdV/qMpuikcPf+A/fdId363KhqXUtHoF086lioyoCuq6DzhOYCh9kRyzEHOn9xLlgnt+oxxaF6Y1CO/R02DEeCreQ8YsgR3UFwFr1YdgumHs4Zp8Hcv1KW18o/wBBHebGr8w0isvAzvh8xwwVFhl6Q+Z+m6ehcv0v0OAh4XgCEzWoBkL8neDdCAzVv9JWvBDpl7bmS6hNhWj5ji3eb3i8ClFHXimav1cZdEDIcR0tr6lCoeHUsv1GvpUMKmT1lxoOuUsfFSpV78GnssArrvb/AFCsUvNrmiFQoavlDuZwNtzWK/0sfyLhDRbKsh7+WOwF1NNv+Idhi4cWf9QcwR8B28Vj3lQWK65FhaJ9iWYc2/h/AnABarQeY6BQG2WyMUDL7gr7gKcYagUXnOgLeVdzGVCyv4PNUksYAB+ai7SO/hKw7r3MoypV0j8Ah3DTOcNlTH0YX/APDbtAFrHfjycFAe2YYQh91bQw1rLtxo+csK4pXqVp7rtntLK4msb0IsvD/W/hdBsdgdn3AtqooHKnZvmKQikaIcX7tsaDyRwLHLaBLTzmPHf5YITg3zFTuReLV/qV8Bd+0QVa0dhf4hgrcuJ0JV+xiF6XL9DHAROiuTwDGXjQ2uBxplvlHnTH/YxoLt0iDu3U0vBUCF76e0O8/wCUlf5B49k03MPZiXLiyx6RXSrryriHBtNNbE9fwhIUd4paT3ViE8GixdbPOj2iAWI171/UKGi0OMCU5fBQ/wBiR4V8QKoFwyH4guC1JulAfpRNmWTUslkDsGC10ZFnWXVrQV7LiV8UhvPRfljmCC4NV103Ual2xtUg34RlkIoeRhA0lZaLZsoSOWmTGr61LvPHo2Iyxq9X/OZd6KxfNV4DgGJf3ZvORX2qXHAYsABdrqX6mgO8v4gK7IHmv9x4bwjherDly9LrGy/CHAci24A7xTPh8i37mzFmVzBuYYOX0RZfS/S8RlrjoM8fhmVcaxUUJfsRkydZZBTnMW0HU4nQS9FalkBb5XBGw2HXaNZaJ4Xv2gpslWo28MCmJtgkEpoQNnquYwboIKt7IO17hSTBPiZ6uzaj8gQnj2KRG1pz1ZHyszfqCocoeGuscLUSttGGs7uVY07QOHIJQO3GI91NJygyw1+xgm7LlkuG63NUZkKRhcOK+YzFglAGCp5lRxy1pVEvPlEGPV8EQFpSZzJnuipkE2tQ8dYNBZmQpnHGYEyO7dGKIpd4nQgbnXs+uZ8sZtrHDWy/UpEyApNlRj5w0XZh4vNzOJLlYOAPuGEj+4QofLX5h1a1MLdg8jD9Shtkzd47rMr8whCk2VOAO9amnHpG5UPSYWdf0RZeYst6NItirRLMdoqkfCDcYyAE5K37w6I4k1yOiuowQ0Cqs7hDVxkK/oVFH5YS2nKA77xwY9SnsbgR7Myi8EJocBouoQejJaxGBrZLWOgUKm0bxqC0SShG99aEyIquvBcHxAoNzorlTiHbTWM3FU8doKOtL3l6yqdcTvmNHhZlK5hxiH5/0SwvMWXLirBleJQ5fELNkPQ5ziqmI9A30iNszZSD5YE5lGIB1WoClheoyTW8R6AtAqFMxq4jsS1+BlAXx7xB65hLQdFj6p5W3zFRzLQ15plpRXn6SHgA9EfZT9RnTKkC+AImK7gUc1AIiCJfJRAGdx/Yj+xKv+IrCrsi9kzLgQ8gfkmGD0E0R50dPIC4TYYAYCftUT/4gev4nn+JS+ELCQSgt3Y8FiBQ44/MQFqzKD5UJgBQLyju7h+hM/8AER/4hb/Ebf5nUD2lpvArt+vMFUt+vMZRf78zqQECoOJjAE//2Q=="
+    },
+    "type": "object",
+    "properties": {
+      "avatar": {
+        "description": "",
+        "example": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wgARCAEVAOwDASIAAhEBAxEB/8QAHAAAAQUBAQEAAAAAAAAAAAAABQABAgQGBwMI/8QAGgEAAwEBAQEAAAAAAAAAAAAAAAECAwQFBv/aAAwDAQACEAMQAAAB6kyQJJhZ8LmmL7CkiUkkJ0gSXmA314zqx9LToTJMCZMCZmaUVEHjGLU7Y+2HukppoyQceCdao8+2r9QhRT7pLpzTsgfEbfyH8+agxUx06khRImbO20NF2E0XixoSgDQlBpW6dsVlJTajKvLHVvXx+e7vJ/NubXRWc1off4fR2ftxTPXli66b5v0Gn4vnR73zh33OL1Z27sIxeLIwlBqMXiDXKV0VtnabVax45sP4+vj856Hinjz6ImH8uiNs9az9L5yp3PGGAZm+a9Fmdoa9/Adc7ZhBj6Tz4RlDeIwn5tRi8RRu0bwXGdptoTQAa9yh816MefdCxekaXEdDr5WaOZTT+pz+iS9HmzfmQHfN+i1W1WwsC4bd9uOY6Tmim0lYSj7XFDznBqMJDoq3fHELi8ztNpnYBgk8B8HuaEvHz9/RqNC0bPZcr0TplHy+j83zAXKnj9kYvHyOl4xrJ2nzxPadnGna+n8xq7ZvaC9ECHx13xwYSIIp2sZnQeec0w3g3DQIP5HXlaW8G9mLl/Kx2ZUM/qeT+ljsat6PJpeb0h8z6HkE0NnScZqlD0+c6GmG9jlMhA4vZT3kSET5FRJVSUSWejJ2BV/cCw3LJewaLGc+7TbzMcN1pnPdXz/eUe5TlvU4Cr5AOl0aIrlAdBD7TjlvU6SNUWb2ea1DXpD3rxHgXDFxF07Z6qpVgyVQNgtTWeGpCsHlNDyBvpoLonOYLhElzJoj0iOTSuc72mM2fcuD9fxmb3HPCOmRTwG8zVBelcx4ur+Hn6551DAcwIrjdlnODrsc+K2uhZvclMf05WL1LWyCMHLe6A+lkunQwOnE83qC/md1jXrlhHSc75h0TjHZdDj3aOeEgyfTsvaTFaTHaIQjZ47SqUXElpi+G0Vfg6shrZ+uiWD3lLpz55sMAT2YHpWe8CQeztD/AC+nP7eta6spXrz3HItZ7cz3e4F9G4kLr3J+sYpPb8/KGkrfLdZsQqqxXiKhUUVcmGSz1TJAoyQZbn/R8Ju+g8nO6ERrF+RGXa3WV1cCSaV4cf7JidH4RyvQLMj0DDggo9Fxu9C0RFFs48K9iuKoVFFXJdJZ6skgSSDI+XhrNTlHUOS9gp88B7bn1HXzdS3ziZJJZHXYiiziNmF1ejx92+jM6vPm2Fyw0lnNetZqk1Swks5Ls7Z6pJAkoAEqjKeyD7qjjGdJ5P2DkJXYyA4jikkkNzg7S0IH6gseW2oTQNZXVZDeNvdoX85r1bdVzTLCyrksybPVJnBxpEczK5zY4DoWxyHROcquu8Z7VxCTuNoeQxSSrhjbWI6XsAR3hoRg9HntvByrqHI+oWIvUt5z4VrVdzTKDyQiLPGNHSYJY3Y4Sw9zrSibejxWvxg+r8a6TkcNN6fyGozVgGYxe+XP+1YTRaGB6zyvqo+a6TM6qDOaDHdFAn5vGZ8q9jwarEx5Fzei8J0d4oJVLEkeQLRQy0wZu0Ti8z56t08+UvNtkqt1rkAA2mS8nt8N2GN+lzZrNdDGxoP04C64vQo2N8Z+Pp5NeREaTc3oJTaSQeApJHrZSC7JIGdJjRSAXZSQvZJFhJNskgZkmoxSCEUmo3kg/8QALRAAAQQBAgUDBAIDAQAAAAAABAECAwUABhEQEhMUICEyMxUjMDUiMSQ0QSb/2gAIAQEAAQUC8Lew7KOpuJCCfwHHwhoGZEWzz3zfN83XN1zmXGrunhfk9cjTDEfY+b3IxtiSpBWk0c6T8sXt4uTdLYN4rg51GKjcj2eWp3yNhcm6afL7Yr8sPt8LcNpaQhDwJHMrMjkR/lIxsjb+v5XB1G2Rz8qNcjk/HD7eK+iPXdXcGuVqwyc7fGV/O7g1ytWKVJE8F8ofbxm9GLi8Yn8rmO5m8Z12i8GuVqxP6jeK+UHs4zex3iLJsvEr4v8AmLxifyORd0/BB7OMvsdwX+8le2OMQqMhsD+dnCVN4/EsuIVAZ2vZ+Af2cV9UdwdkJ0jTTY+sLUSuaeI/Z/F6cr+BEnShrTpJVu4Fkg09O5zY3czPJcH9nhN6O4TVDnGYkUaSMXZY3czOBbdnrwnjSaEEAiOwxrWtwR/ri+HUVku++DezwKT18gnbt4Et5ovKJ/8ANF3ThI9sbIJ1mx72vli33F+PwJTeN39493I1hcDsKsoYkgY5rB5OSTdN0lYr5Z53yL6LwVcQiJUMso4kHj6bBpN2775JNFG2GHv3XJzocpUl7lcE+Pwcm7XpsvA6viLwOqjgkZE+TIRkYttIREPWXXVmMvIm5WGqY3gqb4ZWQkYJUshkjidIrI0jbKwVxP04VMuLFw61gvdzL6J67B/H4yj8y9tJnavxA8dJE2Vz5o8MKiEiBn7sU+GUCwOBS0Fratg6q1yZ64jHLjRpFwh8IznqR2s9lDELfc615ExLg64Jxk3JyO/pHYH8Xi+WNjkVF4LIxFte3aQBaIZYaiA6kOnzu3I1LAkgGnie4AAZyxp6+F42J0QJjSSdRw9OQxqmVmnX/fVWQ41vI1cdgXxeG+2EDR2C2EbQ82htQIpJBS9ojRDIJK82tKacHajdmdM59jRUxfaGkK7pnRvr6ajNmmMsWP7EYyZC54WywivUQ+7hSeuoJ+qDZIgNpLs/FxcXAfh4zzshRg6vlONHr46Ul5x9DzD2OpReQjTJm7NRh9cTTDZ2yapg3j0z+tJrutbBioMyxm71RJuiX6OQuNYSa6buAdRi9Eynm7usDIfXm6hRJQaAvdP+LjsA+Hh3bXyxBRMfZXjI8YyUwmrrIwVs/wDCu7IZCgBpnDkMc2aIo8isyTlNqqt5OBiQgxWtym2lmorrCBRy6efuK7U43IRpgrZ90P3AAMwUDtQh9KenRC6oiGWvLFnaTA7HYB8Krsls4maaQscQawtZinV9bIY97hKeEGzmIO1LDzg0JHXBvA+3O00T1BdVxfbppCeyc4augs7OQt9fXTGqGNCGzU4u8enzOgUeK0sZjnCFwytnhsIuws5WMNDpJu0JtBELH09KrXux2AfC7ZEk257ZnMOBRsjz7smTK0G9vUSCcqNCA6UrtDbwfuAKwrtjUVJi7G3iGSaaWeWsplfhBcQiLbyLaTRtIgIhePPWkd0HqMXpE6ZI5o9UQbpp2fqB6iaqWFKapUNmLKNMM57xn4D8MkfUyVn3Sw5So4Wv5M1VDvFZlIVSUc/XrreHo2FJP1668CUUuDd45FdLIXXVsITSVlLwUSEZt9FyS6cN642phfTT5iQz2o3dBAEqEVK2M4KlHIjsTRmFj9uTAc1i8rsdgPw42NEcjER/A2FCBZB3Mo9KT7S6oH9NLEfdvo3qKyZI0mf2rUZIa9E2TLoTuIQCVDLekZQxMTxSaoruwtSCNik0yVult1o4qEyWdeRrXLjsdgPw+K/0UxGgUW6WtzH1a0Gfty1OGnVldHBZ2aL3HGVMtxOgVpg3mZqgXdmmyFiNtIGzhQyvFIOlmlBqdvpq4uOx2A/D5WLV5akBxEl0cWwvtGfQNLNRSiJ0XVFon+Vxf6MuE55aOeMewOKEMY6meJA2YmwJu42xE++npv1a4uOx2A/F5akIdCFpfb6dqD9qPs+t0si98rlbclxdQzwvsth4RqvT6b2uoZelW6ch5itQptYiO309TJtVrjsdjsB+Hy1OxZMHiYMMdIppo0fbh6bZhq/58S8zfCwk31Bqh+1fpYdHSajJRxemm7janbsfWt6mnqj9YuOx2PwH4fIjaW01BP0q+ig61jfz9GuqI0jrrVOWxC9ReK4S5s1/ZRfVLCV0VXXnDP7PTibVeqf9ulby1Vdv2a4uOx2A/D4ucjW0c3cWGqnfd04P0hbsp5JAHoFb/sgf9XjdudI+7Z2odMB9PgIniNbdr0ajT/6rVC7nApyg1knVBXHY7HYF8XjYNfIINGwC31G7ezsZ3g1N09ryxU2gsF57CL+LOJb0TUFbM6xL1EanSLj7QHVfpNQsVlZev6lov2g6Vd6tcXHY5MC+LxPKYJAEM8oq0n61jZx9aptBOzNb7GfcNWaNk/CRy5aSN7moh6FeDD3t7Ysc+51WnMSzlggZzGWFu7krQI+kCuLi47A/i8bJkZVtbEdpX0ELJrHUj5WBXir1xXc457WsOfHHKu/CVz4IhUUgslqOFoye2OdGjprKRSdQXpCwg6bbGuM6rrFeC4uOwT4/EGZHXOpZUeNpdu52odupYAzMnBNiYGYN3J1T8mb+mo5ukBpWJFl1BO6GuoBuudDkUv8A6W5jSeupY5Gkyj9WffFxcXFwT418ZR4ZsbGxiGh+sYMs80oUsrvp0ufTyMEHIgf99can8ZBB5cmGaPlmx5UGn2NHdF6R3A8KxtlVzqr34vBcXFwX4183+wPm22XNs2zbF4leo6uysa5vB0aOySvHfkYD4HbF5yELjGq1q4uLgqfbVM2zbOXJoGys+nK1WBytztEXEYiZtm2bZtjmI5Eromr270xw3OkcMcabZtnLnLnLnJnTzpZ0s6GIOm7U2T//xAAnEQACAgEEAgEDBQAAAAAAAAABAgARAxASITEgMBMEIlEUQEFCYf/aAAgBAwEBPwHTrj3qhfmPjK6g1FTdGQr36ByYolTNj2HQCzUAriVMuLbyPNe4NHAYbYRRqJwRq1VzHXafNORMobjbGx2wafULRvRDuFw9TGC6U8yYqTVULdeGA2um4DmZV3pp9P1WthvtjrtNaYn2G477zeuBwvc+VPzGfFe6PnZtMT7W/wAlxyn9p8yoKxwknuVCfcYfUIPAwTEgfuZsWw8StQCYTAL78TDpjybZkfcb8MFA3MigNxrWvXnXvv3j98qluoMLt/Ey4/jO3wEqvPG5Q3HbY5KT9Tk/Mdy5s6YVXIn3TKAGpZhyqnYmZ/kbd7LPn//EACoRAAEDAwMEAQQDAQAAAAAAAAEAAgMEERIhIjEQEyAyQQUUQlEwQFJx/9oACAECAQE/Af6M1U2JQ1TJdBz4STMi9io6iOX1P8Dzi0lSuusrG4VHU95tjz0e7FpcnvLzcoOI1Co6vu7Xc+couwqTlFU7nxnuDhNcHC4UzcoyEekWeYw5UEvdbfznGLrKjdEMhL8qGp7cboyOV9OlyZj0qGdt5am2yF1UPZBOHwqmqw6c/APWSQR+yvfjr9QZjJfo2CRxxAVHJ2pen1JlnByKsTwu26ICR2n6UMncYHBAKpp+8yyhh7TMetdA6UXavtJv8qKnrC3t3sFBQMi15KYL7VVwiSI25TmkKETtN4rplBNO7OpKiYG7Qg35KJv42RbgnDGzgnjUOCcLFYXF01mSYMgvxuna69D0t+02O+rloSQE3eyyaSRihubZav0CZYEtUWjrIbHpvJCA/HoVU1DoLFqoqgSsydyss1wQ5ej1IRG/VBmepRfjtYtWG5UotuCfubknatDkf9o/tFVFMJeFTxdpmCabG6c3bonbmXX1BznMACgfI6IZq/wgM2WUe5uJUZttK9btVy3TyYdCm7G6rGxsjwOkbrFO2vunDI3Cdrqjz5cMUmgCGrij0Zym+hJXqxH1CPPkG7gEdz/+KP2KPRgsudPhONwnegR58Rymeyjso/k9XCzVxYI+oT/gI8+Lf2m+l0HNYAXGy+5ij1c5RS95uSaLmyfq6yl50XyESL6ec0YkbZRt7kQEuq+zhP4pkbYxi3pUzSU82w8qJ7pGBz+VNE6Th1lBGY2Yn+T58//EADwQAAEDAQUHAgMGBQMFAAAAAAEAAgMRBBIhIjETIDJBUWFxEEIjUoEUMDNicqFAQ5GxwQVjgjRTktHh/9oACAEBAAY/AtwXcZHIQz0zaEfcjanMdAFeiOmo6fd6rVa71W8IwCBd7RUfcFzsAE+Q8zgpn+2lP4IjqgH4g8KZK32lNeNHCu/HdrszxIFBrvw34H+DjBddurJGCepVPb0WG8WvaHNPIqH7LFgcKNCvWl2PytQB0Cw/hKhd97t64Lv/AAtdw7tR/C0PP7uo+9O6578GhXoXVC7+rt5u1rm6IFpq13P707l8zF0RNC0qWMakYJrLobUXSFTruEer34YdUGz3c1bpCbI1t7Z6jspQdAfufrun1vscBETXuPQyBjb55+gPqD19Xxu0cKJm0BuR+70ytA8KnXeLXmo5LBfXdrvlvqe2/gq+pdI4Nb1KLrt2P2k+7unUe19MMOS7L67vj1JK/FaOxVGHaScgFV7qvOJQ74KiLQ4Fw1CLAzYx/O7nu1EjP6q7ERJKdAEK8Z4j3V3osEXPkaANcVJJbWOug0jYcBRfZYMoAxP+ECxhdHo70PndI3LxyyfMEJHuvuGiyhXnYuQNkbefXHDkhFNE0SO0c3mU6N8EoeNQn3wA5p/b1xV4fDf1CD3uvkaDksP6rBGGSO69wwOl7wvwGrZQkXyMT0TnzVcwanqUBE3DtosdUfO9VpXJcli5GJodta3Q52l5QOLWhukgHJX5nUH902WoF7pyTvmDr7XdVDaRSOYtx8KS48vkoMeRWIK0WDSuiuyX3OpXAaKsj9m+IF2T39E2WtXPGVvUqN5we1wOHJNns8z9kcHj5SjeqI/c5Ms8DA1gFSen/wBVBp6HzvUe9rT3KwI9KF7a9Kr7Q99AQBVramqkjbgxzcoehaGVL2cXhbGQ/Ck/YoyUzRlXHcUeVOLuIOLa9t1sjnN+HrzwUEEZfRjCLzvcobQ3wnXBi9lQpYHirXt0KELAG/KF1PM+p87wvUdG11cOa29la2/GM7PmanOs5LXEcjoUHmt+N2KxFY5Gq7U1aatcg/no4J7G8PE1fD4y3H6Jpd+G7K5bKCm0l59O6uxyuvs9y2domc4OGCl2L3NeBUEFRPkle4B2NSpI6cQomF38t9CnkYlucINrmjNFDaW4NfxKORuN03gdw+dwXzicAOZW1tBvEcLeTUcBfOIY1WkT47WP+inh6cuqbaGjLJr5RsrtRi1bVo+JFj9E43D9nfz7qKce3KV/zKkis5BaccPauJz3kULnK0WaLFsTLxPdRSdHLsVLGfa5QydsVtQMsuP1Vx2Lm5CuwN146hRyNxANQjZnnuzcPn1MUGd/MjRq2svxJhjfdyRjsmZ/zcgqCr5HlBxdemIoTyUNp9j9VIwdLzUyUYFpQdq1wTrGxraDgf2RJ0fHVOisxPxcDRG75c4p0NlPmRWmvQBSxEaHBRO5gXSmzjSTA+U+zE8WZqePc3MFFBZiL0gxIX2hoyP17FOhlxAN1Dq01aeqbIzn6nyqqIWY/A99DQovoGge0alUBMcfyhCrSyHm5Ua3Ofq4qziaJrGuvAISc2OTWnjjylOLR8OTMEYHcUenhQzAYg3SooGwO1/EdoAvaxv91dbli5N6qvBF8xWyi11PUptpaMW4O8LZOPw5MPqnRO56HoUHaPjcmyMxa4I3NA6+1UPDI1S2SfKScPKLf5jcWlSwOr19T5WKdd0VaVQfbHB35VSMCKIaHmUNrV8craVcrLahxNfRSM5Pas/A/K5OLcXszBRv9taO8J4nAMf8uuiMcNHyDDsFekcXvKElsF1vydVca0vdTCOMYqKZ7NnGMtOycw4teE5h4mFRyc6UPlCdoyya+VJZz7cwUU45ZSnRE4xn9lfpQObqjHJ+Kz9wn2yzvpXUDko3Si68jEeh8oVKLWIMicGPa4OxQ2xDn9h6RTD24FQO9166VGTxNylTNphWoUdcS3KVk/DkxaotqKSUxV2BtQ7E9leOaXm4rZWc3IvdL/gL4TceZ5lMoD7gti8/Ej/cJtpYNMHLYv4JNPKkj92rfKEtNMHBEDFkjcE/27PB9eadG/6HotlFXbN0uoGXj59PU+fQu5ou6+skR9wQrqZaqWHqLwUdoH6SpYDzzBNmiaDJC6/io9u9plk5NW3IOXkPcmPkDo4B/LOrvKw9JANeIJko0GvhEaxyNT4jxNKY/wBwwd5TZ2DB+B8p9ncfzMRtFmdR7BmFNQpIpST7g5EgZjz3D53jRRsOoP8A7qobp5qZuppVRSN5HFOhjdtCRjRWeKpeXNLsVYT/ALu4D0UwAw4x4KNlecW4tTLS3UZXLZE5JP7qVjulR5UcmNRipnAXWllVZy0AZd0+d9jrpNyv1FMUZ7PLcZG7KSMVJAJsg6BYRi/sq1UhPtaoae3Iv9PH+7uFWdtPi7NzvPZMfLg3SvRGxslD5JNLvJOtDps8YvCijjllcbxTWN5MXmFWfxunzvhjNZMPoj+sqb6KOnOL/Cl6Bv8AlXnnETKyO+RxO7Z2x/iuko08wpy1jakUrTUqHtVOA1ebqkfyY2i/4hV6RkKz+N0+d+ytbqXUCawUDWjFOf8AOaNCYxx4G4lWqUDBz8FM7/cUbuo3bEz5UG/M9STmtWZQmRVyRYnyppD7nph6sTm9Q5Wevy7p879mZ/2gXlFoOaTKmV4WZlJjRz8FAG8xVWkfnKg/QN2z7F1+5xuCjhikGyjbVzhyRLRlYMO5TbY9158j8yZ3cVD+hQjqKplRTUfvunzvFztArVKdXaeFA2ugqjM/WTTwnGp2OjQoB+QK0/rKg/QNyzWRhptXZqdFFBY23do67l1KeZXC+7E9lappDWzwC6zu7qrHBpUCqi+qaOjFAPyKN3n++6fO8+OPiflUFnYa3o6OPUp/YAKzRN1eKEoNiAEbGBoAUQ/KFP3emDsBuNe85IY7x7J1oeKRRYRjv1X2SJ3xXHEDorLYAM8zgXlWdvRqivc6lTdsq/TH/hQV6bp87xkf9B1TbfaKNPsYFK9vWgXxBR9AfBVytWmhBQp0Qvml6TFRxOOLuH1ozjKkbHjjmd8xUQ5kXipXudVsbr3lWD5MSrMOZFE0cmNWXEvfVT920CgZ0bunzvWazycIBcQnujArwjsgJReAFfqgI6XHGjioQSCWxNUTurQp2twaHlWJ1avZQtPb1tVpcMaZR2CjbdJvOxopG4tF0hN5tfkKjcdWYpkdKhjg1ODTQyZVJc/HHNw5dk+z2otezijqKbx871qfaiGubgy90UTYjezVNMU91NGKybRx2Zdi1OrmrioWONHNbQhSyjLG7+qoTW62g9WxD+YdVNL0F1OuavN1BzuGLMnPrW8U9zm0q4hSD3NzBMlbUH5OblDK52MWIG8fO9WWJrqdQqMaAOiMsRofy4Lbvdt7mjHlX3TAOPtu6LCSP+i4ov3RdSN2HVcMY+qzYr4kTXeUXQi40n2YJoMjspUxfeMhw05IVwW3uAStPENVe2lVI467/wBfuCieX3D1RPLmltfTELGMeRgibPaXtB5OF5fiw/8Ags07R+lioXF3c7n13brifpgslrtLf+VV/wBbOf6L4kkj/JWG7R2IXw3zM8PWFok/ZUkke4eVkaBvarVarVarEqgX/8QAKBABAAIBAwMEAwEBAQEAAAAAAQARITFBURBhcSCBobGRwdHw4TDx/9oACAEBAAE/IVmZmZlTJoL2OYTD7NT/AONmL3Exvb3GvoXLZbLeZbmK5YrljzJ3n5gbqle+haFdCAt7CVoFy5f/AAe4Hasfa/wCbJB93ofQx6MYx/Kb9Qd0FMZIUqNyPpTk7k0WQPWXUI4c7XA3Rl8q9kdn/wAGPR6M+2PosUlmjUg48s2U2FPwgeeePVq1gDWAusF7yYaT8DyyrdhVy/O/UxjGMZ9voVi7R7/QGBd7j0rRbpFs9kZcv7pnEDqeoxlxjNfz6FZ3jzNMWXEuIBDeHW++3V16AdSDZvudHqejGM1PMepz8zVGOvXhL7Q66vmX6R7CGeg9WMYxjNbz6MvH0vUVCjazFoamiShdmHrXu026PVVeSilzZU7oYxjGMZq+Y9TS5h1IzEULaiIkcD5o7RXH20rXEF23ZkDjrS522Y9GEyGNnvFZS9A0/ULc2vKpoMlK0GVzuYYxjGMejXh9ApxZ+pnIrv8ABPEFmxJMzQNTJA5s61DoOh6MCPgtO2E2qXLELW2lX0M9DGMbLHPZKZKasPopPKOvocQcztpnrjmuR1ZeOjCLLRqAY3jGHEeqURInbWsH0IgOZLxrqnUh9GQjDpPQRB8K3SklM7Y0d92XpF7N9pd3SG8Zq5ozTNSM+p0re0IbDjrRa6GZ8GLG+CWQD3ljugPJA2NRftAAUJ2ZqnLRqW6Hk1G9HQnbhFMJl2rzNPboj6O9B1lL1i3sxr5myxqqCMfK6QslWnBFh5WpUJgIQV2GXWnS0Zj3gUH4TeMIpodZi3suHyS7PboqKGcb8JXMl1eZuX46eTmOiuM76zz3I1/sqBmEfYicI8UaEujHl61sAZ2Ylt+UH1p7xHT9iWTpGbF1UO8keOidr+4kPsBquxHoVbHwPeICv5AXFJELTDHgek8BH6M+InJ+Jq49prIHuxu/Y8NLh9iBYO7+k4jm6f5Q5nYdxI92efnf9mNjLnn7XzDwbI/7Uo0kRT5n1CnDQquasq4elBj3kdouCaDeHQmADPE1jORcOeUfXDWfySiioj2dZQUarubQvgGBxMBSJ2ldj8TMca4lvy9Q2XYh2m6P2Q0mdZ3MkErCF31moxL0rJb2pZmGYy7c8j0qfO+lGpCJTDBV4an5hWODs2/ccbosDxspUYh+SVNFlXmJAFbbmzEOFjt3ecilvZlweoPLqJbCsL+/aXJZGWh3gDawF85YpZXN3I/dbwxDEopeVKYKeMCz+gYBtEiLtrDxtBztYnzAVYCLccej5+T+vQ/DZyzggDap/wAL3hIN3weWUm4FbA2+YM/wb7D/ACFtEwJ7r37m5P6SG6F+up20lc9Xt7QBa7XBxpHc7u6La3NPUIW0bQ3tqLfjGLaqXxL7C+5hYUIYDlJ2JhmgL4jWVa0G/wAYjBzahEroU7JNZ4uz5I6Ot8j+uqEksCzd2Aswf03EYcaS/g5gd88X7YrBYDo7E+EP8MzFuT32mua6fZANVv7Mb1mpraLN+mc1MKOFTTv2hniuXyvmO7C/hGTK0SmwL7HSF+ywQR+LDwgY6/I3hnF/H6/EYxzRdtbxOBctuq3gakBn2lM0jjk4eOr8z+oTLQmxsOSZ/k4JAMkV1jhNfLGndqfULOSaA9y8QuiIHKwKrVeziefCcbR94R77ywN77dQ3UFOzKEmWH/tZZHwjLiZE9D7QxWnUtfEMjSLH8k/x0QYg5Dg7bGYtdX4CXA1Y8axviy/pHoqF4I208jxOQynSn9lJK9xcQHw6Th0er8j+okOmJtg9oSq0Sje4hhew6e8LnGBS/AbS0RBvaL/0mJEWGlTUwmvxKcVe1vMrxsffmNd0vdJgvKupz79I0jfkmP8Ak5JQ3+UOgOoAeNo6sWXd7sovpb7Mt/Nb9MG/zo9msP8ARCzG237brFF4y/qZhsbyhoICuSRQLPX5pmxuJn+pnph0HzP6h5ADY3gADEFhHtgefjUdOVS7zpODqPCEt9Ye4TQ4vbMsz+lf8jyuRo2dyBl6qXmONepcOAaKuy8cTJNtLWv85lCEWrnyMxaA5PP8gcMS/ZluWaPjZjtqTLicaWD2kvNW3Y7kVnLLjiHhxO1xKCi8vv5hVybLd38RlI0KGh6/zP66Dwyho16hx1a7Mqxlo7GJY7j3gmANP+coUMfe3gElA4bzADQNguUidquyHap5u/zz2doAAANjowAqX9zaWSCY87ooa+IZhJw36YN3i9pCbj0m3KJp/gfkhEuYLH9yME3MNOSAi0U709F+Z/XqKlg1iYT0Xe+LIsOijySniik8TaUfs3gHaQZhZzE4qq9E0qZyV9AW3/4iO1P8XZnc6F1NyUANA54jKkNV8JQxuHYRRgepyQYjoO1S24BujV9I/M+vMSvQMJueI/b+SSOoABxXiYgh6DLvNvgQgAsAXlJ5Kvr0NSFoaS6Cm0aEJoVQW/nMTItYXmBdKgdyV6dsMAeIZuBmDb/+Ez837fSvzv69b40t3c3QYJmGFnC+JxeAQbnIw+sZj7zhL4b0qisCB7qQJC61knv4+ImjFCf0QZck2JNRqN3vz6R+Z/UfVqxcXdgo6LfLB+Z8M0IF2FaeIC0Fd9pTwk/M7LD+T03Tob92FdZD4my0HbOstOorN9kcRnX9p2iPuOTqIgTff16Q+Z/UfUNeU7jYmKpKeN5ZRu/1K8LA18wtKpfllIbQzH+K9CoVwRTZ01Aa7zPRDt5OnmHAKA3k+zHjocS0cuf7O8vrc/KJaYQOwq9K/M/RH0shRWsRveg4tiC6siIoavjZqgHCQ3/MH+IxFcTD/Bj0PT3xTC6vXTY5lyivhJLhABsxDH1YDwRX5ftOyjOwh+pbZThXhdQQw/m/qPp4UI8csbFYV5BiG2iCW1eIbzZwopi/3Ox5fEsXL9wmxBPx6BBko/JIZfxC2Cb6j3mcEieY+CWdvxOyzBsiDGXaH1Qj9Vvt9KB+bH0rjbpvKYxx2BywC5XvKlRToKFTdcbiKt0GvxAEqZPGZiXfg11FVboXod5c5Jn6/wAu0FsD3SymzVWcHBBVClHkzKU1fyl36e+1EGG+C3/ILrr5LEunCNnf1ML6WS1ba9o2NgPugK0COlJ5sixxUr7D137x78zviYSxHaaIMTemermSS4NCXUZoF4vMsHkQ2xNLWe5lwwuNUPnEQyEA7ZYTJFbNeZUaBC3KgqIcas80b9D6N87H0govaBaDcL7Sil4VPvESVi+/eItFpG17SmFlHRl4Vd5IKNWpNiDTMGsyHShToE1NpD3liaJfsy4QZl7u0KrbB2JUUxFmHBqfaP1Yqhg/RFpJEZrfLFb+gnomrpcuXGRXoh2wOMRLVxZCZm1REz2YsyxaEXAxIzvLJRokJwTShy2z36mIUQt8Yjl1zZqqbmPagxHg02vmVwhiXD/qWCPDiEACulF2J63dw3nKBfUaeg6kavRekzx0z4abl5Cno8wjfrYas8adD4RcAs5XYywTGWrKvpirJapnyPia6ADCJbnlH7if/Ld4Tbnl9Aa/eLJ5zznlERo7u0zHbKfYimfI/wCJZw3FB8QAMA0Cec8+u/IUyMdPbWr5mMU+4v1B5FjC/wASsePMzznnPKeU843h/wAEf8kf9kRX8xBtSAOAJ//aAAwDAQACAAMAAAAQABcE2CCHyOCJydpKKEu2uG64WbtSUBqCzcuqAmKZrtN6XGbCk0g9MQjTklPzW5E7DkvkgWUKYUlWGi8JQx+HaZHDjWm6IczL6B+WR+Nzo+iAbuCkA6P5NtduyG2hqLpDNZSn7vTwkOjs11DDpjOvkPxmq5/WJdvas9ESiee6pP1wFToqIRqCS6W5W/Ad1hC2ksBWCWd35d9zSBhOd1O6KnrLTkm3S2W1222Qe1ImdfcivqW3UgS6/dDkZ1oqAyxcc/hDghh9CiB8g8//xAAhEQEAAgMBAQADAAMAAAAAAAABABEQITFBIFFhcTCBsf/aAAgBAwEBPxDCdPmg193mgjbprNi4mwaZxn+A0EoCbFM2hxxUQZpEJTEfh8MMOizmEth2xmXSK1+4EOQWeY9fmH4Gm4tkTbwxyGqlZ+eK2A2rsXdool2kYy5OjcpGnOs/ECJrMvK7htlCWHZeRv8AMZVAn6Mx9KsqotMo8ThrYbRojGC4A8YwpkaaiNrbNO4DvzVTzHkvdSrhPLi9wNufZyUsORal1tlHbNGcYdleQVO5eFtQgFphTREgtQ6wlOjbFVmVKolR2XB7N9w0xb3/AKybpAblhamJHlxVzZvA1Fhbh348rDkduCexMMYd+L8lHk7HBPIMeRjD4/MFEI4MGGMMv7hzUMOPcEuMYdzVykiFC5rhf8m5NtQIYFjFDZUY/NZRlFfyVzbO2WzUBp/kf8IDVsNRyJKlZGX8XPK/hz//xAAnEQEAAgIBAwQCAwEBAAAAAAABABEhMUEQUXEgYYGRocHR4fEwsf/aAAgBAgEBPxD11666XMFtmTK7H0Gfg5mIzduf+HsiRmrBlsIPEN9CY4LjhssVspIB4v59L0oPsxRgw2LRpePEJ6mMHyMUWIUb4VDHV5PfodHollSwXEw+oYX9e8O3g49mXz2Z6eyz+Iwmtl+JXNVDRrn/ANI7V2PvCEpnRavt5gBas62HdTEvBLA78QDzZr7/AL6CDyU/roMwXAQNn5Vt8QOZTkdTaqdnb5hVFepkbSWNW+pQ3kvHxbK9/oPBBCjMJDhn6i1IkOlb2188QFg9v8wQUGjUpy3UuR11C8s4MRDe5ywQDko9HeDQ6IgUmA7S1HIYxHFhNOgCG4BB0hWPiDJ2RmSF9jGzjIIF3OLxRlwoYCL2TTU0l4DPDvzHpYNf5FPPHEsI1PrYOUF69/EdaCHgTH5pcJEITDNkK0JVw5mkcKArl5qNe7sr4JfYxV9kP6733x2/mHbzXy9vxF1TULuCIaVxna+7C7JHXoDM7iaBdzKHbrGlgCBb63G1fMwUI69CgBtmLdynhRaO3QXCrmIfZNuboR16M14lrjUNUZs9MDuxyo2IlvvFhmyEddb0rcyttDPmJb3mOmDKuETy4hTHyxYJlXFahHXXG+wlRWzCoW7yygD7h0dW14lR3Rp9sZ70UAdR7tf6hCOvQgTTwnDKafKP94/zK20SiZJNL75hw0twTNALIwhH0c+kDLqQ6M//xAAnEAEAAgIBAwQCAwEBAAAAAAABABEhMUFRYXEQgZGxofAgweHR8f/aAAgBAQABPxBro1L6mX1MvqYlxknUtqZgKA2AunrzLerLerLerLerLerBerLest6/mbwhHZdexETpVht3ILxZFesV6/Et1Z3GPWfmd58x5F8z/hmf66UD7IyQBMHC3cyDTpxzHb6kyoLXoRzA/YNvzFognejHsv8AA/gjMrlAEcCGB0cATJcct7Tj4hr0d+rmOphFLzH6FEv5R29XdpCHRKimfSup56MZIKi/OfEX22Dslw16mvV3QhYHcdNzZULUj4VZuoBTk06jGPoxiizFzHFi3U2+X9QZ9H0fOyuxXYdGDyJkR/mIFYKAVTtB73D2Q16noPKKuCNdNAi1i9OcytjUjZgJ9IN7aCsygc1rkjGMY6mHoUR/ct7RRZ+Udx9B0IXFCd5iscxYIWk3mBggSoGIeoJgGWPLYNCPPeNvMMVD8zgMA+I8xjibYi5iuOVRVcXSZ+b9Ed+q90D0itShZtD61mJPgfDNJz6UBtoe8uwYuYqRMJHRoPz2h0lEqyPoeZp6Vm0c2lXyfog9bu0Iqh2vpXC7xu7jCubfSNPQhVDgs2RauPmG47hlMcnWauSMef4Zbs9DxPzv0R3EjB41p194vScUpjrLW5b1HaIbIpizxY6lnMU9MU25Hkl4Ra3MyGo4uEJ3Daxt9oA4Vlp/dR6fwTjGMCWRpmXk/R6GMOkuiSoDY5nlLV8JDqhdRJD22y0ODoZlBQR0aIVyk6Ki/JZ+YJ4FXvxDXoAR04jJ6Sp3x3mKtl7qLwrpCf0BtedJyi6e0YwURTccdNwnwrZSCmvi/eZhgKz0vETdMeGNAxF0n5D6PUyphesqSjEt2ZYXnmfUWg5zMVsBghxWooyKSqQ9iABxm8+lY7SvWgvcjyJFMQzW9L0+zGVAqWJdPO9Qyz/7AqBQIXVqUWOBT5JT1M+YkdXUtRC6sl4iCgnaK8/L6PQ7iTiVFo1BTO83HeSGo6DK7cy2nLpfR9cKXKcjHNRYjYF46TmPvKcVvVwnE0CAY69ObLNcSsrAGlp+AczCTFFV0ekG6KZXmO/P+j+Co6gtVzI7y6JccndBa9g6xClcWd6I5iBRmUsaPcgUkjdHs6AMSv1pYO/SVWYbPE354d+U4mALnLlItY5YiO1V9SXF0sAsoFPQ6w0uJef+kovBnWwK17RXi1ndla96iJ6rV1lzE47Igj4qOBKqLT0ozfaU87KFqV1lesFoZIYRjoY3G0BTweq20iqhVMHYmdnX9EEqJFndYImTrUcbhIoNNl8SqiHC+DmMjReeuFOWMBkunEPeC4B5EWXzQCZaoxOxpQhoeF1LmosIDv07wnIAfPl1erLyxieeIdVnQuJIaKr/ANp5iy6QVnhTmNEmyahiVTN+sSh/TeByA4HSHGhB2eC5z5gukBbYsUHVGbDsGdwnnvGDaVkHiaPh01cW7q+iPqlyq8RyEpe7OWPENlu9wldUp1KqOIKcNWtE51MB8N20xWqfpUH5+u6bYrLwhplRdFnDmLXIcYCrfYkWp1ZrZsOTYyzkZiAc/wCkpZ29iWv7UQp6Ajvj+omaGOm20d7p4iYIDVXqw4x8kd1NoSgGnJbmAfoTbCnjLAawHgSsqs2D3jdJdxfQtrrxDzEd40BX5ETQMACbIxzf+BHn+FQpv2B7V7h68+pallYT5h9IFKLe25Tzxu0idKmLeIazTQWva2u5R0sivXBoTtxBdAoVh9eDqNVOWN1D+5SVLX1TL4sgG0q0zPjUQpmWOQnUj5EPA51UNFxbtxAXGpPFSOVppNQ81Sq4brJxTWbwRRLtDG2DgoSoSi//AIlPyRC5A5ypEef+S8+dPfk8m3tMzbLe32+OAi44myMdX+BH0qVCLI6rUPucwMph4yuMTOWQpk4DplcMaQzIB3x3m+4hVaaS+sFp+VDAL+R+oY1HXL/BIuizt2gnRjW0I6DMHs4hwyfYU/I1cRURc4FoXlHKFXlpS9qcdWNdCzJYuOkpapaKa+OajK1FBbKvcj/o0kbSJ4isrxR1MP1AyaRN0P0IwsqCOQynuLMIQp3fKhP1qOBun7lMX3KAU1U+E+IaxHHVwWf2qHn0uAmCA2vQQ7VrUJ7fkS/jAQLbo0d4kANUZKgHaEZVRbpmx1gNVQp08+5Ki+Utv5Rz7ws8sNGV09t+zEyVowNCHPSNZqihyyn3lTFm+DCXSM5YaKdGVy0D0DAOA6TYMEQLi3YGZE23c0/hjZiO31B/sMpC/F4lkbNWRZPchDSdq4xfPDAsddyHJ8fUW9ghwNPubhHhdze99RHFta0fq/MdpuzcCj2jo3Hev/KGXUe1OcVPm7EUBYGyno0CGEinWnPc/EuDmtqdegEa8dDgU/sjCCgK/p03K4cVZxLp5lrIXYaT8jKyTV4Q1+WZoHEc6zGrNQgNRFpmx3EgQWTWd835VZMSNLCIyq43iMjLHpu3/cwObnmxtbfeM4uisXWj5/EVjpa5MP1U4FEn7WTrDreGh5MytCbQtHg/WoEwSohtm83ZUO5SUHB9MIMMvKUh4WJYhB6Lv3MM5epy8694HM5T9d0hQaK1l0QtDqZDdNdkO9FAwjABy95glNkTz1vEZIm6azpfbFs9ecFGLUXHzECwyhHVB7wiXMkMmZDRimZajb4+o34ZA4Fr859472rZlWPhxH+WquNh+YC2N9BLdhvsTAPW0FzLQZVY2umxSDnr8alaKKwHYeX8Qs9xN8NpZMuVm1s8MVWGWj8ZemXNoVthtB1tOVaqHuXD+GI98J32SyyuWLbdfcrGd9rpYncYD0p8dYqvspGC4XkGQb8X7haRSOJoqEzeYQtjA/2qFIAmbhD8WDhUa5GgxzmA+QW4XeW17RnXCij4x5gPfuiFD0DgOsUK48BXyvVq5jTaJndiImIycTQvDB3SHcBgeSPahE8rT8NPtBLYqhxZI9erluZambqumuhMKEhSt8A48EVuChvgvwdo16zQQbRodWXQPL7TlOW8xiUdWRDD9MwNoNNNh21KYnKWsAYVGinwbPkplyKAebMPA595f9tEaHK8Xj3msBCueL4Y6EkcaTnqYlEHts8PkafaMCq80c9i7iZR0FJ7cdan5T9t0hwbaSEgAwG7alsKSKb2HzBIKG0eoPo4OlycGS+R+ZxFqtrD8kq4pu86S/aMDZu9l+7jFw2/K6F/CK6Umc/9VxCnXeQDb3lJL4IxzfacaAM8joRoTCYi/IX4RyVg9+0ywQIFFhBonTImQoSxnkd618TjYK3LZ4ce8MmNY44vnUE4+OMmPOYer6nLx5CoVW+fJLXskUABRGlaB1vZCxoUVvCP7goFW5Q2X6iD7cjXya65lm1Ve83zP23T0X8lu3NeJePVScQ+PQ3SASaMj8xtVLGwWLfqx8aH8SrLsk4Nr+pREAHsxT2r4msaklRPbkfaDKnZmxR2OViV8IBYUnk8kISy21wgND5cwohUBQHQJWKdSgaNbNVPuCYqgDz6P7xMKJh6hh9vuMq0Q4suw/EfJan02Pvv3ivHCUCWe4/JOsejmuL7ij6h/Um/IMUnitRLldHUIYYSsVNF9O0G5amO3vP0XT1X6tQKhdGtx4ANXXGOtDftKo2N7bj3I9BmA5V4jH0uHfi3amKD6XQQp0uri9iwZntBBqwxtc4HUrL5hLpghFsidVuXkkKaUz+nMQCTvyf0u/CwiYpzg7e0EHR26O3xZBbKN+jIG/x7wHrwUJNIdnJBcnktVbL7zgIJijCvVxPbOc7sR9p+i6EvNfwuJY+KlxIckcB0OSdyB6KZSmTDHaGH/AzWb8xO7T7JLWwyM8LWtXLgt5cIU+YVEyivEG2LOYY9lFywWMgNlL77W/acFRYNMLocQUCYdTkUYDEyQnZDVmAiUKpMrTxAQlte7VmW2HujdV/qMpuikcPf+A/fdId363KhqXUtHoF086lioyoCuq6DzhOYCh9kRyzEHOn9xLlgnt+oxxaF6Y1CO/R02DEeCreQ8YsgR3UFwFr1YdgumHs4Zp8Hcv1KW18o/wBBHebGr8w0isvAzvh8xwwVFhl6Q+Z+m6ehcv0v0OAh4XgCEzWoBkL8neDdCAzVv9JWvBDpl7bmS6hNhWj5ji3eb3i8ClFHXimav1cZdEDIcR0tr6lCoeHUsv1GvpUMKmT1lxoOuUsfFSpV78GnssArrvb/AFCsUvNrmiFQoavlDuZwNtzWK/0sfyLhDRbKsh7+WOwF1NNv+Idhi4cWf9QcwR8B28Vj3lQWK65FhaJ9iWYc2/h/AnABarQeY6BQG2WyMUDL7gr7gKcYagUXnOgLeVdzGVCyv4PNUksYAB+ai7SO/hKw7r3MoypV0j8Ah3DTOcNlTH0YX/APDbtAFrHfjycFAe2YYQh91bQw1rLtxo+csK4pXqVp7rtntLK4msb0IsvD/W/hdBsdgdn3AtqooHKnZvmKQikaIcX7tsaDyRwLHLaBLTzmPHf5YITg3zFTuReLV/qV8Bd+0QVa0dhf4hgrcuJ0JV+xiF6XL9DHAROiuTwDGXjQ2uBxplvlHnTH/YxoLt0iDu3U0vBUCF76e0O8/wCUlf5B49k03MPZiXLiyx6RXSrryriHBtNNbE9fwhIUd4paT3ViE8GixdbPOj2iAWI171/UKGi0OMCU5fBQ/wBiR4V8QKoFwyH4guC1JulAfpRNmWTUslkDsGC10ZFnWXVrQV7LiV8UhvPRfljmCC4NV103Ual2xtUg34RlkIoeRhA0lZaLZsoSOWmTGr61LvPHo2Iyxq9X/OZd6KxfNV4DgGJf3ZvORX2qXHAYsABdrqX6mgO8v4gK7IHmv9x4bwjherDly9LrGy/CHAci24A7xTPh8i37mzFmVzBuYYOX0RZfS/S8RlrjoM8fhmVcaxUUJfsRkydZZBTnMW0HU4nQS9FalkBb5XBGw2HXaNZaJ4Xv2gpslWo28MCmJtgkEpoQNnquYwboIKt7IO17hSTBPiZ6uzaj8gQnj2KRG1pz1ZHyszfqCocoeGuscLUSttGGs7uVY07QOHIJQO3GI91NJygyw1+xgm7LlkuG63NUZkKRhcOK+YzFglAGCp5lRxy1pVEvPlEGPV8EQFpSZzJnuipkE2tQ8dYNBZmQpnHGYEyO7dGKIpd4nQgbnXs+uZ8sZtrHDWy/UpEyApNlRj5w0XZh4vNzOJLlYOAPuGEj+4QofLX5h1a1MLdg8jD9Shtkzd47rMr8whCk2VOAO9amnHpG5UPSYWdf0RZeYst6NItirRLMdoqkfCDcYyAE5K37w6I4k1yOiuowQ0Cqs7hDVxkK/oVFH5YS2nKA77xwY9SnsbgR7Myi8EJocBouoQejJaxGBrZLWOgUKm0bxqC0SShG99aEyIquvBcHxAoNzorlTiHbTWM3FU8doKOtL3l6yqdcTvmNHhZlK5hxiH5/0SwvMWXLirBleJQ5fELNkPQ5ziqmI9A30iNszZSD5YE5lGIB1WoClheoyTW8R6AtAqFMxq4jsS1+BlAXx7xB65hLQdFj6p5W3zFRzLQ15plpRXn6SHgA9EfZT9RnTKkC+AImK7gUc1AIiCJfJRAGdx/Yj+xKv+IrCrsi9kzLgQ8gfkmGD0E0R50dPIC4TYYAYCftUT/4gev4nn+JS+ELCQSgt3Y8FiBQ44/MQFqzKD5UJgBQLyju7h+hM/8AER/4hb/Ebf5nUD2lpvArt+vMFUt+vMZRf78zqQECoOJjAE//2Q==",
+        "type": "string"
+      }
+    },
+    "required": [
+      "avatar"
+    ]
+  },
+  "Bananas": {
+    "title": "Banana's",
+    "example": {
+      "tiny": "Qmch37wDEe6oBZRhv51Wyikkit8tMBhPJ2LNmDUrnaxJ4L",
+      "small": "QmQZhwKzVq7Q2LbenFix7JUddt6ccoKWaP37TFr4RdhWBS",
+      "medium": "Qmc8shT1LDst8zvLcbkDmSDUWGdbPzAQJLs5XtvfFfSH2Y",
+      "large": "QmdERoscyWTiEpcrMpytuPUkkAMhViueCABepJdaDJDNXd",
+      "original": "QmUQmMHqpFR2SN6s5iNktUBHgBnzxpH9862pCDpNKnA5Vd"
+    },
+    "type": "object",
+    "properties": {
+      "tiny": {
+        "description": "",
+        "example": "Qmch37wDEe6oBZRhv51Wyikkit8tMBhPJ2LNmDUrnaxJ4L",
+        "type": "string"
+      },
+      "small": {
+        "description": "",
+        "example": "QmQZhwKzVq7Q2LbenFix7JUddt6ccoKWaP37TFr4RdhWBS",
+        "type": "string"
+      },
+      "medium": {
+        "description": "",
+        "example": "Qmc8shT1LDst8zvLcbkDmSDUWGdbPzAQJLs5XtvfFfSH2Y",
+        "type": "string"
+      },
+      "large": {
+        "description": "",
+        "example": "QmdERoscyWTiEpcrMpytuPUkkAMhViueCABepJdaDJDNXd",
+        "type": "string"
+      },
+      "original": {
+        "description": "",
+        "example": "QmUQmMHqpFR2SN6s5iNktUBHgBnzxpH9862pCDpNKnA5Vd",
+        "type": "string"
+      }
+    },
+    "required": [
+      "tiny",
+      "small",
+      "medium",
+      "large",
+      "original"
+    ]
+  },
+  "SetTheHeaderrequest": {
+    "title": "Set the headerRequest",
+    "example": {
+      "header": "/9j/4QAYRXhpZgAASUkqAAgAAAAAAAAAAAAAAP/sABFEdWNreQABAAQAAAA8AAD/4QPVaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLwA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/PiA8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjMtYzAxMSA2Ni4xNDU2NjEsIDIwMTIvMDIvMDYtMTQ6NTY6MjcgICAgICAgICI+IDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+IDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcFJpZ2h0cz0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3JpZ2h0cy8iIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iIHhtcFJpZ2h0czpNYXJrZWQ9IkZhbHNlIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOkYzRjk3OEZFRUQ2QzExRTI5OEZGOEFGQjE3ODRGN0Q5IiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOkYzRjk3OEZERUQ2QzExRTI5OEZGOEFGQjE3ODRGN0Q5IiB4bXA6Q3JlYXRvclRvb2w9IkFkb2JlIFBob3Rvc2hvcCA3LjAiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0idXVpZDoyN2JkN2M2Ny1jZGU0LTExZDktOWNlNS1hMDYxYTA5YTA0NDciIHN0UmVmOmRvY3VtZW50SUQ9ImFkb2JlOmRvY2lkOnBob3Rvc2hvcDplNzQ4ZWE4Yi1jZDk3LTExZDktYjlkYS1lYzFjMmJlMGIyNmYiLz4gPGRjOmNyZWF0b3I+IDxyZGY6U2VxLz4gPC9kYzpjcmVhdG9yPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pv/tAEhQaG90b3Nob3AgMy4wADhCSU0EBAAAAAAADxwBWgADGyVHHAIAAAIAAgA4QklNBCUAAAAAABD84R+JyLfJeC80YjQHWHfr/+4ADkFkb2JlAGTAAAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoKDBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8AAEQgBQAK8AwERAAIRAQMRAf/EALIAAQACAwEBAQAAAAAAAAAAAAACAwEEBgUHCAEBAAMBAQEBAAAAAAAAAAAAAAECAwQFBgcQAAIBAwIDBQUEBwQJBAMBAAABAhEDBCExQRIFUWFxEwaBkSIyB6GxQhTB0VJicoIj4ZIzRPDxotJDY3MkFcJTRQiTVBYXEQEAAgIABAMGBQMEAgEFAAAAAQIRAyExEgRBUQVhcZGhIjKB0UJSE7EUBvDhYjNyFcGCosJTJP/aAAwDAQACEQMRAD8A/VIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGLlyFuErlyShCKrKUnRJLi2JnA5XN9f4dq/wAmNYd+0nrdcuTm/hTT072eJt9cpFsUjrjz5O2nZWmOM4bGF676PfX9aNzHfHmjzRVO+NfuNNPrWi/PNffCtuzvHLi9/HyLGRZhfsXI3bNxVhci6prxR6tbRaMxxhyzExOJWFkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxKUYxcpNKKVW3okkJnA+d+rPVH56fkY8munwfDR3ZLi/3VwPlvUe+ndPTX/rj/wC7/b+r1+27bo4z939P93K3suMq8j5mqKfMkq1VdDgmMRwdXSjZyqpyi3HlXNyyVHv2mGOCs1dT6N6tk4GdySm5dPypqNy0/wDhznpG5Hsq9JHqek91bXfpmfot8pcvdaotXP6ofSD6t5QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOC9d+p5O/c6TjypZtR5syaesnv5fgt37j571Xu5tb+GvKPu/L8/g9Ls9OPrn8PzcDfzbl1Pk15Hy0T2r29x5taZ5eD0Y4Ne2n5Tkm1yLmcn4lba8VzC2eLchelKUZQj/jw5XadWk940prrTRMwvafD9UKzV03pboeV1DIdpxdqxCUXkzWqSi+ZKL7Z8Ow6vT+yndfHKtZjP4eEe/5OXuNsUj2vqJ9k8YAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANXqvULPTum5OdedLePblcffRaL2vQz27IpWbTyhalZtMRD89v1JDK6rfs3Yyj1B3PzMZvSFznq5Qrx3PjKXm2bz902y96tcR7Flydtt+W5RuRhy25J6KjrGtVR761N4mPBbLFl3b/lxUncc0m4/DFKS+bl7e6vAyveZx4pzEOk9OdNu5N6Nu3SV2U1qtUp104Lh7jHVW228Vrzmfgy27YiMy+u9L6dY6fhwxrWqjrOb3lJ7yZ9r2+iuqkUr4PE2Xm05ltGygAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfOPrJ6ghj4GN0WE+W7mN3byW/l2/lX80vuPF9a34pGuP1c/d/r+jt7OnGbeT4veyZq4pV95850vRiyL6pejFqMmq0r7CYiUTse16etX8qTnfuzdv8AGtFVJ1pUy2TlnN8vsX096WvLnnyjSMa27C4d79mx7voHbcJ2z7q+5x93flV2p9I4gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxKUYxcpNKMVVt6JJAfm71r6jl1nruXnJ1tTnyY/dZhpDTv39p8Z3e/wDl2zbw8Pc9nXTorEOUvXG3UywmZwrsKV68ox7aMW4QytL6N6d6c6WMa2qzm0nTte1DitE2mKxztOCOHN9y6bhW8LBs4sFpaik2uL4v3n3/AG+mNVIpHKsPMvbqnLZNlQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4r6r+pP/ABPpuWLany5fUq2Y03Vqn9WXufL7TzfVO4/j1Yjnbh+bq7TX1Wz4Q/Pl+826M+XrD0JlpXZ/bsaxDOZe16XwfNyFcnrGOv8AYYbrKw+vfTjpiyepzypR/p4ey4czVI/rOr0Xt/5O4655Uj5zw/Nn3FsUx5vpp9k88AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMSlGEXKTUYxVZSeiSXFgfnD6geqH1/r9/KhKuJb/o4S7LUG/i/nfxHx/fdz/NtmY+2OEPZ1a+imPFx12fvOeqJUxi5ypv3IvM4Zy7voOEsfEtr8c9WvuODbfHFasPtnobp35ToVuclS5kt3ZdtNor3I+r9C7fo7eLeN/q/L5OLurZvjydAey5gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+efV71fHp3TF0TEu8ud1CL/MOL1t420vB3PlXtPJ9V7vop0R91v6O3s9PVPVPKHwq/cTemkVt4HzMQ9CWjclzLmda8EbVhlL0vT3TpZeZbT+WtZeBltt4KY4vo/ScF5GXC1Haqjp7jitWdlopHjOGscIy+049mNmxbsxVI24qKp3Kh+i66RWsVjlDxpnM5WF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADh/qB9Uuk+l7bw8amd1u4qW8WL+G03tK9JfKv3d2cPd99XVGI42dWjtZvxnhV8I6h1PMzsm/nZ95387Klz37z4vgkuEYrRI+U2bLbLTa3N6sViIxHJ5zm23XbgMIwgoc0ktycs7Q7X01grHwpX5LWWz7kcd785K1fRvQ3TnPNszktq3JP8Ah2r7Ts9F09fcVmfCJn8lO7nFJfSD7h5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABRn5+F0/EuZebfhjY1pc1y9ckoxS8WVveKxmZxC1azacQ+N+tvrNmZquYPprmxcR1jPqUlS7Nf8mL+RfvPXwPB7v1WZ+nX8Xp6eyivG/GfJ8e6nlRtxm3crek3Jzbq67uTb3PM11mZzLrmWlgdctZSpC4p03cXXY02aJqiHpwuKS09rMJhOHp9IwZZWRC3FayZz7r4hTpfRrWEoTt4sVokl2Kq3OO0fpXrD6L6KxVbhdnSnLGMUnvr/qPov8AHtf1Xt7ocPfzyh1B9Q80AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAByXrT6ldC9MRePJ/nerNVt4FlrmVdndltCP29xx913tNMceNvJ1aO1ts48q+b4h6k9T9b9SZSyer3+a3Bt2MO3VWLX8MeL/elqfMdz3l908Z4PX1aa64xV4ORc/DEwrCzzsjAjdUnNLl4t9htXZhHS1sb0/Zxk5WoUlJ1bWhe3cTbmdLZtWLsXR7V0KTaE9LvfQvTJ3bzvNaWo82vaedunqtjyVmHa4+PXNi+EdSkfctEcHb+mLvJdnZenmQqvGL/Uz6H/AB6+LXr7ped39eUuiPp3mgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfJPqL9X/KuXui+l7qnkRbhmdVjSULTW8LPCU+2W0fHbyO+9Sima0+56Xa9nn6r8vJ8mjF80rs5SnduNzuXJtynKT3cpPVs+btabTmXpo3bsqOMd+8RAjbt8+vYxKcNuxYUn8uj4MrMpw2beLanbUofK9vBFZlOEH0yM7i+HWtUVtsxCYh9M9I9I/LdMUpRpK9q/BGGmM5tPiyvzexDDcbuiqmlr2eJfomDL1MF3LPUsW9zUtRbjcj28+lTu7DZOruKW8J4T+P+7l7iItrmPF159u8UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMTnC3CU5yUIQTlKUnRJLVttgfCvqT9XrnV3e6H6Zuu30zWGb1SDpK+tnbsPdW+2f4tlpv4nf+o/pp8Xq9r2ePqv8HzzHhbtwUIpJR2SPn5nL0Upza0b1eyEQjCqsILnk6Kur8S3NaIbcLack+K217TOZTD0bFutElqUmU4b8Lfw0KTJENrpuI7+XbilrKS+0491+C76lasRswhbiqKEVFew9WmuKxEeThm0ysSVSejMImVjjWLXH9KK7K8Fcuoxbvm41q5vzxTfjQ+207OukW84eNeuJmFpqqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVZeZi4eLdy8u9DHxrEXO9euSUYQjHVuUnokJlMRl+d/qR9VMv1dcudK6RKeN6Zi6XLmsLmbTjLjGz2R3lu+w8HvvUM/TTk9bte16Pqt939HIWLELaqklw5eB4dpy718moxrx4dxUUpVevvLJWwjRETI3LMdUUlaHo48NE6arh+kzlLccZaKNFqm69nEztKYdH6PxFdz1ckqwtVk692xhqrFtsRPKOKu2cVdtDzFH+pLnlV1klSuumngevSOHFx29jPmQ8xW26TknJR4tLdjqiJivijE4yuixeOCkOh6Q2+nWa9jS8Ks+p9Nn/+enueXv8AvluHayAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaPW+udK6H0y/1TquTDEwcaPNdvTencklrKT2UVqyLWiIzKa1mZxD81+vPqP1b11leWoTwvTdqVcXp7fx3mtruTTRv9mG0e9nz/AH3fTeemv2vZ7btopxn7ni2LCjHhoeNazrbCgoxr2aoplMKp8z1+xFoSlCKSEpX24NupWZS3LNutF2lZlL08e20u3xM5kXxcXOME/jnWipwRhsngvEO59M4ccbE5/wAdz7ka9rr4dU85c+62Ze4pJUq6d7O7OGEQkmaVnKlowsi1Rv2ldk4rKsQ6bpkHHp9hPfkT9+p9X2NOnRSP+MPK3Tm8z7WydTMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADn/AFn656B6Q6Z+e6refPcrHEw7dJX780q8tuH3t6LiZ7dtaRmzTVqtecQ/N3q31b6g9a9UjndWfk4llt4HSrbbtWV+1L9u6+M37KI+c7zvp2Tj9L2tHb11xw5tXHxVFJ00Wx5lrOjDaVuiq3TuM8pRdZOmxKRKNaLwdO7tJMJxh7akZThfC3NU5VXaqe1CuUt/Hs1a7CkyN63FKi+0ztOEw9Po/T45OS1JPy1rJLRswrHVbCbWxDucZKFtJbR7qaHpVhyWXRnGS5uG6bX6ybYlEQui9DSkqWhYk5Ugvmm1Fe10ItWbzFI52mIUmcRM+Tr4QUIRgtopJew+2iMRh4sskgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPnn1C+sXSfTcrnTOlxj1T1AtHjRl/Rx325E1t/Avifccfc95XVHtdfb9pbZxnhV8Fzsjq3WuqXOrdYyZ5vUb2juT0jCFfktQWkILsR833HdW2TmZexTVWsYq2rOMopNrU4rWaYXwg3XTRfaUmVsMyhXT3iJGOTcnJgjbSboqN7tcRlK6Fp124aPgVynDZtWm9lsVmyG7agoUXbsVyls2rbnKKWtdNO8wvZaHZ9FwfIsKMqebSsqab7HVo14j2sNlsvWUkpKNHy/ilwVDozjgywouXsh3o242pcsq/1YcrUV2urMrWmZ5NK1jDdx7fLD4nKTT3lxpxojXVThxY3t5PV6Nj+dnRk1WFhc7f7z0ier6Xp6902nlSPnP+zi7q+K483Rn0rzQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1updT6f0zCu53UMi3i4llc12/dkoxivFkWtERmU1rMziHxD1z9Zer9adzp3pZ3OndMb5bnVWnHJvLj5MXrai/2n8XgeJ3fqsR9NPi9Xt+wiON/g+fYfTLVmPLbjq3WUnq23u23u2eDfbMzmXpYehbxUuBjN1sLvKSWvsM+pOGPLda8N0icjDty7Fy8Vx7iYkPLGRbGytCMjYt2KrtKdQ2YW1GNKalYlK2MddOOxW1kug9P9NUrqu3FRQ1ilxI006rZnwU2WxDppeZFJQgnquZt004tHoTnwc8YYhcncuzsqPLbgvjntXjRGfVMzNfBbGIytxLXxO5KKWtINOviWpTMovbENxySVeC7DptOIc/N0/SMN4uIlNf1bnx3O5vh7EfUdh238OqKz93Ofe8rfs67Z8G6djEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcN6z+rHQ+gzuYOCv/ACnWY1i8a1L+nal/z7uqj/Cqy7ji7rv9ennOZ8nX2/Z32ceVXxfr3V+vep8xZfXch3+Vt4+HCsMezXhC3V1f70qs+b7rv77Z4ziHs6dFdcYr8VdvColpRI8+btsNq3i8EvaZW2JwtdqNuNFrLtMurKcKfLb149ppkS5KcCOoHa7PcTFgVvR6DqGxbstUb4lJtkbMLaiqviSHK2+4rMph6HTun3ciacY8eP6DOIm04hEzh2OJZjasqEEqR0oj0KVxGI5Oa0rHci6pOqjvTepabGDGspLmo4zk05Kqq6aUZGunj5ptZuwiopJbcDprXEOe1svS6LhfmMrzZr+jYde5z4L2bnoem9v/AC7euftpy/8AL/b+rl7nZ016Y5z/AEdKfSvNAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPF9Q+sPT/QLdeo5Sjfarbxbfx3p+EFr7XoYb+616ozacNtXb32T9MPk/qj6iepevxnjYvN0npcqxlbtS/7i5F/t3V8qfZD3nzvdes2vw18Ievo7GlONvqn5OVsdMtWYqNuCjFa0R4trzPGXa2beItFTUznYnDZjh0Xx6LsMJ2ZWwNKKolQhKvy6k5Qx5XcMjDtrYnIK33ajJhbaxqvYiZF8bNFT3FoQOroyJsmIX4mLK9c5V7TOZ44hM8HWdN6fDHhSKVZb6tnbq1Yc97ZbsbMlPm53y0SUFRJUOmK4ZzKlKdy7J26u2+LaUVKOnwx31MvunhyX5RxbuPblGOun3+06ddWN7NmzauXbsLVpVuTdIr9L7ka9Nr2ilfut/qZ/BjNorE2nlDrsPFt4uPCzDaK1fFt7t+J9Zo0V1UileUPJvebTmVxsoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABz3XPXvpvpEpWruR+Zy1/lMVebc/mo+WP8AM0cnc99q0/db8HTp7TZs5Rw83Adc+o/qbqfNawUuk4r4wauZDXfNrlj/ACr2nz/c+u3tw1x0x5+L09Pp1K8bfVPycrHCrcldm3cvXHW5dm3Kcn2uUtWeLe9rTm05l3xwjELo41NKFJsLIYUnvojC25ZONi1bl8Cq3q29dTLMzzSjOFX2loFbtVlVblsiPIqdlRkY5NwMO3rTj2DIlCxs3uMjZhb5d/cEI3G26UWmxM2IhPHxpXJKMVVtmVrccJdBg9LjDlclSSdd6aLw3OjTp82VrvUT5JKMNbiVVBOldNFXhU7o4cmPNm9O5OStx0clrxp7SLzMziE1jHFbhxk4Pmjy8snFa1qlx9ppqjgpsnDZbSVftN7WisZljzl0fQ+mvHtvIvRpfur4Y/sw7PF8T3/S+znXXrv/ANlvlHl+fted3O7qnEfbD1T1XKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGj1LrvR+mRrnZdqw+EJS+N+EFWT9xlt301xm8xDTXpvf7Yy5TqX1Nt0cOkYM78tlfyK2ra/l1m/cjxd/+Qaq8NcTefk79fplp++cOT6r1r1J1bmhnZsljy/yuPWzb8Hyvml/NI8XuPVe428M9NfY9DV2uqnKMz5y86z063CPLCCit9FQ87HHMuibLPyNfl1lw8SJsjKUcJ0Tno+KRjbdEclsJxsxgtFrvUx65snCuabrTSpMCrk0bSr2FokY5a6vf3E5GHCNeFXuiYGJW6p6VdKkiry3x8KDKU42W6Nb9naQZW+VyptqrS1QQjKLlOLT+Fr5e/wARkTs40rk6RW5lN/BL2cfCyLEceWPbhd5rjjkc0lFwt8rfOk/n10odWnViuc/UytbMvWt2lFKrrT7zsrXDKZS54xbolzvShab496MJQtSclrRbtrtFaSTZswjGMUlojrrGIYWnMvV6F015NxZV2P8A29t1tJ/jkvxeCPQ9M7T+W0bbfZH2x5z+73eXxcvdbumOiOfj+TpD6R5oAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADTyusdKxVXIy7NunCU4191amOzuNdPutEe+WlNV7comXlZHrrodt8tjzsuT28m26f3pcqPP2+udtXlbqn/jGXVX0/bPOMe95WR676rc0w8C3Zj+3kTc3/dgl955+z/IZn7Nf42dFPTY/Vb4PGzOr+os2qyOoThbaa8uwlZjTjVx+L7TzdvqfdbOE26Y/wCP5uuna6q8q597zbfT7EJOSgud/NN6y9snqedamZzac+90dU4XRxHPaL2JzCGVgUXxNL7TO14gHZtx05avtexjbatEI8jrXRRfZ2oymJnjKyuUOx+wYMqpwim6aoYgUzh8T+4sKoxbTdOV70YSwoqSa0ZMDDjHSPElDKttfrARxo/LFbcRlOU3bVGnx3YQjPSnuaKzZOCzjyuT+FGeZnhCeT2sPBjbt1l8z29u506tOOfNlazft21HdbKleJ10phnMsu5GEa97ouLZpNoiEYZx7TnJzuL4pcOCXBDVrmZ6p5lrY4Q3IpJdnYdUVYzLc6X06efe1TWJbf8AVn+0/wBiP6Tq7PtJ7m3H/qjn/wAvZHs8/g59+7+OP+X9HWQhGEFCCUYxVIxWySPrIiIjEPJlkkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK5ZOPH5rsF4ySKzaI5ymKzKD6hgL/ADNr+/H9ZnPca452r8YXjVbylVPrHSofNl2l/MmUt3mmOd6/GExovP6Z+CD690ZKv5u2/B1MZ9U7b/8AZX4r/wBrt/bKL9RdHX+YX92X6ik+r9rH64+aY7Pb+1XL1N0qO0rku9W5P9BS3rXbR+qZ90T+S0djtnw+amfq3p6ry2r03/Cl97Mp9e0eEXn8PzXj0/Z5x8WvP1fL/h4UvGc4r7uY57f5BHhrt+MxH5tI9O87NW56q6tL5Ldi14803/6Tnt67unlWse+ZlrHp9PGZlp3usdevVTzXBPSlqEY/bqzlv6p3Vv1xHur+bava6o/T8ZaV61fvr/uMi9d7ee5Jp07q0OS+3bf7r3n8W9a1ryrEfgpWBiw+LkjH96n6TCdVOcr9crli9ldXTRFuEK5S/J6aadwyZUzxppqk1TtSr7DG1rea0YZVtRWsa9rK9U+KSTfKnqqarhqZSKbybhOSq2k6KOrb3oitoTCmK5oKVOVSVWmtV4kRCZRcYx1rXTXxGBi5B8tHv/psTjhyGvdjTb39pPQlVy1ppURCVXlNPUgRdpRbkvxOvdoRMpZ8rmexMVyhJQonUnAnRRXK9ewgUyeur1WzM7WTEM2bE7s3VJR4P9ZnzTPB6uLixtwrJVpxOjXSIhnact6HDu4dlTrrHFnKblGEHJ8DbPTCuMoW7avvn/Dw7OwitYtxTM4b0IpUS2OusMJls4GBfz7/AJVtuNmH+Ne7F+yv3mdHa9rbuLdMcKR91v8A8Y9vnPgx3bo1xnx8I/8Al11ixasWYWbUeW3BUjFH1uvXWlYrWMVh5NrTaczzTLqgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABiUoxi5SaUVq29EB4ud6z9O4cnCWXG9djvasf1X/s6facG/1PRq524+UcXVr7Pbbw4e3g8TK+o0pp/kMJuKr/AFL0tdOHJCrr7Tydv+Q5/wCuk/8A1flDrp6Z+63webd9U+ocqWuXGzGW0LMFF+98zOG/qfdbP1RX3R+bpr2mmvhn3qebLvut/Ku3WnV805P7KnJedl/vvefxbRFa8qxH4JLHtLgq9rVVXvMp008fmt1y1rmdgY1+ML1+y1c0hHaVVvQrNNcccQtEWnzejiSxsiDlZSklo2tKNF6dE8YiFLZjm2lYhpoaRjyUyl5UKonMI4jtR7dvt8SJsQi7PM6Oi7XTUpPFbLEca0tyOmCbJq1aWy34jgjMpKEV3smEZZaj2AKU/SQK7SveX/XcXOrq4VUaV037itYnH1JnHgw6OvLqVsmEXbXFV7GRNU5VShJKqVdfiXiZ9MrZVXFBxVKSi99dCtqxKYUr5tKv7qUKRCyU7aktnsW6UZUXLUlvtulsVmiYlF227a7Y7P8ASTEcBWsdybfdTlJrGU5U3YShNRo5Kf4lsqa6+JWc5TCM4Kmj0W74kCuVtUaS0KJEktK0kvcWgYk3rXhsRNjCuUq+PEytZaIWWcSU6yknyr31IrrmYzKJs9CxYhGLrouJvSikyvi1zV4LaPabVVlZCao5PRPX+w2r7VZVpSyL1KUhHbXQiIm8+xMz0w9CEYxSottjrrEQxmW1h4d/Nv8AkWfhSo7t7hBP/wBT4I6O27e++/RThEfdby9n/lPy5sNu2KRmfwj/AF4OuxMWzi2I2LMaQj72+Lfez6/TprqpFKxiIePe82nM81pqqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPE6t6z9P9MbhdyfPyF/l8debc90dF/M0ce/v9Or7rRny8XRq7XZflHBynUPqN1vIk4dPxLeFZ4X7786612q3CkI+2TPG3+vTP/XX8Z/J36/Tqx9059zwsvK6l1H4s/LvZNdeVy5bar2QjSP2Hjb+527f+y8z7OUO3XrrT7YwWcX4VGEUo+HBGMRERwXmWzDHjRp0TdaVZM3hGE1j2FGkqa/MkZ2vC0ZTxOn41m+78bt6UpVSjOdYJN7KOxFZjwTNpmHpbxUaRcW6XFJVqu4txlmg+n4c3TyYx5dnyqq7qiKRyT1y2bWOrcUofDHii3ThWbZX8Ny+FBuKeu/YTmATTdGqdiYjEks1WoQw6cRMJU5MMylt4rtpq5F3vNTadr8ajy7S7CJqmsx4tilN9kW6cKsSapputiJIUXMqFtpXE4c2ibWj9qMpvEc+C8UzyRvXZuNt24qcJSpOSa0jTfv1LeWDHmzjJx5uZ+0vKqVZJdnjw7TPishLZ6010ZEwmGv5MbcVC3BRin8MV2t1Zn0YXzklbkm68aaLgTNDKUFHko1otyK4wiUXa+Jp68UOniZVuEdE1oVwshG2uXVfFXWuzaKxUyxO0pKtNGqJ8NCZgiWrfguaq8PHQpaq0KHJJ8ko693eVmYjglVJvV7uu5la60QrSlJpbU4mXVlK61jRhWSXzOrb7djSIjmrNm5bcW60pFbtG0cZzhRNTbq3xXyloE1KirJ6bmteHFCNJ3prhFCYm0+xHJv2rcYRSXtZ10riGVpyvw8fIzctY2Mqta3bj+W3F8Zd/Yjo7fRfffop+Nv2/wC/lH4stuyNdcz+EebtMLCsYePGxZXwx3k95Pi33s+w7ft6aaRSkYiP9Zn2vF2bJvOZXm6gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADnfWv1D9HeicGzm+pupW+n2sibt48WpzuXJJVfJbtqU3Ti6UXEiZwtWsy4u9/wDYH03nW5S9OeXnRWjvXLkY0f8A0k+f30PH7r1S1JxWk5/5OzX2eeMz8HkZHqjrHXl/32bcjYf+XsvyrbXeo6y9rPC7jv8Adf7rTjyjg9DVqpT7Y+JYxcW0qQTXb2HlW2xHJ1ZmebfseQ2korTav3kV35T0r27UealObi0uzYtOxGFbvSXjxKzeVsI+bXXjx8CvMWRcnTXTT7ewv0obVpqtW9V7i9YRLbtSa/04dhrVSVsZcK+3sJRhPmb02/UShn4dKt0fuImA5rcdVVLjLahHCDiy7lpUk99kTNq8zEsxu83yqvfwIi+eRNcMylcboktdpCZtyhERCi427kbTvO3O6nyw/FLlXxcqZnNZmcZmMrxyzhbatKCa1eii69xpTXEKzOVqeunvNFUZLmTT1T3T2EwQ05Y/5aUrtmrhJ/Harp4oxmvTOYaxbq4S2oScoqUVRNbM0ic8YZzDKtyaTej4+IivmZHbjFLSrImIgiUXDR8z1XBESnKvy00+3t/QUwnKKjKMqdv3FcYlOSidf3OPGgx8hGUUlVL4ualHqJhLV8iUJTcbjrOXmPm+JKtNI9xlNcTwlfKUrnMmtkqt02J6kYaV9xbpSmlWlt4mNrQtENW5XTX/AFmFrrwxyN01oU4zKU1Dy6OlU9y8VwrnKamlWSa5V7qmsVQlG6tEt3q3TTuLxMIwnCVE5T2NIxjMoWQU7qpSkNNeJaIm3uRyehbtKMUmkjrrSIZTK7Dw8rqOQ8bF+FRp5196xtp/fLsRv2vbX7m/TThWPut5eyPay27a64zbn4Q7Pp3TcXp+MrGPGi3nN6ylLjKT4s+y7btqaadFIxH+uM+14u3ba85s2jdmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0Ov9e6T6f6Nmda6vkLF6bgW3eyr8k2owj2RinKTb0SSq3ogRD8P/Xn6qYf1P9Q42X0zDnjdH6PZuWceeQ0r1xzkpyuzhGqgpcqUVV7Ve9Fhe+JderXw4vmfSer3um5+N1LHTlOxJRnCWiuQ2cJU3Uo6FNumL1mk+LTXsxi0e5+mPT/UZ5eNjZmJKUsPJhC/Y5lryTWz71sfFdxpmszWecPUpMO3wLkbkVzaPjVUPPtVrCrr93ruDgXMromLazcxU5LN6vK1XWiTVXTgzbtqa+r6/ta06ZnEzhvdMycnM6bj5GVjSw8y5CuViy/BcXzKL4riiNlKxaemc1VnhKc090611RXHkhiNEteK2LRCJbFpKqpw7OBesIlcrtuMk3rX7xNogxLM5QyrVFOVpxktbbo33VGY2R5YI+mWVnSb5IcF829KLsKzt8E9C6FzInR88YVpzNrdMiLWn2IxCXNdcXKUqU4/6eJEzPOZFitXXXTSlK9vh3FopKOqGxC2lGnCmptFYiFJlco0pTY0wplNL2vtJwhGWPalKMpwUpW23bk1Vxb3oyOiPFPVKfKnQ06Vcs8tBgyjKLaKTCYkVta1Va9pEVJlJRSVC2EZOAEXtVasrPmmEJOt5Q5HyctfM0pWvy9pWefJMcmJLSta+HdxKzCYVyq3Fpvlo06bMiUwrdVJPTWuvBlJWQlOklTWm5Wb4lOGvK5V1i0mtjCbr4a9ydKtui7DG+xMQ1rl1OVI8NKsym0ytEIJe/uEVSymknpvsaxXgrlmLqqexlqx4IYcba/Dp2PctiEka1q/YXiENmFvmq3sltsaxXKuW7aUYxXcjesYhSW90vpmZ1S5/Tfl4kX/AFcjt/dgu3vOzseyv3c5+3V+7xn2V/Nzb+4rq9tvL83Z4WFjYWPGxjwULcfe3xbfFs+y0aKaqRSkYrDxr3m85nmvNVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD4//APbDN/LfRfqdvm5fzWTiWdHRtefG417rZW08l6c34kx53pXZ9Nx1FrJnGtxqkmoLbXhTUwmIx1T4OrZwtNYU3bNuNpzsPmg7k+abSSXK/h5Y60bWpMW48StJxmOT7L9O+v5NnEt9Ouu4reFasQXNpSUouco/7R856jqibdUeOXdS2MQ+sdN6panbXxpptVT1Z4O2ropZ0eLmWblvllLSnDbQzpaOUtctqMpXeScGktaxktZxS3SNYzM5hPJLyIyipL5WtHt7CYrH4Iyr8ik6cV28RjinJKypW3FScK7Nb6cBauY54IlK1bTXltaLR6717aFejhiTLZs41qM03rRVWvEtXVGeKs2bEcO05qVKSfZpUtGqM5R1NmGPGOtKt6U4F4phSbLY2oqiilpt3F+mPBGUuWr1pQtMeauUowitkIrEEyzRF8KpEjJKCpAAU5lvIuY04Y1xW77pyTaqlR9hntiZrMRPFekxE8eS2NaLm+amviXifPmrLDfD3FZSw9/ArIMiZSi2isylVclSL4P7DO1uC0Qq8yNKJ0aVKcDPrWwquXHXSi5XrrwZE7FohqXMqEaxlKr2+E5bbfBeKtO7mSbaSUU93xMLXmVoq13drRvVlcLIylJe4vEShOD08DaIVK/Cu8nwElKj+8tHBCXMtNm/1lsiy3GqqtuLeyL1qrMrndjCNW6feaWvFURGXRdD9MX8tRyM+MrOLvCw9Jz/AI/2Y9257fYei224vu4U/b4z/wCX5fF5/c97Ffppz8/ydhatW7VuNu3FQtwVIxiqJJH1laxEYjhDyZnPGUiUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD5r/9iPSUvU/0r6nh26+diztZtqSTfK7MvidF+5KVTHfaa16o44aapjOJ8X4j67i3MHqX5edtPMjbTv3Yvlt3rUklzKvyumjocXb26qZ/T/SXo3mJnPi8jB6V1DqmfDGwrNZXXSsdLcVF7uW1FxZ1X21pXNpc0a7TPDk+vdHx7tiEawq9pXUqKTSUa/YfOb7RLr8XUYOf+XXM58sVq23oefs15b1y6TB6lNJa0fE4Nmp01exDqauJeYlNLbdNV7GjCay1hs4mdCxWVqc026tSk5KvHRk9UxyTPF6H/mLLdX81TWN3nCnQmupY0riSdJauhb+aJk6ZZjlYzu81Ep1rzP3a0EWpnJiV7zrXMvip7aFpvXzR0tnH6nizm7UbsfOjRytqS5knsaxaFZpLftX4uqrXuXYXhSYXq5X9BaFMJKaar9xbEoSTqBmpbKMM1IyYZTJiUYKjIxUr4JOZDJhhyImxEIzbo6fZuVmVoVwyIyfK38S0Zn/JHJM1ZlfsqtZorO2seJFZalzqOPHaVWuFTmt3NWka5ad7qy2jHZ7vs7DC/cz4Q0jW159Qm+ZRapL3mc7LSmKqJ5E2vjk3oV4+K2Fe6oi3SZVTb7aUI6TLCdF9heKoyxV7faWiELIJKlX4l4hGSd1p6610qTaZIQrJumq01XaMJXWlxetS9YVlvYlrKzMiOLi2ndub8sdl3yb0Rvqrs236NcdVvlHvUvatI6rTiHa9C9KY+C45OW1kZu6f4Ifwp8e9n1vp3o9NH13+vb5+Ee783jdz3s7OFeFf6+9757TiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABicIThKE4qUJJxlGSqmno00wPzv9TPo3DpmVcz8TBhm9FcnOHNbV2eLzbwdU5eX2P2M8DvO1vqmbUz0+x3atvVGPFweR0vlsRswhG1a05FCKUVTsoeb1xPFvx8Wx09eTHyJqtt8FSvdQyvdrWHt2Oj4d63tq6qMtnTc5LbJiXRRc+nXrK02Mv5Il0RDMLtyG9Ss1iVohs28trd6mc0WXwyqsrNRbHJ1rUrhK2GRJutSJgXRu1Trr495GBLGt2LWRcyIQjG/djGFy6vmlGNeVPwqyZtOMeBMy3reRJNNSap3syicIXLLuxVIXZrXm0b3L/y2jxRiFkeoZynzRyJRr4PY0juL84lHRXybC65mxS+Wb2bentJ/vLq/xQ2LfXrjVZwi3wSbQjvbeSJ0wsj17hK2nKlaIf3tvJH8MJLr0P8A29O2pP8Aez5I/hZ/89bX4PtEd77D+FBdfkrvL5fw7VKR31s8k/wwlLrumlsT3k+R/Cg+tXmqpJMrPd3mE/xQpn1bJb7KGc77rRrhrfm7spOTk0+4z6pnnK2EHebda1K9KUJ3qoYFfmap8ScCXP7EX6VcoOTaLRUyK40u5bdpZDDmm9SRiuupOMiWnhFbonCBt708GWiviIp61aq+FRFTKzmilVujFpiOZDoOjekM/qPLdyE8XDdHzNf1J/wxey72ev2Xom3f9Wz6KfOfycW/vq6+Ffqt8nedO6Zg9OsKxiWlbh+J7yk+2T3Z9h23a69FemkYh423ba85tLaOhmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANJqj1T3QHz71d9KOn5/mZnRYwxMuVZXMV6WLj30S/w5eGh5Pd+l1v9VPpt8pdmnuscL8Y+b5F1P01m4OVPHvWZ4+RDWVma+Jd8eEovtR8/t12rbptGLPRrETGazmFWJfvWJqNyLVOLRyXo1q97FyLd3hs6UezOW0YbxBfxLU1WOnaViWkNC7iyg+4vFkq1GS2LZFi5kUF0ZumujK4F0LstiuEtiF1qmuhGENiN6VKp+0rhCayJexEdKU1fb0pTvImqE1eT337CswllXGqUI6RJTbfYMCauJLehGBhXF7eFRhGVcsq3bl8beu1NWR0pXK61+st04Rk83dtk9KMsebrqx0mWFeVKiIB3OJPSK3ce3FjokFKnEnoGFe15aNU1LYDnk3pt2jCGU6e0YGW9u3sGBla+BfCE4RpGjde1svEIJOmql8Pf+gmZiDDb6T0Tq3VryWHYfkVpPJn8NuK8fxew6u17Dd3H2RivnLLbvprj6p4+TvehejOndNcb95/m8xaq5NfDF/uR/S9T6rsPRtWj6p+q/nP/AMPI7jvr7OEcKuhPXcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPL6/6b6T1zF8jPtc0o/4V+Oly2+2Mv0bGG/t6ba9Noa6t1tc5q+S+qvQ3UOitzvL8z0+vwZsF8vZ5sfw+Ox8z3nYX08fup5+Xvexo7imzlwt5fk5pYt6xOM7MkoPVxeqa/dZ5eykS66zhuWc2LXLP4ZcYs5JrMNI4rnCE47kQlrXcb4tCUq/Ka3RGRlQXYBbGHACyC/sAujUrhCaff7gJ82hEwMp0em5GBNS27FuRhCVZUrXQjAVrv4DAxV7114ImKmWHbtympyWq41J6U5T85cWT0whD8wuGvcOkwi8iS2S31qTwMDu3HtL2JCZThKknu5PxIygrRaulO+oGPOSWmrpWpVOEoT5lVotCJT5mloqupOEM678OBOEM1o+/vJBzjFOU5JcXXQjqiOZh6HS+hdY6tR4eNLyXSuTdrC34pvWXsR39t6dv3/bXpr5yw29zr1854+UO06R6A6djct3qE3m31ryNctlPuhx9p9H2noOnXxv9dvby+DzN3qF7cK/THzdTCEIRUIRUYRVIxSoku5I9uIw8+ZZJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGJwhchKE4qUJJqUZKqae6aYmBwHqX6X2bjnldDcbMnrPAnpak/wDlv8D7tvA8TvPSIt9WvhPl4f7PS0eoTHC/H2+L5xnYFzHvTxcqzKzetv4rVxUku/8AtPmt1LUnptGJevS0TGYnMNW08ixL5nctdj3Rz3pHg0iW/bvRuJcTHKcLHajJaf6yYQqdlp/cJSworiMoTSf9oEtWqIgST4VAnGrfd2gE6119gEk6bbEIFNduoiBh3OFdexE4Sg70nt4kxBhCNy5KT5nvSlHuTwMJJ8OwoJL/AFoZBtaLZUIGeZp6L3gZUpyrrTtIBQ4d9Sekysja0rxJwjKxQX9heI4IymoLT/ShWbRCErdud6atWYSu3paRt24uUm/BCnVsnppE2n2EzERmeEOg6Z6C65l8s8nkwbL35/ju07oJ0XtZ7Pbegb9nHZMUj4y4tvqGuv2/VPydZ0v0P0LBlG7O08vIX/Fv0lR90PlXuPou19I0aeMR1W854vN297svwziPY6BJJUWiWyPTcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHm9a9O9J6zZ8rOsKcl/h3o/Dch/DJamHcdtr3VxeMtdW62uc1l816/9NOudPcr3TKdRxdW7ekb8V4bS9nuPnO59FvTjr+qPLxevp9Qpbhb6Z+TkaUuyhKMrV6Okrck4yT74s8S+vjiYxL0InhnwbFrIlF/Gq04mFtcwnOV8JW5KsXr3FIkZlGNVVavZIuChF7adqIGVZ10oEM+UuyrIGHB07K8QljldG1qTgYVubjoMQZZ/LTrzce0gyyrarTXxGRjylvwIyIOLT2p2lcpTUWntVjIz5cqa7cQhmNnTXUnBlPy5VToWQnG327sqJK3GKq/ays3iBK1/Wl5WLbnk3W6KFmLm2/5U6GurVs2TilZsi0xXnOPe9zp3ov1Nl/4mPDCtPa5kSrP+5Cr99D19PoXcXj6sUj5uPZ3+qvL6nS9P+nPTLTU8+/czJ78i/pW/dH4n7z1+3/x7RTjfN5+Th2epXn7Y6XS4XT8HCteViWIWIdkIqNfGm57erTTXGKxER7HDfZa05tOWwaKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5vV/TnROrxS6hiW70l8t2lLkfCapIw39rr2xi8Za6t96fbOHHdR+k8dZdMzmv2bWSuan88aP7Dxt3oUTx12x73oa/U/wB0fBzOf6G9T4jfPgzupPS5itXE/Yvi+w8rb6Rvrzrn3Oynfap8ce95N2z1PHl/UtTi1VJXbcov7Uefftb15xMe+HTXZWeUwisxtfHGj40aZhMTDRbDNx6auj4p6FJML7WRbuU5ZRq9aVVaETbCJhOUrfN+1+gj+SDAppv5aU4+BHXBhOEoyVVs+JWbwYZaqu57DrjzEHBR1rXvLZgYi8eSrG5Fpbta+wTwOLMvy1NZxXZVpFcx4JxLPPj7KSdXpy6/cTEzPKJRhbax8i7Jxx8PIvy0+S1ce/sOmnabrTwpafwUtsrHOYj8W9j+nPUeRyuHS70K/wDu8tun95o6qek91b9Hx4Mbd3qr+pv4/oH1Ndo7kbGNXfnuc7X9xP7zr1/493E/datWNvUdUcsy9PG+mVyTTzOpy/ehjwUf9qfN9x6Gr/GtcffabfJzW9Un9Nfi9rD9Bemcblc8Z5U47SyJO5/s/L9h6en0jttfKkfjxct++228ce57tjGx8e2rdi1C1bW0IRUV7kejWsRGIjDlmZnjKwlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHGLVGk090wNa50vplz/ExLM/4rcX96M51UnnEfBeNlo8Za1z0z6euKkum4zX/SivuRnPaaZ/RX4QvHcbP3T8Wvc9Fek7lObpdjTakafcZz6fon9ELx3m2P1SqfoH0g//AIy0vBzX3Mj/ANb2/wCyE/3u790or6f+kVt0+Kr+/c/3is+l9tP6IT/fbv3Sz/8AwPpL/wDQX/5Lv+8V/wDU9t+yPn+Z/f7v3f0Y/wD8/wDSNa/kFX/qXf8AeJj0rtv2R8z+/wB37v6JL0D6QX/xtt02rKb++Rb/ANb2/wCyEf32790rrPoz0rZ/w+lY64OsFKvjWpeOw0R+ivwVt3e2edpbdroXRLSSt4GPBLalqC/QaV7bVXlWsfhCk77zztPxbdvHsWlS3bjBLZRil9xrWsRyjDObTPNMsgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAf/Z"
+    },
+    "type": "object",
+    "properties": {
+      "header": {
+        "description": "",
+        "example": "/9j/4QAYRXhpZgAASUkqAAgAAAAAAAAAAAAAAP/sABFEdWNreQABAAQAAAA8AAD/4QPVaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLwA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/PiA8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjMtYzAxMSA2Ni4xNDU2NjEsIDIwMTIvMDIvMDYtMTQ6NTY6MjcgICAgICAgICI+IDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+IDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcFJpZ2h0cz0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3JpZ2h0cy8iIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iIHhtcFJpZ2h0czpNYXJrZWQ9IkZhbHNlIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOkYzRjk3OEZFRUQ2QzExRTI5OEZGOEFGQjE3ODRGN0Q5IiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOkYzRjk3OEZERUQ2QzExRTI5OEZGOEFGQjE3ODRGN0Q5IiB4bXA6Q3JlYXRvclRvb2w9IkFkb2JlIFBob3Rvc2hvcCA3LjAiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0idXVpZDoyN2JkN2M2Ny1jZGU0LTExZDktOWNlNS1hMDYxYTA5YTA0NDciIHN0UmVmOmRvY3VtZW50SUQ9ImFkb2JlOmRvY2lkOnBob3Rvc2hvcDplNzQ4ZWE4Yi1jZDk3LTExZDktYjlkYS1lYzFjMmJlMGIyNmYiLz4gPGRjOmNyZWF0b3I+IDxyZGY6U2VxLz4gPC9kYzpjcmVhdG9yPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pv/tAEhQaG90b3Nob3AgMy4wADhCSU0EBAAAAAAADxwBWgADGyVHHAIAAAIAAgA4QklNBCUAAAAAABD84R+JyLfJeC80YjQHWHfr/+4ADkFkb2JlAGTAAAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoKDBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8AAEQgBQAK8AwERAAIRAQMRAf/EALIAAQACAwEBAQAAAAAAAAAAAAACAwEEBgUHCAEBAAMBAQEBAAAAAAAAAAAAAAECAwQFBgcQAAIBAwIDBQUEBwQJBAMBAAABAhEDBCExQRIFUWFxEwaBkSIyB6GxQhTB0VJicoIj4ZIzRPDxotJDY3MkFcJTRQiTVBYXEQEAAgIABAMGBQMEAgEFAAAAAQIRAyExEgRBUQVhcZGhIjKB0UJSE7EUBvDhYjNyFcGCosJTJP/aAAwDAQACEQMRAD8A/VIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGLlyFuErlyShCKrKUnRJLi2JnA5XN9f4dq/wAmNYd+0nrdcuTm/hTT072eJt9cpFsUjrjz5O2nZWmOM4bGF676PfX9aNzHfHmjzRVO+NfuNNPrWi/PNffCtuzvHLi9/HyLGRZhfsXI3bNxVhci6prxR6tbRaMxxhyzExOJWFkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxKUYxcpNKKVW3okkJnA+d+rPVH56fkY8munwfDR3ZLi/3VwPlvUe+ndPTX/rj/wC7/b+r1+27bo4z939P93K3suMq8j5mqKfMkq1VdDgmMRwdXSjZyqpyi3HlXNyyVHv2mGOCs1dT6N6tk4GdySm5dPypqNy0/wDhznpG5Hsq9JHqek91bXfpmfot8pcvdaotXP6ofSD6t5QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOC9d+p5O/c6TjypZtR5syaesnv5fgt37j571Xu5tb+GvKPu/L8/g9Ls9OPrn8PzcDfzbl1Pk15Hy0T2r29x5taZ5eD0Y4Ne2n5Tkm1yLmcn4lba8VzC2eLchelKUZQj/jw5XadWk940prrTRMwvafD9UKzV03pboeV1DIdpxdqxCUXkzWqSi+ZKL7Z8Ow6vT+yndfHKtZjP4eEe/5OXuNsUj2vqJ9k8YAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANXqvULPTum5OdedLePblcffRaL2vQz27IpWbTyhalZtMRD89v1JDK6rfs3Yyj1B3PzMZvSFznq5Qrx3PjKXm2bz902y96tcR7Flydtt+W5RuRhy25J6KjrGtVR761N4mPBbLFl3b/lxUncc0m4/DFKS+bl7e6vAyveZx4pzEOk9OdNu5N6Nu3SV2U1qtUp104Lh7jHVW228Vrzmfgy27YiMy+u9L6dY6fhwxrWqjrOb3lJ7yZ9r2+iuqkUr4PE2Xm05ltGygAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfOPrJ6ghj4GN0WE+W7mN3byW/l2/lX80vuPF9a34pGuP1c/d/r+jt7OnGbeT4veyZq4pV95850vRiyL6pejFqMmq0r7CYiUTse16etX8qTnfuzdv8AGtFVJ1pUy2TlnN8vsX096WvLnnyjSMa27C4d79mx7voHbcJ2z7q+5x93flV2p9I4gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxKUYxcpNKMVVt6JJAfm71r6jl1nruXnJ1tTnyY/dZhpDTv39p8Z3e/wDl2zbw8Pc9nXTorEOUvXG3UywmZwrsKV68ox7aMW4QytL6N6d6c6WMa2qzm0nTte1DitE2mKxztOCOHN9y6bhW8LBs4sFpaik2uL4v3n3/AG+mNVIpHKsPMvbqnLZNlQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4r6r+pP/ABPpuWLany5fUq2Y03Vqn9WXufL7TzfVO4/j1Yjnbh+bq7TX1Wz4Q/Pl+826M+XrD0JlpXZ/bsaxDOZe16XwfNyFcnrGOv8AYYbrKw+vfTjpiyepzypR/p4ey4czVI/rOr0Xt/5O4655Uj5zw/Nn3FsUx5vpp9k88AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMSlGEXKTUYxVZSeiSXFgfnD6geqH1/r9/KhKuJb/o4S7LUG/i/nfxHx/fdz/NtmY+2OEPZ1a+imPFx12fvOeqJUxi5ypv3IvM4Zy7voOEsfEtr8c9WvuODbfHFasPtnobp35ToVuclS5kt3ZdtNor3I+r9C7fo7eLeN/q/L5OLurZvjydAey5gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+efV71fHp3TF0TEu8ud1CL/MOL1t420vB3PlXtPJ9V7vop0R91v6O3s9PVPVPKHwq/cTemkVt4HzMQ9CWjclzLmda8EbVhlL0vT3TpZeZbT+WtZeBltt4KY4vo/ScF5GXC1Haqjp7jitWdlopHjOGscIy+049mNmxbsxVI24qKp3Kh+i66RWsVjlDxpnM5WF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADh/qB9Uuk+l7bw8amd1u4qW8WL+G03tK9JfKv3d2cPd99XVGI42dWjtZvxnhV8I6h1PMzsm/nZ95387Klz37z4vgkuEYrRI+U2bLbLTa3N6sViIxHJ5zm23XbgMIwgoc0ktycs7Q7X01grHwpX5LWWz7kcd785K1fRvQ3TnPNszktq3JP8Ah2r7Ts9F09fcVmfCJn8lO7nFJfSD7h5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABRn5+F0/EuZebfhjY1pc1y9ckoxS8WVveKxmZxC1azacQ+N+tvrNmZquYPprmxcR1jPqUlS7Nf8mL+RfvPXwPB7v1WZ+nX8Xp6eyivG/GfJ8e6nlRtxm3crek3Jzbq67uTb3PM11mZzLrmWlgdctZSpC4p03cXXY02aJqiHpwuKS09rMJhOHp9IwZZWRC3FayZz7r4hTpfRrWEoTt4sVokl2Kq3OO0fpXrD6L6KxVbhdnSnLGMUnvr/qPov8AHtf1Xt7ocPfzyh1B9Q80AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAByXrT6ldC9MRePJ/nerNVt4FlrmVdndltCP29xx913tNMceNvJ1aO1ts48q+b4h6k9T9b9SZSyer3+a3Bt2MO3VWLX8MeL/elqfMdz3l908Z4PX1aa64xV4ORc/DEwrCzzsjAjdUnNLl4t9htXZhHS1sb0/Zxk5WoUlJ1bWhe3cTbmdLZtWLsXR7V0KTaE9LvfQvTJ3bzvNaWo82vaedunqtjyVmHa4+PXNi+EdSkfctEcHb+mLvJdnZenmQqvGL/Uz6H/AB6+LXr7ped39eUuiPp3mgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfJPqL9X/KuXui+l7qnkRbhmdVjSULTW8LPCU+2W0fHbyO+9Sima0+56Xa9nn6r8vJ8mjF80rs5SnduNzuXJtynKT3cpPVs+btabTmXpo3bsqOMd+8RAjbt8+vYxKcNuxYUn8uj4MrMpw2beLanbUofK9vBFZlOEH0yM7i+HWtUVtsxCYh9M9I9I/LdMUpRpK9q/BGGmM5tPiyvzexDDcbuiqmlr2eJfomDL1MF3LPUsW9zUtRbjcj28+lTu7DZOruKW8J4T+P+7l7iItrmPF159u8UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMTnC3CU5yUIQTlKUnRJLVttgfCvqT9XrnV3e6H6Zuu30zWGb1SDpK+tnbsPdW+2f4tlpv4nf+o/pp8Xq9r2ePqv8HzzHhbtwUIpJR2SPn5nL0Upza0b1eyEQjCqsILnk6Kur8S3NaIbcLack+K217TOZTD0bFutElqUmU4b8Lfw0KTJENrpuI7+XbilrKS+0491+C76lasRswhbiqKEVFew9WmuKxEeThm0ysSVSejMImVjjWLXH9KK7K8Fcuoxbvm41q5vzxTfjQ+207OukW84eNeuJmFpqqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVZeZi4eLdy8u9DHxrEXO9euSUYQjHVuUnokJlMRl+d/qR9VMv1dcudK6RKeN6Zi6XLmsLmbTjLjGz2R3lu+w8HvvUM/TTk9bte16Pqt939HIWLELaqklw5eB4dpy718moxrx4dxUUpVevvLJWwjRETI3LMdUUlaHo48NE6arh+kzlLccZaKNFqm69nEztKYdH6PxFdz1ckqwtVk692xhqrFtsRPKOKu2cVdtDzFH+pLnlV1klSuumngevSOHFx29jPmQ8xW26TknJR4tLdjqiJivijE4yuixeOCkOh6Q2+nWa9jS8Ks+p9Nn/+enueXv8AvluHayAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaPW+udK6H0y/1TquTDEwcaPNdvTencklrKT2UVqyLWiIzKa1mZxD81+vPqP1b11leWoTwvTdqVcXp7fx3mtruTTRv9mG0e9nz/AH3fTeemv2vZ7btopxn7ni2LCjHhoeNazrbCgoxr2aoplMKp8z1+xFoSlCKSEpX24NupWZS3LNutF2lZlL08e20u3xM5kXxcXOME/jnWipwRhsngvEO59M4ccbE5/wAdz7ka9rr4dU85c+62Ze4pJUq6d7O7OGEQkmaVnKlowsi1Rv2ldk4rKsQ6bpkHHp9hPfkT9+p9X2NOnRSP+MPK3Tm8z7WydTMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADn/AFn656B6Q6Z+e6refPcrHEw7dJX780q8tuH3t6LiZ7dtaRmzTVqtecQ/N3q31b6g9a9UjndWfk4llt4HSrbbtWV+1L9u6+M37KI+c7zvp2Tj9L2tHb11xw5tXHxVFJ00Wx5lrOjDaVuiq3TuM8pRdZOmxKRKNaLwdO7tJMJxh7akZThfC3NU5VXaqe1CuUt/Hs1a7CkyN63FKi+0ztOEw9Po/T45OS1JPy1rJLRswrHVbCbWxDucZKFtJbR7qaHpVhyWXRnGS5uG6bX6ybYlEQui9DSkqWhYk5Ugvmm1Fe10ItWbzFI52mIUmcRM+Tr4QUIRgtopJew+2iMRh4sskgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPnn1C+sXSfTcrnTOlxj1T1AtHjRl/Rx325E1t/Avifccfc95XVHtdfb9pbZxnhV8Fzsjq3WuqXOrdYyZ5vUb2juT0jCFfktQWkILsR833HdW2TmZexTVWsYq2rOMopNrU4rWaYXwg3XTRfaUmVsMyhXT3iJGOTcnJgjbSboqN7tcRlK6Fp124aPgVynDZtWm9lsVmyG7agoUXbsVyls2rbnKKWtdNO8wvZaHZ9FwfIsKMqebSsqab7HVo14j2sNlsvWUkpKNHy/ilwVDozjgywouXsh3o242pcsq/1YcrUV2urMrWmZ5NK1jDdx7fLD4nKTT3lxpxojXVThxY3t5PV6Nj+dnRk1WFhc7f7z0ier6Xp6902nlSPnP+zi7q+K483Rn0rzQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1updT6f0zCu53UMi3i4llc12/dkoxivFkWtERmU1rMziHxD1z9Zer9adzp3pZ3OndMb5bnVWnHJvLj5MXrai/2n8XgeJ3fqsR9NPi9Xt+wiON/g+fYfTLVmPLbjq3WUnq23u23u2eDfbMzmXpYehbxUuBjN1sLvKSWvsM+pOGPLda8N0icjDty7Fy8Vx7iYkPLGRbGytCMjYt2KrtKdQ2YW1GNKalYlK2MddOOxW1kug9P9NUrqu3FRQ1ilxI006rZnwU2WxDppeZFJQgnquZt004tHoTnwc8YYhcncuzsqPLbgvjntXjRGfVMzNfBbGIytxLXxO5KKWtINOviWpTMovbENxySVeC7DptOIc/N0/SMN4uIlNf1bnx3O5vh7EfUdh238OqKz93Ofe8rfs67Z8G6djEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcN6z+rHQ+gzuYOCv/ACnWY1i8a1L+nal/z7uqj/Cqy7ji7rv9ennOZ8nX2/Z32ceVXxfr3V+vep8xZfXch3+Vt4+HCsMezXhC3V1f70qs+b7rv77Z4ziHs6dFdcYr8VdvColpRI8+btsNq3i8EvaZW2JwtdqNuNFrLtMurKcKfLb149ppkS5KcCOoHa7PcTFgVvR6DqGxbstUb4lJtkbMLaiqviSHK2+4rMph6HTun3ciacY8eP6DOIm04hEzh2OJZjasqEEqR0oj0KVxGI5Oa0rHci6pOqjvTepabGDGspLmo4zk05Kqq6aUZGunj5ptZuwiopJbcDprXEOe1svS6LhfmMrzZr+jYde5z4L2bnoem9v/AC7euftpy/8AL/b+rl7nZ016Y5z/AEdKfSvNAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPF9Q+sPT/QLdeo5Sjfarbxbfx3p+EFr7XoYb+616ozacNtXb32T9MPk/qj6iepevxnjYvN0npcqxlbtS/7i5F/t3V8qfZD3nzvdes2vw18Ievo7GlONvqn5OVsdMtWYqNuCjFa0R4trzPGXa2beItFTUznYnDZjh0Xx6LsMJ2ZWwNKKolQhKvy6k5Qx5XcMjDtrYnIK33ajJhbaxqvYiZF8bNFT3FoQOroyJsmIX4mLK9c5V7TOZ44hM8HWdN6fDHhSKVZb6tnbq1Yc97ZbsbMlPm53y0SUFRJUOmK4ZzKlKdy7J26u2+LaUVKOnwx31MvunhyX5RxbuPblGOun3+06ddWN7NmzauXbsLVpVuTdIr9L7ka9Nr2ilfut/qZ/BjNorE2nlDrsPFt4uPCzDaK1fFt7t+J9Zo0V1UileUPJvebTmVxsoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABz3XPXvpvpEpWruR+Zy1/lMVebc/mo+WP8AM0cnc99q0/db8HTp7TZs5Rw83Adc+o/qbqfNawUuk4r4wauZDXfNrlj/ACr2nz/c+u3tw1x0x5+L09Pp1K8bfVPycrHCrcldm3cvXHW5dm3Kcn2uUtWeLe9rTm05l3xwjELo41NKFJsLIYUnvojC25ZONi1bl8Cq3q29dTLMzzSjOFX2loFbtVlVblsiPIqdlRkY5NwMO3rTj2DIlCxs3uMjZhb5d/cEI3G26UWmxM2IhPHxpXJKMVVtmVrccJdBg9LjDlclSSdd6aLw3OjTp82VrvUT5JKMNbiVVBOldNFXhU7o4cmPNm9O5OStx0clrxp7SLzMziE1jHFbhxk4Pmjy8snFa1qlx9ppqjgpsnDZbSVftN7WisZljzl0fQ+mvHtvIvRpfur4Y/sw7PF8T3/S+znXXrv/ANlvlHl+fted3O7qnEfbD1T1XKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGj1LrvR+mRrnZdqw+EJS+N+EFWT9xlt301xm8xDTXpvf7Yy5TqX1Nt0cOkYM78tlfyK2ra/l1m/cjxd/+Qaq8NcTefk79fplp++cOT6r1r1J1bmhnZsljy/yuPWzb8Hyvml/NI8XuPVe428M9NfY9DV2uqnKMz5y86z063CPLCCit9FQ87HHMuibLPyNfl1lw8SJsjKUcJ0Tno+KRjbdEclsJxsxgtFrvUx65snCuabrTSpMCrk0bSr2FokY5a6vf3E5GHCNeFXuiYGJW6p6VdKkiry3x8KDKU42W6Nb9naQZW+VyptqrS1QQjKLlOLT+Fr5e/wARkTs40rk6RW5lN/BL2cfCyLEceWPbhd5rjjkc0lFwt8rfOk/n10odWnViuc/UytbMvWt2lFKrrT7zsrXDKZS54xbolzvShab496MJQtSclrRbtrtFaSTZswjGMUlojrrGIYWnMvV6F015NxZV2P8A29t1tJ/jkvxeCPQ9M7T+W0bbfZH2x5z+73eXxcvdbumOiOfj+TpD6R5oAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADTyusdKxVXIy7NunCU4191amOzuNdPutEe+WlNV7comXlZHrrodt8tjzsuT28m26f3pcqPP2+udtXlbqn/jGXVX0/bPOMe95WR676rc0w8C3Zj+3kTc3/dgl955+z/IZn7Nf42dFPTY/Vb4PGzOr+os2qyOoThbaa8uwlZjTjVx+L7TzdvqfdbOE26Y/wCP5uuna6q8q597zbfT7EJOSgud/NN6y9snqedamZzac+90dU4XRxHPaL2JzCGVgUXxNL7TO14gHZtx05avtexjbatEI8jrXRRfZ2oymJnjKyuUOx+wYMqpwim6aoYgUzh8T+4sKoxbTdOV70YSwoqSa0ZMDDjHSPElDKttfrARxo/LFbcRlOU3bVGnx3YQjPSnuaKzZOCzjyuT+FGeZnhCeT2sPBjbt1l8z29u506tOOfNlazft21HdbKleJ10phnMsu5GEa97ouLZpNoiEYZx7TnJzuL4pcOCXBDVrmZ6p5lrY4Q3IpJdnYdUVYzLc6X06efe1TWJbf8AVn+0/wBiP6Tq7PtJ7m3H/qjn/wAvZHs8/g59+7+OP+X9HWQhGEFCCUYxVIxWySPrIiIjEPJlkkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK5ZOPH5rsF4ySKzaI5ymKzKD6hgL/ADNr+/H9ZnPca452r8YXjVbylVPrHSofNl2l/MmUt3mmOd6/GExovP6Z+CD690ZKv5u2/B1MZ9U7b/8AZX4r/wBrt/bKL9RdHX+YX92X6ik+r9rH64+aY7Pb+1XL1N0qO0rku9W5P9BS3rXbR+qZ90T+S0djtnw+amfq3p6ry2r03/Cl97Mp9e0eEXn8PzXj0/Z5x8WvP1fL/h4UvGc4r7uY57f5BHhrt+MxH5tI9O87NW56q6tL5Ldi14803/6Tnt67unlWse+ZlrHp9PGZlp3usdevVTzXBPSlqEY/bqzlv6p3Vv1xHur+bava6o/T8ZaV61fvr/uMi9d7ee5Jp07q0OS+3bf7r3n8W9a1ryrEfgpWBiw+LkjH96n6TCdVOcr9crli9ldXTRFuEK5S/J6aadwyZUzxppqk1TtSr7DG1rea0YZVtRWsa9rK9U+KSTfKnqqarhqZSKbybhOSq2k6KOrb3oitoTCmK5oKVOVSVWmtV4kRCZRcYx1rXTXxGBi5B8tHv/psTjhyGvdjTb39pPQlVy1ppURCVXlNPUgRdpRbkvxOvdoRMpZ8rmexMVyhJQonUnAnRRXK9ewgUyeur1WzM7WTEM2bE7s3VJR4P9ZnzTPB6uLixtwrJVpxOjXSIhnact6HDu4dlTrrHFnKblGEHJ8DbPTCuMoW7avvn/Dw7OwitYtxTM4b0IpUS2OusMJls4GBfz7/AJVtuNmH+Ne7F+yv3mdHa9rbuLdMcKR91v8A8Y9vnPgx3bo1xnx8I/8Al11ixasWYWbUeW3BUjFH1uvXWlYrWMVh5NrTaczzTLqgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABiUoxi5SaUVq29EB4ud6z9O4cnCWXG9djvasf1X/s6facG/1PRq524+UcXVr7Pbbw4e3g8TK+o0pp/kMJuKr/AFL0tdOHJCrr7Tydv+Q5/wCuk/8A1flDrp6Z+63webd9U+ocqWuXGzGW0LMFF+98zOG/qfdbP1RX3R+bpr2mmvhn3qebLvut/Ku3WnV805P7KnJedl/vvefxbRFa8qxH4JLHtLgq9rVVXvMp008fmt1y1rmdgY1+ML1+y1c0hHaVVvQrNNcccQtEWnzejiSxsiDlZSklo2tKNF6dE8YiFLZjm2lYhpoaRjyUyl5UKonMI4jtR7dvt8SJsQi7PM6Oi7XTUpPFbLEca0tyOmCbJq1aWy34jgjMpKEV3smEZZaj2AKU/SQK7SveX/XcXOrq4VUaV037itYnH1JnHgw6OvLqVsmEXbXFV7GRNU5VShJKqVdfiXiZ9MrZVXFBxVKSi99dCtqxKYUr5tKv7qUKRCyU7aktnsW6UZUXLUlvtulsVmiYlF227a7Y7P8ASTEcBWsdybfdTlJrGU5U3YShNRo5Kf4lsqa6+JWc5TCM4Kmj0W74kCuVtUaS0KJEktK0kvcWgYk3rXhsRNjCuUq+PEytZaIWWcSU6yknyr31IrrmYzKJs9CxYhGLrouJvSikyvi1zV4LaPabVVlZCao5PRPX+w2r7VZVpSyL1KUhHbXQiIm8+xMz0w9CEYxSottjrrEQxmW1h4d/Nv8AkWfhSo7t7hBP/wBT4I6O27e++/RThEfdby9n/lPy5sNu2KRmfwj/AF4OuxMWzi2I2LMaQj72+Lfez6/TprqpFKxiIePe82nM81pqqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPE6t6z9P9MbhdyfPyF/l8debc90dF/M0ce/v9Or7rRny8XRq7XZflHBynUPqN1vIk4dPxLeFZ4X7786612q3CkI+2TPG3+vTP/XX8Z/J36/Tqx9059zwsvK6l1H4s/LvZNdeVy5bar2QjSP2Hjb+527f+y8z7OUO3XrrT7YwWcX4VGEUo+HBGMRERwXmWzDHjRp0TdaVZM3hGE1j2FGkqa/MkZ2vC0ZTxOn41m+78bt6UpVSjOdYJN7KOxFZjwTNpmHpbxUaRcW6XFJVqu4txlmg+n4c3TyYx5dnyqq7qiKRyT1y2bWOrcUofDHii3ThWbZX8Ny+FBuKeu/YTmATTdGqdiYjEks1WoQw6cRMJU5MMylt4rtpq5F3vNTadr8ajy7S7CJqmsx4tilN9kW6cKsSapputiJIUXMqFtpXE4c2ibWj9qMpvEc+C8UzyRvXZuNt24qcJSpOSa0jTfv1LeWDHmzjJx5uZ+0vKqVZJdnjw7TPishLZ6010ZEwmGv5MbcVC3BRin8MV2t1Zn0YXzklbkm68aaLgTNDKUFHko1otyK4wiUXa+Jp68UOniZVuEdE1oVwshG2uXVfFXWuzaKxUyxO0pKtNGqJ8NCZgiWrfguaq8PHQpaq0KHJJ8ko693eVmYjglVJvV7uu5la60QrSlJpbU4mXVlK61jRhWSXzOrb7djSIjmrNm5bcW60pFbtG0cZzhRNTbq3xXyloE1KirJ6bmteHFCNJ3prhFCYm0+xHJv2rcYRSXtZ10riGVpyvw8fIzctY2Mqta3bj+W3F8Zd/Yjo7fRfffop+Nv2/wC/lH4stuyNdcz+EebtMLCsYePGxZXwx3k95Pi33s+w7ft6aaRSkYiP9Zn2vF2bJvOZXm6gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADnfWv1D9HeicGzm+pupW+n2sibt48WpzuXJJVfJbtqU3Ti6UXEiZwtWsy4u9/wDYH03nW5S9OeXnRWjvXLkY0f8A0k+f30PH7r1S1JxWk5/5OzX2eeMz8HkZHqjrHXl/32bcjYf+XsvyrbXeo6y9rPC7jv8Adf7rTjyjg9DVqpT7Y+JYxcW0qQTXb2HlW2xHJ1ZmebfseQ2korTav3kV35T0r27UealObi0uzYtOxGFbvSXjxKzeVsI+bXXjx8CvMWRcnTXTT7ewv0obVpqtW9V7i9YRLbtSa/04dhrVSVsZcK+3sJRhPmb02/UShn4dKt0fuImA5rcdVVLjLahHCDiy7lpUk99kTNq8zEsxu83yqvfwIi+eRNcMylcboktdpCZtyhERCi427kbTvO3O6nyw/FLlXxcqZnNZmcZmMrxyzhbatKCa1eii69xpTXEKzOVqeunvNFUZLmTT1T3T2EwQ05Y/5aUrtmrhJ/Harp4oxmvTOYaxbq4S2oScoqUVRNbM0ic8YZzDKtyaTej4+IivmZHbjFLSrImIgiUXDR8z1XBESnKvy00+3t/QUwnKKjKMqdv3FcYlOSidf3OPGgx8hGUUlVL4ualHqJhLV8iUJTcbjrOXmPm+JKtNI9xlNcTwlfKUrnMmtkqt02J6kYaV9xbpSmlWlt4mNrQtENW5XTX/AFmFrrwxyN01oU4zKU1Dy6OlU9y8VwrnKamlWSa5V7qmsVQlG6tEt3q3TTuLxMIwnCVE5T2NIxjMoWQU7qpSkNNeJaIm3uRyehbtKMUmkjrrSIZTK7Dw8rqOQ8bF+FRp5196xtp/fLsRv2vbX7m/TThWPut5eyPay27a64zbn4Q7Pp3TcXp+MrGPGi3nN6ylLjKT4s+y7btqaadFIxH+uM+14u3ba85s2jdmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0Ov9e6T6f6Nmda6vkLF6bgW3eyr8k2owj2RinKTb0SSq3ogRD8P/Xn6qYf1P9Q42X0zDnjdH6PZuWceeQ0r1xzkpyuzhGqgpcqUVV7Ve9Fhe+JderXw4vmfSer3um5+N1LHTlOxJRnCWiuQ2cJU3Uo6FNumL1mk+LTXsxi0e5+mPT/UZ5eNjZmJKUsPJhC/Y5lryTWz71sfFdxpmszWecPUpMO3wLkbkVzaPjVUPPtVrCrr93ruDgXMromLazcxU5LN6vK1XWiTVXTgzbtqa+r6/ta06ZnEzhvdMycnM6bj5GVjSw8y5CuViy/BcXzKL4riiNlKxaemc1VnhKc090611RXHkhiNEteK2LRCJbFpKqpw7OBesIlcrtuMk3rX7xNogxLM5QyrVFOVpxktbbo33VGY2R5YI+mWVnSb5IcF829KLsKzt8E9C6FzInR88YVpzNrdMiLWn2IxCXNdcXKUqU4/6eJEzPOZFitXXXTSlK9vh3FopKOqGxC2lGnCmptFYiFJlco0pTY0wplNL2vtJwhGWPalKMpwUpW23bk1Vxb3oyOiPFPVKfKnQ06Vcs8tBgyjKLaKTCYkVta1Va9pEVJlJRSVC2EZOAEXtVasrPmmEJOt5Q5HyctfM0pWvy9pWefJMcmJLSta+HdxKzCYVyq3Fpvlo06bMiUwrdVJPTWuvBlJWQlOklTWm5Wb4lOGvK5V1i0mtjCbr4a9ydKtui7DG+xMQ1rl1OVI8NKsym0ytEIJe/uEVSymknpvsaxXgrlmLqqexlqx4IYcba/Dp2PctiEka1q/YXiENmFvmq3sltsaxXKuW7aUYxXcjesYhSW90vpmZ1S5/Tfl4kX/AFcjt/dgu3vOzseyv3c5+3V+7xn2V/Nzb+4rq9tvL83Z4WFjYWPGxjwULcfe3xbfFs+y0aKaqRSkYrDxr3m85nmvNVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD4//APbDN/LfRfqdvm5fzWTiWdHRtefG417rZW08l6c34kx53pXZ9Nx1FrJnGtxqkmoLbXhTUwmIx1T4OrZwtNYU3bNuNpzsPmg7k+abSSXK/h5Y60bWpMW48StJxmOT7L9O+v5NnEt9Ouu4reFasQXNpSUouco/7R856jqibdUeOXdS2MQ+sdN6panbXxpptVT1Z4O2ropZ0eLmWblvllLSnDbQzpaOUtctqMpXeScGktaxktZxS3SNYzM5hPJLyIyipL5WtHt7CYrH4Iyr8ik6cV28RjinJKypW3FScK7Nb6cBauY54IlK1bTXltaLR6717aFejhiTLZs41qM03rRVWvEtXVGeKs2bEcO05qVKSfZpUtGqM5R1NmGPGOtKt6U4F4phSbLY2oqiilpt3F+mPBGUuWr1pQtMeauUowitkIrEEyzRF8KpEjJKCpAAU5lvIuY04Y1xW77pyTaqlR9hntiZrMRPFekxE8eS2NaLm+amviXifPmrLDfD3FZSw9/ArIMiZSi2isylVclSL4P7DO1uC0Qq8yNKJ0aVKcDPrWwquXHXSi5XrrwZE7FohqXMqEaxlKr2+E5bbfBeKtO7mSbaSUU93xMLXmVoq13drRvVlcLIylJe4vEShOD08DaIVK/Cu8nwElKj+8tHBCXMtNm/1lsiy3GqqtuLeyL1qrMrndjCNW6feaWvFURGXRdD9MX8tRyM+MrOLvCw9Jz/AI/2Y9257fYei224vu4U/b4z/wCX5fF5/c97Ffppz8/ydhatW7VuNu3FQtwVIxiqJJH1laxEYjhDyZnPGUiUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD5r/9iPSUvU/0r6nh26+diztZtqSTfK7MvidF+5KVTHfaa16o44aapjOJ8X4j67i3MHqX5edtPMjbTv3Yvlt3rUklzKvyumjocXb26qZ/T/SXo3mJnPi8jB6V1DqmfDGwrNZXXSsdLcVF7uW1FxZ1X21pXNpc0a7TPDk+vdHx7tiEawq9pXUqKTSUa/YfOb7RLr8XUYOf+XXM58sVq23oefs15b1y6TB6lNJa0fE4Nmp01exDqauJeYlNLbdNV7GjCay1hs4mdCxWVqc026tSk5KvHRk9UxyTPF6H/mLLdX81TWN3nCnQmupY0riSdJauhb+aJk6ZZjlYzu81Ep1rzP3a0EWpnJiV7zrXMvip7aFpvXzR0tnH6nizm7UbsfOjRytqS5knsaxaFZpLftX4uqrXuXYXhSYXq5X9BaFMJKaar9xbEoSTqBmpbKMM1IyYZTJiUYKjIxUr4JOZDJhhyImxEIzbo6fZuVmVoVwyIyfK38S0Zn/JHJM1ZlfsqtZorO2seJFZalzqOPHaVWuFTmt3NWka5ad7qy2jHZ7vs7DC/cz4Q0jW159Qm+ZRapL3mc7LSmKqJ5E2vjk3oV4+K2Fe6oi3SZVTb7aUI6TLCdF9heKoyxV7faWiELIJKlX4l4hGSd1p6610qTaZIQrJumq01XaMJXWlxetS9YVlvYlrKzMiOLi2ndub8sdl3yb0Rvqrs236NcdVvlHvUvatI6rTiHa9C9KY+C45OW1kZu6f4Ifwp8e9n1vp3o9NH13+vb5+Ee783jdz3s7OFeFf6+9757TiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABicIThKE4qUJJxlGSqmno00wPzv9TPo3DpmVcz8TBhm9FcnOHNbV2eLzbwdU5eX2P2M8DvO1vqmbUz0+x3atvVGPFweR0vlsRswhG1a05FCKUVTsoeb1xPFvx8Wx09eTHyJqtt8FSvdQyvdrWHt2Oj4d63tq6qMtnTc5LbJiXRRc+nXrK02Mv5Il0RDMLtyG9Ss1iVohs28trd6mc0WXwyqsrNRbHJ1rUrhK2GRJutSJgXRu1Trr495GBLGt2LWRcyIQjG/djGFy6vmlGNeVPwqyZtOMeBMy3reRJNNSap3syicIXLLuxVIXZrXm0b3L/y2jxRiFkeoZynzRyJRr4PY0juL84lHRXybC65mxS+Wb2bentJ/vLq/xQ2LfXrjVZwi3wSbQjvbeSJ0wsj17hK2nKlaIf3tvJH8MJLr0P8A29O2pP8Aez5I/hZ/89bX4PtEd77D+FBdfkrvL5fw7VKR31s8k/wwlLrumlsT3k+R/Cg+tXmqpJMrPd3mE/xQpn1bJb7KGc77rRrhrfm7spOTk0+4z6pnnK2EHebda1K9KUJ3qoYFfmap8ScCXP7EX6VcoOTaLRUyK40u5bdpZDDmm9SRiuupOMiWnhFbonCBt708GWiviIp61aq+FRFTKzmilVujFpiOZDoOjekM/qPLdyE8XDdHzNf1J/wxey72ev2Xom3f9Wz6KfOfycW/vq6+Ffqt8nedO6Zg9OsKxiWlbh+J7yk+2T3Z9h23a69FemkYh423ba85tLaOhmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANJqj1T3QHz71d9KOn5/mZnRYwxMuVZXMV6WLj30S/w5eGh5Pd+l1v9VPpt8pdmnuscL8Y+b5F1P01m4OVPHvWZ4+RDWVma+Jd8eEovtR8/t12rbptGLPRrETGazmFWJfvWJqNyLVOLRyXo1q97FyLd3hs6UezOW0YbxBfxLU1WOnaViWkNC7iyg+4vFkq1GS2LZFi5kUF0ZumujK4F0LstiuEtiF1qmuhGENiN6VKp+0rhCayJexEdKU1fb0pTvImqE1eT337CswllXGqUI6RJTbfYMCauJLehGBhXF7eFRhGVcsq3bl8beu1NWR0pXK61+st04Rk83dtk9KMsebrqx0mWFeVKiIB3OJPSK3ce3FjokFKnEnoGFe15aNU1LYDnk3pt2jCGU6e0YGW9u3sGBla+BfCE4RpGjde1svEIJOmql8Pf+gmZiDDb6T0Tq3VryWHYfkVpPJn8NuK8fxew6u17Dd3H2RivnLLbvprj6p4+TvehejOndNcb95/m8xaq5NfDF/uR/S9T6rsPRtWj6p+q/nP/AMPI7jvr7OEcKuhPXcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPL6/6b6T1zF8jPtc0o/4V+Oly2+2Mv0bGG/t6ba9Noa6t1tc5q+S+qvQ3UOitzvL8z0+vwZsF8vZ5sfw+Ox8z3nYX08fup5+Xvexo7imzlwt5fk5pYt6xOM7MkoPVxeqa/dZ5eykS66zhuWc2LXLP4ZcYs5JrMNI4rnCE47kQlrXcb4tCUq/Ka3RGRlQXYBbGHACyC/sAujUrhCaff7gJ82hEwMp0em5GBNS27FuRhCVZUrXQjAVrv4DAxV7114ImKmWHbtympyWq41J6U5T85cWT0whD8wuGvcOkwi8iS2S31qTwMDu3HtL2JCZThKknu5PxIygrRaulO+oGPOSWmrpWpVOEoT5lVotCJT5mloqupOEM678OBOEM1o+/vJBzjFOU5JcXXQjqiOZh6HS+hdY6tR4eNLyXSuTdrC34pvWXsR39t6dv3/bXpr5yw29zr1854+UO06R6A6djct3qE3m31ryNctlPuhx9p9H2noOnXxv9dvby+DzN3qF7cK/THzdTCEIRUIRUYRVIxSoku5I9uIw8+ZZJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGJwhchKE4qUJJqUZKqae6aYmBwHqX6X2bjnldDcbMnrPAnpak/wDlv8D7tvA8TvPSIt9WvhPl4f7PS0eoTHC/H2+L5xnYFzHvTxcqzKzetv4rVxUku/8AtPmt1LUnptGJevS0TGYnMNW08ixL5nctdj3Rz3pHg0iW/bvRuJcTHKcLHajJaf6yYQqdlp/cJSworiMoTSf9oEtWqIgST4VAnGrfd2gE6119gEk6bbEIFNduoiBh3OFdexE4Sg70nt4kxBhCNy5KT5nvSlHuTwMJJ8OwoJL/AFoZBtaLZUIGeZp6L3gZUpyrrTtIBQ4d9Sekysja0rxJwjKxQX9heI4IymoLT/ShWbRCErdud6atWYSu3paRt24uUm/BCnVsnppE2n2EzERmeEOg6Z6C65l8s8nkwbL35/ju07oJ0XtZ7Pbegb9nHZMUj4y4tvqGuv2/VPydZ0v0P0LBlG7O08vIX/Fv0lR90PlXuPou19I0aeMR1W854vN297svwziPY6BJJUWiWyPTcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHm9a9O9J6zZ8rOsKcl/h3o/Dch/DJamHcdtr3VxeMtdW62uc1l816/9NOudPcr3TKdRxdW7ekb8V4bS9nuPnO59FvTjr+qPLxevp9Qpbhb6Z+TkaUuyhKMrV6Okrck4yT74s8S+vjiYxL0InhnwbFrIlF/Gq04mFtcwnOV8JW5KsXr3FIkZlGNVVavZIuChF7adqIGVZ10oEM+UuyrIGHB07K8QljldG1qTgYVubjoMQZZ/LTrzce0gyyrarTXxGRjylvwIyIOLT2p2lcpTUWntVjIz5cqa7cQhmNnTXUnBlPy5VToWQnG327sqJK3GKq/ays3iBK1/Wl5WLbnk3W6KFmLm2/5U6GurVs2TilZsi0xXnOPe9zp3ov1Nl/4mPDCtPa5kSrP+5Cr99D19PoXcXj6sUj5uPZ3+qvL6nS9P+nPTLTU8+/czJ78i/pW/dH4n7z1+3/x7RTjfN5+Th2epXn7Y6XS4XT8HCteViWIWIdkIqNfGm57erTTXGKxER7HDfZa05tOWwaKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5vV/TnROrxS6hiW70l8t2lLkfCapIw39rr2xi8Za6t96fbOHHdR+k8dZdMzmv2bWSuan88aP7Dxt3oUTx12x73oa/U/wB0fBzOf6G9T4jfPgzupPS5itXE/Yvi+w8rb6Rvrzrn3Oynfap8ce95N2z1PHl/UtTi1VJXbcov7Uefftb15xMe+HTXZWeUwisxtfHGj40aZhMTDRbDNx6auj4p6FJML7WRbuU5ZRq9aVVaETbCJhOUrfN+1+gj+SDAppv5aU4+BHXBhOEoyVVs+JWbwYZaqu57DrjzEHBR1rXvLZgYi8eSrG5Fpbta+wTwOLMvy1NZxXZVpFcx4JxLPPj7KSdXpy6/cTEzPKJRhbax8i7Jxx8PIvy0+S1ce/sOmnabrTwpafwUtsrHOYj8W9j+nPUeRyuHS70K/wDu8tun95o6qek91b9Hx4Mbd3qr+pv4/oH1Ndo7kbGNXfnuc7X9xP7zr1/493E/datWNvUdUcsy9PG+mVyTTzOpy/ehjwUf9qfN9x6Gr/GtcffabfJzW9Un9Nfi9rD9Bemcblc8Z5U47SyJO5/s/L9h6en0jttfKkfjxct++228ce57tjGx8e2rdi1C1bW0IRUV7kejWsRGIjDlmZnjKwlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHGLVGk090wNa50vplz/ExLM/4rcX96M51UnnEfBeNlo8Za1z0z6euKkum4zX/SivuRnPaaZ/RX4QvHcbP3T8Wvc9Fek7lObpdjTakafcZz6fon9ELx3m2P1SqfoH0g//AIy0vBzX3Mj/ANb2/wCyE/3u790or6f+kVt0+Kr+/c/3is+l9tP6IT/fbv3Sz/8AwPpL/wDQX/5Lv+8V/wDU9t+yPn+Z/f7v3f0Y/wD8/wDSNa/kFX/qXf8AeJj0rtv2R8z+/wB37v6JL0D6QX/xtt02rKb++Rb/ANb2/wCyEf32790rrPoz0rZ/w+lY64OsFKvjWpeOw0R+ivwVt3e2edpbdroXRLSSt4GPBLalqC/QaV7bVXlWsfhCk77zztPxbdvHsWlS3bjBLZRil9xrWsRyjDObTPNMsgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAf/Z",
+        "type": "string"
+      }
+    },
+    "required": [
+      "header"
+    ]
+  },
+  "BananaCrop": {
+    "title": "Banana-crop",
+    "example": {
+      "tiny": "Qmavc5kgtpbkgZ6vmRUKSpe4cVZwBfLumTJj2ZKdCKfm2P",
+      "small": "QmRz7atxA7W57EeDRJ17RjV7w6xBm9X6i4h8agxdnnVaK9",
+      "medium": "QmSaYCYQNZNRPS2ozfDnZm63gSnS2DzRDSLrLtN94ZjUkn",
+      "large": "QmXZZekqM1HwNrgBTLksKd6W1VCyTesbdxnPCwkVKBVNBJ",
+      "original": "QmcY9Pt3ZzivBGxXenjbrG4xQ4uAd4BUvLRLuXv3E6688S"
+    },
+    "type": "object",
+    "properties": {
+      "tiny": {
+        "description": "",
+        "example": "Qmavc5kgtpbkgZ6vmRUKSpe4cVZwBfLumTJj2ZKdCKfm2P",
+        "type": "string"
+      },
+      "small": {
+        "description": "",
+        "example": "QmRz7atxA7W57EeDRJ17RjV7w6xBm9X6i4h8agxdnnVaK9",
+        "type": "string"
+      },
+      "medium": {
+        "description": "",
+        "example": "QmSaYCYQNZNRPS2ozfDnZm63gSnS2DzRDSLrLtN94ZjUkn",
+        "type": "string"
+      },
+      "large": {
+        "description": "",
+        "example": "QmXZZekqM1HwNrgBTLksKd6W1VCyTesbdxnPCwkVKBVNBJ",
+        "type": "string"
+      },
+      "original": {
+        "description": "",
+        "example": "QmcY9Pt3ZzivBGxXenjbrG4xQ4uAd4BUvLRLuXv3E6688S",
+        "type": "string"
+      }
+    },
+    "required": [
+      "tiny",
+      "small",
+      "medium",
+      "large",
+      "original"
+    ]
+  },
+  "Chris'Listing": {
+    "title": "Chris' Listing",
+    "example": {
+      "hash": "QmeCofX3Ukn9iGwDrFT7FKGiPVA6UKTLMLrtePThbWzvoM",
+      "slug": "cool-t-shirt",
+      "title": "Cool t-shirt",
+      "category": [],
+      "contractType": "PHYSICAL_GOOD",
+      "description": "",
+      "thumbnail": {
+        "tiny": "QmWE2wHey4KCsmcQA1rby7wfckP6fZ5Fowek4yF7RDpWqP",
+        "small": "QmWassc1riFs9yZWcjoPMNQ8TLD1NXHuxBLQ8jQFxB9zv5",
+        "medium": "QmT8HWD2mu1ieAhiwyBzWJFfrsvxDmx8ky6Q3pduz47FbR"
+      },
+      "price": {
+        "currencyCode": "USD",
+        "amount": 1000
+      },
+      "shipsTo": [
+        "AFGHANISTAN"
+      ],
+      "freeShipping": []
+    },
+    "type": "object",
+    "properties": {
+      "hash": {
+        "description": "",
+        "example": "QmeCofX3Ukn9iGwDrFT7FKGiPVA6UKTLMLrtePThbWzvoM",
+        "type": "string"
+      },
+      "slug": {
+        "description": "",
+        "example": "cool-t-shirt",
+        "type": "string"
+      },
+      "title": {
+        "description": "",
+        "example": "Cool t-shirt",
+        "type": "string"
+      },
+      "category": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "contractType": {
+        "description": "",
+        "example": "PHYSICAL_GOOD",
+        "type": "string"
+      },
+      "description": {
+        "description": "",
+        "type": "string"
+      },
+      "thumbnail": {
+        "$ref": "#/definitions/Thumbnail"
+      },
+      "price": {
+        "$ref": "#/definitions/Price"
+      },
+      "shipsTo": {
+        "description": "",
+        "example": [
+          "AFGHANISTAN"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "freeShipping": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": [
+      "hash",
+      "slug",
+      "title",
+      "category",
+      "contractType",
+      "description",
+      "thumbnail",
+      "price",
+      "shipsTo",
+      "freeShipping"
+    ]
+  },
+  "Thumbnail": {
+    "title": "Thumbnail",
+    "example": {
+      "tiny": "QmWE2wHey4KCsmcQA1rby7wfckP6fZ5Fowek4yF7RDpWqP",
+      "small": "QmWassc1riFs9yZWcjoPMNQ8TLD1NXHuxBLQ8jQFxB9zv5",
+      "medium": "QmT8HWD2mu1ieAhiwyBzWJFfrsvxDmx8ky6Q3pduz47FbR"
+    },
+    "type": "object",
+    "properties": {
+      "tiny": {
+        "description": "",
+        "example": "QmWE2wHey4KCsmcQA1rby7wfckP6fZ5Fowek4yF7RDpWqP",
+        "type": "string"
+      },
+      "small": {
+        "description": "",
+        "example": "QmWassc1riFs9yZWcjoPMNQ8TLD1NXHuxBLQ8jQFxB9zv5",
+        "type": "string"
+      },
+      "medium": {
+        "description": "",
+        "example": "QmT8HWD2mu1ieAhiwyBzWJFfrsvxDmx8ky6Q3pduz47FbR",
+        "type": "string"
+      }
+    },
+    "required": [
+      "tiny",
+      "small",
+      "medium"
+    ]
+  },
+  "Price": {
+    "title": "Price",
+    "example": {
+      "currencyCode": "USD",
+      "amount": 1000
+    },
+    "type": "object",
+    "properties": {
+      "currencyCode": {
+        "description": "",
+        "example": "USD",
+        "type": "string"
+      },
+      "amount": {
+        "description": "",
+        "example": 1000,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "currencyCode",
+      "amount"
+    ]
+  },
+  "Get testListing from sam": {
+    "title": "Get test-listing from Sam",
+    "example": {
+      "vendorListings": [
+        {
+          "slug": "test-listing-1",
+          "vendorID": {
+            "guid": "QmRBhyTivwngraebqBVoPYCh8SBrsagqRtMwj44dMLXhwn",
+            "pubkeys": {
+              "guid": "CAASpgQwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDBHtePZNwvHhP2AJT/ZVNkMUcqR5h80xAj4E4qzKfLJVo5VLxekTGiRd4UrJok3rAjnT9koxcGDXA49SHjc2guONK3O3WkiZnrCr0fvCGmAIkd38dGqE9grhr5pktkVxAVbvizj/e9CUG8bx++Bu0puSXeuDaMjnEjcNxtn+TIfmkl6iDnQtEdhOdJR7o1FkVs4NpFu3+/6cj7/Z4WUimW17+CODaQO3z5SF9HSHnJ9SzLKuLqCcPnqCJqkXaG8HIhnUNhkCW+eFlgy1ieoysjL2rYPQUusMhnUN1+lBcN++MPFnMHIrPBrRvw9lHH8eaGZSEhchNZpXWjKNh82ZQT1Duyq/21+gdkBTGabgXWWK1yO9jlKyeuSLiYqYUyBiBpscaMAPQTtBUbawEtUXXUves+P2YBNMMD5DzdAg+cMdLH/EjT6dV6XwVkwfUjgyyXTvJMpaDBI6B/tFrru5A+cyrQxXn1P9CcWLK63UeuD3XtK2mw/OMUOUQLYVnu5F1jrOwSGOvo30OMizsxiD3frq3h5V9LOM9kUIdjWaUM2afczPUTIhjLvONTaOGXDsRp/Y01UYq7gqclmash89qh+fnMjw3i8cR9zsmCGCtiTGf3P13jCkleaP4iDjan/XJ4gd8VpbyHRVGpm2BOpmm2Xj6WCmwjHviFTt0q4/KJ/QIDAQAB",
+              "bitcoin": "A8usB22d+jDWOK1yoZkjvhOfTzk+VcRiblUhTlwHMaWj"
+            },
+            "bitcoinSig": "MEUCIQCIfxbYcSYhh+zSg0WgqgCRt/gQ81ELnzFOWFeS3vM4ugIgN/uXYYwpf92X2CHjmDYQkKSiPHOc9CBxKYSWUIik3Jc="
+          },
+          "metadata": {
+            "version": 1,
+            "contractType": "DIGITAL_GOOD",
+            "format": "FIXED_PRICE",
+            "expiry": "2037-12-31T05:00:00Z",
+            "acceptedCurrency": "btc",
+            "pricingCurrency": "USD"
+          },
+          "item": {
+            "title": "Test listing 1",
+            "description": "<p>This is a digital good. A good digital good.</p>",
+            "price": 300,
+            "tags": [
+              "test"
+            ],
+            "images": [
+              {
+                "filename": "pp.jpg",
+                "original": "QmfC1TAANVAMVPXd5cC7EYQgajT8F4aUs8FJJBrgAcq8d1",
+                "large": "QmZm6ZWs9tEVcoMBtRGAuviJYdY5r5xAetMGNeM4msWRAw",
+                "medium": "QmRCNyrAaE51jw6kLz7MoK9pznBKJ4PP49siLwcTehqgX8",
+                "small": "QmbLQ23QQ1NrMHhDQgjNTqTsr7EDqndEfDJy26wEMayiXJ",
+                "tiny": "QmXyv7cyRCDMYW26X2VZkSJSghbeMYb1nDgJxeUhroz4UT"
+              }
+            ],
+            "categories": [
+              "test1"
+            ],
+            "condition": "NEW"
+          },
+          "shippingOptions": [],
+          "termsAndConditions": "test",
+          "refundPolicy": "test\n\n"
+        }
+      ],
+      "signatures": [
+        {
+          "section": "LISTING",
+          "signatureBytes": "MWUmTzx39v13odWqbuT3ByKF/QHCWeDE8zROQWguwENkh5dHAnr57CS7TyjRNKVVAPTcfxUiNNUOiz4KDCTs5tKxJEkOEsQ6PVMjmHPjAeJRgEHeMIFUoqbUJo8nyl5/6ifFcqBcow2jKxIT+OSfReOmYHTEzNLEScgzBG8Ftyz72yIvdWEx8dzjzLBqkE1rtLpuBV/waoPnAJtwHAH+mbED3GL/T0JAo44thSM2gY/u5Z6vVz9QyJLxW/l4etq3m4se0JPWxtZFrBsKU+48NMuHhre+1aqdKdmeUw+sNwfjVFuRpxLnJloYdVOKMmc7/6RCtI60u09AQq+yp6cItrJ7Jv5XzwK5GI/VdHUg32kjHMD+uuTEg4rs0MjcDKckyHTRN9hxtc1AZmlkiAdvsq/IeZSQVFX3KhN7ngTqCqqJYTbzMAcsfMSx/8F6rfO+XrcPQHDuzazD26M4I6bmzeLU+ibjHphbadpSytPpQvS+v1bjefgXAUeEDV/zS/yU1dwr3ZLY+s7pOUU3APrDaB+NyGhP8+WovHQNmKgCUvx3EaKikarkveeOnSiZ4z2qfYezA33UGvO9/0kOQKOpSKSqlxfIHqKY/FbxERbysknrOS9SZBCJXG5t02KAoHdZcINMRgNHSNL/BvOmFJc7WnhcmO1ovR7KCKLHDkSffjI="
+        }
+      ]
+    },
+    "type": "object",
+    "properties": {
+      "vendorListings": {
+        "description": "",
+        "example": [
+          {
+            "slug": "test-listing-1",
+            "vendorID": {
+              "guid": "QmRBhyTivwngraebqBVoPYCh8SBrsagqRtMwj44dMLXhwn",
+              "pubkeys": {
+                "guid": "CAASpgQwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDBHtePZNwvHhP2AJT/ZVNkMUcqR5h80xAj4E4qzKfLJVo5VLxekTGiRd4UrJok3rAjnT9koxcGDXA49SHjc2guONK3O3WkiZnrCr0fvCGmAIkd38dGqE9grhr5pktkVxAVbvizj/e9CUG8bx++Bu0puSXeuDaMjnEjcNxtn+TIfmkl6iDnQtEdhOdJR7o1FkVs4NpFu3+/6cj7/Z4WUimW17+CODaQO3z5SF9HSHnJ9SzLKuLqCcPnqCJqkXaG8HIhnUNhkCW+eFlgy1ieoysjL2rYPQUusMhnUN1+lBcN++MPFnMHIrPBrRvw9lHH8eaGZSEhchNZpXWjKNh82ZQT1Duyq/21+gdkBTGabgXWWK1yO9jlKyeuSLiYqYUyBiBpscaMAPQTtBUbawEtUXXUves+P2YBNMMD5DzdAg+cMdLH/EjT6dV6XwVkwfUjgyyXTvJMpaDBI6B/tFrru5A+cyrQxXn1P9CcWLK63UeuD3XtK2mw/OMUOUQLYVnu5F1jrOwSGOvo30OMizsxiD3frq3h5V9LOM9kUIdjWaUM2afczPUTIhjLvONTaOGXDsRp/Y01UYq7gqclmash89qh+fnMjw3i8cR9zsmCGCtiTGf3P13jCkleaP4iDjan/XJ4gd8VpbyHRVGpm2BOpmm2Xj6WCmwjHviFTt0q4/KJ/QIDAQAB",
+                "bitcoin": "A8usB22d+jDWOK1yoZkjvhOfTzk+VcRiblUhTlwHMaWj"
+              },
+              "bitcoinSig": "MEUCIQCIfxbYcSYhh+zSg0WgqgCRt/gQ81ELnzFOWFeS3vM4ugIgN/uXYYwpf92X2CHjmDYQkKSiPHOc9CBxKYSWUIik3Jc="
+            },
+            "metadata": {
+              "version": 1,
+              "contractType": "DIGITAL_GOOD",
+              "format": "FIXED_PRICE",
+              "expiry": "2037-12-31T05:00:00Z",
+              "acceptedCurrency": "btc",
+              "pricingCurrency": "USD"
+            },
+            "item": {
+              "title": "Test listing 1",
+              "description": "<p>This is a digital good. A good digital good.</p>",
+              "price": 300,
+              "tags": [
+                "test"
+              ],
+              "images": [
+                {
+                  "filename": "pp.jpg",
+                  "original": "QmfC1TAANVAMVPXd5cC7EYQgajT8F4aUs8FJJBrgAcq8d1",
+                  "large": "QmZm6ZWs9tEVcoMBtRGAuviJYdY5r5xAetMGNeM4msWRAw",
+                  "medium": "QmRCNyrAaE51jw6kLz7MoK9pznBKJ4PP49siLwcTehqgX8",
+                  "small": "QmbLQ23QQ1NrMHhDQgjNTqTsr7EDqndEfDJy26wEMayiXJ",
+                  "tiny": "QmXyv7cyRCDMYW26X2VZkSJSghbeMYb1nDgJxeUhroz4UT"
+                }
+              ],
+              "categories": [
+                "test1"
+              ],
+              "condition": "NEW"
+            },
+            "shippingOptions": [],
+            "termsAndConditions": "test",
+            "refundPolicy": "test\n\n"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/VendorListing100"
+        }
+      },
+      "signatures": {
+        "description": "",
+        "example": [
+          {
+            "section": "LISTING",
+            "signatureBytes": "MWUmTzx39v13odWqbuT3ByKF/QHCWeDE8zROQWguwENkh5dHAnr57CS7TyjRNKVVAPTcfxUiNNUOiz4KDCTs5tKxJEkOEsQ6PVMjmHPjAeJRgEHeMIFUoqbUJo8nyl5/6ifFcqBcow2jKxIT+OSfReOmYHTEzNLEScgzBG8Ftyz72yIvdWEx8dzjzLBqkE1rtLpuBV/waoPnAJtwHAH+mbED3GL/T0JAo44thSM2gY/u5Z6vVz9QyJLxW/l4etq3m4se0JPWxtZFrBsKU+48NMuHhre+1aqdKdmeUw+sNwfjVFuRpxLnJloYdVOKMmc7/6RCtI60u09AQq+yp6cItrJ7Jv5XzwK5GI/VdHUg32kjHMD+uuTEg4rs0MjcDKckyHTRN9hxtc1AZmlkiAdvsq/IeZSQVFX3KhN7ngTqCqqJYTbzMAcsfMSx/8F6rfO+XrcPQHDuzazD26M4I6bmzeLU+ibjHphbadpSytPpQvS+v1bjefgXAUeEDV/zS/yU1dwr3ZLY+s7pOUU3APrDaB+NyGhP8+WovHQNmKgCUvx3EaKikarkveeOnSiZ4z2qfYezA33UGvO9/0kOQKOpSKSqlxfIHqKY/FbxERbysknrOS9SZBCJXG5t02KAoHdZcINMRgNHSNL/BvOmFJc7WnhcmO1ovR7KCKLHDkSffjI="
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Signature"
+        }
+      }
+    },
+    "required": [
+      "vendorListings",
+      "signatures"
+    ]
+  },
+  "VendorListing100": {
+    "title": "VendorListing100",
+    "example": {
+      "slug": "test-listing-1",
+      "vendorID": {
+        "guid": "QmRBhyTivwngraebqBVoPYCh8SBrsagqRtMwj44dMLXhwn",
+        "pubkeys": {
+          "guid": "CAASpgQwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDBHtePZNwvHhP2AJT/ZVNkMUcqR5h80xAj4E4qzKfLJVo5VLxekTGiRd4UrJok3rAjnT9koxcGDXA49SHjc2guONK3O3WkiZnrCr0fvCGmAIkd38dGqE9grhr5pktkVxAVbvizj/e9CUG8bx++Bu0puSXeuDaMjnEjcNxtn+TIfmkl6iDnQtEdhOdJR7o1FkVs4NpFu3+/6cj7/Z4WUimW17+CODaQO3z5SF9HSHnJ9SzLKuLqCcPnqCJqkXaG8HIhnUNhkCW+eFlgy1ieoysjL2rYPQUusMhnUN1+lBcN++MPFnMHIrPBrRvw9lHH8eaGZSEhchNZpXWjKNh82ZQT1Duyq/21+gdkBTGabgXWWK1yO9jlKyeuSLiYqYUyBiBpscaMAPQTtBUbawEtUXXUves+P2YBNMMD5DzdAg+cMdLH/EjT6dV6XwVkwfUjgyyXTvJMpaDBI6B/tFrru5A+cyrQxXn1P9CcWLK63UeuD3XtK2mw/OMUOUQLYVnu5F1jrOwSGOvo30OMizsxiD3frq3h5V9LOM9kUIdjWaUM2afczPUTIhjLvONTaOGXDsRp/Y01UYq7gqclmash89qh+fnMjw3i8cR9zsmCGCtiTGf3P13jCkleaP4iDjan/XJ4gd8VpbyHRVGpm2BOpmm2Xj6WCmwjHviFTt0q4/KJ/QIDAQAB",
+          "bitcoin": "A8usB22d+jDWOK1yoZkjvhOfTzk+VcRiblUhTlwHMaWj"
+        },
+        "bitcoinSig": "MEUCIQCIfxbYcSYhh+zSg0WgqgCRt/gQ81ELnzFOWFeS3vM4ugIgN/uXYYwpf92X2CHjmDYQkKSiPHOc9CBxKYSWUIik3Jc="
+      },
+      "metadata": {
+        "version": 1,
+        "contractType": "DIGITAL_GOOD",
+        "format": "FIXED_PRICE",
+        "expiry": "2037-12-31T05:00:00Z",
+        "acceptedCurrency": "btc",
+        "pricingCurrency": "USD"
+      },
+      "item": {
+        "title": "Test listing 1",
+        "description": "<p>This is a digital good. A good digital good.</p>",
+        "price": 300,
+        "tags": [
+          "test"
+        ],
+        "images": [
+          {
+            "filename": "pp.jpg",
+            "original": "QmfC1TAANVAMVPXd5cC7EYQgajT8F4aUs8FJJBrgAcq8d1",
+            "large": "QmZm6ZWs9tEVcoMBtRGAuviJYdY5r5xAetMGNeM4msWRAw",
+            "medium": "QmRCNyrAaE51jw6kLz7MoK9pznBKJ4PP49siLwcTehqgX8",
+            "small": "QmbLQ23QQ1NrMHhDQgjNTqTsr7EDqndEfDJy26wEMayiXJ",
+            "tiny": "QmXyv7cyRCDMYW26X2VZkSJSghbeMYb1nDgJxeUhroz4UT"
+          }
+        ],
+        "categories": [
+          "test1"
+        ],
+        "condition": "NEW"
+      },
+      "shippingOptions": [],
+      "termsAndConditions": "test",
+      "refundPolicy": "test\n\n"
+    },
+    "type": "object",
+    "properties": {
+      "slug": {
+        "description": "",
+        "example": "test-listing-1",
+        "type": "string"
+      },
+      "vendorID": {
+        "$ref": "#/definitions/VendorID"
+      },
+      "metadata": {
+        "$ref": "#/definitions/Metadata"
+      },
+      "item": {
+        "$ref": "#/definitions/Item"
+      },
+      "shippingOptions": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "termsAndConditions": {
+        "description": "",
+        "example": "test",
+        "type": "string"
+      },
+      "refundPolicy": {
+        "description": "",
+        "example": "test\n\n",
+        "type": "string"
+      }
+    },
+    "required": [
+      "slug",
+      "vendorID",
+      "metadata",
+      "item",
+      "shippingOptions",
+      "termsAndConditions",
+      "refundPolicy"
+    ]
+  },
+  "CreateANewListing(physical;NoOptions)request": {
+    "title": "Create a new listing (physical; no options)Request",
+    "example": {
+      "slug": "vintage-dress-physical-no-options",
+      "metadata": {
+        "contractType": "PHYSICAL_GOOD",
+        "format": "FIXED_PRICE",
+        "expiry": "2037-12-31T05:00:00Z",
+        "pricingCurrency": "USD"
+      },
+      "item": {
+        "title": "Vintage dress (physical; no options)",
+        "description": "This is a listing example.",
+        "processingTime": "3 days",
+        "price": 100,
+        "tags": [
+          "vintage dress"
+        ],
+        "images": [
+          {
+            "filename": "front",
+            "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz",
+            "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+            "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+            "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+            "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq"
+          },
+          {
+            "filename": "cream",
+            "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq",
+            "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+            "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+            "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+            "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny"
+          },
+          {
+            "filename": "black",
+            "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe",
+            "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+            "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+            "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+            "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr"
+          },
+          {
+            "filename": "other_red",
+            "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt",
+            "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+            "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+            "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+            "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF"
+          }
+        ],
+        "categories": [
+          "👚 Apparel & Accessories"
+        ],
+        "condition": "New",
+        "options": [],
+        "skus": [],
+        "nsfw": false
+      },
+      "shippingOptions": [
+        {
+          "name": "Worldwide",
+          "type": "FIXED_PRICE",
+          "regions": [
+            "ALL"
+          ],
+          "services": [
+            {
+              "name": "Standard",
+              "price": 0,
+              "estimatedDelivery": "3 days"
+            },
+            {
+              "name": "Express",
+              "price": 1,
+              "estimatedDelivery": "3 days"
+            }
+          ]
+        }
+      ],
+      "taxes": [],
+      "coupons": [],
+      "moderators": [
+        "QmamG5uQjRqrdxAxp4DJK4TLvs2Yet8Nuiztip4ALD7i1U",
+        "Qmbh95GgLueUusSgm4tUhHFEZA6hNuB8yYAgzi1FCDQX2G"
+      ],
+      "termsAndConditions": "Terms and conditions.",
+      "refundPolicy": "Refund policy."
+    },
+    "type": "object",
+    "properties": {
+      "slug": {
+        "description": "",
+        "example": "vintage-dress-physical-no-options",
+        "type": "string"
+      },
+      "metadata": {
+        "$ref": "#/definitions/Metadata108"
+      },
+      "item": {
+        "$ref": "#/definitions/Item109"
+      },
+      "shippingOptions": {
+        "description": "",
+        "example": [
+          {
+            "name": "Worldwide",
+            "type": "FIXED_PRICE",
+            "regions": [
+              "ALL"
+            ],
+            "services": [
+              {
+                "name": "Standard",
+                "price": 0,
+                "estimatedDelivery": "3 days"
+              },
+              {
+                "name": "Express",
+                "price": 1,
+                "estimatedDelivery": "3 days"
+              }
+            ]
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/ShippingOption40"
+        }
+      },
+      "taxes": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "coupons": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "moderators": {
+        "description": "",
+        "example": [
+          "QmamG5uQjRqrdxAxp4DJK4TLvs2Yet8Nuiztip4ALD7i1U",
+          "Qmbh95GgLueUusSgm4tUhHFEZA6hNuB8yYAgzi1FCDQX2G"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "termsAndConditions": {
+        "description": "",
+        "example": "Terms and conditions.",
+        "type": "string"
+      },
+      "refundPolicy": {
+        "description": "",
+        "example": "Refund policy.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "slug",
+      "metadata",
+      "item",
+      "shippingOptions",
+      "taxes",
+      "coupons",
+      "moderators",
+      "termsAndConditions",
+      "refundPolicy"
+    ]
+  },
+  "Metadata108": {
+    "title": "Metadata108",
+    "example": {
+      "contractType": "PHYSICAL_GOOD",
+      "format": "FIXED_PRICE",
+      "expiry": "2037-12-31T05:00:00Z",
+      "pricingCurrency": "USD"
+    },
+    "type": "object",
+    "properties": {
+      "contractType": {
+        "description": "",
+        "example": "PHYSICAL_GOOD",
+        "type": "string"
+      },
+      "format": {
+        "description": "",
+        "example": "FIXED_PRICE",
+        "type": "string"
+      },
+      "expiry": {
+        "description": "",
+        "example": "12/31/2037 5:00:00 AM",
+        "type": "string"
+      },
+      "pricingCurrency": {
+        "description": "",
+        "example": "USD",
+        "type": "string"
+      }
+    },
+    "required": [
+      "contractType",
+      "format",
+      "expiry",
+      "pricingCurrency"
+    ]
+  },
+  "Item109": {
+    "title": "Item109",
+    "example": {
+      "title": "Vintage dress (physical; no options)",
+      "description": "This is a listing example.",
+      "processingTime": "3 days",
+      "price": 100,
+      "tags": [
+        "vintage dress"
+      ],
+      "images": [
+        {
+          "filename": "front",
+          "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz",
+          "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+          "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+          "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+          "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq"
+        },
+        {
+          "filename": "cream",
+          "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq",
+          "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+          "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+          "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+          "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny"
+        },
+        {
+          "filename": "black",
+          "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe",
+          "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+          "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+          "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+          "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr"
+        },
+        {
+          "filename": "other_red",
+          "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt",
+          "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+          "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+          "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+          "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF"
+        }
+      ],
+      "categories": [
+        "👚 Apparel & Accessories"
+      ],
+      "condition": "New",
+      "options": [],
+      "skus": [],
+      "nsfw": false
+    },
+    "type": "object",
+    "properties": {
+      "title": {
+        "description": "",
+        "example": "Vintage dress (physical; no options)",
+        "type": "string"
+      },
+      "description": {
+        "description": "",
+        "example": "This is a listing example.",
+        "type": "string"
+      },
+      "processingTime": {
+        "description": "",
+        "example": "3 days",
+        "type": "string"
+      },
+      "price": {
+        "description": "",
+        "example": 100,
+        "type": "integer",
+        "format": "int32"
+      },
+      "tags": {
+        "description": "",
+        "example": [
+          "vintage dress"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "images": {
+        "description": "",
+        "example": [
+          {
+            "filename": "front",
+            "tiny": "QmbjyAxYee4y3443kAMLcmRVwggZsRDKiyXnXus1qdJJWz",
+            "small": "QmVsoT9iabv6GZhxhvtjSpQMJA6QyMivGTs6MmHJr6TBm9",
+            "medium": "QmTJfeeapZwFM8EoZAuf16JsSJyxZtKaAR6hmWiMf4CTcF",
+            "large": "QmfTKL3Z67mWKTKf9XKSCj1ptmDRaZLr5yjPS4JrVDgo5h",
+            "original": "QmNexx7SaJCVCjyGGG3j2k7fenn3iVhtWdm9RvKvT7GTLq"
+          },
+          {
+            "filename": "cream",
+            "tiny": "QmU1cBgjyHpuzDYbEd4iDVuPzxgKM3CqhRhDJqkHWCKBXq",
+            "small": "QmP3BVFuga7N4XEX8iU2MFYC7pc6mfTRQRrpZbKiVy2Csr",
+            "medium": "QmQaSzaoHzp8raZLtPEFyCjTnwfXvDGKdXFM83STDVWG43",
+            "large": "QmNsFdsX2LNALG2WBxw6E6FTPZWgJcRAcLHnKdWczrCNf9",
+            "original": "QmTEUnCjuQPj1ggj5UL5vJujkgBiNYY4jkteugnogiCJny"
+          },
+          {
+            "filename": "black",
+            "tiny": "QmdA3Nmc8VnwSvt98Deo2RQztEiCsAkNLhron73bnBzARe",
+            "small": "QmcADxUo89ZsEAWiYsuUk7hrgjWDMKXL1CtoA9sTNrQFFP",
+            "medium": "QmZydpAJoLsJWbP5vmh59W6bW1kuiCV34yD62hq28AtP7b",
+            "large": "QmXixGseetihe6vZiWcTw9N1pieok1YtRoxwvyd5d7jz6s",
+            "original": "QmZsZ78FJwt281gfeUvGzDnsBW7WNjPWW3aJWDKskhpCRr"
+          },
+          {
+            "filename": "other_red",
+            "tiny": "QmbRFtxNWqACak1vvMJrrxUjzWjTJbMqi3vdUK5ZYvibgt",
+            "small": "QmRdYph9YrfpdzMsaDnuySj6U4AY9dZhmjd8Cv2e6SscUG",
+            "medium": "QmcD4pkp7SwCmN95pFnED2hz1LfsoYTPpynxeZbxCMoYPL",
+            "large": "QmbSQZNAL3pZspUYWm6WNBD1oEQ6i9EnWPEsnk1DfdKnAv",
+            "original": "QmZpgjK4jXmdqPg8Jt9YHGVmiuowVve3sbN2AZx7GXioDF"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Image"
+        }
+      },
+      "categories": {
+        "description": "",
+        "example": [
+          "👚 Apparel & Accessories"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "condition": {
+        "description": "",
+        "example": "New",
+        "type": "string"
+      },
+      "options": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "skus": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "nsfw": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "title",
+      "description",
+      "processingTime",
+      "price",
+      "tags",
+      "images",
+      "categories",
+      "condition",
+      "options",
+      "skus",
+      "nsfw"
+    ]
+  },
+  "Godfather": {
+    "title": "Godfather",
+    "example": {
+      "slug": "godfather"
+    },
+    "type": "object",
+    "properties": {
+      "slug": {
+        "description": "",
+        "example": "godfather",
+        "type": "string"
+      }
+    },
+    "required": [
+      "slug"
+    ]
+  },
+  "AmIFollowingSam": {
+    "title": "Am I following Sam",
+    "example": {
+      "isFollowing": "true"
+    },
+    "type": "object",
+    "properties": {
+      "isFollowing": {
+        "description": "",
+        "example": "true",
+        "type": "string"
+      }
+    },
+    "required": [
+      "isFollowing"
+    ]
+  },
+  "DoesSamFollowMe?": {
+    "title": "Does Sam follow me?",
+    "example": {
+      "followsMe": "false"
+    },
+    "type": "object",
+    "properties": {
+      "followsMe": {
+        "description": "",
+        "example": "false",
+        "type": "string"
+      }
+    },
+    "required": [
+      "followsMe"
+    ]
+  },
+  "GetSam'sProfile": {
+    "title": "Get Sam's profile",
+    "example": {
+      "handle": "",
+      "name": "Sam's Store",
+      "location": "",
+      "about": "What do you want to know?",
+      "shortDescription": "This is my store. I like it.",
+      "website": "samuelrpatterson.com",
+      "email": "sam@openbazaar.org",
+      "phoneNumber": "",
+      "social": [],
+      "avgRating": 0,
+      "numRatings": 0,
+      "nsfw": false,
+      "vendor": false,
+      "moderator": false,
+      "primaryColor": "#086A9E",
+      "secondaryColor": "#317DB8",
+      "textColor": "#ffffff",
+      "avatarHashes": {
+        "tiny": "QmRmPcTfztPLGsPrxuwC888XrYzhP7LhGC3yVs6cbCvFGG",
+        "small": "QmVfXcmtBcKvCiSUUkytNyJ15r2RojYrLwxtWb3zTK9nq6",
+        "medium": "QmbgUKbqadg5ApLtk1r9FL86Lq9yJ7K4LQrEUSo1LW8ydq",
+        "large": "QmYQ3pM2TrYZo6ci2wsUpgXoTvWyvyLpHr3KVnNAtyYZ5B",
+        "original": "QmPF1bqbUuZT4WfA3XPbGby6HTJb7xbzyBiVohaSgjuwpF"
+      },
+      "headerHashes": {
+        "tiny": "QmVWdEwPMZriAbU6R8ZtVGktf8u4TSXJ57t1FaEC4yhW7U",
+        "small": "QmWGcdiSis7iKqtQqbp9fYfkMkJKd3gjDdv4WDAAc68SiE",
+        "medium": "QmSxsfdwTLo5EAydopzxHhdTzpDCdWJHnym47nMxaEB7NA",
+        "large": "QmYwZXDcDhPMx8c9haAQMigc4xhfjQpRioQT4HJvaMtvTb",
+        "original": "QmTzxAfQ7GZj9pKA3TkwHTR468HDLKe7ZcmxCubq6KbZeg"
+      },
+      "followerCount": 1,
+      "followingCount": 1,
+      "listingCount": 1,
+      "lastModified": 1480546384
+    },
+    "type": "object",
+    "properties": {
+      "handle": {
+        "description": "",
+        "type": "string"
+      },
+      "name": {
+        "description": "",
+        "example": "Sam's Store",
+        "type": "string"
+      },
+      "location": {
+        "description": "",
+        "type": "string"
+      },
+      "about": {
+        "description": "",
+        "example": "What do you want to know?",
+        "type": "string"
+      },
+      "shortDescription": {
+        "description": "",
+        "example": "This is my store. I like it.",
+        "type": "string"
+      },
+      "website": {
+        "description": "",
+        "example": "samuelrpatterson.com",
+        "type": "string"
+      },
+      "email": {
+        "description": "",
+        "example": "sam@openbazaar.org",
+        "type": "string"
+      },
+      "phoneNumber": {
+        "description": "",
+        "type": "string"
+      },
+      "social": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "avgRating": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "numRatings": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "nsfw": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "vendor": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "moderator": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "primaryColor": {
+        "description": "",
+        "example": "#086A9E",
+        "type": "string"
+      },
+      "secondaryColor": {
+        "description": "",
+        "example": "#317DB8",
+        "type": "string"
+      },
+      "textColor": {
+        "description": "",
+        "example": "#ffffff",
+        "type": "string"
+      },
+      "avatarHashes": {
+        "$ref": "#/definitions/AvatarHashes"
+      },
+      "headerHashes": {
+        "$ref": "#/definitions/HeaderHashes"
+      },
+      "followerCount": {
+        "description": "",
+        "example": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "followingCount": {
+        "description": "",
+        "example": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "listingCount": {
+        "description": "",
+        "example": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "lastModified": {
+        "description": "",
+        "example": 1480546384,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "handle",
+      "name",
+      "location",
+      "about",
+      "shortDescription",
+      "website",
+      "email",
+      "phoneNumber",
+      "social",
+      "avgRating",
+      "numRatings",
+      "nsfw",
+      "vendor",
+      "moderator",
+      "primaryColor",
+      "secondaryColor",
+      "textColor",
+      "avatarHashes",
+      "headerHashes",
+      "followerCount",
+      "followingCount",
+      "listingCount",
+      "lastModified"
+    ]
+  },
+  "AvatarHashes": {
+    "title": "AvatarHashes",
+    "example": {
+      "tiny": "QmRmPcTfztPLGsPrxuwC888XrYzhP7LhGC3yVs6cbCvFGG",
+      "small": "QmVfXcmtBcKvCiSUUkytNyJ15r2RojYrLwxtWb3zTK9nq6",
+      "medium": "QmbgUKbqadg5ApLtk1r9FL86Lq9yJ7K4LQrEUSo1LW8ydq",
+      "large": "QmYQ3pM2TrYZo6ci2wsUpgXoTvWyvyLpHr3KVnNAtyYZ5B",
+      "original": "QmPF1bqbUuZT4WfA3XPbGby6HTJb7xbzyBiVohaSgjuwpF"
+    },
+    "type": "object",
+    "properties": {
+      "tiny": {
+        "description": "",
+        "example": "QmRmPcTfztPLGsPrxuwC888XrYzhP7LhGC3yVs6cbCvFGG",
+        "type": "string"
+      },
+      "small": {
+        "description": "",
+        "example": "QmVfXcmtBcKvCiSUUkytNyJ15r2RojYrLwxtWb3zTK9nq6",
+        "type": "string"
+      },
+      "medium": {
+        "description": "",
+        "example": "QmbgUKbqadg5ApLtk1r9FL86Lq9yJ7K4LQrEUSo1LW8ydq",
+        "type": "string"
+      },
+      "large": {
+        "description": "",
+        "example": "QmYQ3pM2TrYZo6ci2wsUpgXoTvWyvyLpHr3KVnNAtyYZ5B",
+        "type": "string"
+      },
+      "original": {
+        "description": "",
+        "example": "QmPF1bqbUuZT4WfA3XPbGby6HTJb7xbzyBiVohaSgjuwpF",
+        "type": "string"
+      }
+    },
+    "required": [
+      "tiny",
+      "small",
+      "medium",
+      "large",
+      "original"
+    ]
+  },
+  "HeaderHashes": {
+    "title": "HeaderHashes",
+    "example": {
+      "tiny": "QmVWdEwPMZriAbU6R8ZtVGktf8u4TSXJ57t1FaEC4yhW7U",
+      "small": "QmWGcdiSis7iKqtQqbp9fYfkMkJKd3gjDdv4WDAAc68SiE",
+      "medium": "QmSxsfdwTLo5EAydopzxHhdTzpDCdWJHnym47nMxaEB7NA",
+      "large": "QmYwZXDcDhPMx8c9haAQMigc4xhfjQpRioQT4HJvaMtvTb",
+      "original": "QmTzxAfQ7GZj9pKA3TkwHTR468HDLKe7ZcmxCubq6KbZeg"
+    },
+    "type": "object",
+    "properties": {
+      "tiny": {
+        "description": "",
+        "example": "QmVWdEwPMZriAbU6R8ZtVGktf8u4TSXJ57t1FaEC4yhW7U",
+        "type": "string"
+      },
+      "small": {
+        "description": "",
+        "example": "QmWGcdiSis7iKqtQqbp9fYfkMkJKd3gjDdv4WDAAc68SiE",
+        "type": "string"
+      },
+      "medium": {
+        "description": "",
+        "example": "QmSxsfdwTLo5EAydopzxHhdTzpDCdWJHnym47nMxaEB7NA",
+        "type": "string"
+      },
+      "large": {
+        "description": "",
+        "example": "QmYwZXDcDhPMx8c9haAQMigc4xhfjQpRioQT4HJvaMtvTb",
+        "type": "string"
+      },
+      "original": {
+        "description": "",
+        "example": "QmTzxAfQ7GZj9pKA3TkwHTR468HDLKe7ZcmxCubq6KbZeg",
+        "type": "string"
+      }
+    },
+    "required": [
+      "tiny",
+      "small",
+      "medium",
+      "large",
+      "original"
+    ]
+  },
+  "FollowAPeerrequest": {
+    "title": "Follow a peerRequest",
+    "example": {
+      "id": "QmNgBZN7z1CfMLbwyEwnGoixjbSaBcP9fS5ecMzZwCq3Ku"
+    },
+    "type": "object",
+    "properties": {
+      "id": {
+        "description": "",
+        "example": "QmNgBZN7z1CfMLbwyEwnGoixjbSaBcP9fS5ecMzZwCq3Ku",
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ]
+  },
+  "UnfollowAPeerrequest": {
+    "title": "Unfollow a peerRequest",
+    "example": {
+      "id": "QmaKEKXgxiW9iCWfvY8VN3xUhyqhBY8kKEgZWwUbQF6P2H"
+    },
+    "type": "object",
+    "properties": {
+      "id": {
+        "description": "",
+        "example": "QmaKEKXgxiW9iCWfvY8VN3xUhyqhBY8kKEgZWwUbQF6P2H",
+        "type": "string"
+      }
+    },
+    "required": [
+      "id"
+    ]
+  },
+  "MySettings": {
+    "title": "My settings",
+    "example": {
+      "paymentDataInQR": false,
+      "showNotificatons": null,
+      "showNsfw": true,
+      "shippingAddresses": [],
+      "localCurrency": "USD",
+      "country": "UNITED_STATES",
+      "language": "en-US",
+      "termsAndConditions": "",
+      "refundPolicy": "",
+      "blockedNodes": [],
+      "storeModerators": [],
+      "smtpSettings": {
+        "notifications": true,
+        "serverAddress": "",
+        "username": "",
+        "password": "",
+        "senderEmail": "",
+        "recipientEmail": ""
+      }
+    },
+    "type": "object",
+    "properties": {
+      "paymentDataInQR": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "showNotificatons": {
+        "description": "",
+        "type": "string"
+      },
+      "showNsfw": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "shippingAddresses": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "localCurrency": {
+        "description": "",
+        "example": "USD",
+        "type": "string"
+      },
+      "country": {
+        "description": "",
+        "example": "UNITED_STATES",
+        "type": "string"
+      },
+      "language": {
+        "description": "",
+        "example": "en-US",
+        "type": "string"
+      },
+      "termsAndConditions": {
+        "description": "",
+        "type": "string"
+      },
+      "refundPolicy": {
+        "description": "",
+        "type": "string"
+      },
+      "blockedNodes": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "storeModerators": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "smtpSettings": {
+        "$ref": "#/definitions/SmtpSettings"
+      }
+    },
+    "required": [
+      "paymentDataInQR",
+      "showNotificatons",
+      "showNsfw",
+      "shippingAddresses",
+      "localCurrency",
+      "country",
+      "language",
+      "termsAndConditions",
+      "refundPolicy",
+      "blockedNodes",
+      "storeModerators",
+      "smtpSettings"
+    ]
+  },
+  "SmtpSettings": {
+    "title": "SmtpSettings",
+    "example": {
+      "notifications": true,
+      "serverAddress": "",
+      "username": "",
+      "password": "",
+      "senderEmail": "",
+      "recipientEmail": ""
+    },
+    "type": "object",
+    "properties": {
+      "notifications": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "serverAddress": {
+        "description": "",
+        "type": "string"
+      },
+      "username": {
+        "description": "",
+        "type": "string"
+      },
+      "password": {
+        "description": "",
+        "type": "string"
+      },
+      "senderEmail": {
+        "description": "",
+        "type": "string"
+      },
+      "recipientEmail": {
+        "description": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "notifications",
+      "serverAddress",
+      "username",
+      "password",
+      "senderEmail",
+      "recipientEmail"
+    ]
+  },
+  "SetSettingsrequest": {
+    "title": "Set settingsRequest",
+    "example": {
+      "paymentDataInQR": true,
+      "showNotifications": true,
+      "showNsfw": true,
+      "shippingAddresses": [
+        {
+          "name": "Seymour Butts",
+          "company": "Globex Corporation",
+          "addressLineOne": "31 Spooner Street",
+          "addressLineTwo": "Apt. 124",
+          "city": "Quahog",
+          "state": "RI",
+          "country": "UNITED_STATES",
+          "addressNotes": "Leave package at back door"
+        }
+      ],
+      "localCurrency": "USD",
+      "country": "UNITED_STATES",
+      "language": "English",
+      "termsAndConditions": "By purchasing this item you agree to the following...",
+      "refundPolicy": "All sales are final.",
+      "blockedNodes": [
+        "QmecpJrN9RJ7smyYByQdZUy5mF6aapgCfKLKRmDtycv9aG",
+        "QmamudHQGtztShX7Nc9HcczehdpGGWpFBWu2JvKWcpELxr",
+        "QmPDLS7TV9Q3gtxRXQVqrm2RpEtz1Mq6u2YGeuEJWCqu6B"
+      ],
+      "moderators": [
+        "QmNedYJ6WmLhacAL2ozxb4k33Gxd9wmKB7HyoxZCwXid1e",
+        "QmQdi7EaJUmuRUtSaCPkijw5cptFfNcX2EPvMyQwR117Y2"
+      ],
+      "smtpSettings": {
+        "notifications": true,
+        "serverAddress": "smtp.urbanart.com:465",
+        "username": "urbanart",
+        "password": "letmein",
+        "senderEmail": "notifications@urbanart.com",
+        "recipientEmail": "Dave@gmail.com"
+      }
+    },
+    "type": "object",
+    "properties": {
+      "paymentDataInQR": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "showNotifications": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "showNsfw": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "shippingAddresses": {
+        "description": "",
+        "example": [
+          {
+            "name": "Seymour Butts",
+            "company": "Globex Corporation",
+            "addressLineOne": "31 Spooner Street",
+            "addressLineTwo": "Apt. 124",
+            "city": "Quahog",
+            "state": "RI",
+            "country": "UNITED_STATES",
+            "addressNotes": "Leave package at back door"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/ShippingAddress"
+        }
+      },
+      "localCurrency": {
+        "description": "",
+        "example": "USD",
+        "type": "string"
+      },
+      "country": {
+        "description": "",
+        "example": "UNITED_STATES",
+        "type": "string"
+      },
+      "language": {
+        "description": "",
+        "example": "English",
+        "type": "string"
+      },
+      "termsAndConditions": {
+        "description": "",
+        "example": "By purchasing this item you agree to the following...",
+        "type": "string"
+      },
+      "refundPolicy": {
+        "description": "",
+        "example": "All sales are final.",
+        "type": "string"
+      },
+      "blockedNodes": {
+        "description": "",
+        "example": [
+          "QmecpJrN9RJ7smyYByQdZUy5mF6aapgCfKLKRmDtycv9aG",
+          "QmamudHQGtztShX7Nc9HcczehdpGGWpFBWu2JvKWcpELxr",
+          "QmPDLS7TV9Q3gtxRXQVqrm2RpEtz1Mq6u2YGeuEJWCqu6B"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "moderators": {
+        "description": "",
+        "example": [
+          "QmNedYJ6WmLhacAL2ozxb4k33Gxd9wmKB7HyoxZCwXid1e",
+          "QmQdi7EaJUmuRUtSaCPkijw5cptFfNcX2EPvMyQwR117Y2"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "smtpSettings": {
+        "$ref": "#/definitions/SmtpSettings"
+      }
+    },
+    "required": [
+      "paymentDataInQR",
+      "showNotifications",
+      "showNsfw",
+      "shippingAddresses",
+      "localCurrency",
+      "country",
+      "language",
+      "termsAndConditions",
+      "refundPolicy",
+      "blockedNodes",
+      "moderators",
+      "smtpSettings"
+    ]
+  },
+  "ShippingAddress": {
+    "title": "ShippingAddress",
+    "example": {
+      "name": "Seymour Butts",
+      "company": "Globex Corporation",
+      "addressLineOne": "31 Spooner Street",
+      "addressLineTwo": "Apt. 124",
+      "city": "Quahog",
+      "state": "RI",
+      "country": "UNITED_STATES",
+      "addressNotes": "Leave package at back door"
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Seymour Butts",
+        "type": "string"
+      },
+      "company": {
+        "description": "",
+        "example": "Globex Corporation",
+        "type": "string"
+      },
+      "addressLineOne": {
+        "description": "",
+        "example": "31 Spooner Street",
+        "type": "string"
+      },
+      "addressLineTwo": {
+        "description": "",
+        "example": "Apt. 124",
+        "type": "string"
+      },
+      "city": {
+        "description": "",
+        "example": "Quahog",
+        "type": "string"
+      },
+      "state": {
+        "description": "",
+        "example": "RI",
+        "type": "string"
+      },
+      "country": {
+        "description": "",
+        "example": "UNITED_STATES",
+        "type": "string"
+      },
+      "addressNotes": {
+        "description": "",
+        "example": "Leave package at back door",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name",
+      "company",
+      "addressLineOne",
+      "addressLineTwo",
+      "city",
+      "state",
+      "country",
+      "addressNotes"
+    ]
+  },
+  "UpdateSettingsrequest": {
+    "title": "Update settingsRequest",
+    "example": {
+      "paymentDataInQR": true,
+      "showNotifications": true,
+      "showNsfw": true,
+      "shippingAddresses": [
+        {
+          "name": "Blah",
+          "company": "",
+          "addressLineOne": "",
+          "addressLineTwo": "",
+          "city": "",
+          "state": "",
+          "country": "AUSTRALIA",
+          "postalCode": "",
+          "addressNotes": ""
+        }
+      ],
+      "localCurrency": "USD",
+      "country": "AUSTRALIA",
+      "language": "English",
+      "termsAndConditions": "...",
+      "refundPolicy": "...",
+      "blockedNodes": [],
+      "storeModerators": [],
+      "mispaymentBuffer": 1,
+      "smtpSettings": {
+        "notifications": true,
+        "serverAddress": "",
+        "username": "",
+        "password": "",
+        "senderEmail": "",
+        "recipientEmail": ""
+      },
+      "version": "/openbazaar-go:0.5.0/"
+    },
+    "type": "object",
+    "properties": {
+      "paymentDataInQR": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "showNotifications": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "showNsfw": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "shippingAddresses": {
+        "description": "",
+        "example": [
+          {
+            "name": "Blah",
+            "company": "",
+            "addressLineOne": "",
+            "addressLineTwo": "",
+            "city": "",
+            "state": "",
+            "country": "AUSTRALIA",
+            "postalCode": "",
+            "addressNotes": ""
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/ShippingAddress130"
+        }
+      },
+      "localCurrency": {
+        "description": "",
+        "example": "USD",
+        "type": "string"
+      },
+      "country": {
+        "description": "",
+        "example": "AUSTRALIA",
+        "type": "string"
+      },
+      "language": {
+        "description": "",
+        "example": "English",
+        "type": "string"
+      },
+      "termsAndConditions": {
+        "description": "",
+        "example": "...",
+        "type": "string"
+      },
+      "refundPolicy": {
+        "description": "",
+        "example": "...",
+        "type": "string"
+      },
+      "blockedNodes": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "storeModerators": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "mispaymentBuffer": {
+        "description": "",
+        "example": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "smtpSettings": {
+        "$ref": "#/definitions/SmtpSettings"
+      },
+      "version": {
+        "description": "",
+        "example": "/openbazaar-go:0.5.0/",
+        "type": "string"
+      }
+    },
+    "required": [
+      "paymentDataInQR",
+      "showNotifications",
+      "showNsfw",
+      "shippingAddresses",
+      "localCurrency",
+      "country",
+      "language",
+      "termsAndConditions",
+      "refundPolicy",
+      "blockedNodes",
+      "storeModerators",
+      "mispaymentBuffer",
+      "smtpSettings",
+      "version"
+    ]
+  },
+  "ShippingAddress130": {
+    "title": "ShippingAddress130",
+    "example": {
+      "name": "Blah",
+      "company": "",
+      "addressLineOne": "",
+      "addressLineTwo": "",
+      "city": "",
+      "state": "",
+      "country": "AUSTRALIA",
+      "postalCode": "",
+      "addressNotes": ""
+    },
+    "type": "object",
+    "properties": {
+      "name": {
+        "description": "",
+        "example": "Blah",
+        "type": "string"
+      },
+      "company": {
+        "description": "",
+        "type": "string"
+      },
+      "addressLineOne": {
+        "description": "",
+        "type": "string"
+      },
+      "addressLineTwo": {
+        "description": "",
+        "type": "string"
+      },
+      "city": {
+        "description": "",
+        "type": "string"
+      },
+      "state": {
+        "description": "",
+        "type": "string"
+      },
+      "country": {
+        "description": "",
+        "example": "AUSTRALIA",
+        "type": "string"
+      },
+      "postalCode": {
+        "description": "",
+        "type": "string"
+      },
+      "addressNotes": {
+        "description": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name",
+      "company",
+      "addressLineOne",
+      "addressLineTwo",
+      "city",
+      "state",
+      "country",
+      "postalCode",
+      "addressNotes"
+    ]
+  },
+  "PatchSettingsrequest": {
+    "title": "Patch settingsRequest",
+    "example": {
+      "localCurrency": "AUD"
+    },
+    "type": "object",
+    "properties": {
+      "localCurrency": {
+        "description": "",
+        "example": "AUD",
+        "type": "string"
+      }
+    },
+    "required": [
+      "localCurrency"
+    ]
+  },
+  "ReleaseFundsrequest": {
+    "title": "Release fundsRequest",
+    "example": {
+      "orderId": "QmZDKnKFxxN5chiFmMErULhUZngEHEoLwpRy3ShFqLm1pa"
+    },
+    "type": "object",
+    "properties": {
+      "orderId": {
+        "description": "",
+        "example": "QmZDKnKFxxN5chiFmMErULhUZngEHEoLwpRy3ShFqLm1pa",
+        "type": "string"
+      }
+    },
+    "required": [
+      "orderId"
+    ]
+  },
+  "GetBitcoinAddress": {
+    "title": "Get Bitcoin address",
+    "example": {
+      "address": "17oicUtbT93VFfaWyQArUFDsj1H1E8Xrya"
+    },
+    "type": "object",
+    "properties": {
+      "address": {
+        "description": "",
+        "example": "17oicUtbT93VFfaWyQArUFDsj1H1E8Xrya",
+        "type": "string"
+      }
+    },
+    "required": [
+      "address"
+    ]
+  },
+  "GetMnemonicSeed": {
+    "title": "Get mnemonic seed",
+    "example": {
+      "mnemonic": "hair hat bar alert pulp pyramid evolve hollow duck group path habit"
+    },
+    "type": "object",
+    "properties": {
+      "mnemonic": {
+        "description": "",
+        "example": "hair hat bar alert pulp pyramid evolve hollow duck group path habit",
+        "type": "string"
+      }
+    },
+    "required": [
+      "mnemonic"
+    ]
+  },
+  "GetWalletBalance": {
+    "title": "Get wallet balance",
+    "example": {
+      "confirmed": "0",
+      "unconfirmed": "0"
+    },
+    "type": "object",
+    "properties": {
+      "confirmed": {
+        "description": "",
+        "example": "0",
+        "type": "string"
+      },
+      "unconfirmed": {
+        "description": "",
+        "example": "0",
+        "type": "string"
+      }
+    },
+    "required": [
+      "confirmed",
+      "unconfirmed"
+    ]
+  },
+  "TransactionHistory": {
+    "title": "Transaction History",
+    "example": {
+      "address": "",
+      "confirmations": 109,
+      "memo": "",
+      "orderId": "",
+      "status": "CONFIRMED",
+      "thumbnail": "",
+      "timestamp": "2017-03-10T06:19:44Z",
+      "txid": "52b70ab04a5e23d621404ef8e256d4a646a6a9cc34a7aa28df880fa38f4233eb",
+      "value": 631385
+    },
+    "type": "object",
+    "properties": {
+      "address": {
+        "description": "",
+        "type": "string"
+      },
+      "confirmations": {
+        "description": "",
+        "example": 109,
+        "type": "integer",
+        "format": "int32"
+      },
+      "memo": {
+        "description": "",
+        "type": "string"
+      },
+      "orderId": {
+        "description": "",
+        "type": "string"
+      },
+      "status": {
+        "description": "",
+        "example": "CONFIRMED",
+        "type": "string"
+      },
+      "thumbnail": {
+        "description": "",
+        "type": "string"
+      },
+      "timestamp": {
+        "description": "",
+        "example": "3/10/2017 6:19:44 AM",
+        "type": "string"
+      },
+      "txid": {
+        "description": "",
+        "example": "52b70ab04a5e23d621404ef8e256d4a646a6a9cc34a7aa28df880fa38f4233eb",
+        "type": "string"
+      },
+      "value": {
+        "description": "",
+        "example": 631385,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "address",
+      "confirmations",
+      "memo",
+      "orderId",
+      "status",
+      "thumbnail",
+      "timestamp",
+      "txid",
+      "value"
+    ]
+  },
+  "AllRates": {
+    "title": "All rates",
+    "example": {
+      "AED": 4396.561028,
+      "AFN": 79666.267945,
+      "ALL": 152793.468097,
+      "AMD": 580222.94765,
+      "ANG": 2125.207865,
+      "AOA": 198592.012405,
+      "ARS": 19119.880367,
+      "AUD": 1592.236098,
+      "AWG": 2154.582,
+      "AZN": 2130.6422,
+      "BAM": 2211.017685,
+      "BBD": 2393.98,
+      "BDT": 95826.248198,
+      "BGN": 2209.219806,
+      "BHD": 451.235305,
+      "BIF": 2017945.5915,
+      "BMD": 1196.99,
+      "BND": 1701.163385,
+      "BOB": 8273.624805,
+      "BRL": 3821.869371,
+      "BSD": 1196.99,
+      "BTC": 1,
+      "BTN": 79890.119439,
+      "BWP": 12541.292752,
+      "BYR": 23971220.9875,
+      "BZD": 2399.737522,
+      "CAD": 1599.777135,
+      "CDF": 1586043.260762,
+      "CHF": 1211.25453,
+      "CLF": 29.386105,
+      "CLP": 796596.845,
+      "CNY": 8273.770838,
+      "COP": 3588755.5685,
+      "CRC": 665316.96675,
+      "CUP": 29599.627167,
+      "CVE": 124846.057,
+      "CZK": 30526.716271,
+      "DJF": 214225.3003,
+      "DKK": 8398.721033,
+      "DOP": 56173.012246,
+      "DZD": 131980.1174,
+      "EEK": 17708.388562,
+      "EGP": 21010.166975,
+      "ETB": 27078.167732,
+      "EUR": 1129.749087,
+      "FJD": 2516.383,
+      "FKP": 984.257346,
+      "GBP": 984.257346,
+      "GEL": 2964.621043,
+      "GHS": 5533.689558,
+      "GIP": 984.257346,
+      "GMD": 53457.5734,
+      "GNF": 11220823.658,
+      "GTQ": 8802.449002,
+      "GYD": 248090.601229,
+      "HKD": 9295.604094,
+      "HNL": 28119.040311,
+      "HRK": 8392.09689,
+      "HTG": 79600.927852,
+      "HUF": 352281.937435,
+      "IDR": 16031627.533457,
+      "ILS": 4401.894815,
+      "INR": 79830.255575,
+      "IQD": 1407600.3905,
+      "IRR": 38819773.159837,
+      "ISK": 129981.1441,
+      "JEP": 984.257346,
+      "JMD": 153592.158478,
+      "JOD": 847.707121,
+      "JPY": 137884.150876,
+      "KES": 122817.15895,
+      "KGS": 82779.45819,
+      "KHR": 4802862.5255,
+      "KMF": 555450.785941,
+      "KPW": 1077398.7291,
+      "KRW": 1386952.313,
+      "KWD": 366.050315,
+      "KYD": 994.899784,
+      "KZT": 377767.45132,
+      "LAK": 9797123.752,
+      "LBP": 1798537.3245,
+      "LKR": 180817.751089,
+      "LRD": 111918.565,
+      "LSL": 15831.283208,
+      "LTL": 3907.792904,
+      "LVL": 795.413022,
+      "LYD": 1715.091561,
+      "MAD": 12080.793942,
+      "MDL": 23639.35551,
+      "MGA": 3820612.5315,
+      "MKD": 69551.702445,
+      "MMK": 1638679.31,
+      "MNT": 2940539.839877,
+      "MOP": 9550.817923,
+      "MRO": 429266.40315,
+      "MUR": 42514.092325,
+      "MVR": 18625.1644,
+      "MWK": 866477.1212,
+      "MXN": 23749.89634,
+      "MYR": 5335.48956,
+      "MZN": 83187.660507,
+      "NAD": 15840.085872,
+      "NGN": 375316.095998,
+      "NIO": 35293.786402,
+      "NOK": 10265.863839,
+      "NPR": 127518.308447,
+      "NZD": 1732.081637,
+      "OMR": 460.843544,
+      "PAB": 1196.99,
+      "PEN": 3947.665838,
+      "PGK": 3784.14264,
+      "PHP": 60250.49165,
+      "PKR": 125162.458564,
+      "PLN": 4886.387291,
+      "PYG": 6476254.5455,
+      "QAR": 4358.779236,
+      "RON": 5139.28255,
+      "RSD": 140014.912775,
+      "RUB": 70940.450243,
+      "RWF": 999399.796406,
+      "SAR": 4488.892049,
+      "SBD": 9336.665639,
+      "SCR": 16132.779852,
+      "SDG": 7668.274643,
+      "SEK": 10809.130917,
+      "SGD": 1699.717421,
+      "SHP": 984.257346,
+      "SLL": 8883952.398027,
+      "SOS": 690702.121402,
+      "SRD": 9030.09256,
+      "STD": 27706134.472926,
+      "SVC": 10446.539904,
+      "SYP": 256570.816932,
+      "SZL": 15795.59136,
+      "THB": 42345.91523,
+      "TJS": 9646.663306,
+      "TMT": 4189.448242,
+      "TND": 2743.983467,
+      "TOP": 2735.672765,
+      "TRY": 4511.815604,
+      "TTD": 8034.748692,
+      "TWD": 37271.952424,
+      "TZS": 2667252.817,
+      "UAH": 32098.935105,
+      "UGX": 4292047.043,
+      "USD": 1196.99,
+      "UYU": 33857.315809,
+      "UZS": 3942896.965263,
+      "VEF": 11963.917444,
+      "VND": 27289289.88976,
+      "VUV": 129957.125299,
+      "WST": 3045.523203,
+      "XAF": 741795.489928,
+      "XAG": 70.819435,
+      "XAU": 0.998876,
+      "XCD": 3234.925324,
+      "XOF": 744519.916973,
+      "XPF": 135080.3215,
+      "YER": 299337.27425,
+      "ZAR": 15910.039165,
+      "ZMW": 11461.667622,
+      "ZWL": 385817.138447
+    },
+    "type": "object",
+    "properties": {
+      "AED": {
+        "description": "",
+        "example": 4396.561028,
+        "type": "number",
+        "format": "double"
+      },
+      "AFN": {
+        "description": "",
+        "example": 79666.267945,
+        "type": "number",
+        "format": "double"
+      },
+      "ALL": {
+        "description": "",
+        "example": 152793.468097,
+        "type": "number",
+        "format": "double"
+      },
+      "AMD": {
+        "description": "",
+        "example": 580222.94765,
+        "type": "number",
+        "format": "double"
+      },
+      "ANG": {
+        "description": "",
+        "example": 2125.207865,
+        "type": "number",
+        "format": "double"
+      },
+      "AOA": {
+        "description": "",
+        "example": 198592.012405,
+        "type": "number",
+        "format": "double"
+      },
+      "ARS": {
+        "description": "",
+        "example": 19119.880367,
+        "type": "number",
+        "format": "double"
+      },
+      "AUD": {
+        "description": "",
+        "example": 1592.236098,
+        "type": "number",
+        "format": "double"
+      },
+      "AWG": {
+        "description": "",
+        "example": 2154.582,
+        "type": "number",
+        "format": "double"
+      },
+      "AZN": {
+        "description": "",
+        "example": 2130.6422,
+        "type": "number",
+        "format": "double"
+      },
+      "BAM": {
+        "description": "",
+        "example": 2211.017685,
+        "type": "number",
+        "format": "double"
+      },
+      "BBD": {
+        "description": "",
+        "example": 2393.98,
+        "type": "number",
+        "format": "double"
+      },
+      "BDT": {
+        "description": "",
+        "example": 95826.248198,
+        "type": "number",
+        "format": "double"
+      },
+      "BGN": {
+        "description": "",
+        "example": 2209.219806,
+        "type": "number",
+        "format": "double"
+      },
+      "BHD": {
+        "description": "",
+        "example": 451.235305,
+        "type": "number",
+        "format": "double"
+      },
+      "BIF": {
+        "description": "",
+        "example": 2017945.5915,
+        "type": "number",
+        "format": "double"
+      },
+      "BMD": {
+        "description": "",
+        "example": 1196.99,
+        "type": "number",
+        "format": "double"
+      },
+      "BND": {
+        "description": "",
+        "example": 1701.163385,
+        "type": "number",
+        "format": "double"
+      },
+      "BOB": {
+        "description": "",
+        "example": 8273.624805,
+        "type": "number",
+        "format": "double"
+      },
+      "BRL": {
+        "description": "",
+        "example": 3821.869371,
+        "type": "number",
+        "format": "double"
+      },
+      "BSD": {
+        "description": "",
+        "example": 1196.99,
+        "type": "number",
+        "format": "double"
+      },
+      "BTC": {
+        "description": "",
+        "example": 1,
+        "type": "integer",
+        "format": "int32"
+      },
+      "BTN": {
+        "description": "",
+        "example": 79890.119439,
+        "type": "number",
+        "format": "double"
+      },
+      "BWP": {
+        "description": "",
+        "example": 12541.292752,
+        "type": "number",
+        "format": "double"
+      },
+      "BYR": {
+        "description": "",
+        "example": 23971220.9875,
+        "type": "number",
+        "format": "double"
+      },
+      "BZD": {
+        "description": "",
+        "example": 2399.737522,
+        "type": "number",
+        "format": "double"
+      },
+      "CAD": {
+        "description": "",
+        "example": 1599.777135,
+        "type": "number",
+        "format": "double"
+      },
+      "CDF": {
+        "description": "",
+        "example": 1586043.260762,
+        "type": "number",
+        "format": "double"
+      },
+      "CHF": {
+        "description": "",
+        "example": 1211.25453,
+        "type": "number",
+        "format": "double"
+      },
+      "CLF": {
+        "description": "",
+        "example": 29.386105,
+        "type": "number",
+        "format": "double"
+      },
+      "CLP": {
+        "description": "",
+        "example": 796596.845,
+        "type": "number",
+        "format": "double"
+      },
+      "CNY": {
+        "description": "",
+        "example": 8273.770838,
+        "type": "number",
+        "format": "double"
+      },
+      "COP": {
+        "description": "",
+        "example": 3588755.5685,
+        "type": "number",
+        "format": "double"
+      },
+      "CRC": {
+        "description": "",
+        "example": 665316.96675,
+        "type": "number",
+        "format": "double"
+      },
+      "CUP": {
+        "description": "",
+        "example": 29599.627167,
+        "type": "number",
+        "format": "double"
+      },
+      "CVE": {
+        "description": "",
+        "example": 124846.057,
+        "type": "number",
+        "format": "double"
+      },
+      "CZK": {
+        "description": "",
+        "example": 30526.716271,
+        "type": "number",
+        "format": "double"
+      },
+      "DJF": {
+        "description": "",
+        "example": 214225.3003,
+        "type": "number",
+        "format": "double"
+      },
+      "DKK": {
+        "description": "",
+        "example": 8398.721033,
+        "type": "number",
+        "format": "double"
+      },
+      "DOP": {
+        "description": "",
+        "example": 56173.012246,
+        "type": "number",
+        "format": "double"
+      },
+      "DZD": {
+        "description": "",
+        "example": 131980.1174,
+        "type": "number",
+        "format": "double"
+      },
+      "EEK": {
+        "description": "",
+        "example": 17708.388562,
+        "type": "number",
+        "format": "double"
+      },
+      "EGP": {
+        "description": "",
+        "example": 21010.166975,
+        "type": "number",
+        "format": "double"
+      },
+      "ETB": {
+        "description": "",
+        "example": 27078.167732,
+        "type": "number",
+        "format": "double"
+      },
+      "EUR": {
+        "description": "",
+        "example": 1129.749087,
+        "type": "number",
+        "format": "double"
+      },
+      "FJD": {
+        "description": "",
+        "example": 2516.383,
+        "type": "number",
+        "format": "double"
+      },
+      "FKP": {
+        "description": "",
+        "example": 984.257346,
+        "type": "number",
+        "format": "double"
+      },
+      "GBP": {
+        "description": "",
+        "example": 984.257346,
+        "type": "number",
+        "format": "double"
+      },
+      "GEL": {
+        "description": "",
+        "example": 2964.621043,
+        "type": "number",
+        "format": "double"
+      },
+      "GHS": {
+        "description": "",
+        "example": 5533.689558,
+        "type": "number",
+        "format": "double"
+      },
+      "GIP": {
+        "description": "",
+        "example": 984.257346,
+        "type": "number",
+        "format": "double"
+      },
+      "GMD": {
+        "description": "",
+        "example": 53457.5734,
+        "type": "number",
+        "format": "double"
+      },
+      "GNF": {
+        "description": "",
+        "example": 11220823.658,
+        "type": "number",
+        "format": "double"
+      },
+      "GTQ": {
+        "description": "",
+        "example": 8802.449002,
+        "type": "number",
+        "format": "double"
+      },
+      "GYD": {
+        "description": "",
+        "example": 248090.601229,
+        "type": "number",
+        "format": "double"
+      },
+      "HKD": {
+        "description": "",
+        "example": 9295.604094,
+        "type": "number",
+        "format": "double"
+      },
+      "HNL": {
+        "description": "",
+        "example": 28119.040311,
+        "type": "number",
+        "format": "double"
+      },
+      "HRK": {
+        "description": "",
+        "example": 8392.09689,
+        "type": "number",
+        "format": "double"
+      },
+      "HTG": {
+        "description": "",
+        "example": 79600.927852,
+        "type": "number",
+        "format": "double"
+      },
+      "HUF": {
+        "description": "",
+        "example": 352281.937435,
+        "type": "number",
+        "format": "double"
+      },
+      "IDR": {
+        "description": "",
+        "example": 16031627.533457,
+        "type": "number",
+        "format": "double"
+      },
+      "ILS": {
+        "description": "",
+        "example": 4401.894815,
+        "type": "number",
+        "format": "double"
+      },
+      "INR": {
+        "description": "",
+        "example": 79830.255575,
+        "type": "number",
+        "format": "double"
+      },
+      "IQD": {
+        "description": "",
+        "example": 1407600.3905,
+        "type": "number",
+        "format": "double"
+      },
+      "IRR": {
+        "description": "",
+        "example": 38819773.159837,
+        "type": "number",
+        "format": "double"
+      },
+      "ISK": {
+        "description": "",
+        "example": 129981.1441,
+        "type": "number",
+        "format": "double"
+      },
+      "JEP": {
+        "description": "",
+        "example": 984.257346,
+        "type": "number",
+        "format": "double"
+      },
+      "JMD": {
+        "description": "",
+        "example": 153592.158478,
+        "type": "number",
+        "format": "double"
+      },
+      "JOD": {
+        "description": "",
+        "example": 847.707121,
+        "type": "number",
+        "format": "double"
+      },
+      "JPY": {
+        "description": "",
+        "example": 137884.150876,
+        "type": "number",
+        "format": "double"
+      },
+      "KES": {
+        "description": "",
+        "example": 122817.15895,
+        "type": "number",
+        "format": "double"
+      },
+      "KGS": {
+        "description": "",
+        "example": 82779.45819,
+        "type": "number",
+        "format": "double"
+      },
+      "KHR": {
+        "description": "",
+        "example": 4802862.5255,
+        "type": "number",
+        "format": "double"
+      },
+      "KMF": {
+        "description": "",
+        "example": 555450.785941,
+        "type": "number",
+        "format": "double"
+      },
+      "KPW": {
+        "description": "",
+        "example": 1077398.7291,
+        "type": "number",
+        "format": "double"
+      },
+      "KRW": {
+        "description": "",
+        "example": 1386952.313,
+        "type": "number",
+        "format": "double"
+      },
+      "KWD": {
+        "description": "",
+        "example": 366.050315,
+        "type": "number",
+        "format": "double"
+      },
+      "KYD": {
+        "description": "",
+        "example": 994.899784,
+        "type": "number",
+        "format": "double"
+      },
+      "KZT": {
+        "description": "",
+        "example": 377767.45132,
+        "type": "number",
+        "format": "double"
+      },
+      "LAK": {
+        "description": "",
+        "example": 9797123.752,
+        "type": "number",
+        "format": "double"
+      },
+      "LBP": {
+        "description": "",
+        "example": 1798537.3245,
+        "type": "number",
+        "format": "double"
+      },
+      "LKR": {
+        "description": "",
+        "example": 180817.751089,
+        "type": "number",
+        "format": "double"
+      },
+      "LRD": {
+        "description": "",
+        "example": 111918.565,
+        "type": "number",
+        "format": "double"
+      },
+      "LSL": {
+        "description": "",
+        "example": 15831.283208,
+        "type": "number",
+        "format": "double"
+      },
+      "LTL": {
+        "description": "",
+        "example": 3907.792904,
+        "type": "number",
+        "format": "double"
+      },
+      "LVL": {
+        "description": "",
+        "example": 795.413022,
+        "type": "number",
+        "format": "double"
+      },
+      "LYD": {
+        "description": "",
+        "example": 1715.091561,
+        "type": "number",
+        "format": "double"
+      },
+      "MAD": {
+        "description": "",
+        "example": 12080.793942,
+        "type": "number",
+        "format": "double"
+      },
+      "MDL": {
+        "description": "",
+        "example": 23639.35551,
+        "type": "number",
+        "format": "double"
+      },
+      "MGA": {
+        "description": "",
+        "example": 3820612.5315,
+        "type": "number",
+        "format": "double"
+      },
+      "MKD": {
+        "description": "",
+        "example": 69551.702445,
+        "type": "number",
+        "format": "double"
+      },
+      "MMK": {
+        "description": "",
+        "example": 1638679.31,
+        "type": "number",
+        "format": "double"
+      },
+      "MNT": {
+        "description": "",
+        "example": 2940539.839877,
+        "type": "number",
+        "format": "double"
+      },
+      "MOP": {
+        "description": "",
+        "example": 9550.817923,
+        "type": "number",
+        "format": "double"
+      },
+      "MRO": {
+        "description": "",
+        "example": 429266.40315,
+        "type": "number",
+        "format": "double"
+      },
+      "MUR": {
+        "description": "",
+        "example": 42514.092325,
+        "type": "number",
+        "format": "double"
+      },
+      "MVR": {
+        "description": "",
+        "example": 18625.1644,
+        "type": "number",
+        "format": "double"
+      },
+      "MWK": {
+        "description": "",
+        "example": 866477.1212,
+        "type": "number",
+        "format": "double"
+      },
+      "MXN": {
+        "description": "",
+        "example": 23749.89634,
+        "type": "number",
+        "format": "double"
+      },
+      "MYR": {
+        "description": "",
+        "example": 5335.48956,
+        "type": "number",
+        "format": "double"
+      },
+      "MZN": {
+        "description": "",
+        "example": 83187.660507,
+        "type": "number",
+        "format": "double"
+      },
+      "NAD": {
+        "description": "",
+        "example": 15840.085872,
+        "type": "number",
+        "format": "double"
+      },
+      "NGN": {
+        "description": "",
+        "example": 375316.095998,
+        "type": "number",
+        "format": "double"
+      },
+      "NIO": {
+        "description": "",
+        "example": 35293.786402,
+        "type": "number",
+        "format": "double"
+      },
+      "NOK": {
+        "description": "",
+        "example": 10265.863839,
+        "type": "number",
+        "format": "double"
+      },
+      "NPR": {
+        "description": "",
+        "example": 127518.308447,
+        "type": "number",
+        "format": "double"
+      },
+      "NZD": {
+        "description": "",
+        "example": 1732.081637,
+        "type": "number",
+        "format": "double"
+      },
+      "OMR": {
+        "description": "",
+        "example": 460.843544,
+        "type": "number",
+        "format": "double"
+      },
+      "PAB": {
+        "description": "",
+        "example": 1196.99,
+        "type": "number",
+        "format": "double"
+      },
+      "PEN": {
+        "description": "",
+        "example": 3947.665838,
+        "type": "number",
+        "format": "double"
+      },
+      "PGK": {
+        "description": "",
+        "example": 3784.14264,
+        "type": "number",
+        "format": "double"
+      },
+      "PHP": {
+        "description": "",
+        "example": 60250.49165,
+        "type": "number",
+        "format": "double"
+      },
+      "PKR": {
+        "description": "",
+        "example": 125162.458564,
+        "type": "number",
+        "format": "double"
+      },
+      "PLN": {
+        "description": "",
+        "example": 4886.387291,
+        "type": "number",
+        "format": "double"
+      },
+      "PYG": {
+        "description": "",
+        "example": 6476254.5455,
+        "type": "number",
+        "format": "double"
+      },
+      "QAR": {
+        "description": "",
+        "example": 4358.779236,
+        "type": "number",
+        "format": "double"
+      },
+      "RON": {
+        "description": "",
+        "example": 5139.28255,
+        "type": "number",
+        "format": "double"
+      },
+      "RSD": {
+        "description": "",
+        "example": 140014.912775,
+        "type": "number",
+        "format": "double"
+      },
+      "RUB": {
+        "description": "",
+        "example": 70940.450243,
+        "type": "number",
+        "format": "double"
+      },
+      "RWF": {
+        "description": "",
+        "example": 999399.796406,
+        "type": "number",
+        "format": "double"
+      },
+      "SAR": {
+        "description": "",
+        "example": 4488.892049,
+        "type": "number",
+        "format": "double"
+      },
+      "SBD": {
+        "description": "",
+        "example": 9336.665639,
+        "type": "number",
+        "format": "double"
+      },
+      "SCR": {
+        "description": "",
+        "example": 16132.779852,
+        "type": "number",
+        "format": "double"
+      },
+      "SDG": {
+        "description": "",
+        "example": 7668.274643,
+        "type": "number",
+        "format": "double"
+      },
+      "SEK": {
+        "description": "",
+        "example": 10809.130917,
+        "type": "number",
+        "format": "double"
+      },
+      "SGD": {
+        "description": "",
+        "example": 1699.717421,
+        "type": "number",
+        "format": "double"
+      },
+      "SHP": {
+        "description": "",
+        "example": 984.257346,
+        "type": "number",
+        "format": "double"
+      },
+      "SLL": {
+        "description": "",
+        "example": 8883952.398027,
+        "type": "number",
+        "format": "double"
+      },
+      "SOS": {
+        "description": "",
+        "example": 690702.121402,
+        "type": "number",
+        "format": "double"
+      },
+      "SRD": {
+        "description": "",
+        "example": 9030.09256,
+        "type": "number",
+        "format": "double"
+      },
+      "STD": {
+        "description": "",
+        "example": 27706134.472926,
+        "type": "number",
+        "format": "double"
+      },
+      "SVC": {
+        "description": "",
+        "example": 10446.539904,
+        "type": "number",
+        "format": "double"
+      },
+      "SYP": {
+        "description": "",
+        "example": 256570.816932,
+        "type": "number",
+        "format": "double"
+      },
+      "SZL": {
+        "description": "",
+        "example": 15795.59136,
+        "type": "number",
+        "format": "double"
+      },
+      "THB": {
+        "description": "",
+        "example": 42345.91523,
+        "type": "number",
+        "format": "double"
+      },
+      "TJS": {
+        "description": "",
+        "example": 9646.663306,
+        "type": "number",
+        "format": "double"
+      },
+      "TMT": {
+        "description": "",
+        "example": 4189.448242,
+        "type": "number",
+        "format": "double"
+      },
+      "TND": {
+        "description": "",
+        "example": 2743.983467,
+        "type": "number",
+        "format": "double"
+      },
+      "TOP": {
+        "description": "",
+        "example": 2735.672765,
+        "type": "number",
+        "format": "double"
+      },
+      "TRY": {
+        "description": "",
+        "example": 4511.815604,
+        "type": "number",
+        "format": "double"
+      },
+      "TTD": {
+        "description": "",
+        "example": 8034.748692,
+        "type": "number",
+        "format": "double"
+      },
+      "TWD": {
+        "description": "",
+        "example": 37271.952424,
+        "type": "number",
+        "format": "double"
+      },
+      "TZS": {
+        "description": "",
+        "example": 2667252.817,
+        "type": "number",
+        "format": "double"
+      },
+      "UAH": {
+        "description": "",
+        "example": 32098.935105,
+        "type": "number",
+        "format": "double"
+      },
+      "UGX": {
+        "description": "",
+        "example": 4292047.043,
+        "type": "number",
+        "format": "double"
+      },
+      "USD": {
+        "description": "",
+        "example": 1196.99,
+        "type": "number",
+        "format": "double"
+      },
+      "UYU": {
+        "description": "",
+        "example": 33857.315809,
+        "type": "number",
+        "format": "double"
+      },
+      "UZS": {
+        "description": "",
+        "example": 3942896.965263,
+        "type": "number",
+        "format": "double"
+      },
+      "VEF": {
+        "description": "",
+        "example": 11963.917444,
+        "type": "number",
+        "format": "double"
+      },
+      "VND": {
+        "description": "",
+        "example": 27289289.88976,
+        "type": "number",
+        "format": "double"
+      },
+      "VUV": {
+        "description": "",
+        "example": 129957.125299,
+        "type": "number",
+        "format": "double"
+      },
+      "WST": {
+        "description": "",
+        "example": 3045.523203,
+        "type": "number",
+        "format": "double"
+      },
+      "XAF": {
+        "description": "",
+        "example": 741795.489928,
+        "type": "number",
+        "format": "double"
+      },
+      "XAG": {
+        "description": "",
+        "example": 70.819435,
+        "type": "number",
+        "format": "double"
+      },
+      "XAU": {
+        "description": "",
+        "example": 0.998876,
+        "type": "number",
+        "format": "double"
+      },
+      "XCD": {
+        "description": "",
+        "example": 3234.925324,
+        "type": "number",
+        "format": "double"
+      },
+      "XOF": {
+        "description": "",
+        "example": 744519.916973,
+        "type": "number",
+        "format": "double"
+      },
+      "XPF": {
+        "description": "",
+        "example": 135080.3215,
+        "type": "number",
+        "format": "double"
+      },
+      "YER": {
+        "description": "",
+        "example": 299337.27425,
+        "type": "number",
+        "format": "double"
+      },
+      "ZAR": {
+        "description": "",
+        "example": 15910.039165,
+        "type": "number",
+        "format": "double"
+      },
+      "ZMW": {
+        "description": "",
+        "example": 11461.667622,
+        "type": "number",
+        "format": "double"
+      },
+      "ZWL": {
+        "description": "",
+        "example": 385817.138447,
+        "type": "number",
+        "format": "double"
+      }
+    },
+    "required": [
+      "AED",
+      "AFN",
+      "ALL",
+      "AMD",
+      "ANG",
+      "AOA",
+      "ARS",
+      "AUD",
+      "AWG",
+      "AZN",
+      "BAM",
+      "BBD",
+      "BDT",
+      "BGN",
+      "BHD",
+      "BIF",
+      "BMD",
+      "BND",
+      "BOB",
+      "BRL",
+      "BSD",
+      "BTC",
+      "BTN",
+      "BWP",
+      "BYR",
+      "BZD",
+      "CAD",
+      "CDF",
+      "CHF",
+      "CLF",
+      "CLP",
+      "CNY",
+      "COP",
+      "CRC",
+      "CUP",
+      "CVE",
+      "CZK",
+      "DJF",
+      "DKK",
+      "DOP",
+      "DZD",
+      "EEK",
+      "EGP",
+      "ETB",
+      "EUR",
+      "FJD",
+      "FKP",
+      "GBP",
+      "GEL",
+      "GHS",
+      "GIP",
+      "GMD",
+      "GNF",
+      "GTQ",
+      "GYD",
+      "HKD",
+      "HNL",
+      "HRK",
+      "HTG",
+      "HUF",
+      "IDR",
+      "ILS",
+      "INR",
+      "IQD",
+      "IRR",
+      "ISK",
+      "JEP",
+      "JMD",
+      "JOD",
+      "JPY",
+      "KES",
+      "KGS",
+      "KHR",
+      "KMF",
+      "KPW",
+      "KRW",
+      "KWD",
+      "KYD",
+      "KZT",
+      "LAK",
+      "LBP",
+      "LKR",
+      "LRD",
+      "LSL",
+      "LTL",
+      "LVL",
+      "LYD",
+      "MAD",
+      "MDL",
+      "MGA",
+      "MKD",
+      "MMK",
+      "MNT",
+      "MOP",
+      "MRO",
+      "MUR",
+      "MVR",
+      "MWK",
+      "MXN",
+      "MYR",
+      "MZN",
+      "NAD",
+      "NGN",
+      "NIO",
+      "NOK",
+      "NPR",
+      "NZD",
+      "OMR",
+      "PAB",
+      "PEN",
+      "PGK",
+      "PHP",
+      "PKR",
+      "PLN",
+      "PYG",
+      "QAR",
+      "RON",
+      "RSD",
+      "RUB",
+      "RWF",
+      "SAR",
+      "SBD",
+      "SCR",
+      "SDG",
+      "SEK",
+      "SGD",
+      "SHP",
+      "SLL",
+      "SOS",
+      "SRD",
+      "STD",
+      "SVC",
+      "SYP",
+      "SZL",
+      "THB",
+      "TJS",
+      "TMT",
+      "TND",
+      "TOP",
+      "TRY",
+      "TTD",
+      "TWD",
+      "TZS",
+      "UAH",
+      "UGX",
+      "USD",
+      "UYU",
+      "UZS",
+      "VEF",
+      "VND",
+      "VUV",
+      "WST",
+      "XAF",
+      "XAG",
+      "XAU",
+      "XCD",
+      "XOF",
+      "XPF",
+      "YER",
+      "ZAR",
+      "ZMW",
+      "ZWL"
+    ]
+  },
+  "SendBitcoinsrequest": {
+    "title": "Send bitcoinsRequest",
+    "example": {
+      "address": "mvxv1VCqELVrskAZbS3Cj9sjuGET16GX1P",
+      "amount": 666664,
+      "feeLevel": "PRIORITY"
+    },
+    "type": "object",
+    "properties": {
+      "address": {
+        "description": "",
+        "example": "mvxv1VCqELVrskAZbS3Cj9sjuGET16GX1P",
+        "type": "string"
+      },
+      "amount": {
+        "description": "",
+        "example": 666664,
+        "type": "integer",
+        "format": "int32"
+      },
+      "feeLevel": {
+        "description": "",
+        "example": "PRIORITY",
+        "type": "string"
+      }
+    },
+    "required": [
+      "address",
+      "amount",
+      "feeLevel"
+    ]
+  },
+  "Example": {
+    "title": "Example",
+    "example": {
+      "bestHash": "00000000000000000039fadaa41baaee1c1a91e8d98590e2a960c6ba27be8e85",
+      "height": 487012
+    },
+    "type": "object",
+    "properties": {
+      "bestHash": {
+        "description": "",
+        "example": "00000000000000000039fadaa41baaee1c1a91e8d98590e2a960c6ba27be8e85",
+        "type": "string"
+      },
+      "height": {
+        "description": "",
+        "example": 487012,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "bestHash",
+      "height"
+    ]
+  },
+  "ProfileExample": {
+    "title": "Profile Example",
+    "example": {
+      "peerID": "Qmai9U7856XKgDSvMFExPbQufcsc4ksG779VyG4Md5dn4J",
+      "handle": "drwasho",
+      "name": "Washington Sanchez",
+      "location": "Brisbane",
+      "about": "The Dude",
+      "shortDescription": "Yo",
+      "nsfw": true,
+      "vendor": true,
+      "moderator": false,
+      "contactInfo": {
+        "website": "openbazaar.org",
+        "email": "drwasho@openbazaar.org",
+        "phoneNumber": "12345"
+      },
+      "colors": {
+        "primary": "#000000",
+        "secondary": "#FFD700",
+        "text": "#ffffff",
+        "highlight": "#123ABC",
+        "highlightText": "#DEAD00"
+      },
+      "avatarHashes": {
+        "tiny": "QmPjkgnvCY8RnYQ5LFBrr36EEzTiagjZjVtxcZ5kV7NFNw",
+        "small": "QmPJhf9FQ74qZebKZBXXR81bFNbC1tWPXzTNjmNNm58rES",
+        "medium": "QmWdwMSNWFSKYdL8n47dK5EN7DRmPuTzjG12LPqQHAWb6P",
+        "large": "QmSReXYhgiWATTuiYWDXzPMDy2k9g3PnM5VmHhwNREVA3B",
+        "original": "QmUQmMHqpFR2SN6s5iNktUBHgBnzxpH9862pCDpNKnA5Vd"
+      },
+      "stats": {
+        "followerCount": 0,
+        "followingCount": 0,
+        "listingCount": 0,
+        "ratingCount": 0,
+        "averageRating": 0
+      },
+      "bitcoinPubkey": "03b54f70a26768dfc6335ff1896de9fb34c7c8de98b45141fc264913583b867387",
+      "lastModified": "2017-03-24T13:10:53.419703009Z"
+    },
+    "type": "object",
+    "properties": {
+      "peerID": {
+        "description": "",
+        "example": "Qmai9U7856XKgDSvMFExPbQufcsc4ksG779VyG4Md5dn4J",
+        "type": "string"
+      },
+      "handle": {
+        "description": "",
+        "example": "drwasho",
+        "type": "string"
+      },
+      "name": {
+        "description": "",
+        "example": "Washington Sanchez",
+        "type": "string"
+      },
+      "location": {
+        "description": "",
+        "example": "Brisbane",
+        "type": "string"
+      },
+      "about": {
+        "description": "",
+        "example": "The Dude",
+        "type": "string"
+      },
+      "shortDescription": {
+        "description": "",
+        "example": "Yo",
+        "type": "string"
+      },
+      "nsfw": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "vendor": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "moderator": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "contactInfo": {
+        "$ref": "#/definitions/ContactInfo"
+      },
+      "colors": {
+        "$ref": "#/definitions/Colors"
+      },
+      "avatarHashes": {
+        "$ref": "#/definitions/AvatarHashes"
+      },
+      "stats": {
+        "$ref": "#/definitions/Stats"
+      },
+      "bitcoinPubkey": {
+        "description": "",
+        "example": "03b54f70a26768dfc6335ff1896de9fb34c7c8de98b45141fc264913583b867387",
+        "type": "string"
+      },
+      "lastModified": {
+        "description": "",
+        "example": "2017-03-24T13:10:53.419703009Z",
+        "type": "string"
+      }
+    },
+    "required": [
+      "peerID",
+      "handle",
+      "name",
+      "location",
+      "about",
+      "shortDescription",
+      "nsfw",
+      "vendor",
+      "moderator",
+      "contactInfo",
+      "colors",
+      "avatarHashes",
+      "stats",
+      "bitcoinPubkey",
+      "lastModified"
+    ]
+  },
+  "ContactInfo": {
+    "title": "ContactInfo",
+    "example": {
+      "website": "openbazaar.org",
+      "email": "drwasho@openbazaar.org",
+      "phoneNumber": "12345"
+    },
+    "type": "object",
+    "properties": {
+      "website": {
+        "description": "",
+        "example": "openbazaar.org",
+        "type": "string"
+      },
+      "email": {
+        "description": "",
+        "example": "drwasho@openbazaar.org",
+        "type": "string"
+      },
+      "phoneNumber": {
+        "description": "",
+        "example": "12345",
+        "type": "string"
+      }
+    },
+    "required": [
+      "website",
+      "email",
+      "phoneNumber"
+    ]
+  },
+  "Colors": {
+    "title": "Colors",
+    "example": {
+      "primary": "#000000",
+      "secondary": "#FFD700",
+      "text": "#ffffff",
+      "highlight": "#123ABC",
+      "highlightText": "#DEAD00"
+    },
+    "type": "object",
+    "properties": {
+      "primary": {
+        "description": "",
+        "example": "#000000",
+        "type": "string"
+      },
+      "secondary": {
+        "description": "",
+        "example": "#FFD700",
+        "type": "string"
+      },
+      "text": {
+        "description": "",
+        "example": "#ffffff",
+        "type": "string"
+      },
+      "highlight": {
+        "description": "",
+        "example": "#123ABC",
+        "type": "string"
+      },
+      "highlightText": {
+        "description": "",
+        "example": "#DEAD00",
+        "type": "string"
+      }
+    },
+    "required": [
+      "primary",
+      "secondary",
+      "text",
+      "highlight",
+      "highlightText"
+    ]
+  },
+  "Stats": {
+    "title": "Stats",
+    "example": {
+      "followerCount": 0,
+      "followingCount": 0,
+      "listingCount": 0,
+      "ratingCount": 0,
+      "averageRating": 0
+    },
+    "type": "object",
+    "properties": {
+      "followerCount": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "followingCount": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "listingCount": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "ratingCount": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "averageRating": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "required": [
+      "followerCount",
+      "followingCount",
+      "listingCount",
+      "ratingCount",
+      "averageRating"
+    ]
+  },
+  "SelfProfile": {
+    "title": "Self Profile",
+    "example": {
+      "handle": "@UrbanArt",
+      "name": "Urban Art",
+      "location": "Chicago, Illinois",
+      "about": "We love spray painting and street art and this is the best way to not get arrested or get any tickets but still be able to paint graffiti. We hope you like it.",
+      "shortDescription": "Spray paint artwork on canvas; everything is individually painted and handmade.",
+      "website": "http://urbanart.com",
+      "email": "dave@urbanart.com",
+      "phoneNumber": "555-8790",
+      "social": [
+        {
+          "type": "TWITTER",
+          "username": "@UrbanArtStore",
+          "proof": "https://twitter.com/UrbanArtStore/status/774773006132391936"
+        },
+        {
+          "type": "FACEBOOK",
+          "username": "urbanart",
+          "proof": ""
+        }
+      ],
+      "avgRating": 0,
+      "numRatings": 0,
+      "nsfw": true,
+      "vendor": true,
+      "moderator": true,
+      "primaryColor": "#AF854C",
+      "secondaryColor": "#E3E3E3",
+      "textColor": "#FFFFFF",
+      "highlightColor": "",
+      "highlightTextColor": "",
+      "avatarHashes": {
+        "tiny": "Qmch37wDEe6oBZRhv51Wyikkit8tMBhPJ2LNmDUrnaxJ4L",
+        "small": "QmQZhwKzVq7Q2LbenFix7JUddt6ccoKWaP37TFr4RdhWBS",
+        "medium": "Qmc8shT1LDst8zvLcbkDmSDUWGdbPzAQJLs5XtvfFfSH2Y",
+        "large": "QmdERoscyWTiEpcrMpytuPUkkAMhViueCABepJdaDJDNXd",
+        "original": "QmUQmMHqpFR2SN6s5iNktUBHgBnzxpH9862pCDpNKnA5Vd"
+      },
+      "headerHashes": {
+        "tiny": "QmNedYJ6WmLhacAL2ozxb4k33Gxd9wmKB7HyoxZCwXid1e",
+        "small": "QmamudHQGtztShX7Nc9HcczehdpGGWpFBWu2JvKWcpELxr",
+        "medium": "QmbyUYWZEBRFw9uxVThS4FYMwkdhWfGAsYwppBKTF6L968",
+        "large": "QmanB2z2s6jig7SXxDtSTdZpnu9fZN9eNVQtqDeUroE5w4",
+        "original": "QmecpJrN9RJ7smyYByQdZUy5mF6aapgCfKLKRmDtycv9aG"
+      },
+      "followerCount": 0,
+      "followingCount": 0,
+      "listingCount": 0,
+      "lastModified": "2016-12-21T04:42:14Z"
+    },
+    "type": "object",
+    "properties": {
+      "handle": {
+        "description": "",
+        "example": "@UrbanArt",
+        "type": "string"
+      },
+      "name": {
+        "description": "",
+        "example": "Urban Art",
+        "type": "string"
+      },
+      "location": {
+        "description": "",
+        "example": "Chicago, Illinois",
+        "type": "string"
+      },
+      "about": {
+        "description": "",
+        "example": "We love spray painting and street art and this is the best way to not get arrested or get any tickets but still be able to paint graffiti. We hope you like it.",
+        "type": "string"
+      },
+      "shortDescription": {
+        "description": "",
+        "example": "Spray paint artwork on canvas; everything is individually painted and handmade.",
+        "type": "string"
+      },
+      "website": {
+        "description": "",
+        "example": "http://urbanart.com",
+        "type": "string"
+      },
+      "email": {
+        "description": "",
+        "example": "dave@urbanart.com",
+        "type": "string"
+      },
+      "phoneNumber": {
+        "description": "",
+        "example": "555-8790",
+        "type": "string"
+      },
+      "social": {
+        "description": "",
+        "example": [
+          {
+            "type": "TWITTER",
+            "username": "@UrbanArtStore",
+            "proof": "https://twitter.com/UrbanArtStore/status/774773006132391936"
+          },
+          {
+            "type": "FACEBOOK",
+            "username": "urbanart",
+            "proof": ""
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Social"
+        }
+      },
+      "avgRating": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "numRatings": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "nsfw": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "vendor": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "moderator": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "primaryColor": {
+        "description": "",
+        "example": "#AF854C",
+        "type": "string"
+      },
+      "secondaryColor": {
+        "description": "",
+        "example": "#E3E3E3",
+        "type": "string"
+      },
+      "textColor": {
+        "description": "",
+        "example": "#FFFFFF",
+        "type": "string"
+      },
+      "highlightColor": {
+        "description": "",
+        "type": "string"
+      },
+      "highlightTextColor": {
+        "description": "",
+        "type": "string"
+      },
+      "avatarHashes": {
+        "$ref": "#/definitions/AvatarHashes"
+      },
+      "headerHashes": {
+        "$ref": "#/definitions/HeaderHashes"
+      },
+      "followerCount": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "followingCount": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "listingCount": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "lastModified": {
+        "description": "",
+        "example": "12/21/2016 4:42:14 AM",
+        "type": "string"
+      }
+    },
+    "required": [
+      "handle",
+      "name",
+      "location",
+      "about",
+      "shortDescription",
+      "website",
+      "email",
+      "phoneNumber",
+      "social",
+      "avgRating",
+      "numRatings",
+      "nsfw",
+      "vendor",
+      "moderator",
+      "primaryColor",
+      "secondaryColor",
+      "textColor",
+      "highlightColor",
+      "highlightTextColor",
+      "avatarHashes",
+      "headerHashes",
+      "followerCount",
+      "followingCount",
+      "listingCount",
+      "lastModified"
+    ]
+  },
+  "Social": {
+    "title": "Social",
+    "example": {
+      "type": "TWITTER",
+      "username": "@UrbanArtStore",
+      "proof": "https://twitter.com/UrbanArtStore/status/774773006132391936"
+    },
+    "type": "object",
+    "properties": {
+      "type": {
+        "description": "",
+        "example": "TWITTER",
+        "type": "string"
+      },
+      "username": {
+        "description": "",
+        "example": "@UrbanArtStore",
+        "type": "string"
+      },
+      "proof": {
+        "description": "",
+        "example": "https://twitter.com/UrbanArtStore/status/774773006132391936",
+        "type": "string"
+      }
+    },
+    "required": [
+      "type",
+      "username",
+      "proof"
+    ]
+  },
+  "ChrisPacia": {
+    "title": "Chris Pacia",
+    "example": {
+      "handle": "chrispacia",
+      "name": "Chris",
+      "location": "Manchester NH",
+      "about": "",
+      "shortDescription": "asdfasdfasdf",
+      "website": "",
+      "email": "",
+      "phoneNumber": "",
+      "social": [],
+      "avgRating": 0,
+      "numRatings": 0,
+      "nsfw": false,
+      "vendor": false,
+      "moderator": false,
+      "primaryColor": "#FFFFFF",
+      "secondaryColor": "#FFFFFF",
+      "textColor": "#FFFFFF",
+      "highlightColor": "",
+      "highlightTextColor": "",
+      "avatarHashes": {
+        "tiny": "QmUWn4Vd8xFjmnfLikviptmysKLuRU6aCqytzApBKhfpSp",
+        "small": "Qmb9hCTdmvyUXUTV7kocnu4JFtKvJvtb9fjsmykKVWaes4",
+        "medium": "QmXhJWgjbJRzPaKB3WJKQK8xTUEECr37Wo1bBZuL7jP3bL",
+        "large": "QmPv83AZnx6shw1yQn1NUjTM3wh1jcorCcYwaH3RrZH9bd",
+        "original": "QmVkivHPvv1QLoN8Z9BhKN4nv4MRYAMXF1W8HJrZmCx8Yc"
+      },
+      "headerHashes": {
+        "tiny": "QmVS4NmRJY59i8pcy4a7R1cT9SsQ4GyWdTStowvKMfmVjt",
+        "small": "QmZF74QW1HLE6xdgZwMZSCFe7TgPJHxBQ24dYbk6HfFNp6",
+        "medium": "QmXxDubfq8W9VpouoCtgub8heL785ErPZeviPnBHZzR5yC",
+        "large": "QmRfPrMp44YwTa6BjTFUNSLZXvUbmV9Fwio24KDpyYWGAh",
+        "original": "QmQmZjyg7DApPkghfXh5U3ktnCG7kJoD43A65eZ9fY5Yd3"
+      },
+      "followerCount": 9,
+      "followingCount": 9,
+      "listingCount": 2,
+      "lastModified": "2016-12-27T20:17:34Z"
+    },
+    "type": "object",
+    "properties": {
+      "handle": {
+        "description": "",
+        "example": "chrispacia",
+        "type": "string"
+      },
+      "name": {
+        "description": "",
+        "example": "Chris",
+        "type": "string"
+      },
+      "location": {
+        "description": "",
+        "example": "Manchester NH",
+        "type": "string"
+      },
+      "about": {
+        "description": "",
+        "type": "string"
+      },
+      "shortDescription": {
+        "description": "",
+        "example": "asdfasdfasdf",
+        "type": "string"
+      },
+      "website": {
+        "description": "",
+        "type": "string"
+      },
+      "email": {
+        "description": "",
+        "type": "string"
+      },
+      "phoneNumber": {
+        "description": "",
+        "type": "string"
+      },
+      "social": {
+        "description": "",
+        "example": [],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "avgRating": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "numRatings": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "nsfw": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "vendor": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "moderator": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "primaryColor": {
+        "description": "",
+        "example": "#FFFFFF",
+        "type": "string"
+      },
+      "secondaryColor": {
+        "description": "",
+        "example": "#FFFFFF",
+        "type": "string"
+      },
+      "textColor": {
+        "description": "",
+        "example": "#FFFFFF",
+        "type": "string"
+      },
+      "highlightColor": {
+        "description": "",
+        "type": "string"
+      },
+      "highlightTextColor": {
+        "description": "",
+        "type": "string"
+      },
+      "avatarHashes": {
+        "$ref": "#/definitions/AvatarHashes"
+      },
+      "headerHashes": {
+        "$ref": "#/definitions/HeaderHashes"
+      },
+      "followerCount": {
+        "description": "",
+        "example": 9,
+        "type": "integer",
+        "format": "int32"
+      },
+      "followingCount": {
+        "description": "",
+        "example": 9,
+        "type": "integer",
+        "format": "int32"
+      },
+      "listingCount": {
+        "description": "",
+        "example": 2,
+        "type": "integer",
+        "format": "int32"
+      },
+      "lastModified": {
+        "description": "",
+        "example": "12/27/2016 8:17:34 PM",
+        "type": "string"
+      }
+    },
+    "required": [
+      "handle",
+      "name",
+      "location",
+      "about",
+      "shortDescription",
+      "website",
+      "email",
+      "phoneNumber",
+      "social",
+      "avgRating",
+      "numRatings",
+      "nsfw",
+      "vendor",
+      "moderator",
+      "primaryColor",
+      "secondaryColor",
+      "textColor",
+      "highlightColor",
+      "highlightTextColor",
+      "avatarHashes",
+      "headerHashes",
+      "followerCount",
+      "followingCount",
+      "listingCount",
+      "lastModified"
+    ]
+  },
+  "SetTheProfilerequest": {
+    "title": "Set the profileRequest",
+    "example": {
+      "handle": "drwasho",
+      "name": "Washington Sanchez",
+      "location": "Brisbane",
+      "about": "The Dude",
+      "shortDescription": "Yo",
+      "contactInfo": {
+        "website": "openbazaar.org",
+        "email": "drwasho@openbazaar.org",
+        "phoneNumber": "12345"
+      },
+      "nsfw": true,
+      "vendor": true,
+      "moderator": false,
+      "colors": {
+        "primary": "#000000",
+        "secondary": "#FFD700",
+        "text": "#ffffff",
+        "highlight": "#123ABC",
+        "highlightText": "#DEAD00"
+      }
+    },
+    "type": "object",
+    "properties": {
+      "handle": {
+        "description": "",
+        "example": "drwasho",
+        "type": "string"
+      },
+      "name": {
+        "description": "",
+        "example": "Washington Sanchez",
+        "type": "string"
+      },
+      "location": {
+        "description": "",
+        "example": "Brisbane",
+        "type": "string"
+      },
+      "about": {
+        "description": "",
+        "example": "The Dude",
+        "type": "string"
+      },
+      "shortDescription": {
+        "description": "",
+        "example": "Yo",
+        "type": "string"
+      },
+      "contactInfo": {
+        "$ref": "#/definitions/ContactInfo"
+      },
+      "nsfw": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "vendor": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "moderator": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "colors": {
+        "$ref": "#/definitions/Colors"
+      }
+    },
+    "required": [
+      "handle",
+      "name",
+      "location",
+      "about",
+      "shortDescription",
+      "contactInfo",
+      "nsfw",
+      "vendor",
+      "moderator",
+      "colors"
+    ]
+  },
+  "EditTheProfilerequest": {
+    "title": "Edit the profileRequest",
+    "example": {
+      "peerID": "QmVD3WwjZKRwEnczMcVEwEm9Xq9ZKoZpQbDkqPp5Uoi9RZ",
+      "handle": "@manbazaar",
+      "name": "Men&#39;s Clothing Bazaar",
+      "location": "",
+      "about": "",
+      "shortDescription": "Clothing for men",
+      "nsfw": false,
+      "vendor": true,
+      "moderator": false,
+      "contactInfo": {
+        "website": "",
+        "email": "",
+        "phoneNumber": ""
+      },
+      "colors": {
+        "primary": "",
+        "secondary": "",
+        "text": "",
+        "highlight": "",
+        "highlightText": ""
+      },
+      "avatarHashes": {
+        "tiny": "Qmckqkv8su5Tw6Styrmzzi3gv78k95iReZrQywb5Rny3gz",
+        "small": "QmZ6irSjduA6w3p9EMi7fcZGNdPNYungpxekBAn3PWhDKK",
+        "medium": "QmRfe8HTeUqEYj2NvrTo24SZBxUaBganTVSo76PRksFggE",
+        "large": "QmYwgMDSYpokfz7seLkj3rtZhat6qJtcvddt1c1XR4s5jL",
+        "original": "QmPK8X2FPi9cregxSRvfhPxMVowSLxHBJfdMnyRg1LkyUW"
+      },
+      "headerHashes": {
+        "tiny": "Qmdzo6zCzTUyDdwWC5hg4axXkxPRS7wFiKX6nvcBkRFQUw",
+        "small": "QmZpAfKAy4NG9PZfJaSM9ahXS9mQTtjQ8hDNPcHyQJLBps",
+        "medium": "QmZirmkZpuLTBUmBU4G5iPZ2ZFLeb3hkmx46mPrWhqRkWR",
+        "large": "QmXA6ZSLM9HXCNfyk3QS4z436VeZoZ2sXLWN3NCvwSH6sM",
+        "original": "QmVYEs71oQM78ZFWpWD5RX1tYXpjYoSzitvfuyfi8ovQWJ"
+      },
+      "stats": {
+        "followerCount": 0,
+        "followingCount": 0,
+        "listingCount": 3,
+        "ratingCount": 0,
+        "averageRating": 0
+      },
+      "bitcoinPubkey": "0299f8403f38e7af3487faceada4d60919d01ed6ed2b6d5f38e151ffc9c0d71be2",
+      "lastModified": "2017-06-08T11:02:38.264019143Z"
+    },
+    "type": "object",
+    "properties": {
+      "peerID": {
+        "description": "",
+        "example": "QmVD3WwjZKRwEnczMcVEwEm9Xq9ZKoZpQbDkqPp5Uoi9RZ",
+        "type": "string"
+      },
+      "handle": {
+        "description": "",
+        "example": "@manbazaar",
+        "type": "string"
+      },
+      "name": {
+        "description": "",
+        "example": "Men&#39;s Clothing Bazaar",
+        "type": "string"
+      },
+      "location": {
+        "description": "",
+        "type": "string"
+      },
+      "about": {
+        "description": "",
+        "type": "string"
+      },
+      "shortDescription": {
+        "description": "",
+        "example": "Clothing for men",
+        "type": "string"
+      },
+      "nsfw": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "vendor": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "moderator": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "contactInfo": {
+        "$ref": "#/definitions/ContactInfo"
+      },
+      "colors": {
+        "$ref": "#/definitions/Colors"
+      },
+      "avatarHashes": {
+        "$ref": "#/definitions/AvatarHashes"
+      },
+      "headerHashes": {
+        "$ref": "#/definitions/HeaderHashes"
+      },
+      "stats": {
+        "$ref": "#/definitions/Stats"
+      },
+      "bitcoinPubkey": {
+        "description": "",
+        "example": "0299f8403f38e7af3487faceada4d60919d01ed6ed2b6d5f38e151ffc9c0d71be2",
+        "type": "string"
+      },
+      "lastModified": {
+        "description": "",
+        "example": "2017-06-08T11:02:38.264019143Z",
+        "type": "string"
+      }
+    },
+    "required": [
+      "peerID",
+      "handle",
+      "name",
+      "location",
+      "about",
+      "shortDescription",
+      "nsfw",
+      "vendor",
+      "moderator",
+      "contactInfo",
+      "colors",
+      "avatarHashes",
+      "headerHashes",
+      "stats",
+      "bitcoinPubkey",
+      "lastModified"
+    ]
+  },
+  "Drwasho": {
+    "title": "drwasho",
+    "example": {
+      "handle": "@drwasho",
+      "name": "Dr Washington Sanchez",
+      "location": "Brisbane, Australia",
+      "about": "drwasho's node",
+      "shortDescription": "drwasho's node",
+      "website": "https://openbazaar.org",
+      "email": "drwasho@openbazaar.org",
+      "phoneNumber": "555-8790",
+      "social": [
+        {
+          "type": "TWITTER",
+          "username": "@drwasho",
+          "proof": "https://twitter.com/drwasho/status/792595422376144897"
+        }
+      ],
+      "avgRating": 0,
+      "numRatings": 0,
+      "nsfw": false,
+      "vendor": true,
+      "moderator": true,
+      "primaryColor": "#AF854C",
+      "secondaryColor": "#E3E3E3",
+      "textColor": "#FFFFFF",
+      "highlightColor": "",
+      "highlightTextColor": "",
+      "avatarHashes": {
+        "tiny": "QmPjkgnvCY8RnYQ5LFBrr36EEzTiagjZjVtxcZ5kV7NFNw",
+        "small": "QmPJhf9FQ74qZebKZBXXR81bFNbC1tWPXzTNjmNNm58rES",
+        "medium": "QmWdwMSNWFSKYdL8n47dK5EN7DRmPuTzjG12LPqQHAWb6P",
+        "large": "QmSReXYhgiWATTuiYWDXzPMDy2k9g3PnM5VmHhwNREVA3B",
+        "original": "QmUQmMHqpFR2SN6s5iNktUBHgBnzxpH9862pCDpNKnA5Vd"
+      },
+      "headerHashes": {
+        "tiny": "Qmavc5kgtpbkgZ6vmRUKSpe4cVZwBfLumTJj2ZKdCKfm2P",
+        "small": "QmRz7atxA7W57EeDRJ17RjV7w6xBm9X6i4h8agxdnnVaK9",
+        "medium": "QmSaYCYQNZNRPS2ozfDnZm63gSnS2DzRDSLrLtN94ZjUkn",
+        "large": "QmXZZekqM1HwNrgBTLksKd6W1VCyTesbdxnPCwkVKBVNBJ",
+        "original": "QmcY9Pt3ZzivBGxXenjbrG4xQ4uAd4BUvLRLuXv3E6688S"
+      },
+      "followerCount": 0,
+      "followingCount": 0,
+      "listingCount": 0,
+      "bitcoinPubkey": "03486870b222ff981bf0ff202680a3b8bd0c1be1ae65a9284914995bab7952c225",
+      "acceptStealth": false
+    },
+    "type": "object",
+    "properties": {
+      "handle": {
+        "description": "",
+        "example": "@drwasho",
+        "type": "string"
+      },
+      "name": {
+        "description": "",
+        "example": "Dr Washington Sanchez",
+        "type": "string"
+      },
+      "location": {
+        "description": "",
+        "example": "Brisbane, Australia",
+        "type": "string"
+      },
+      "about": {
+        "description": "",
+        "example": "drwasho's node",
+        "type": "string"
+      },
+      "shortDescription": {
+        "description": "",
+        "example": "drwasho's node",
+        "type": "string"
+      },
+      "website": {
+        "description": "",
+        "example": "https://openbazaar.org",
+        "type": "string"
+      },
+      "email": {
+        "description": "",
+        "example": "drwasho@openbazaar.org",
+        "type": "string"
+      },
+      "phoneNumber": {
+        "description": "",
+        "example": "555-8790",
+        "type": "string"
+      },
+      "social": {
+        "description": "",
+        "example": [
+          {
+            "type": "TWITTER",
+            "username": "@drwasho",
+            "proof": "https://twitter.com/drwasho/status/792595422376144897"
+          }
+        ],
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Social"
+        }
+      },
+      "avgRating": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "numRatings": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "nsfw": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "vendor": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "moderator": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "primaryColor": {
+        "description": "",
+        "example": "#AF854C",
+        "type": "string"
+      },
+      "secondaryColor": {
+        "description": "",
+        "example": "#E3E3E3",
+        "type": "string"
+      },
+      "textColor": {
+        "description": "",
+        "example": "#FFFFFF",
+        "type": "string"
+      },
+      "highlightColor": {
+        "description": "",
+        "type": "string"
+      },
+      "highlightTextColor": {
+        "description": "",
+        "type": "string"
+      },
+      "avatarHashes": {
+        "$ref": "#/definitions/AvatarHashes"
+      },
+      "headerHashes": {
+        "$ref": "#/definitions/HeaderHashes"
+      },
+      "followerCount": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "followingCount": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "listingCount": {
+        "description": "",
+        "example": 0,
+        "type": "integer",
+        "format": "int32"
+      },
+      "bitcoinPubkey": {
+        "description": "",
+        "example": "03486870b222ff981bf0ff202680a3b8bd0c1be1ae65a9284914995bab7952c225",
+        "type": "string"
+      },
+      "acceptStealth": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "handle",
+      "name",
+      "location",
+      "about",
+      "shortDescription",
+      "website",
+      "email",
+      "phoneNumber",
+      "social",
+      "avgRating",
+      "numRatings",
+      "nsfw",
+      "vendor",
+      "moderator",
+      "primaryColor",
+      "secondaryColor",
+      "textColor",
+      "highlightColor",
+      "highlightTextColor",
+      "avatarHashes",
+      "headerHashes",
+      "followerCount",
+      "followingCount",
+      "listingCount",
+      "bitcoinPubkey",
+      "acceptStealth"
+    ]
+  },
+  "UpdateTheProfilerequest": {
+    "title": "Update the profileRequest",
+    "example": {
+      "peerID": "Qmai9U7856XKgDSvMFExPbQufcsc4ksG779VyG4Md5dn4J",
+      "handle": "drwasho",
+      "name": "Washington Sanchez",
+      "location": "Brisbane",
+      "about": "The Dude",
+      "shortDescription": "Yo",
+      "nsfw": true,
+      "vendor": true,
+      "moderator": false,
+      "contactInfo": {
+        "website": "openbazaar.org",
+        "email": "drwasho@openbazaar.org",
+        "phoneNumber": "12345"
+      },
+      "colors": {
+        "primary": "#000000",
+        "secondary": "#FFD700",
+        "text": "#ffffff",
+        "highlight": "#123ABC",
+        "highlightText": "#DEAD00"
+      },
+      "avatarHashes": {
+        "tiny": "QmPjkgnvCY8RnYQ5LFBrr36EEzTiagjZjVtxcZ5kV7NFNw",
+        "small": "QmPJhf9FQ74qZebKZBXXR81bFNbC1tWPXzTNjmNNm58rES",
+        "medium": "QmWdwMSNWFSKYdL8n47dK5EN7DRmPuTzjG12LPqQHAWb6P",
+        "large": "QmSReXYhgiWATTuiYWDXzPMDy2k9g3PnM5VmHhwNREVA3B",
+        "original": "QmUQmMHqpFR2SN6s5iNktUBHgBnzxpH9862pCDpNKnA5Vd"
+      },
+      "stats": {
+        "followerCount": 0,
+        "followingCount": 0,
+        "listingCount": 0,
+        "ratingCount": 0,
+        "averageRating": 0
+      },
+      "bitcoinPubkey": "03b54f70a26768dfc6335ff1896de9fb34c7c8de98b45141fc264913583b867387",
+      "lastModified": "2017-03-24T13:10:53.419703009Z"
+    },
+    "type": "object",
+    "properties": {
+      "peerID": {
+        "description": "",
+        "example": "Qmai9U7856XKgDSvMFExPbQufcsc4ksG779VyG4Md5dn4J",
+        "type": "string"
+      },
+      "handle": {
+        "description": "",
+        "example": "drwasho",
+        "type": "string"
+      },
+      "name": {
+        "description": "",
+        "example": "Washington Sanchez",
+        "type": "string"
+      },
+      "location": {
+        "description": "",
+        "example": "Brisbane",
+        "type": "string"
+      },
+      "about": {
+        "description": "",
+        "example": "The Dude",
+        "type": "string"
+      },
+      "shortDescription": {
+        "description": "",
+        "example": "Yo",
+        "type": "string"
+      },
+      "nsfw": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "vendor": {
+        "description": "",
+        "example": true,
+        "type": "boolean"
+      },
+      "moderator": {
+        "description": "",
+        "example": false,
+        "type": "boolean"
+      },
+      "contactInfo": {
+        "$ref": "#/definitions/ContactInfo"
+      },
+      "colors": {
+        "$ref": "#/definitions/Colors"
+      },
+      "avatarHashes": {
+        "$ref": "#/definitions/AvatarHashes"
+      },
+      "stats": {
+        "$ref": "#/definitions/Stats"
+      },
+      "bitcoinPubkey": {
+        "description": "",
+        "example": "03b54f70a26768dfc6335ff1896de9fb34c7c8de98b45141fc264913583b867387",
+        "type": "string"
+      },
+      "lastModified": {
+        "description": "",
+        "example": "2017-03-24T13:10:53.419703009Z",
+        "type": "string"
+      }
+    },
+    "required": [
+      "peerID",
+      "handle",
+      "name",
+      "location",
+      "about",
+      "shortDescription",
+      "nsfw",
+      "vendor",
+      "moderator",
+      "contactInfo",
+      "colors",
+      "avatarHashes",
+      "stats",
+      "bitcoinPubkey",
+      "lastModified"
+    ]
+  }
+}

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -1,3 +1,27 @@
+// OpenBazaar 2.0 JSON API (Remote).
+//
+// The OpenBazaar networking daemon combines a Kademlia DHT, IPFS node, Bitcoin wallet, and a peer-to-peer contracting system. This JSON API is the primary mechanism for controlling the node. It offers a RESTful api for building user interfaces as well as a number of RPC calls. In this documentation you'll find a full list of API calls and example usages.<br># Authentication<br>When running on localhost (the default), the API is unauthenticated. You can enable authentication by setting the config file as follows: <br><code><br>{<br>    \"JSON-API\": {<br>      \"Authenticated\": true<br>      }<br>}<br></code><br>Note that on mainnet the server enables authentication automatically if the gateway url is bound to anything other than localhost (implying open internet access) even if the config file is set to false.<br><br>There are two ways for a client to authenticate. The default (and preferred) is via an authentication cookie. On start up the server generates a random cookie and saves it in the data directory as a .cookie file. You need to add this cookie to the header of all requests. For example:<br><code><br>cookie: OpenBazaar_Auth_Cookie=2Yc7VZtG/pVKrH5Lp0mKRSEPC4xlm1dGpkbUXLehTUI<br></code><br>Alternatively, you can use basic authentication by setting a username and password in the config file:<br><code><br>    {<br>        \"JSON-API\": {<br>          \"Username\": \"Aladdin\",<br>          \"Password\": \"1c8bfe8f801d79745c4631d09fff36c82aa37fc4cce4fc946683d7b336b63032\"<br>          }<br>    }<br></code><br>The password should be saved as the hex - encoded SHA - 256 hash of your password. You can run <em>openbazaar-go setapicreds` to have it hash and save the password in the config file for you.<br><br>The username and password need to be included in the request header following [RFC 2617](https://www.ietf.org/rfc/rfc2617.txt):<br><code><br>Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==<br></code><br>Where the username and password are encoded as <em>base64encode(username + \":\" + password)</em><br>or included in the Url:<br><code><br>http://username:password@localhost\:8080/ob/<br></code><br># SSL<br><strong>NEVER</strong> open the JSON API to the internet without also encrypting the connection with SSL. Without SSL enabled your authentication information be sent to the server in the clear allowing anyone who views your packets to access your server and potentially steal your bitcoins. For instructions on how to enable SSL, see [here](https://github.com/OpenBazaar/openbazaar-go/blob/master/docs/ssl.md).<br># Cross-Origin Resource Sharing<br>CORS is turned off by default, meaning that you will not be able to make API calls from a browser to a running server on localhost. You can turn CORS on for a specific domain by setting an origin in the config file as follows:<br><code><br>{<br>    \"JSON-API\": {<br>      \"CORS\": \"https://openbazaar.org\"<br>      }<br>}<br></code><br>Use \"*\" to allow all domains. Keep in mind that running the server with CORS enabled for all domains is a potential secrity risk as it will allow any website you visit to make calls to your server. Authentication should be enabled along side CORS.
+//
+//     Schemes: http
+//     Version: 1.0
+//
+//     Consumes:
+//     - application/json
+//
+//     Produces:
+//     - application/json
+//
+//     Security:
+//     - bearer
+//
+//     SecurityDefinitions:
+//     bearer:
+//          type: apiKey
+//          name: Authorization
+//          in: header
+//	   
+//     
+// swagger:meta
 package api
 
 import (
@@ -229,6 +253,31 @@ func SanitizedResponseM(w http.ResponseWriter, response string, m proto.Message)
 }
 
 func (i *jsonAPIHandler) POSTProfile(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /ob/profile profile postProfile
+	//
+	// Create new profile for node.
+	//
+	// Any new profile
+	//
+	// ---
+	// parameters:
+	// - name: Body
+	//   in: body
+	//   required: true
+	//   description: Profile to create
+	//   schema:
+	//     $ref: "#/definitions/SetTheProfilerequest"
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    description: "Creates a new profile for the node"
+	//    schema:
+	//      type: object
+
 
 	// If the profile is already set tell them to use PUT
 	profilePath := path.Join(i.node.RepoPath, "root", "profile.json")
@@ -291,7 +340,31 @@ func (i *jsonAPIHandler) POSTProfile(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) PUTProfile(w http.ResponseWriter, r *http.Request) {
-
+	// swagger:operation PUT /ob/profile profile putProfile
+	//
+	// Update the profile for this node.
+	//
+	// Update the profile
+	//
+	// ---
+	// parameters:
+	// - name: Body
+	//   in: body
+	//   required: true
+	//   description: Profile to create
+	//   schema:
+	//     $ref: "#/definitions/UpdateTheProfilerequest"
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    description: "Updates an existing profile"
+	//    schema:
+	//      $ref: "#/definitions/Drwasho"
+	
 	// If profile is not set tell them to use POST
 	currentProfile, err := i.node.GetProfile()
 	if err != nil {
@@ -356,7 +429,33 @@ func (i *jsonAPIHandler) PUTProfile(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
+
 func (i *jsonAPIHandler) PATCHProfile(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation PATCH /ob/profile profile patchProfile
+	//
+	// Update the profile for this node.
+	//
+	// Update the profile
+	//
+	// ---
+	// parameters:
+	// - name: Body
+	//   in: body
+	//   required: true
+	//   description: Profile to create
+	//   schema:
+	//     $ref: "#/definitions/UpdateTheProfilerequest"
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    description: "Updates an existing profile"
+	//    schema:
+	//      $ref: "#/definitions/Drwasho"
+	
 	// If profile is not set tell them to use POST
 	profilePath := path.Join(i.node.RepoPath, "root", "profile.json")
 	_, ferr := os.Stat(profilePath)
@@ -401,6 +500,30 @@ func (i *jsonAPIHandler) PATCHProfile(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) POSTAvatar(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /ob/avatar profile postAvatar
+	//
+	// Set the avatar image. This will also update the avatar hash in the profile.
+	//
+	// Set the avatar
+	//
+	// ---
+	// parameters:
+	// - name: Body
+	//   in: body
+	//   required: true
+	//   schema:
+	//     $ref: "definitions.json#/SetTheAvatarrequest"
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    schema:
+	//      "$ref": "definitions.json#/Bananas"
+
+
 	type ImgData struct {
 		Avatar string `json:"avatar"`
 	}

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -19,8 +19,8 @@
 //          type: apiKey
 //          name: Authorization
 //          in: header
-//	   
-//     
+//
+//
 // swagger:meta
 package api
 
@@ -278,7 +278,6 @@ func (i *jsonAPIHandler) POSTProfile(w http.ResponseWriter, r *http.Request) {
 	//    schema:
 	//      type: object
 
-
 	// If the profile is already set tell them to use PUT
 	profilePath := path.Join(i.node.RepoPath, "root", "profile.json")
 	_, ferr := os.Stat(profilePath)
@@ -364,7 +363,7 @@ func (i *jsonAPIHandler) PUTProfile(w http.ResponseWriter, r *http.Request) {
 	//    description: "Updates an existing profile"
 	//    schema:
 	//      $ref: "#/definitions/Drwasho"
-	
+
 	// If profile is not set tell them to use POST
 	currentProfile, err := i.node.GetProfile()
 	if err != nil {
@@ -429,7 +428,6 @@ func (i *jsonAPIHandler) PUTProfile(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
-
 func (i *jsonAPIHandler) PATCHProfile(w http.ResponseWriter, r *http.Request) {
 	// swagger:operation PATCH /ob/profile profile patchProfile
 	//
@@ -455,7 +453,7 @@ func (i *jsonAPIHandler) PATCHProfile(w http.ResponseWriter, r *http.Request) {
 	//    description: "Updates an existing profile"
 	//    schema:
 	//      $ref: "#/definitions/Drwasho"
-	
+
 	// If profile is not set tell them to use POST
 	profilePath := path.Join(i.node.RepoPath, "root", "profile.json")
 	_, ferr := os.Stat(profilePath)
@@ -522,7 +520,6 @@ func (i *jsonAPIHandler) POSTAvatar(w http.ResponseWriter, r *http.Request) {
 	//  '200':
 	//    schema:
 	//      "$ref": "definitions.json#/Bananas"
-
 
 	type ImgData struct {
 		Avatar string `json:"avatar"`

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -919,6 +919,7 @@ func (i *jsonAPIHandler) GETStatus(w http.ResponseWriter, r *http.Request) {
 
 func (i *jsonAPIHandler) GETPeers(w http.ResponseWriter, r *http.Request) {
 	peers := ipfs.ConnectedPeers(i.node.IpfsNode)
+
 	peerJson, err := json.MarshalIndent(peers, "", "    ")
 	if err != nil {
 		ErrorResponse(w, http.StatusInternalServerError, err.Error())
@@ -928,6 +929,30 @@ func (i *jsonAPIHandler) GETPeers(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) POSTFollow(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /ob/follow followers postFollow
+	//
+	// RPC call to follow another peer on the network.
+	//
+	// Follow a peer
+	//
+	// ---
+	// parameters:
+	// - name: Body
+	//   in: body
+	//   required: true
+	//   schema:
+	//     $ref: "definitions.json#/FollowAPeerrequest"
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    schema:
+	//      type: object
+	//  '400':
+	//  '500':
 	type PeerId struct {
 		ID string `json:"id"`
 	}
@@ -948,6 +973,30 @@ func (i *jsonAPIHandler) POSTFollow(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) POSTUnfollow(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /ob/unfollow followers postUnfollow
+	//
+	// RPC call to unfollow another peer on the network.
+	//
+	// Unfollow a peer
+	//
+	// ---
+	// parameters:
+	// - name: Body
+	//   in: body
+	//   required: true
+	//   schema:
+	//     $ref: "definitions.json#/UnfollowAPeerrequest"
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    schema:
+	//      type: object
+	//  '400':
+	//  '500':
 	type PeerId struct {
 		ID string `json:"id"`
 	}
@@ -967,6 +1016,22 @@ func (i *jsonAPIHandler) POSTUnfollow(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) GETAddress(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation GET /wallet/address wallet getWalletAddress
+	//
+	// Returns an unused bitcoin address. Note the same address is returned until the address is used.
+	//
+	// Get a bitcoin address
+	//
+	// ---
+	// responses:
+	//  '200':
+	//    schema:
+	//      $ref: "definitions.json#/GetBitcoinAddress"
+	//    examples:
+	//      "application/json":
+	//        "address": "17oicUtbT93VFfaWyQArUFDsj1H1E8Xrya"
+	//  '400':
+	//  '500':
 	addr := i.node.Wallet.CurrentAddress(wallet.EXTERNAL)
 	SanitizedResponse(w, fmt.Sprintf(`{"address": "%s"}`, addr.EncodeAddress()))
 }

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -14,6 +14,8 @@
 //     Security:
 //     - bearer
 //
+//     Host: localhost:4002
+//
 //     SecurityDefinitions:
 //     bearer:
 //          type: apiKey
@@ -266,7 +268,7 @@ func (i *jsonAPIHandler) POSTProfile(w http.ResponseWriter, r *http.Request) {
 	//   required: true
 	//   description: Profile to create
 	//   schema:
-	//     $ref: "#/definitions/SetTheProfilerequest"
+	//     $ref: "definitions.json#/SetTheProfilerequest"
 	// - name: Content-Type
 	//   in: header
 	//   required: true
@@ -352,7 +354,7 @@ func (i *jsonAPIHandler) PUTProfile(w http.ResponseWriter, r *http.Request) {
 	//   required: true
 	//   description: Profile to create
 	//   schema:
-	//     $ref: "#/definitions/UpdateTheProfilerequest"
+	//     $ref: "definitions.json#/UpdateTheProfilerequest"
 	// - name: Content-Type
 	//   in: header
 	//   required: true
@@ -362,7 +364,7 @@ func (i *jsonAPIHandler) PUTProfile(w http.ResponseWriter, r *http.Request) {
 	//  '200':
 	//    description: "Updates an existing profile"
 	//    schema:
-	//      $ref: "#/definitions/Drwasho"
+	//      $ref: "definitions.json#/Drwasho"
 
 	// If profile is not set tell them to use POST
 	currentProfile, err := i.node.GetProfile()
@@ -442,7 +444,7 @@ func (i *jsonAPIHandler) PATCHProfile(w http.ResponseWriter, r *http.Request) {
 	//   required: true
 	//   description: Profile to create
 	//   schema:
-	//     $ref: "#/definitions/UpdateTheProfilerequest"
+	//     $ref: "definitions.json#/UpdateTheProfilerequest"
 	// - name: Content-Type
 	//   in: header
 	//   required: true
@@ -452,7 +454,7 @@ func (i *jsonAPIHandler) PATCHProfile(w http.ResponseWriter, r *http.Request) {
 	//  '200':
 	//    description: "Updates an existing profile"
 	//    schema:
-	//      $ref: "#/definitions/Drwasho"
+	//      $ref: "definitions.json#/Drwasho"
 
 	// If profile is not set tell them to use POST
 	profilePath := path.Join(i.node.RepoPath, "root", "profile.json")
@@ -559,6 +561,30 @@ func (i *jsonAPIHandler) POSTAvatar(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) POSTHeader(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /ob/header images postHeader
+	//
+	// Set the header image. This will also update the header hash in the profile.
+	//
+	// Set the header
+	//
+	// ---
+	// parameters:
+	// - name: Body
+	//   in: body
+	//   required: true
+	//   description: Profile to create
+	//   schema:
+	//     $ref: "definitions.json#/SetTheHeaderrequest"
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    schema:
+	//      "$ref": "definitions.json#/BananaCrop"
+
 	type ImgData struct {
 		Header string `json:"header"`
 	}
@@ -597,6 +623,30 @@ func (i *jsonAPIHandler) POSTHeader(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) POSTImage(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /ob/images images postImage
+	//
+	// Upload one or more images. Returns the IPFS hash of each image which can be used to fetch the image using the IPFS API call.
+	//
+	// Upload images (e.g. cat image)
+	//
+	// ---
+	// parameters:
+	// - name: Body
+	//   in: body
+	//   required: true
+	//   description: Profile to create
+	//   schema:
+	//     $ref: "definitions.json#/UploadImages(e.g.CatImage)request"
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    schema:
+	//      $ref: "definitions.json#/YoDawg"
+
 	type ImgData struct {
 		Filename string `json:"filename"`
 		Image    string `json:"image"`
@@ -632,6 +682,31 @@ func (i *jsonAPIHandler) POSTImage(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) POSTListing(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /ob/listing listings postListing
+	//
+	// Create a new listing and set its inventory.
+	//
+	// Create a new listing (physical; no options)
+	//
+	// ---
+	// parameters:
+	// - name: Body
+	//   in: body
+	//   required: true
+	//   schema:
+	//     $ref: "definitions.json#/CreateANewListing(physical;NoOptions)request"
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    schema:
+	//      $ref: "definitions.json#/Godfather"
+	//    examples:
+	//      "application/json":
+	//        "slug": "godfather"
 	ld := new(pb.Listing)
 	err := jsonpb.Unmarshal(r.Body, ld)
 	if err != nil {
@@ -654,6 +729,28 @@ func (i *jsonAPIHandler) POSTListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) PUTListing(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation PUT /ob/listing listings putListing
+	//
+	// Update a listing. The currentSlug field is used specify the listing being updated. If the listing contains a new slug, the listing will be renamed using the new slug.
+	//
+	// Update a listing
+	//
+	// ---
+	// parameters:
+	// - name: Body
+	//   in: body
+	//   required: true
+	//   schema:
+	//     $ref: "definitions.json#/CreateANewListing(physical;NoOptions)request"
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '400':
+	//  '200':
+
 	ld := new(pb.Listing)
 	err := jsonpb.Unmarshal(r.Body, ld)
 	if err != nil {
@@ -677,6 +774,29 @@ func (i *jsonAPIHandler) PUTListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) DELETEListing(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation DELETE /ob/listing/{slug_or_listing_hash} listings deleteListing
+	//
+	// Delete a listing and associated inventory.
+	//
+	// Delete a listing
+	//
+	// ---
+	// parameters:
+	// - name: slug_or_listing_hash
+	//   in: path
+	//   required: true
+	//   type: string
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//  '400':
+	//    description: Listing not found.
+	//  '500':
+	//    description: "File Write Error: [error_message]"
 	_, slug := path.Split(r.URL.Path)
 	listingPath := path.Join(i.node.RepoPath, "root", "listings", slug+".json")
 	_, ferr := os.Stat(listingPath)
@@ -703,6 +823,37 @@ func (i *jsonAPIHandler) DELETEListing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) POSTPurchase(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation POST /ob/purchase orders postPurchase
+	//
+	// The purchase call can be made to a reachable or a unreachable vendor (offline or not able to receive incoming messages). \r\n\r\nAn order will be created in the AWAITING_PAYMENT state after this call.\r\n\r\nIf the total of the purchase is not more than 4X the current transaction fee, the purchase will be rejected (ie: if the fee is 0.0001, the total purchase must be more than 0.0004).
+	//
+	// Purchase an item
+	//
+	// ---
+	// parameters:
+	// - name: Body
+	//   in: body
+	//   required: true
+	//   schema:
+	//     $ref: "definitions.json#/PurchaseAnItemrequest"
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    schema: 
+	//      $ref: "definitions.json#/PurchaseOrder"
+	//    examples:
+	//      "application/json":
+	//        "amount": 81967
+	//        "orderId": "QmXRGXywXHmcr18PYpDNyKuhdQqB8C8iaTbhbasZCoN1QV"
+	//        "paymentAddress": "mhAoRQavWqaF6WPWtVwyhMVQ8sjqoWEESF"
+	//        "vendorOnline": true
+	//  '400':
+	//  '500':
+	//    description: "JSON error or marshalling error"
 	decoder := json.NewDecoder(r.Body)
 	var data core.PurchaseData
 	err := decoder.Decode(&data)
@@ -732,6 +883,31 @@ func (i *jsonAPIHandler) POSTPurchase(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) GETStatus(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation GET /ob/status/{peerId} miscellaneous getStatus
+	//
+	// Pings the peer and returns if it is online or not.
+	//
+	// Get peer online status
+	//
+	// ---
+	// parameters:
+	// - name: peerId
+	//   in: path
+	//   required: true
+	//   type: string
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    schema: 
+	//      $ref: "definitions.json#/IsSamOnline?"
+	//    examples:
+	//      "application/json":
+	//        "status": "online"
+	//  '400':
 	_, peerId := path.Split(r.URL.Path)
 	status, err := i.node.GetPeerStatus(peerId)
 	if err != nil {

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -843,7 +843,7 @@ func (i *jsonAPIHandler) POSTPurchase(w http.ResponseWriter, r *http.Request) {
 	//   description: "Usually application/json"
 	// responses:
 	//  '200':
-	//    schema: 
+	//    schema:
 	//      $ref: "definitions.json#/PurchaseOrder"
 	//    examples:
 	//      "application/json":
@@ -902,7 +902,7 @@ func (i *jsonAPIHandler) GETStatus(w http.ResponseWriter, r *http.Request) {
 	//   description: "Usually application/json"
 	// responses:
 	//  '200':
-	//    schema: 
+	//    schema:
 	//      $ref: "definitions.json#/IsSamOnline?"
 	//    examples:
 	//      "application/json":
@@ -918,6 +918,26 @@ func (i *jsonAPIHandler) GETStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (i *jsonAPIHandler) GETPeers(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation GET /ob/peers miscellaneous getPeers
+	//
+	// Returns a list of IDs of the peers connected to this node.
+	//
+	// Get connected peers
+	//
+	// ---
+	// parameters:
+	// - name: Content-Type
+	//   in: header
+	//   required: true
+	//   type: string
+	//   description: "Usually application/json"
+	// responses:
+	//  '200':
+	//    schema: 
+	//      type: array
+	//      items:
+	//        type: string
+	//  '400':
 	peers := ipfs.ConnectedPeers(i.node.IpfsNode)
 
 	peerJson, err := json.MarshalIndent(peers, "", "    ")


### PR DESCRIPTION
I'm going to slowly hammer away at this migration to self-documenting Swagger docs for our API in the hopes that we can work to keep our API well documented and up to date. The Swagger doc can be generated automatically during the Travis builds when we publish and then can be imported into Postman if we like. I've begun porting over the current Postman docs to the golang code. It will take a bit of time to catch it up, but once it's in there it should be straightforward to maintain.

Thoughts @cpacia @placer14 @tyler-smith ?