### PR TITLE
CLEANUP: Add .vscode to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ dist
 
 # Development environment files
 .ackrc
+.vscode
 .tags*
 *.sw?
 


### PR DESCRIPTION
Add .vscode directory to .gitignore to make it more difficult for devs using VSCode to accidentally commit it.

They could all manually set git up globally to ignore it, but the % of people that do that is probably very small.