### PR TITLE
IPNS pubsub refactor

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -3591,7 +3591,7 @@ func (i *jsonAPIHandler) GETIPNS(w http.ResponseWriter, r *http.Request) {
 	var keyBytes []byte
 	pubkey := i.node.IpfsNode.Peerstore.PubKey(pid)
 	if pubkey == nil || !pid.MatchesPublicKey(pubkey) {
-		keyval, err := i.node.IpfsNode.Repo.Datastore().Get(ds.NewKey(core.KeyCachePrefix + "/ipns/" + peerId))
+		keyval, err := i.node.IpfsNode.Repo.Datastore().Get(ds.NewKey(core.KeyCachePrefix + peerId))
 		if err != nil {
 			ErrorResponse(w, http.StatusNotFound, err.Error())
 			return

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -47,6 +47,7 @@ import (
 	ipnspb "github.com/ipfs/go-ipfs/namesys/pb"
 	ipnspath "github.com/ipfs/go-ipfs/path"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
+	"gx/ipfs/QmTmqJGRQfuH8eKWD1FjThwPRipt1QhqJQNZ8MpzmfAAxo/go-ipfs-ds-help"
 )
 
 type JsonAPIConfig struct {
@@ -1050,6 +1051,7 @@ func (i *jsonAPIHandler) GETExchangeRate(w http.ResponseWriter, r *http.Request)
 
 func (i *jsonAPIHandler) GETFollowers(w http.ResponseWriter, r *http.Request) {
 	_, peerId := path.Split(r.URL.Path)
+	useCache, _ := strconv.ParseBool(r.URL.Query().Get("usecache"))
 	if peerId == "" || strings.ToLower(peerId) == "followers" || peerId == i.node.IPFSIdentityString() {
 		offset := r.URL.Query().Get("offsetId")
 		limit := r.URL.Query().Get("limit")
@@ -1086,7 +1088,7 @@ func (i *jsonAPIHandler) GETFollowers(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		peerId = pid.Pretty()
-		followBytes, err := i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "followers.json")), time.Minute)
+		followBytes, err := i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "followers.json")), time.Minute, useCache)
 		if err != nil {
 			ErrorResponse(w, http.StatusNotFound, err.Error())
 			return
@@ -1116,6 +1118,7 @@ func (i *jsonAPIHandler) GETFollowers(w http.ResponseWriter, r *http.Request) {
 
 func (i *jsonAPIHandler) GETFollowing(w http.ResponseWriter, r *http.Request) {
 	_, peerId := path.Split(r.URL.Path)
+	useCache, _ := strconv.ParseBool(r.URL.Query().Get("usecache"))
 	if peerId == "" || strings.ToLower(peerId) == "following" || peerId == i.node.IPFSIdentityString() {
 		offset := r.URL.Query().Get("offsetId")
 		limit := r.URL.Query().Get("limit")
@@ -1144,7 +1147,7 @@ func (i *jsonAPIHandler) GETFollowing(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		peerId = pid.Pretty()
-		followBytes, err := i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "following.json")), time.Minute)
+		followBytes, err := i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "following.json")), time.Minute, useCache)
 		if err != nil {
 			ErrorResponse(w, http.StatusNotFound, err.Error())
 			return
@@ -1339,6 +1342,7 @@ func (i *jsonAPIHandler) DELETEModerator(w http.ResponseWriter, r *http.Request)
 
 func (i *jsonAPIHandler) GETListings(w http.ResponseWriter, r *http.Request) {
 	_, peerId := path.Split(r.URL.Path)
+	useCache, _ := strconv.ParseBool(r.URL.Query().Get("usecache"))
 	if peerId == "" || strings.ToLower(peerId) == "listings" || peerId == i.node.IPFSIdentityString() {
 		listingsBytes, err := i.node.GetListings()
 		if err != nil {
@@ -1353,7 +1357,7 @@ func (i *jsonAPIHandler) GETListings(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		peerId = pid.Pretty()
-		listingsBytes, err := i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "listings.json")), time.Minute)
+		listingsBytes, err := i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "listings.json")), time.Minute, useCache)
 		if err != nil {
 			ErrorResponse(w, http.StatusNotFound, err.Error())
 			return
@@ -1366,6 +1370,7 @@ func (i *jsonAPIHandler) GETListings(w http.ResponseWriter, r *http.Request) {
 func (i *jsonAPIHandler) GETListing(w http.ResponseWriter, r *http.Request) {
 	urlPath, listingId := path.Split(r.URL.Path)
 	_, peerId := path.Split(urlPath[:len(urlPath)-1])
+	useCache, _ := strconv.ParseBool(r.URL.Query().Get("usecache"))
 	m := jsonpb.Marshaler{
 		EnumsAsInts:  false,
 		EmitDefaults: false,
@@ -1442,7 +1447,7 @@ func (i *jsonAPIHandler) GETListing(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			peerId = pid.Pretty()
-			listingBytes, err = i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "listings", listingId+".json")), time.Minute)
+			listingBytes, err = i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "listings", listingId+".json")), time.Minute, useCache)
 			if err != nil {
 				ErrorResponse(w, http.StatusNotFound, err.Error())
 				return
@@ -3227,6 +3232,7 @@ func (i *jsonAPIHandler) POSTEstimateTotal(w http.ResponseWriter, r *http.Reques
 func (i *jsonAPIHandler) GETRatings(w http.ResponseWriter, r *http.Request) {
 	urlPath, slug := path.Split(r.URL.Path)
 	_, peerId := path.Split(urlPath[:len(urlPath)-1])
+	useCache, _ := strconv.ParseBool(r.URL.Query().Get("usecache"))
 
 	if peerId == "ratings" {
 		peerId = slug
@@ -3235,7 +3241,7 @@ func (i *jsonAPIHandler) GETRatings(w http.ResponseWriter, r *http.Request) {
 
 	var indexBytes []byte
 	if peerId != i.node.IPFSIdentityString() {
-		indexBytes, _ = i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "ratings.json")), time.Minute)
+		indexBytes, _ = i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "ratings.json")), time.Minute, useCache)
 
 	} else {
 		indexBytes, _ = ioutil.ReadFile(path.Join(i.node.RepoPath, "root", "ratings.json"))
@@ -3572,7 +3578,7 @@ func (i *jsonAPIHandler) GETResolve(w http.ResponseWriter, r *http.Request) {
 func (i *jsonAPIHandler) GETIPNS(w http.ResponseWriter, r *http.Request) {
 	_, peerId := path.Split(r.URL.Path)
 
-	val, err := i.node.IpfsNode.Repo.Datastore().Get(ds.NewKey(core.CachePrefix + peerId))
+	val, err := i.node.IpfsNode.Repo.Datastore().Get(dshelp.NewKeyFromBinary([]byte("/ipns/" + peerId)))
 	if err != nil { // No record in datastore
 		ErrorResponse(w, http.StatusNotFound, err.Error())
 		return
@@ -3585,7 +3591,7 @@ func (i *jsonAPIHandler) GETIPNS(w http.ResponseWriter, r *http.Request) {
 	var keyBytes []byte
 	pubkey := i.node.IpfsNode.Peerstore.PubKey(pid)
 	if pubkey == nil || !pid.MatchesPublicKey(pubkey) {
-		keyval, err := i.node.IpfsNode.Repo.Datastore().Get(ds.NewKey(core.KeyCachePrefix + peerId))
+		keyval, err := i.node.IpfsNode.Repo.Datastore().Get(ds.NewKey(core.KeyCachePrefix + "/ipns/" + peerId))
 		if err != nil {
 			ErrorResponse(w, http.StatusNotFound, err.Error())
 			return
@@ -3621,7 +3627,7 @@ func (i *jsonAPIHandler) GETIPNS(w http.ResponseWriter, r *http.Request) {
 		ErrorResponse(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	go ipfs.Resolve(i.node.IpfsNode, pid, time.Minute)
+	go ipfs.Resolve(i.node.IpfsNode, pid, time.Minute, false)
 	fmt.Fprint(w, string(retBytes))
 }
 
@@ -3844,6 +3850,7 @@ func (i *jsonAPIHandler) DELETEPost(w http.ResponseWriter, r *http.Request) {
 // GET a list of posts (self or peer)
 func (i *jsonAPIHandler) GETPosts(w http.ResponseWriter, r *http.Request) {
 	_, peerId := path.Split(r.URL.Path)
+	useCache, _ := strconv.ParseBool(r.URL.Query().Get("usecache"))
 	if peerId == "" || strings.ToLower(peerId) == "posts" || peerId == i.node.IPFSIdentityString() {
 		postsBytes, err := i.node.GetPosts()
 		if err != nil {
@@ -3858,7 +3865,7 @@ func (i *jsonAPIHandler) GETPosts(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		peerId = pid.Pretty()
-		postsBytes, err := i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "posts.json")), time.Minute)
+		postsBytes, err := i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "posts.json")), time.Minute, useCache)
 		if err != nil {
 			ErrorResponse(w, http.StatusNotFound, err.Error())
 			return
@@ -3872,6 +3879,7 @@ func (i *jsonAPIHandler) GETPosts(w http.ResponseWriter, r *http.Request) {
 func (i *jsonAPIHandler) GETPost(w http.ResponseWriter, r *http.Request) {
 	urlPath, postId := path.Split(r.URL.Path)
 	_, peerId := path.Split(urlPath[:len(urlPath)-1])
+	useCache, _ := strconv.ParseBool(r.URL.Query().Get("usecache"))
 	m := jsonpb.Marshaler{
 		EnumsAsInts:  false,
 		EmitDefaults: false,
@@ -3928,7 +3936,7 @@ func (i *jsonAPIHandler) GETPost(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			peerId = pid.Pretty()
-			postBytes, err = i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "posts", postId+".json")), time.Minute)
+			postBytes, err = i.node.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "posts", postId+".json")), time.Minute, useCache)
 			if err != nil {
 				ErrorResponse(w, http.StatusNotFound, err.Error())
 				return

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -13,7 +13,6 @@ import (
 	obnet "github.com/OpenBazaar/openbazaar-go/net"
 	ipfscore "github.com/ipfs/go-ipfs/core"
 	bitswap "github.com/ipfs/go-ipfs/exchange/bitswap/network"
-	"github.com/ipfs/go-ipfs/namesys"
 	"io/ioutil"
 	"strings"
 
@@ -254,7 +253,8 @@ func (x *Restore) Execute(args []string) error {
 		Repo:   r,
 		Online: true,
 		ExtraOpts: map[string]bool{
-			"mplex": true,
+			"mplex":  true,
+			"ipnsps": true,
 		},
 		DNSResolver: nil,
 		Routing:     DHTOption,
@@ -276,7 +276,6 @@ func (x *Restore) Execute(args []string) error {
 	} else {
 		dhtutil.QuerySize = 16
 	}
-	namesys.UsePersistentCache = cfg.Ipns.UsePersistentCache
 
 	<-dht.DefaultBootstrapConfig.DoneChan
 	wg := new(sync.WaitGroup)
@@ -286,7 +285,7 @@ func (x *Restore) Execute(args []string) error {
 		PrintError(err.Error())
 		return err
 	}
-	k, err := ipfs.Resolve(nd, pid, time.Minute)
+	k, err := ipfs.Resolve(nd, pid, time.Minute, false)
 	if err != nil || k == "" {
 		PrintError(fmt.Sprintf("IPNS record for %s not found on network\n", identity.PeerID))
 		return err
@@ -331,7 +330,7 @@ func (x *Restore) Execute(args []string) error {
 
 func RestoreFile(repoPath, peerID, filename string, n *core.IpfsNode, wg *sync.WaitGroup) {
 	defer wg.Done()
-	b, err := ipfs.ResolveThenCat(n, ipfspath.FromString(path.Join(peerID, filename)), time.Minute)
+	b, err := ipfs.ResolveThenCat(n, ipfspath.FromString(path.Join(peerID, filename)), time.Minute, false)
 	if err != nil {
 		PrintError(fmt.Sprintf("Failed to find %s\n", filename))
 	} else {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -447,6 +447,10 @@ func (x *Start) Execute(args []string) error {
 		Routing:     DHTOption,
 	}
 
+	if cfg.Ipns.UsePersistentCache {
+		ncfg.ExtraOpts["ipnsps"] = true
+	}
+
 	if onionTransport != nil {
 		ncfg.Host = defaultHostOption
 	}
@@ -473,7 +477,6 @@ func (x *Start) Execute(args []string) error {
 	} else {
 		dhtutil.QuerySize = 16
 	}
-	namesys.UsePersistentCache = cfg.Ipns.UsePersistentCache
 
 	log.Info("Peer ID: ", nd.Identity.Pretty())
 	printSwarmAddrs(nd)

--- a/core/ipns.go
+++ b/core/ipns.go
@@ -129,7 +129,7 @@ func (n *OpenBazaarNode) IPNSResolve(peerId string, timeout time.Duration, useca
 
 		go func() {
 			n.IpfsNode.Repo.Datastore().Put(dshelp.NewKeyFromBinary([]byte("/ipns/"+pid.Pretty())), entryBytes)
-			n.IpfsNode.Repo.Datastore().Put(ds.NewKey(KeyCachePrefix+"/ipns/"+pid.Pretty()), pubkeyBytes)
+			n.IpfsNode.Repo.Datastore().Put(ds.NewKey(KeyCachePrefix+pid.Pretty()), pubkeyBytes)
 		}()
 
 		p, err := ipnspath.ParsePath(string(entry.Value))

--- a/core/ipns.go
+++ b/core/ipns.go
@@ -11,6 +11,7 @@ import (
 	npb "github.com/ipfs/go-ipfs/namesys/pb"
 	ipfspath "github.com/ipfs/go-ipfs/path"
 	ipnspath "github.com/ipfs/go-ipfs/path"
+	dshelp "gx/ipfs/QmTmqJGRQfuH8eKWD1FjThwPRipt1QhqJQNZ8MpzmfAAxo/go-ipfs-ds-help"
 	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
 	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
 	"gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
@@ -28,9 +29,9 @@ as a last ditch effort if it fails to find the record in the DHT. The API endpoi
 We need to take care to observe the Tor preference.
 */
 
-func (n *OpenBazaarNode) IPNSResolveThenCat(ipnsPath ipfspath.Path, timeout time.Duration) ([]byte, error) {
+func (n *OpenBazaarNode) IPNSResolveThenCat(ipnsPath ipfspath.Path, timeout time.Duration, usecache bool) ([]byte, error) {
 	var ret []byte
-	hash, err := n.IPNSResolve(ipnsPath.Segments()[0], timeout)
+	hash, err := n.IPNSResolve(ipnsPath.Segments()[0], timeout, usecache)
 	if err != nil {
 		return ret, err
 	}
@@ -46,12 +47,12 @@ func (n *OpenBazaarNode) IPNSResolveThenCat(ipnsPath ipfspath.Path, timeout time
 	return b, nil
 }
 
-func (n *OpenBazaarNode) IPNSResolve(peerId string, timeout time.Duration) (string, error) {
+func (n *OpenBazaarNode) IPNSResolve(peerId string, timeout time.Duration, usecache bool) (string, error) {
 	pid, err := peer.IDB58Decode(peerId)
 	if err != nil {
 		return "", err
 	}
-	val, err := ipfs.Resolve(n.IpfsNode, pid, timeout)
+	val, err := ipfs.Resolve(n.IpfsNode, pid, timeout, usecache)
 	if err != nil && n.IPNSBackupAPI != "" {
 		dial := net.Dial
 		if n.TorDialer != nil {
@@ -127,8 +128,8 @@ func (n *OpenBazaarNode) IPNSResolve(peerId string, timeout time.Duration) (stri
 		}
 
 		go func() {
-			n.IpfsNode.Repo.Datastore().Put(ds.NewKey(CachePrefix+peerId), entryBytes)
-			n.IpfsNode.Repo.Datastore().Put(ds.NewKey(KeyCachePrefix+peerId), pubkeyBytes)
+			n.IpfsNode.Repo.Datastore().Put(dshelp.NewKeyFromBinary([]byte("/ipns/"+pid.Pretty())), entryBytes)
+			n.IpfsNode.Repo.Datastore().Put(ds.NewKey(KeyCachePrefix+"/ipns/"+pid.Pretty()), pubkeyBytes)
 		}()
 
 		p, err := ipnspath.ParsePath(string(entry.Value))

--- a/core/order.go
+++ b/core/order.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	peer "gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
 	mh "gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"
 	crypto "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
@@ -1384,7 +1385,7 @@ func (n *OpenBazaarNode) ValidateDirectPaymentAddress(order *pb.Order) error {
 
 func (n *OpenBazaarNode) ValidateModeratedPaymentAddress(order *pb.Order, timeout time.Duration) error {
 	ipnsPath := ipfspath.FromString(order.Payment.Moderator + "/profile.json")
-	profileBytes, err := n.IPNSResolveThenCat(ipnsPath, time.Minute)
+	profileBytes, err := n.IPNSResolveThenCat(ipnsPath, time.Minute, true)
 	if err != nil {
 		return err
 	}

--- a/core/profile.go
+++ b/core/profile.go
@@ -20,9 +20,7 @@ import (
 	"github.com/imdario/mergo"
 )
 
-const (
-	KeyCachePrefix = "IPNSPUBKEYCACHE_"
-)
+const KeyCachePrefix = "/pubkey/"
 
 var ErrorProfileNotFound error = errors.New("Profile not found")
 

--- a/core/profile.go
+++ b/core/profile.go
@@ -6,8 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
-	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
+	ipnspath "github.com/ipfs/go-ipfs/path"
 	"gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
 	"io/ioutil"
 	"os"
@@ -16,18 +15,13 @@ import (
 	"time"
 
 	"github.com/OpenBazaar/jsonpb"
-	"github.com/OpenBazaar/openbazaar-go/ipfs"
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/imdario/mergo"
-	ipnspb "github.com/ipfs/go-ipfs/namesys/pb"
-	ipnspath "github.com/ipfs/go-ipfs/path"
 )
 
 const (
-	CachePrefix       = "IPNSPERSISTENTCACHE_"
-	KeyCachePrefix    = "IPNSPUBKEYCACHE_"
-	CachedProfileTime = time.Hour * 24 * 7
+	KeyCachePrefix = "IPNSPUBKEYCACHE_"
 )
 
 var ErrorProfileNotFound error = errors.New("Profile not found")
@@ -47,104 +41,15 @@ func (n *OpenBazaarNode) GetProfile() (pb.Profile, error) {
 }
 
 func (n *OpenBazaarNode) FetchProfile(peerId string, useCache bool) (pb.Profile, error) {
-	fetch := func(rootHash string) (pb.Profile, error) {
-		var pro pb.Profile
-		var profile []byte
-		var err error
-		if rootHash == "" {
-			profile, err = n.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "profile.json")), time.Minute)
-			if err != nil || len(profile) == 0 {
-				return pro, err
-			}
-		} else {
-			profile, err = ipfs.Cat(n.IpfsNode, path.Join(rootHash, "profile.json"), time.Minute)
-			if err != nil || len(profile) == 0 {
-				return pro, err
-			}
-		}
-		err = jsonpb.UnmarshalString(string(profile), &pro)
-		if err != nil {
-			return pro, err
-		}
-		return pro, nil
-	}
-
 	var pro pb.Profile
-	var err error
-	var recordAvailable bool
-	var val interface{}
-	if useCache {
-		val, err = n.IpfsNode.Repo.Datastore().Get(ds.NewKey(CachePrefix + peerId))
-		if err != nil { // No record in datastore
-			pro, err = fetch("")
-			if err != nil {
-				return pb.Profile{}, err
-			}
-		} else { // Record available, let's see how old it is
-			entry := new(ipnspb.IpnsEntry)
-			err = proto.Unmarshal(val.([]byte), entry)
-			if err != nil {
-				return pb.Profile{}, err
-			}
-			p, err := ipnspath.ParsePath(string(entry.GetValue()))
-			if err != nil {
-				return pb.Profile{}, err
-			}
-			cacheExpiry := time.Time{}
-			if entry.Ttl != nil {
-				cacheExpiry = time.Unix(int64(*entry.Ttl), 0)
-			}
-			if cacheExpiry.Before(time.Now()) { // Too old, fetch new profile
-				pro, err = fetch("")
-				if err != nil { // Not found, let's just return what we have
-					pro, err = fetch(strings.TrimPrefix(p.String(), "/ipfs/"))
-				}
-			} else { // Relatively new, we can do a standard IPFS query (which should be cached)
-				pro, err = fetch(strings.TrimPrefix(p.String(), "/ipfs/"))
-				// Let's now try to get the latest record in a new goroutine so it's available next time
-				go fetch("")
-			}
-			if err != nil {
-				return pb.Profile{}, err
-			}
-			recordAvailable = true
-		}
-	} else {
-		pro, err = fetch("")
-		if err != nil {
-			return pb.Profile{}, err
-		}
-		recordAvailable = false
+	b, err := n.IPNSResolveThenCat(ipnspath.FromString(path.Join(peerId, "profile.json")), time.Minute, useCache)
+	if err != nil || len(b) == 0 {
+		return pro, err
 	}
-
-	if err := ValidateProfile(&pro); err != nil {
-		return pb.Profile{}, err
+	err = jsonpb.UnmarshalString(string(b), &pro)
+	if err != nil {
+		return pro, err
 	}
-
-	// Update the record with a new EOL
-	go func() {
-		if !recordAvailable {
-			val, err = n.IpfsNode.Repo.Datastore().Get(ds.NewKey(CachePrefix + peerId))
-			if err != nil {
-				return
-			}
-		}
-
-		entry := new(ipnspb.IpnsEntry)
-		err = proto.Unmarshal(val.([]byte), entry)
-		if err != nil {
-			return
-		}
-		// Update the ttl field on the record with a new ttl so next time we fetch from cache
-		// the record wont be expired causing us to fetch from the DHT.
-		ttl := uint64(time.Now().Add(CachedProfileTime).Unix())
-		entry.Ttl = &ttl
-		v, err := proto.Marshal(entry)
-		if err != nil {
-			return
-		}
-		n.IpfsNode.Repo.Datastore().Put(ds.NewKey(CachePrefix+peerId), v)
-	}()
 	return pro, nil
 }
 

--- a/ipfs/cat.go
+++ b/ipfs/cat.go
@@ -25,13 +25,13 @@ func Cat(n *core.IpfsNode, path string, timeout time.Duration) ([]byte, error) {
 	return ioutil.ReadAll(r)
 }
 
-func ResolveThenCat(n *core.IpfsNode, ipnsPath path.Path, timeout time.Duration) ([]byte, error) {
+func ResolveThenCat(n *core.IpfsNode, ipnsPath path.Path, timeout time.Duration, usecache bool) ([]byte, error) {
 	var ret []byte
 	pid, err := peer.IDB58Decode(ipnsPath.Segments()[0])
 	if err != nil {
 		return nil, err
 	}
-	hash, err := Resolve(n, pid, timeout)
+	hash, err := Resolve(n, pid, timeout, usecache)
 	if err != nil {
 		return ret, err
 	}

--- a/ipfs/dag.go
+++ b/ipfs/dag.go
@@ -48,7 +48,7 @@ func RemoveAll(nd *core.IpfsNode, peerID string) error {
 	if err != nil {
 		return nil
 	}
-	hash, err := Resolve(nd, pid, time.Minute*5)
+	hash, err := Resolve(nd, pid, time.Minute*5, true)
 	if err != nil {
 		return err
 	}

--- a/ipfs/resolve.go
+++ b/ipfs/resolve.go
@@ -3,12 +3,39 @@ package ipfs
 import (
 	"context"
 	"github.com/ipfs/go-ipfs/core"
+	"github.com/ipfs/go-ipfs/namesys"
+	pb "github.com/ipfs/go-ipfs/namesys/pb"
+	path "github.com/ipfs/go-ipfs/path"
+	dshelp "gx/ipfs/QmTmqJGRQfuH8eKWD1FjThwPRipt1QhqJQNZ8MpzmfAAxo/go-ipfs-ds-help"
+	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
+	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
 	"gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
 	"time"
 )
 
-// Publish a signed IPNS record to our Peer ID
-func Resolve(n *core.IpfsNode, p peer.ID, timeout time.Duration) (string, error) {
+// Resolve an IPNS record. This is a multi-step process.
+// If the usecache flag is provided we will attempt to load the record from the database. If
+// it succeeds we will update the cache in a separate goroutine.
+//
+// If we need to actually get a record from the network the IPNS namesystem will first check to
+// see if it is subscribed to the name with pubsub. If so, it will return cache from the database.
+// If not, it will subscribe to the name and proceed to a DHT query to find the record.
+// If the DHT query returns nothing it will finally attempt to return from cache.
+// All subsequent resolves will return from cache as the pubsub will update the cache in real time
+// as new records are published.
+func Resolve(n *core.IpfsNode, p peer.ID, timeout time.Duration, usecache bool) (string, error) {
+	if usecache {
+		pth, err := getFromDatastore(n.Repo.Datastore(), "/ipns/"+p.Pretty())
+		if err == nil {
+			// Update the cache in background
+			go resolve(n, p, timeout)
+			return pth.Segments()[1], nil
+		}
+	}
+	return resolve(n, p, timeout)
+}
+
+func resolve(n *core.IpfsNode, p peer.ID, timeout time.Duration) (string, error) {
 	cctx, _ := context.WithTimeout(context.Background(), timeout)
 	pth, err := n.Namesys.Resolve(cctx, "/ipns/"+p.Pretty())
 	if err != nil {
@@ -24,4 +51,26 @@ func ResolveAltRoot(n *core.IpfsNode, p peer.ID, altRoot string, timeout time.Du
 		return "", err
 	}
 	return pth.Segments()[1], nil
+}
+
+func getFromDatastore(datastore ds.Datastore, name string) (path.Path, error) {
+	// resolve to what we may already have in the datastore
+	dsval, err := datastore.Get(dshelp.NewKeyFromBinary([]byte(name)))
+	if err != nil {
+		if err == ds.ErrNotFound {
+			return "", namesys.ErrResolveFailed
+		}
+		return "", err
+	}
+
+	data := dsval.([]byte)
+	entry := new(pb.IpnsEntry)
+
+	err = proto.Unmarshal(data, entry)
+	if err != nil {
+		return "", err
+	}
+
+	value, err := path.ParsePath(string(entry.GetValue()))
+	return value, err
 }

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -152,6 +152,10 @@ func NewNode(config NodeConfig) (*Node, error) {
 		Repo:    r,
 		Online:  true,
 		Routing: DHTClientOption,
+		ExtraOpts: map[string]bool{
+			"mplex":  true,
+			"ipnsps": true,
+		},
 	}
 
 	// Set IPNS query size
@@ -161,7 +165,6 @@ func NewNode(config NodeConfig) (*Node, error) {
 	} else {
 		dhtutil.QuerySize = 16
 	}
-	namesys.UsePersistentCache = cfg.Ipns.UsePersistentCache
 
 	// Wallet
 	mn, err := sqliteDB.Config().GetMnemonic()

--- a/net/retriever/retriever.go
+++ b/net/retriever/retriever.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	DefaultPointerPrefixLength = 14
-	KeyCachePrefix             = "IPNSPUBKEYCACHE_"
+	KeyCachePrefix             = "/pubkey/"
 )
 
 var log = logging.MustGetLogger("retriever")

--- a/vendor/github.com/ipfs/go-ipfs/namesys/routing.go
+++ b/vendor/github.com/ipfs/go-ipfs/namesys/routing.go
@@ -23,7 +23,7 @@ import (
 )
 
 var log = logging.Logger("namesys")
-var keyCachePrefix= "IPNSPUBKEYCACHE_"
+const keyCachePrefix = "/pubkey/"
 
 // routingResolver implements NSResolver for the main IPFS SFS-like naming
 type routingResolver struct {
@@ -175,7 +175,7 @@ func (r *routingResolver) resolveOnce(ctx context.Context, pname string, options
 	}()
 
 	go func() {
-		val, err := r.datastore.Get(ds.NewKey(keyCachePrefix + pname))
+		val, err := r.datastore.Get(ds.NewKey(keyCachePrefix + name))
 		if err == nil {
 			b, ok := val.([]byte)
 			if ok {
@@ -278,5 +278,5 @@ func checkEOL(e *pb.IpnsEntry) (time.Time, bool) {
 
 func putToDatabase(datastore ds.Datastore, name string, ipnsRec, pubkey []byte) {
 	datastore.Put(dshelp.NewKeyFromBinary([]byte(name)), ipnsRec)
-	datastore.Put(ds.NewKey(keyCachePrefix+name), pubkey)
+	datastore.Put(ds.NewKey(keyCachePrefix+strings.TrimPrefix(name, "/ipns/")), pubkey)
 }


### PR DESCRIPTION
Major refactor of IPNS code. The `usecache` flag is now fundamental to all IPNS queries rather than having complex add on code for `FetchProfile` and `FetchImage`. 

All main API calls now have a `usecache` flag. 

Resolve flow works like this:

- On startup nodes are not subscribed to any names. 
- Any Resolve queries first get passed into the pubsub resolver which determines it's not subscribed, subscribes to the name, then returns an error.
- Upon an error from the pubsub resolver the routing resolver tries to fetch the record from the DHT. If the record is found, the local db is updated with the current record. 
- If that fails, we query the pubsub resolver again. This time since it's subscribed, it will return its cache from the database if it has any. 

All subsequent resolves will go into the pubsub resolver which will resolve them immediately as it has the record in the database.  

The `usecache` flag tells it to try returning whatever it has in the db then do a regular resolve in a background thread to update the db. 