### PR TITLE
Add multiwallet configuration to config file

### DIFF
--- a/repo/init.go
+++ b/repo/init.go
@@ -168,6 +168,45 @@ func addConfigExtensions(repoRoot string, testnet bool) error {
 			LowFeeDefault:    20,
 			TrustedPeer:      "",
 		}
+		ws = schema.WalletsConfig{
+			BTC: schema.CoinConfig{
+				Type:             "API",
+				API:              "https://btc.bloqapi.net/insight-api",
+				APITestnet:       "https://test-insight.bitpay.com/api",
+				MaxFee:           200,
+				FeeAPI:           "https://btc.fees.openbazaar.org",
+				HighFeeDefault:   50,
+				MediumFeeDefault: 10,
+				LowFeeDefault:    1,
+			},
+			BCH: schema.CoinConfig{
+				Type:             "API",
+				API:              "https://bch-insight.bitpay.com/api",
+				APITestnet:       "https://test-bch-insight.bitpay.com/api",
+				MaxFee:           200,
+				HighFeeDefault:   10,
+				MediumFeeDefault: 5,
+				LowFeeDefault:    1,
+			},
+			LTC: schema.CoinConfig{
+				Type:             "API",
+				API:              "https://insight.litecore.io/api",
+				APITestnet:       "https://testnet.litecore.io/api",
+				MaxFee:           200,
+				HighFeeDefault:   20,
+				MediumFeeDefault: 10,
+				LowFeeDefault:    5,
+			},
+			ZEC: schema.CoinConfig{
+				Type:             "API",
+				API:              "https://zcashnetwork.info/api",
+				APITestnet:       "https://explorer.testnet.z.cash/api",
+				MaxFee:           200,
+				HighFeeDefault:   20,
+				MediumFeeDefault: 10,
+				LowFeeDefault:    5,
+			},
+		}
 
 		a = schema.APIConfig{
 			Enabled:     true,
@@ -187,6 +226,9 @@ func addConfigExtensions(repoRoot string, testnet bool) error {
 		}
 	)
 	if err := r.SetConfigKey("Wallet", w); err != nil {
+		return err
+	}
+	if err := r.SetConfigKey("Wallets", ws); err != nil {
 		return err
 	}
 	if err := r.SetConfigKey("DataSharing", ds); err != nil {

--- a/schema/configuration.go
+++ b/schema/configuration.go
@@ -41,6 +41,24 @@ type WalletConfig struct {
 	TrustedPeer      string
 }
 
+type WalletsConfig struct {
+	BTC CoinConfig `json:"BTC"`
+	BCH CoinConfig `json:"BCH"`
+	LTC CoinConfig `json:"LTC"`
+	ZEC CoinConfig `json:"ZEC"`
+}
+
+type CoinConfig struct {
+	Type             string
+	API              string
+	APITestnet       string
+	MaxFee           int
+	FeeAPI           string
+	HighFeeDefault   int
+	MediumFeeDefault int
+	LowFeeDefault    int
+}
+
 type DataSharing struct {
 	AcceptStoreRequests bool
 	PushTo              []string
@@ -271,6 +289,31 @@ func GetWalletConfig(cfgBytes []byte) (*WalletConfig, error) {
 		MediumFeeDefault: int(mediumFloat),
 		LowFeeDefault:    int(lowFloat),
 		TrustedPeer:      trustedPeerStr,
+	}
+	return wCfg, nil
+}
+
+func GetWalletsConfig(cfgBytes []byte) (*WalletsConfig, error) {
+	var cfgIface interface{}
+	json.Unmarshal(cfgBytes, &cfgIface)
+	cfg, ok := cfgIface.(map[string]interface{})
+	if !ok {
+		return nil, MalformedConfigError
+	}
+
+	walletIface, ok := cfg["Wallets"]
+	if !ok {
+		return nil, MalformedConfigError
+	}
+
+	b, err := json.Marshal(walletIface)
+	if err != nil {
+		return nil, err
+	}
+	wCfg := new(WalletsConfig)
+	err = json.Unmarshal(b, wCfg)
+	if err != nil {
+		return nil, err
 	}
 	return wCfg, nil
 }

--- a/schema/configuration_test.go
+++ b/schema/configuration_test.go
@@ -87,6 +87,108 @@ func TestGetWalletConfig(t *testing.T) {
 	}
 }
 
