### PR TITLE
Add disable options to mobile node config

### DIFF
--- a/mobile/config.go
+++ b/mobile/config.go
@@ -28,6 +28,6 @@ type NodeConfig struct {
 	WalletTrustedPeer string
 
 	// Processes to disable
-	DisableWallet bool
+	DisableWallet        bool
 	DisableExchangerates bool
 }

--- a/mobile/config.go
+++ b/mobile/config.go
@@ -26,4 +26,8 @@ type NodeConfig struct {
 
 	// Add a trusted peer for the wallet
 	WalletTrustedPeer string
+
+	// Processes to disable
+	DisableWallet bool
+	DisableExchangerates bool
 }

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -58,11 +58,11 @@ import (
 )
 
 type Node struct {
-	node       *core.OpenBazaarNode
-	config     NodeConfig
-	cancel     context.CancelFunc
-	ipfsConfig *ipfscore.BuildCfg
-	apiConfig  *schema.APIConfig
+	OpenBazaarNode *core.OpenBazaarNode
+	config         NodeConfig
+	cancel         context.CancelFunc
+	ipfsConfig     *ipfscore.BuildCfg
+	apiConfig      *schema.APIConfig
 }
 
 func NewNode(config NodeConfig) (*Node, error) {
@@ -271,7 +271,7 @@ func NewNode(config NodeConfig) (*Node, error) {
 		return nil, errors.New("No gateway addresses configured")
 	}
 
-	return &Node{node: core.Node, config: config, ipfsConfig: ncfg, apiConfig: apiConfig}, nil
+	return &Node{OpenBazaarNode: core.Node, config: config, ipfsConfig: ncfg, apiConfig: apiConfig}, nil
 }
 
 func (n *Node) startIPFSNode(repoPath string, config *ipfscore.BuildCfg) (*ipfscore.IpfsNode, commands.Context, error) {
@@ -301,7 +301,7 @@ func (n *Node) Start() error {
 		return err
 	}
 
-	n.node.IpfsNode = nd
+	n.OpenBazaarNode.IpfsNode = nd
 
 	// Get current directory root hash
 	_, ipnskey := namesys.IpnsKeysForID(nd.Identity)
@@ -314,9 +314,9 @@ func (n *Node) Start() error {
 	proto.Unmarshal(val, dhtrec)
 	e := new(namepb.IpnsEntry)
 	proto.Unmarshal(dhtrec.GetValue(), e)
-	n.node.RootHash = ipath.Path(e.Value).String()
+	n.OpenBazaarNode.RootHash = ipath.Path(e.Value).String()
 
-	configFile, err := ioutil.ReadFile(path.Join(n.node.RepoPath, "config"))
+	configFile, err := ioutil.ReadFile(path.Join(n.OpenBazaarNode.RepoPath, "config"))
 	if err != nil {
 		return err
 	}
@@ -326,7 +326,7 @@ func (n *Node) Start() error {
 	}
 
 	// Offline messaging storage
-	n.node.MessageStorage = selfhosted.NewSelfHostedStorage(n.node.RepoPath, n.node.IpfsNode, n.node.PushNodes, n.node.SendStore)
+	n.OpenBazaarNode.MessageStorage = selfhosted.NewSelfHostedStorage(n.OpenBazaarNode.RepoPath, n.OpenBazaarNode.IpfsNode, n.OpenBazaarNode.PushNodes, n.OpenBazaarNode.SendStore)
 
 	// Start gateway
 	// Create authentication cookie
@@ -345,32 +345,32 @@ func (n *Node) Start() error {
 
 	go func() {
 		<-dht.DefaultBootstrapConfig.DoneChan
-		n.node.Service = service.New(n.node, n.node.Datastore)
+		n.OpenBazaarNode.Service = service.New(n.OpenBazaarNode, n.OpenBazaarNode.Datastore)
 		MR := ret.NewMessageRetriever(ret.MRConfig{
-			Db:        n.node.Datastore,
-			IPFSNode:  n.node.IpfsNode,
-			BanManger: n.node.BanManager,
+			Db:        n.OpenBazaarNode.Datastore,
+			IPFSNode:  n.OpenBazaarNode.IpfsNode,
+			BanManger: n.OpenBazaarNode.BanManager,
 			Service:   core.Node.Service,
 			PrefixLen: 14,
 			PushNodes: core.Node.PushNodes,
 			Dialer:    nil,
-			SendAck:   n.node.SendOfflineAck,
-			SendError: n.node.SendError,
+			SendAck:   n.OpenBazaarNode.SendOfflineAck,
+			SendError: n.OpenBazaarNode.SendError,
 		})
 		go MR.Run()
-		n.node.MessageRetriever = MR
-		PR := rep.NewPointerRepublisher(n.node.IpfsNode, n.node.Datastore, n.node.PushNodes, n.node.IsModerator)
+		n.OpenBazaarNode.MessageRetriever = MR
+		PR := rep.NewPointerRepublisher(n.OpenBazaarNode.IpfsNode, n.OpenBazaarNode.Datastore, n.OpenBazaarNode.PushNodes, n.OpenBazaarNode.IsModerator)
 		go PR.Run()
-		n.node.PointerRepublisher = PR
+		n.OpenBazaarNode.PointerRepublisher = PR
 		MR.Wait()
-		if n.node.Wallet != nil {
-			TL := lis.NewTransactionListener(n.node.Datastore, n.node.Broadcast, n.node.Wallet)
-			WL := lis.NewWalletListener(n.node.Datastore, n.node.Broadcast)
-			n.node.Wallet.AddTransactionListener(TL.OnTransactionReceived)
-			n.node.Wallet.AddTransactionListener(WL.OnTransactionReceived)
-			su := bitcoin.NewStatusUpdater(n.node.Wallet, n.node.Broadcast, n.node.IpfsNode.Context())
+		if n.OpenBazaarNode.Wallet != nil {
+			TL := lis.NewTransactionListener(n.OpenBazaarNode.Datastore, n.OpenBazaarNode.Broadcast, n.OpenBazaarNode.Wallet)
+			WL := lis.NewWalletListener(n.OpenBazaarNode.Datastore, n.OpenBazaarNode.Broadcast)
+			n.OpenBazaarNode.Wallet.AddTransactionListener(TL.OnTransactionReceived)
+			n.OpenBazaarNode.Wallet.AddTransactionListener(WL.OnTransactionReceived)
+			su := bitcoin.NewStatusUpdater(n.OpenBazaarNode.Wallet, n.OpenBazaarNode.Broadcast, n.OpenBazaarNode.IpfsNode.Context())
 			go su.Start()
-			go n.node.Wallet.Start()
+			go n.OpenBazaarNode.Wallet.Start()
 		}
 
 		core.PublishLock.Unlock()


### PR DESCRIPTION
The `Node` object in the mobile package provides an easy way to import openbazaar-go as a library and spin up a node inside of another project. 

For use this could be useful for the datanodes and our new relay node as it avoids writing a lot of boiler plate code. 

However, those projects don't need the wallet grinding away in the background so this provides ability to disable it. 