### PR TITLE
BUGFIX: Use UTC times for notification timestamps as expected by the …

### DIFF
--- a/repo/db/notifications.go
+++ b/repo/db/notifications.go
@@ -117,7 +117,7 @@ func (n *NotficationsDB) GetAll(offsetId string, limit int, typeFilter []string)
 			read = true
 		}
 		notification.IsRead = read
-		notification.CreatedAt = time.Unix(int64(timestampInt), 0)
+		notification.CreatedAt = time.Unix(int64(timestampInt), 0).UTC()
 		// END
 
 		ret = append(ret, notification)

--- a/repo/db/notifications_test.go
+++ b/repo/db/notifications_test.go
@@ -33,7 +33,7 @@ func TestNotficationsDB_PutRecord(t *testing.T) {
 	var (
 		db, teardown, err = newNotificationStore()
 		// now as Unix() quantizes time to DB's resolution which makes reflect.DeepEqual pass below
-		now               = time.Unix(time.Now().Unix(), 0)
+		now               = time.Unix(time.Now().UTC().Unix(), 0)
 		putRecordExamples = []*repo.Notification{
 			repo.NewNotification(repo.OrderCancelNotification{
 				ID:      "orderCancelNotif",

--- a/repo/notification.go
+++ b/repo/notification.go
@@ -40,7 +40,7 @@ type Notifier interface {
 func NewNotification(n Notifier, createdAt time.Time, isRead bool) *Notification {
 	return &Notification{
 		ID:           n.GetID(),
-		CreatedAt:    createdAt,
+		CreatedAt:    createdAt.UTC(),
 		IsRead:       isRead,
 		NotifierData: n,
 		NotifierType: n.GetType(),


### PR DESCRIPTION
…api tests.