### PR TITLE
[Fixes #1041] Remove grouping SQL method from GET /ob/markchatasread

### DIFF
--- a/repo/db/chat.go
+++ b/repo/db/chat.go
@@ -226,6 +226,7 @@ func (c *ChatDB) MarkAsRead(peerID string, subject string, outgoing bool, messag
 	tx.Commit()
 
 	var peerStm string
+
 	if peerID != "" {
 		peerStm = " and peerID=?"
 	}
@@ -234,17 +235,19 @@ func (c *ChatDB) MarkAsRead(peerID string, subject string, outgoing bool, messag
 		return "", updated, err
 	}
 	defer stmt2.Close()
-	var ts int
-	var msgId string
+	var (
+		timestamp sql.NullInt64
+		msgId     sql.NullString
+	)
 	if peerID != "" {
-		err = stmt2.QueryRow(subject, peerID, outgoingInt).Scan(&ts, &msgId)
+		err = stmt2.QueryRow(subject, peerID, outgoingInt).Scan(&timestamp, &msgId)
 	} else {
-		err = stmt2.QueryRow(subject, outgoingInt).Scan(&ts, &msgId)
+		err = stmt2.QueryRow(subject, outgoingInt).Scan(&timestamp, &msgId)
 	}
 	if err != nil {
 		return "", updated, err
 	}
-	return msgId, updated, nil
+	return msgId.String, updated, nil
 }
 
 func (c *ChatDB) GetUnreadCount(subject string) (int, error) {


### PR DESCRIPTION
max(timestamp) method was generating NULL in the case when SQL
conditions returned no results, as is the case when no chats with a
peerID have yet been created. Since max(timestamp) does not appear to be
used by anything, let's remove it.