### PR TITLE
BUILD: Install test dependencies before running tests to increase tes…

### DIFF
--- a/test_compile.sh
+++ b/test_compile.sh
@@ -2,6 +2,7 @@
 
 set -e
 pwd
+go test -i
 go test -coverprofile=api.cover.out ./api
 go test -coverprofile=bitcoin.cover.out ./bitcoin
 go test -coverprofile=bitcoin.listeners.cover.out ./bitcoin/listeners


### PR DESCRIPTION
…t speed.

Test runs are showing a decrease from 15-25min to a consistent < 6min.