### PR TITLE
Perform black magic for pointer key creation

### DIFF
--- a/ipfs/pointers_test.go
+++ b/ipfs/pointers_test.go
@@ -1,0 +1,34 @@
+package ipfs
+
+import (
+	"gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"
+	"testing"
+)
+
+func TestCreatePointerKey(t *testing.T) {
+	var (
+		hash  = "QmWqVgN2CtEgWgSXTfWHDoEhXXf26oZdfehPsCCWLZ4BB6"
+		tests = []struct {
+			PrefixLen     int
+			ExpectedValue string
+		}{
+			{2, "Qmc9UEWpojkGZLBmt38atvBBnBVBwgcYGbYwMPJ3qyGSE3"},
+			{4, "QmZNXVKUxs9z8h2s65ahg7NdrLy5oZXh2BkHj1wMJB1Vk5"},
+			{8, "QmczhV1WEiodc7rW4T16hYade4iqR9MziVSvkAo8KxHVMM"},
+			{16, "Qmayzi2PkFKbLKhSqjawCndo8yh55MynKnrkZ1SLv8bKd2"},
+			{32, "QmcuE8iD3RpURTXJ1sQBaWDrQEPa45AEyiuibsXYBWY3yk"},
+			{64, "QmRMqdH41sSbsVU1LKaAqb6jssK4UDYmsb5D2RMC79hRBs"},
+		}
+	)
+
+	mh, err := multihash.FromB58String(hash)
+	if err != nil {
+		t.Error(err)
+	}
+	for _, test := range tests {
+		key := CreatePointerKey(mh, test.PrefixLen)
+		if key.B58String() != test.ExpectedValue {
+			t.Error("Returned incorrect pointer key")
+		}
+	}
+}


### PR DESCRIPTION
This PR refactors the function that extracts the prefix bits from peer ID and returns a pointer key based on the prefix. It can be done much cleaner as a simple bit shift rather than the boneheaded way it's currently being done. It will also make it easier to explain to the UI team how to do it in javascript. 