+func TestGetWalletsConfig(t *testing.T) {
+	config, err := GetWalletsConfig(configFixture())
+	if err != nil {
+		t.Error("GetWalletsConfig threw an unexpected error")
+	}
+	if config.BTC.FeeAPI != "https://btc.fees.openbazaar.org" {
+		t.Error("FeeApi does not equal expected value")
+	}
+	if config.BTC.Type != "API" {
+		t.Error("Type does not equal expected value")
+	}
+	if config.BTC.API != "https://btc.bloqapi.net/insight-api" {
+		t.Error("Binary does not equal expected value")
+	}
+	if config.BTC.APITestnet != "https://test-insight.bitpay.com/api" {
+		t.Error("Binary does not equal expected value")
+	}
+	if config.BTC.LowFeeDefault != 1 {
+		t.Error("Expected low to be 1, got ", config.BTC.LowFeeDefault)
+	}
+	if config.BTC.MediumFeeDefault != 10 {
+		t.Error("Expected medium to be 10, got ", config.BTC.MediumFeeDefault)
+	}
+	if config.BTC.HighFeeDefault != 50 {
+		t.Error("Expected high to be 50, got ", config.BTC.HighFeeDefault)
+	}
+	if config.BTC.MaxFee != 200 {
+		t.Error("Expected maxFee to be 200, got ", config.BTC.MaxFee)
+	}
+
+	if config.BCH.Type != "API" {
+		t.Error("Type does not equal expected value")
+	}
+	if config.BCH.API != "https://bch-insight.bitpay.com/api" {
+		t.Error("Binary does not equal expected value")
+	}
+	if config.BCH.APITestnet != "https://test-bch-insight.bitpay.com/api" {
+		t.Error("Binary does not equal expected value")
+	}
+	if config.BCH.LowFeeDefault != 1 {
+		t.Error("Expected low to be 1, got ", config.BCH.LowFeeDefault)
+	}
+	if config.BCH.MediumFeeDefault != 5 {
+		t.Error("Expected medium to be 5, got ", config.BCH.MediumFeeDefault)
+	}
+	if config.BCH.HighFeeDefault != 10 {
+		t.Error("Expected high to be 10, got ", config.BCH.HighFeeDefault)
+	}
+	if config.BTC.MaxFee != 200 {
+		t.Error("Expected maxFee to be 200, got ", config.BTC.MaxFee)
+	}
+
+	if config.LTC.Type != "API" {
+		t.Error("Type does not equal expected value")
+	}
+	if config.LTC.API != "https://insight.litecore.io/api" {
+		t.Error("Binary does not equal expected value")
+	}
+	if config.LTC.APITestnet != "https://testnet.litecore.io/api" {
+		t.Error("Binary does not equal expected value")
+	}
+	if config.LTC.LowFeeDefault != 5 {
+		t.Error("Expected low to be 5, got ", config.LTC.LowFeeDefault)
+	}
+	if config.LTC.MediumFeeDefault != 10 {
+		t.Error("Expected medium to be 10, got ", config.LTC.MediumFeeDefault)
+	}
+	if config.LTC.HighFeeDefault != 20 {
+		t.Error("Expected high to be 20, got ", config.LTC.HighFeeDefault)
+	}
+	if config.LTC.MaxFee != 200 {
+		t.Error("Expected maxFee to be 200, got ", config.LTC.MaxFee)
+	}
+
+	if config.ZEC.Type != "API" {
+		t.Error("Type does not equal expected value")
+	}
+	if config.ZEC.API != "https://zcashnetwork.info/api" {
+		t.Error("Binary does not equal expected value")
+	}
+	if config.ZEC.APITestnet != "https://explorer.testnet.z.cash/api" {
+		t.Error("Binary does not equal expected value")
+	}
+	if config.ZEC.LowFeeDefault != 5 {
+		t.Error("Expected low to be 5, got ", config.ZEC.LowFeeDefault)
+	}
+	if config.ZEC.MediumFeeDefault != 10 {
+		t.Error("Expected medium to be 10, got ", config.ZEC.MediumFeeDefault)
+	}
+	if config.ZEC.HighFeeDefault != 20 {
+		t.Error("Expected high to be 20, got ", config.ZEC.HighFeeDefault)
+	}
+	if config.LTC.MaxFee != 200 {
+		t.Error("Expected maxFee to be 200, got ", config.LTC.MaxFee)
+	}
+
+	_, err = GetWalletsConfig([]byte{})
+	if err == nil {
+		t.Error("GetWalletsConfig didn't throw an error")
+	}
+}
+
 func TestGetDropboxApiToken(t *testing.T) {
 	dropboxApiToken, err := GetDropboxApiToken(configFixture())
 	if dropboxApiToken != "dropbox123" {
@@ -320,6 +422,48 @@ func configFixture() []byte {
     "RPCUser": "username",
     "TrustedPeer": "127.0.0.1:8333",
     "Type": "spvwallet"
+  },
+  "Wallets": {
+    "BCH": {
+      "API": "https://bch-insight.bitpay.com/api",
+      "APITestnet": "https://test-bch-insight.bitpay.com/api",
+      "FeeAPI": "",
+      "HighFeeDefault": 10,
+      "LowFeeDefault": 1,
+      "MaxFee": 200,
+      "MediumFeeDefault": 5,
+      "Type": "API"
+    },
+    "BTC": {
+      "API": "https://btc.bloqapi.net/insight-api",
+      "APITestnet": "https://test-insight.bitpay.com/api",
+      "FeeAPI": "https://btc.fees.openbazaar.org",
+      "HighFeeDefault": 50,
+      "LowFeeDefault": 1,
+      "MaxFee": 200,
+      "MediumFeeDefault": 10,
+      "Type": "API"
+    },
+    "LTC": {
+      "API": "https://insight.litecore.io/api",
+      "APITestnet": "https://testnet.litecore.io/api",
+      "FeeAPI": "",
+      "HighFeeDefault": 20,
+      "LowFeeDefault": 5,
+      "MaxFee": 200,
+      "MediumFeeDefault": 10,
+      "Type": "API"
+    },
+    "ZEC": {
+      "API": "https://zcashnetwork.info/api",
+      "APITestnet": "https://explorer.testnet.z.cash/api",
+      "FeeAPI": "",
+      "HighFeeDefault": 20,
+      "LowFeeDefault": 5,
+      "MaxFee": 200,
+      "MediumFeeDefault": 10,
+      "Type": "API"
+    }
   }
 }`)
 }


### PR DESCRIPTION
This commit sets up the config file for use in the multiwallet refactor.
Each coin has its own config added with the idea that, abset the config, the
defaults will be used.

This commit does not change the existing wallet config object which will be
deprecated when the full refactor is complete.