### PR TITLE
BUGFIX: Call deferred Close() after checking error.

### DIFF
--- a/core/completion.go
+++ b/core/completion.go
@@ -545,10 +545,10 @@ func (n *OpenBazaarNode) updateRatingIndex(rating *pb.Rating, ratingPath string)
 
 	// Write it back to file
 	f, err := os.Create(indexPath)
-	defer f.Close()
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	j, jerr := json.MarshalIndent(index, "", "    ")
 	if jerr != nil {
 		return jerr

--- a/core/posts.go
+++ b/core/posts.go
@@ -285,10 +285,10 @@ func (n *OpenBazaarNode) UpdatePostHashes(hashes map[string]string) error {
 
 	// Write it back to file
 	f, err := os.Create(indexPath)
-	defer f.Close()
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	j, jerr := json.MarshalIndent(index, "", "    ")
 	if jerr != nil {
@@ -356,10 +356,10 @@ func (n *OpenBazaarNode) DeletePost(slug string) error {
 
 	// Write the index back to file
 	f, err := os.Create(indexPath)
-	defer f.Close()
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	j, jerr := json.MarshalIndent(index, "", "    ")
 	if jerr != nil {

--- a/core/profile.go
+++ b/core/profile.go
@@ -96,10 +96,10 @@ func (n *OpenBazaarNode) UpdateProfile(profile *pb.Profile) error {
 
 	profilePath := path.Join(n.RepoPath, "root", "profile.json")
 	f, err := os.Create(profilePath)
-	defer f.Close()
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	if _, err := f.WriteString(out); err != nil {
 		return err
 	}
@@ -205,10 +205,10 @@ func (n *OpenBazaarNode) updateProfileCounts() error {
 	if !os.IsNotExist(ferr) {
 		// Read existing file
 		file, err := os.Open(profilePath)
-		defer file.Close()
 		if err != nil {
 			return err
 		}
+		defer file.Close()
 		err = jsonpb.Unmarshal(file, profile)
 		if err != nil {
 			return err


### PR DESCRIPTION
`defer Close()`'s should be called after checking the potential error returned when the `io.Closer` was created.

Travis passed, but coverage fails because this code is uncovered and there's now more of it even though it's more correct.