### PR TITLE
Bugfixes: Error propagation, migrations version fix, no gofmtcheck for pb's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
 script:
-  - diff -u <(echo -n) <(gofmt -d -s $(find . -type f -name '*.go' -not -path "./vendor/*"))
+  - diff -u <(echo -n) <(gofmt -d -s $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pb/*"))
   - cd $TRAVIS_BUILD_DIR && ./test_compile.sh
   - goveralls -coverprofile=coverage.out -service travis-ci
 after_success:

--- a/repo/db/cases.go
+++ b/repo/db/cases.go
@@ -58,10 +58,8 @@ func (c *CasesDB) PutRecord(dispute *repo.DisputeCaseRecord) error {
 		}
 		return err
 	}
-	if err = tx.Commit(); err != nil {
-		return err
-	}
-	return nil
+
+	return tx.Commit()
 }
 
 func (c *CasesDB) Put(caseID string, state pb.OrderState, buyerOpened bool, claim string) error {

--- a/repo/db/purchases.go
+++ b/repo/db/purchases.go
@@ -80,8 +80,7 @@ func (p *PurchasesDB) Put(orderID string, contract pb.RicardianContract, state p
 		tx.Rollback()
 		return err
 	}
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (p *PurchasesDB) MarkAsRead(orderID string) error {

--- a/repo/db/sales.go
+++ b/repo/db/sales.go
@@ -86,8 +86,8 @@ func (s *SalesDB) Put(orderID string, contract pb.RicardianContract, state pb.Or
 		tx.Rollback()
 		return err
 	}
-	tx.Commit()
-	return nil
+
+	return tx.Commit()
 }
 
 func (s *SalesDB) MarkAsRead(orderID string) error {

--- a/repo/migration.go
+++ b/repo/migration.go
@@ -34,7 +34,7 @@ func MigrateUp(repoPath, dbPassword string, testnet bool) error {
 	} else if err != nil && os.IsNotExist(err) {
 		version = []byte("0")
 	}
-	v, err := strconv.Atoi(string(version[0]))
+	v, err := strconv.Atoi(string(version))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Simple bugfixes

- `tx.Commit()` returns and error so this should be propagated
- Migrations only use a single bytes for writing the repo version to disk (in ASCII). This means migrations don't work after 9. This should allow a full int
- There is no need to check gofmt'ing on protobuf generated Go code because it shouldn't be changed even if it violates gofmt rules.