### PR TITLE
Simplify logging for RecordAgingNotifier

### DIFF
--- a/core/record_aging_notifier.go
+++ b/core/record_aging_notifier.go
@@ -28,6 +28,29 @@ type recordAgingNotifier struct {
 	stopWorker    chan bool
 }
 
+type NotifierResult struct {
+	notificationsMade int
+	recordsUpdated    int
+	subject           string
+}
+
+type NotifierSummary map[string]*NotifierResult
+
+func (result NotifierSummary) Add(operand *NotifierResult) {
+	if result == nil {
+		result = make(map[string]*NotifierResult, 0)
+	}
+	result[operand.subject] = operand
+}
+
+func (result NotifierSummary) String() string {
+	var summaries = make([]string, 0)
+	for subject, result := range result {
+		summaries = append(summaries, fmt.Sprintf("%s: %d/%d", subject, result.notificationsMade, result.recordsUpdated))
+	}
+	return strings.Join(summaries, ", ")
+}
+
 // StartRecordAgingNotifier - start the notifier
 func (n *OpenBazaarNode) StartRecordAgingNotifier() {
 	n.RecordAgingNotifier = &recordAgingNotifier{
@@ -71,48 +94,63 @@ func (notifier *recordAgingNotifier) Stop() {
 }
 
 func (notifier *recordAgingNotifier) PerformTask() {
+	var summary = NotifierSummary{}
 	notifier.runCount++ // += 1
-	notifier.logger.Debugf("performTask started (count %d)", notifier.runCount)
 
-	if err := notifier.generateSellerDisputeNotifications(); err != nil {
+	if result, err := notifier.generateSellerDisputeNotifications(); err != nil {
 		notifier.logger.Errorf("generateSellerDisputeNotifications failed: %s", err)
+	} else {
+		summary.Add(result)
 	}
-	if err := notifier.generateBuyerDisputeTimeoutNotifications(); err != nil {
+	if result, err := notifier.generateBuyerDisputeTimeoutNotifications(); err != nil {
 		notifier.logger.Errorf("generateBuyerDisputeTimeoutNotifications failed: %s", err)
+	} else {
+		summary.Add(result)
 	}
-	if err := notifier.generateBuyerDisputeExpiryNotifications(); err != nil {
+	if result, err := notifier.generateBuyerDisputeExpiryNotifications(); err != nil {
 		notifier.logger.Errorf("generateBuyerDisputeExpiryNotifications failed: %s", err)
+	} else {
+		summary.Add(result)
 	}
-	if err := notifier.generateModeratorDisputeExpiryNotifications(); err != nil {
+	if result, err := notifier.generateModeratorDisputeExpiryNotifications(); err != nil {
 		notifier.logger.Errorf("generateModeratorDisputeExpiryNotifications failed: %s", err)
+	} else {
+		summary.Add(result)
 	}
+	notifier.logger.Debugf("notifications created/records updated: %s", summary.String())
 }
 
-func (notifier *recordAgingNotifier) generateSellerDisputeNotifications() error {
+func (notifier *recordAgingNotifier) generateSellerDisputeNotifications() (*NotifierResult, error) {
 	sales, err := notifier.datastore.Sales().GetSalesForDisputeTimeoutNotification()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var (
 		executedAt         = time.Now()
 		notificationsToAdd = make([]*repo.Notification, 0)
+		updatedSales       = make([]*repo.SaleRecord, 0)
 	)
 
 	for _, s := range sales {
-		var timeSinceCreation = executedAt.Sub(s.Timestamp)
+		var (
+			timeSinceCreation = executedAt.Sub(s.Timestamp)
+			updated           = false
+		)
 		if s.LastDisputeTimeoutNotifiedAt.Before(s.Timestamp.Add(repo.VendorDisputeTimeout_lastInterval)) && timeSinceCreation > repo.VendorDisputeTimeout_lastInterval {
 			notificationsToAdd = append(notificationsToAdd, s.BuildVendorDisputeTimeoutLastNotification(executedAt))
+			updated = true
 		}
-		if len(notificationsToAdd) > 0 {
+		if updated {
 			s.LastDisputeTimeoutNotifiedAt = executedAt
+			updatedSales = append(updatedSales, s)
 		}
 	}
 
 	notifier.datastore.Notifications().Lock()
 	notificationTx, err := notifier.datastore.Notifications().BeginTransaction()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, n := range notificationsToAdd {
@@ -135,57 +173,63 @@ func (notifier *recordAgingNotifier) generateSellerDisputeNotifications() error 
 		if rollbackErr := notificationTx.Rollback(); rollbackErr != nil {
 			err = fmt.Errorf("%s %s %s", err.Error(), "\nand also failed during rollback:", rollbackErr.Error())
 		}
-		return fmt.Errorf("commiting vendor dispute notifications: %s", err.Error())
+		return nil, fmt.Errorf("commiting vendor dispute notifications: %s", err.Error())
 	}
-	notifier.logger.Debugf("created %d vendor dispute notifications", len(notificationsToAdd))
 	notifier.datastore.Notifications().Unlock()
 
 	for _, n := range notificationsToAdd {
 		notifier.broadcast <- n.NotifierData
 	}
 
-	if err = notifier.datastore.Sales().UpdateSalesLastDisputeTimeoutNotifiedAt(sales); err != nil {
-		return fmt.Errorf("update sales disputeTimeoutNotifiedAt: %s", err.Error())
+	if err = notifier.datastore.Sales().UpdateSalesLastDisputeTimeoutNotifiedAt(updatedSales); err != nil {
+		return nil, fmt.Errorf("update sales disputeTimeoutNotifiedAt: %s", err.Error())
 	}
-	notifier.logger.Debugf("updated lastDisputeTimeoutNotifiedAt on %d sales", len(sales))
-	return nil
+	return &NotifierResult{len(notificationsToAdd), len(updatedSales), "sales"}, nil
 }
 
-func (notifier *recordAgingNotifier) generateBuyerDisputeTimeoutNotifications() error {
+func (notifier *recordAgingNotifier) generateBuyerDisputeTimeoutNotifications() (*NotifierResult, error) {
 	purchases, err := notifier.datastore.Purchases().GetPurchasesForDisputeTimeoutNotification()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var (
 		executedAt         = time.Now()
 		notificationsToAdd = make([]*repo.Notification, 0)
+		updatedPurchases   = make([]*repo.PurchaseRecord, 0)
 	)
 
 	for _, p := range purchases {
-		var timeSinceCreation = executedAt.Sub(p.Timestamp)
-		// Extra seconds added to creation time is a hack to order SQL results
+		var (
+			timeSinceCreation = executedAt.Sub(p.Timestamp)
+			updated           = false
+		)
 		if p.LastDisputeTimeoutNotifiedAt.Before(p.Timestamp.Add(repo.BuyerDisputeTimeout_firstInterval)) && timeSinceCreation > repo.BuyerDisputeTimeout_firstInterval {
 			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutFirstNotification(executedAt))
+			updated = true
 		}
 		if p.LastDisputeTimeoutNotifiedAt.Before(p.Timestamp.Add(repo.BuyerDisputeTimeout_secondInterval)) && timeSinceCreation > repo.BuyerDisputeTimeout_secondInterval {
 			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutSecondNotification(executedAt))
+			updated = true
 		}
 		if p.LastDisputeTimeoutNotifiedAt.Before(p.Timestamp.Add(repo.BuyerDisputeTimeout_thirdInterval)) && timeSinceCreation > repo.BuyerDisputeTimeout_thirdInterval {
 			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutThirdNotification(executedAt))
+			updated = true
 		}
 		if p.LastDisputeTimeoutNotifiedAt.Before(p.Timestamp.Add(repo.BuyerDisputeTimeout_lastInterval)) && timeSinceCreation > repo.BuyerDisputeTimeout_lastInterval {
 			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeTimeoutLastNotification(executedAt))
+			updated = true
 		}
-		if len(notificationsToAdd) > 0 {
+		if updated {
 			p.LastDisputeTimeoutNotifiedAt = executedAt
+			updatedPurchases = append(updatedPurchases, p)
 		}
 	}
 
 	notifier.datastore.Notifications().Lock()
 	notificationTx, err := notifier.datastore.Notifications().BeginTransaction()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, n := range notificationsToAdd {
@@ -208,55 +252,59 @@ func (notifier *recordAgingNotifier) generateBuyerDisputeTimeoutNotifications() 
 		if rollbackErr := notificationTx.Rollback(); rollbackErr != nil {
 			err = fmt.Errorf(err.Error(), "\nand also failed during rollback:", rollbackErr.Error())
 		}
-		return fmt.Errorf("commiting purchase dispute notifications: %s", err.Error())
+		return nil, fmt.Errorf("commiting purchase dispute notifications: %s", err.Error())
 	}
-	notifier.logger.Debugf("created %d purchase dispute notifications", len(notificationsToAdd))
 	notifier.datastore.Notifications().Unlock()
 
 	for _, n := range notificationsToAdd {
 		notifier.broadcast <- n.NotifierData
 	}
 
-	if err = notifier.datastore.Purchases().UpdatePurchasesLastDisputeTimeoutNotifiedAt(purchases); err != nil {
-		return fmt.Errorf("updating lastDisputeTimeoutNotifiedAt on purchases: %s", err.Error())
+	if err = notifier.datastore.Purchases().UpdatePurchasesLastDisputeTimeoutNotifiedAt(updatedPurchases); err != nil {
+		return nil, fmt.Errorf("updating lastDisputeTimeoutNotifiedAt on purchases: %s", err.Error())
 	}
-	notifier.logger.Debugf("updated lastDisputeTimeoutNotifiedAt on %d purchases", len(purchases))
-	return nil
+	return &NotifierResult{len(notificationsToAdd), len(updatedPurchases), "purchaseTimeout"}, nil
 }
 
-func (notifier *recordAgingNotifier) generateBuyerDisputeExpiryNotifications() error {
+func (notifier *recordAgingNotifier) generateBuyerDisputeExpiryNotifications() (*NotifierResult, error) {
 	purchases, err := notifier.datastore.Purchases().GetPurchasesForDisputeExpiryNotification()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var (
 		executedAt         = time.Now()
 		notificationsToAdd = make([]*repo.Notification, 0)
+		updatedPurchases   = make([]*repo.PurchaseRecord, 0)
 	)
 
 	for _, p := range purchases {
-		var timeSinceDisputedAt = executedAt.Sub(p.DisputedAt)
-		// Extra seconds added to creation time is a hack to order SQL results
+		var (
+			timeSinceDisputedAt = executedAt.Sub(p.DisputedAt)
+			updated             = false
+		)
 		if p.LastDisputeExpiryNotifiedAt.Before(p.Timestamp.Add(repo.BuyerDisputeExpiry_firstInterval)) && timeSinceDisputedAt > repo.BuyerDisputeExpiry_firstInterval {
 			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeExpiryFirstNotification(executedAt))
+			updated = true
 		}
 		if p.LastDisputeExpiryNotifiedAt.Before(p.Timestamp.Add(repo.BuyerDisputeExpiry_secondInterval)) && timeSinceDisputedAt > repo.BuyerDisputeExpiry_secondInterval {
 			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeExpirySecondNotification(executedAt))
+			updated = true
 		}
 		if p.LastDisputeExpiryNotifiedAt.Before(p.Timestamp.Add(repo.BuyerDisputeExpiry_lastInterval)) && timeSinceDisputedAt > repo.BuyerDisputeExpiry_lastInterval {
 			notificationsToAdd = append(notificationsToAdd, p.BuildBuyerDisputeExpiryLastNotification(executedAt))
+			updated = true
 		}
-		// TODO: Check if THIS purchase made a notification before bumping timestamp
-		if len(notificationsToAdd) > 0 {
+		if updated {
 			p.LastDisputeExpiryNotifiedAt = executedAt
+			updatedPurchases = append(updatedPurchases, p)
 		}
 	}
 
 	notifier.datastore.Notifications().Lock()
 	notificationTx, err := notifier.datastore.Notifications().BeginTransaction()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, n := range notificationsToAdd {
@@ -279,57 +327,63 @@ func (notifier *recordAgingNotifier) generateBuyerDisputeExpiryNotifications() e
 		if rollbackErr := notificationTx.Rollback(); rollbackErr != nil {
 			err = fmt.Errorf(err.Error(), "\nand also failed during rollback:", rollbackErr.Error())
 		}
-		return fmt.Errorf("commiting buyer expiration notifications: %s", err.Error())
+		return nil, fmt.Errorf("commiting buyer expiration notifications: %s", err.Error())
 	}
-	notifier.logger.Debugf("created %d buyer expiration notifications", len(notificationsToAdd))
 	notifier.datastore.Notifications().Unlock()
 
 	for _, n := range notificationsToAdd {
 		notifier.broadcast <- n.NotifierData
 	}
 
-	if err = notifier.datastore.Purchases().UpdatePurchasesLastDisputeExpiryNotifiedAt(purchases); err != nil {
-		return fmt.Errorf("updating lastDisputeExpiryNotifiedAt on purchases: %s", err.Error())
+	if err = notifier.datastore.Purchases().UpdatePurchasesLastDisputeExpiryNotifiedAt(updatedPurchases); err != nil {
+		return nil, fmt.Errorf("updating lastDisputeExpiryNotifiedAt on purchases: %s", err.Error())
 	}
-	notifier.logger.Debugf("updated lastDisputeExpiryNotifiedAt on %d purchases", len(purchases))
-	return nil
+	return &NotifierResult{len(notificationsToAdd), len(updatedPurchases), "purchaseExpire"}, nil
 }
 
-func (notifier *recordAgingNotifier) generateModeratorDisputeExpiryNotifications() error {
+func (notifier *recordAgingNotifier) generateModeratorDisputeExpiryNotifications() (*NotifierResult, error) {
 	disputes, err := notifier.datastore.Cases().GetDisputesForDisputeExpiryNotification()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var (
 		executedAt         = time.Now()
 		notificationsToAdd = make([]*repo.Notification, 0)
+		updatedDisputes    = make([]*repo.DisputeCaseRecord, 0)
 	)
 
 	for _, d := range disputes {
-		var timeSinceCreation = executedAt.Sub(d.Timestamp)
-		// Extra seconds added to creation time is a hack to order SQL results
+		var (
+			timeSinceCreation = executedAt.Sub(d.Timestamp)
+			updated           = false
+		)
 		if d.LastDisputeExpiryNotifiedAt.Before(d.Timestamp.Add(repo.ModeratorDisputeExpiry_firstInterval)) && timeSinceCreation > repo.ModeratorDisputeExpiry_firstInterval {
 			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpiryFirstNotification(executedAt))
+			updated = true
 		}
 		if d.LastDisputeExpiryNotifiedAt.Before(d.Timestamp.Add(repo.ModeratorDisputeExpiry_secondInterval)) && timeSinceCreation > repo.ModeratorDisputeExpiry_secondInterval {
 			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpirySecondNotification(executedAt))
+			updated = true
 		}
 		if d.LastDisputeExpiryNotifiedAt.Before(d.Timestamp.Add(repo.ModeratorDisputeExpiry_thirdInterval)) && timeSinceCreation > repo.ModeratorDisputeExpiry_thirdInterval {
 			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpiryThirdNotification(executedAt))
+			updated = true
 		}
 		if d.LastDisputeExpiryNotifiedAt.Before(d.Timestamp.Add(repo.ModeratorDisputeExpiry_lastInterval)) && timeSinceCreation > repo.ModeratorDisputeExpiry_lastInterval {
 			notificationsToAdd = append(notificationsToAdd, d.BuildModeratorDisputeExpiryLastNotification(executedAt))
+			updated = true
 		}
-		if len(notificationsToAdd) > 0 {
+		if updated {
 			d.LastDisputeExpiryNotifiedAt = executedAt
+			updatedDisputes = append(updatedDisputes, d)
 		}
 	}
 
 	notifier.datastore.Notifications().Lock()
 	notificationTx, err := notifier.datastore.Notifications().BeginTransaction()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, n := range notificationsToAdd {
@@ -352,18 +406,16 @@ func (notifier *recordAgingNotifier) generateModeratorDisputeExpiryNotifications
 		if rollbackErr := notificationTx.Rollback(); rollbackErr != nil {
 			err = fmt.Errorf(err.Error(), "\nand also failed during rollback:", rollbackErr.Error())
 		}
-		return fmt.Errorf("commiting dispute expiration notifications: %s", err.Error())
+		return nil, fmt.Errorf("commiting dispute expiration notifications: %s", err.Error())
 	}
-	notifier.logger.Debugf("created %d dispute expiration notifications", len(notificationsToAdd))
 	notifier.datastore.Notifications().Unlock()
 
 	for _, n := range notificationsToAdd {
 		notifier.broadcast <- n.NotifierData
 	}
 
-	if err = notifier.datastore.Cases().UpdateDisputesLastDisputeExpiryNotifiedAt(disputes); err != nil {
-		return fmt.Errorf("updating lastDisputeExpiryNotifiedAt on disputes: %s", err.Error())
+	if err = notifier.datastore.Cases().UpdateDisputesLastDisputeExpiryNotifiedAt(updatedDisputes); err != nil {
+		return nil, fmt.Errorf("updating lastDisputeExpiryNotifiedAt on disputes: %s", err.Error())
 	}
-	notifier.logger.Debugf("updated lastDisputeExpiryNotifiedAt on %d disputes", len(disputes))
-	return nil
+	return &NotifierResult{len(notificationsToAdd), len(updatedDisputes), "dispute"}, nil
 }

--- a/core/record_aging_notifier.go
+++ b/core/record_aging_notifier.go
@@ -27,22 +27,22 @@ type recordAgingNotifier struct {
 	stopWorker    chan bool
 }
 
-type NotifierResult struct {
+type notifierResult struct {
 	notificationsMade int
 	recordsUpdated    int
 	subject           string
 }
 
-type NotifierSummary map[string]*NotifierResult
+type notifierSummary map[string]*notifierResult
 
-func (result NotifierSummary) Add(operand *NotifierResult) {
+func (result notifierSummary) Add(operand *notifierResult) {
 	if result == nil {
-		result = make(map[string]*NotifierResult, 0)
+		result = make(map[string]*notifierResult, 0)
 	}
 	result[operand.subject] = operand
 }
 
-func (result NotifierSummary) String() string {
+func (result notifierSummary) String() string {
 	var summaries = make([]string, 0)
 	for subject, result := range result {
 		summaries = append(summaries, fmt.Sprintf("%s: %d/%d", subject, result.notificationsMade, result.recordsUpdated))
@@ -91,7 +91,7 @@ func (notifier *recordAgingNotifier) Stop() {
 }
 
 func (notifier *recordAgingNotifier) PerformTask() {
-	var summary = NotifierSummary{}
+	var summary = notifierSummary{}
 
 	if result, err := notifier.generateSellerDisputeNotifications(); err != nil {
 		notifier.logger.Errorf("generateSellerDisputeNotifications failed: %s", err)
@@ -116,7 +116,7 @@ func (notifier *recordAgingNotifier) PerformTask() {
 	notifier.logger.Debugf("notifications created/records updated: %s", summary.String())
 }
 
-func (notifier *recordAgingNotifier) generateSellerDisputeNotifications() (*NotifierResult, error) {
+func (notifier *recordAgingNotifier) generateSellerDisputeNotifications() (*notifierResult, error) {
 	sales, err := notifier.datastore.Sales().GetSalesForDisputeTimeoutNotification()
 	if err != nil {
 		return nil, err
@@ -180,10 +180,10 @@ func (notifier *recordAgingNotifier) generateSellerDisputeNotifications() (*Noti
 	if err = notifier.datastore.Sales().UpdateSalesLastDisputeTimeoutNotifiedAt(updatedSales); err != nil {
 		return nil, fmt.Errorf("update sales disputeTimeoutNotifiedAt: %s", err.Error())
 	}
-	return &NotifierResult{len(notificationsToAdd), len(updatedSales), "sales"}, nil
+	return &notifierResult{len(notificationsToAdd), len(updatedSales), "sales"}, nil
 }
 
-func (notifier *recordAgingNotifier) generateBuyerDisputeTimeoutNotifications() (*NotifierResult, error) {
+func (notifier *recordAgingNotifier) generateBuyerDisputeTimeoutNotifications() (*notifierResult, error) {
 	purchases, err := notifier.datastore.Purchases().GetPurchasesForDisputeTimeoutNotification()
 	if err != nil {
 		return nil, err
@@ -259,10 +259,10 @@ func (notifier *recordAgingNotifier) generateBuyerDisputeTimeoutNotifications() 
 	if err = notifier.datastore.Purchases().UpdatePurchasesLastDisputeTimeoutNotifiedAt(updatedPurchases); err != nil {
 		return nil, fmt.Errorf("updating lastDisputeTimeoutNotifiedAt on purchases: %s", err.Error())
 	}
-	return &NotifierResult{len(notificationsToAdd), len(updatedPurchases), "purchaseTimeout"}, nil
+	return &notifierResult{len(notificationsToAdd), len(updatedPurchases), "purchaseTimeout"}, nil
 }
 
-func (notifier *recordAgingNotifier) generateBuyerDisputeExpiryNotifications() (*NotifierResult, error) {
+func (notifier *recordAgingNotifier) generateBuyerDisputeExpiryNotifications() (*notifierResult, error) {
 	purchases, err := notifier.datastore.Purchases().GetPurchasesForDisputeExpiryNotification()
 	if err != nil {
 		return nil, err
@@ -334,10 +334,10 @@ func (notifier *recordAgingNotifier) generateBuyerDisputeExpiryNotifications() (
 	if err = notifier.datastore.Purchases().UpdatePurchasesLastDisputeExpiryNotifiedAt(updatedPurchases); err != nil {
 		return nil, fmt.Errorf("updating lastDisputeExpiryNotifiedAt on purchases: %s", err.Error())
 	}
-	return &NotifierResult{len(notificationsToAdd), len(updatedPurchases), "purchaseExpire"}, nil
+	return &notifierResult{len(notificationsToAdd), len(updatedPurchases), "purchaseExpire"}, nil
 }
 
-func (notifier *recordAgingNotifier) generateModeratorDisputeExpiryNotifications() (*NotifierResult, error) {
+func (notifier *recordAgingNotifier) generateModeratorDisputeExpiryNotifications() (*notifierResult, error) {
 	disputes, err := notifier.datastore.Cases().GetDisputesForDisputeExpiryNotification()
 	if err != nil {
 		return nil, err
@@ -413,5 +413,5 @@ func (notifier *recordAgingNotifier) generateModeratorDisputeExpiryNotifications
 	if err = notifier.datastore.Cases().UpdateDisputesLastDisputeExpiryNotifiedAt(updatedDisputes); err != nil {
 		return nil, fmt.Errorf("updating lastDisputeExpiryNotifiedAt on disputes: %s", err.Error())
 	}
-	return &NotifierResult{len(notificationsToAdd), len(updatedDisputes), "dispute"}, nil
+	return &notifierResult{len(notificationsToAdd), len(updatedDisputes), "dispute"}, nil
 }

--- a/core/record_aging_notifier.go
+++ b/core/record_aging_notifier.go
@@ -23,7 +23,6 @@ type recordAgingNotifier struct {
 	// Worker-handling dependancies
 	intervalDelay time.Duration
 	logger        *logging.Logger
-	runCount      int
 	watchdogTimer *time.Ticker
 	stopWorker    chan bool
 }
@@ -69,8 +68,6 @@ func (n *OpenBazaarNode) intervalDelay() time.Duration {
 	return notifierRegularInterval
 }
 
-func (notifier *recordAgingNotifier) RunCount() int { return notifier.runCount }
-
 func (notifier *recordAgingNotifier) Run() {
 	notifier.watchdogTimer = time.NewTicker(notifier.intervalDelay)
 	notifier.stopWorker = make(chan bool)
@@ -95,7 +92,6 @@ func (notifier *recordAgingNotifier) Stop() {
 
 func (notifier *recordAgingNotifier) PerformTask() {
 	var summary = NotifierSummary{}
-	notifier.runCount++ // += 1
 
 	if result, err := notifier.generateSellerDisputeNotifications(); err != nil {
 		notifier.logger.Errorf("generateSellerDisputeNotifications failed: %s", err)


### PR DESCRIPTION
Update output from RecordAgingNotifier. Turns:
```
10:33:09.491 [DEBUG] [recordAgingNotifier/PerformTask] performTask started (count 1)
10:33:09.494 [DEBUG] [recordAgingNotifier/generateSellerDisputeNotifications] created 0 vendor dispute notifications
10:33:09.495 [DEBUG] [recordAgingNotifier/generateSellerDisputeNotifications] updated lastDisputeTimeoutNotifiedAt on 0 sales
10:33:09.495 [DEBUG] [recordAgingNotifier/generateBuyerDisputeTimeoutNotifications] created 0 purchase dispute notifications
10:33:09.495 [DEBUG] [recordAgingNotifier/generateBuyerDisputeTimeoutNotifications] updated lastDisputeTimeoutNotifiedAt on 0 purchases
10:33:09.496 [DEBUG] [recordAgingNotifier/generateBuyerDisputeExpiryNotifications] created 0 buyer expiration notifications
10:33:09.496 [DEBUG] [recordAgingNotifier/generateBuyerDisputeExpiryNotifications] updated lastDisputeExpiryNotifiedAt on 0 purchases
10:33:09.497 [DEBUG] [recordAgingNotifier/generateModeratorDisputeExpiryNotifications] created 0 dispute expiration notifications
10:33:09.497 [DEBUG] [recordAgingNotifier/generateModeratorDisputeExpiryNotifications] updated lastDisputeExpiryNotifiedAt on 0 disputes
```

into

`16:34:20.818 [DEBUG] [recordAgingNotifier/PerformTask] notifications created/records updated: sales: 0/0, purchaseTimeout: 0/0, purchaseExpire: 0/0, dispute: 0/0`