### PR TITLE
BUGFIX: Propagate some previously unchecked errors.

### DIFF
--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -575,6 +575,9 @@ func (service *OpenBazaarService) handleReject(p peer.ID, pmes *pb.Message, opti
 			return nil, err
 		}
 		redeemScript, err := hex.DecodeString(contract.BuyerOrder.Payment.RedeemScript)
+		if err != nil {
+			return nil, err
+		}
 		refundAddress, err := service.node.Wallet.DecodeAddress(contract.BuyerOrder.RefundAddress)
 		if err != nil {
 			return nil, err
@@ -624,6 +627,9 @@ func (service *OpenBazaarService) handleReject(p peer.ID, pmes *pb.Message, opti
 			return nil, err
 		}
 		redeemScript, err := hex.DecodeString(contract.BuyerOrder.Payment.RedeemScript)
+		if err != nil {
+			return nil, err
+		}
 
 		buyerSignatures, err := service.node.Wallet.CreateMultisigSignature(ins, []wallet.TransactionOutput{output}, buyerKey, redeemScript, contract.BuyerOrder.RefundFee)
 		if err != nil {

--- a/repo/db/cases.go
+++ b/repo/db/cases.go
@@ -313,6 +313,9 @@ func (c *CasesDB) GetCaseMetadata(caseID string) (buyerContract, vendorContract 
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	stmt, err := c.db.Prepare("select buyerContract, vendorContract, buyerValidationErrors, vendorValidationErrors, state, read, timestamp, buyerOpened, claim, disputeResolution from cases where caseID=?")
+	if err != nil {
+		return nil, nil, []string{}, []string{}, pb.OrderState(0), false, time.Time{}, false, "", nil, err
+	}
 	defer stmt.Close()
 	var buyerCon []byte
 	var vendorCon []byte

--- a/repo/db/cases_test.go
+++ b/repo/db/cases_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"gx/ipfs/QmT6n4mspWYEya864BhCUJEgyxiRfmiSY9ruQwTUNpRKaM/protobuf/proto"
+
 	"github.com/OpenBazaar/jsonpb"
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/openbazaar-go/repo"
@@ -16,7 +18,6 @@ import (
 	"github.com/OpenBazaar/openbazaar-go/schema"
 	"github.com/OpenBazaar/openbazaar-go/test/factory"
 	"github.com/golang/protobuf/ptypes"
-	"gx/ipfs/QmT6n4mspWYEya864BhCUJEgyxiRfmiSY9ruQwTUNpRKaM/protobuf/proto"
 )
 
 func buildNewCaseStore() (repo.CaseStore, func(), error) {
@@ -76,6 +77,9 @@ func TestPutCase(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := casesdb.PrepareQuery("select caseID, state, read, buyerOpened, claim from cases where caseID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 
 	err = stmt.QueryRow("caseID").Scan(&caseID, &state, &read, &buyerOpened, &claim)
@@ -121,6 +125,9 @@ func TestUpdateWithNil(t *testing.T) {
 		t.Error(err)
 	}
 	buyerContract, _, _, _, _, _, _, _, _, _, err := casesdb.GetCaseMetadata("caseID")
+	if err != nil {
+		t.Error(err)
+	}
 	if buyerContract != nil {
 		t.Error("Vendor contract was not nil")
 	}
@@ -242,6 +249,9 @@ func TestUpdateBuyerInfo(t *testing.T) {
 	}
 
 	stmt, err := casesdb.PrepareQuery("select caseID, buyerContract, buyerValidationErrors, buyerPayoutAddress, buyerOutpoints from cases where caseID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 
 	var caseID string
@@ -291,6 +301,9 @@ func TestUpdateVendorInfo(t *testing.T) {
 	}
 
 	stmt, err := casesdb.PrepareQuery("select caseID, vendorContract, vendorValidationErrors, vendorPayoutAddress, vendorOutpoints from cases where caseID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 
 	var caseID string
@@ -344,9 +357,21 @@ func TestCasesGetCaseMetaData(t *testing.T) {
 		t.Error(err)
 	}
 	buyerContract, vendorContract, buyerValidationErrors, vendorValidationErrors, state, read, date, buyerOpened, claim, resolution, err := casesdb.GetCaseMetadata("caseID")
-	ser, _ := proto.Marshal(contract)
-	buyerSer, _ := proto.Marshal(buyerContract)
-	vendorSer, _ := proto.Marshal(vendorContract)
+	if err != nil {
+		t.Error(err)
+	}
+	ser, err := proto.Marshal(contract)
+	if err != nil {
+		t.Error(err)
+	}
+	buyerSer, err := proto.Marshal(buyerContract)
+	if err != nil {
+		t.Error(err)
+	}
+	vendorSer, err := proto.Marshal(vendorContract)
+	if err != nil {
+		t.Error(err)
+	}
 
 	if !bytes.Equal(ser, buyerSer) || !bytes.Equal(ser, vendorSer) {
 		t.Error("Failed to fetch case contract from db")

--- a/repo/db/chat_test.go
+++ b/repo/db/chat_test.go
@@ -40,6 +40,9 @@ func TestChatDB_Put(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := chdb.PrepareQuery("select messageID, peerID, subject, message, read, timestamp, outgoing from chat where peerID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var msgId string
 	var peerId string
@@ -266,6 +269,9 @@ func TestChatDB_MarkAsRead(t *testing.T) {
 		t.Error("Updated bool returned incorrectly")
 	}
 	stmt, err := chdb.PrepareQuery("select read from chat where messageID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var read int
 	err = stmt.QueryRow("11111").Scan(&read)
@@ -279,6 +285,9 @@ func TestChatDB_MarkAsRead(t *testing.T) {
 		t.Error("Returned incorrect last message Id")
 	}
 	stmt2, err := chdb.PrepareQuery("select read from chat where messageID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt2.Close()
 	err = stmt2.QueryRow("22222").Scan(&read)
 	if err != nil {
@@ -295,6 +304,9 @@ func TestChatDB_MarkAsRead(t *testing.T) {
 		t.Error("Updated bool returned incorrectly")
 	}
 	stmt3, err := chdb.PrepareQuery("select read from chat where messageID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt3.Close()
 	err = stmt3.QueryRow("22222").Scan(&read)
 	if err != nil {
@@ -395,6 +407,9 @@ func TestChatDB_DeleteMessage(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := chdb.PrepareQuery("select messageID from chat where messageID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var msgId int
 	err = stmt.QueryRow(messages[0].MessageId).Scan(&msgId)
@@ -428,6 +443,9 @@ func TestChatDB_DeleteConversation(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := chdb.PrepareQuery("select messageID from chat where messageID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	var msgId int
 	err = stmt.QueryRow(messages[0].MessageId).Scan(&msgId)
 	if err == nil {

--- a/repo/db/db.go
+++ b/repo/db/db.go
@@ -264,6 +264,9 @@ func (c *ConfigDB) GetMnemonic() (string, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	stmt, err := c.db.Prepare("select value from config where key=?")
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer stmt.Close()
 	var mnemonic string
 	err = stmt.QueryRow("mnemonic").Scan(&mnemonic)

--- a/repo/db/followers.go
+++ b/repo/db/followers.go
@@ -2,9 +2,10 @@ package db
 
 import (
 	"database/sql"
-	"github.com/OpenBazaar/openbazaar-go/repo"
 	"strconv"
 	"sync"
+
+	"github.com/OpenBazaar/openbazaar-go/repo"
 )
 
 type FollowerDB struct {
@@ -59,7 +60,10 @@ func (f *FollowerDB) Get(offsetId string, limit int) ([]repo.Follower, error) {
 func (f *FollowerDB) Delete(follower string) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	f.db.Exec("delete from followers where peerID=?", follower)
+	_, err := f.db.Exec("delete from followers where peerID=?", follower)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -76,6 +80,9 @@ func (f *FollowerDB) FollowsMe(peerId string) bool {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	stmt, err := f.db.Prepare("select peerID from followers where peerID=?")
+	if err != nil {
+		return false
+	}
 	defer stmt.Close()
 	var follower string
 	err = stmt.QueryRow(peerId).Scan(&follower)

--- a/repo/db/followers_test.go
+++ b/repo/db/followers_test.go
@@ -41,6 +41,9 @@ func TestPutFollower(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := fdb.PrepareQuery("select peerID, proof from followers where peerID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var follower string
 	var proof []byte
@@ -63,7 +66,10 @@ func TestPutDuplicateFollower(t *testing.T) {
 	}
 	defer teardown()
 
-	fdb.Put("abc", []byte("proof"))
+	err = fdb.Put("abc", []byte("proof"))
+	if err != nil {
+		t.Error(err)
+	}
 	err = fdb.Put("abc", []byte("asdf"))
 	if err == nil {
 		t.Error("Expected unquire constriant error to be thrown")

--- a/repo/db/following.go
+++ b/repo/db/following.go
@@ -57,7 +57,10 @@ func (f *FollowingDB) Get(offsetId string, limit int) ([]string, error) {
 func (f *FollowingDB) Delete(follower string) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	f.db.Exec("delete from following where peerID=?", follower)
+	_, err := f.db.Exec("delete from following where peerID=?", follower)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -74,6 +77,9 @@ func (f *FollowingDB) IsFollowing(peerId string) bool {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	stmt, err := f.db.Prepare("select peerID from following where peerID=?")
+	if err != nil {
+		return false
+	}
 	defer stmt.Close()
 	var follower string
 	err = stmt.QueryRow(peerId).Scan(&follower)

--- a/repo/db/following_test.go
+++ b/repo/db/following_test.go
@@ -40,6 +40,9 @@ func TestPutFollowing(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := fldb.PrepareQuery("select peerID from following where peerID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var following string
 	err = stmt.QueryRow("abc").Scan(&following)

--- a/repo/db/inventory_test.go
+++ b/repo/db/inventory_test.go
@@ -47,6 +47,9 @@ func TestPutInventory(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := ivdb.PrepareQuery("select slug, variantIndex, count from inventory where slug=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var slug string
 	var variant int

--- a/repo/db/moderatedstores_test.go
+++ b/repo/db/moderatedstores_test.go
@@ -40,6 +40,9 @@ func TestModeratedDB_Put(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := modDB.PrepareQuery("select peerID from moderatedstores where peerID=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var peerId string
 	err = stmt.QueryRow("abc").Scan(&peerId)

--- a/repo/db/notifications_test.go
+++ b/repo/db/notifications_test.go
@@ -111,6 +111,9 @@ func TestNotficationsDB_Delete(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := db.PrepareQuery("select notifID from notifications where notifID='1'")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var notifId int
 	err = stmt.QueryRow().Scan(&notifId)
@@ -195,6 +198,9 @@ func TestNotficationsDB_MarkAsRead(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := db.PrepareQuery("select read from notifications where notifID='5'")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var read int
 	err = stmt.QueryRow().Scan(&read)

--- a/repo/db/pointers_test.go
+++ b/repo/db/pointers_test.go
@@ -6,15 +6,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/OpenBazaar/openbazaar-go/ipfs"
-	"github.com/OpenBazaar/openbazaar-go/repo"
-	"github.com/OpenBazaar/openbazaar-go/repo/db"
-	"github.com/OpenBazaar/openbazaar-go/schema"
 	ma "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
 	ps "gx/ipfs/QmXauCuJzmzapetmC6W4TuDJLL1yFFrVzSHoWv8YdbmnxH/go-libp2p-peerstore"
 	peer "gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
 	multihash "gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"
 	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
+
+	"github.com/OpenBazaar/openbazaar-go/ipfs"
+	"github.com/OpenBazaar/openbazaar-go/repo"
+	"github.com/OpenBazaar/openbazaar-go/repo/db"
+	"github.com/OpenBazaar/openbazaar-go/schema"
 )
 
 func mustNewPointer() ipfs.Pointer {
@@ -206,6 +207,9 @@ func TestPointersDB_GetByPurpose(t *testing.T) {
 		nil,
 	}
 	err = pdb.Put(m)
+	if err != nil {
+		t.Error("Put pointer returned error")
+	}
 	pointers, err := pdb.GetByPurpose(ipfs.MODERATOR)
 	if err != nil {
 		t.Error("Get pointers returned error")
@@ -254,6 +258,9 @@ func TestPointersDB_Get(t *testing.T) {
 		nil,
 	}
 	err = pdb.Put(m)
+	if err != nil {
+		t.Error("Put pointer returned error")
+	}
 	p, err := pdb.Get(id)
 	if err != nil {
 		t.Error("Get pointers returned error")

--- a/repo/db/settings_test.go
+++ b/repo/db/settings_test.go
@@ -45,6 +45,9 @@ func TestSettingsPut(t *testing.T) {
 	}
 	set := repo.SettingsData{}
 	stmt, err := sdb.PrepareQuery("select value from config where key=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var settingsBytes []byte
 	err = stmt.QueryRow("settings").Scan(&settingsBytes)

--- a/repo/db/txmetadata.go
+++ b/repo/db/txmetadata.go
@@ -2,8 +2,9 @@ package db
 
 import (
 	"database/sql"
-	"github.com/OpenBazaar/openbazaar-go/repo"
 	"sync"
+
+	"github.com/OpenBazaar/openbazaar-go/repo"
 )
 
 type TxMetadataDB struct {
@@ -42,6 +43,9 @@ func (t *TxMetadataDB) Get(txid string) (repo.Metadata, error) {
 	defer t.lock.Unlock()
 	var m repo.Metadata
 	stmt, err := t.db.Prepare("select txid, address, memo, orderID, thumbnail, canBumpFee from txmetadata where txid=?")
+	if err != nil {
+		return m, err
+	}
 	defer stmt.Close()
 	var id, address, memo, orderId, thumbnail string
 	var canBumpFee int

--- a/repo/db/txmetadata_test.go
+++ b/repo/db/txmetadata_test.go
@@ -40,6 +40,9 @@ func TestTxMetadataDB_Put(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := metDB.PrepareQuery("select txid, address, memo, orderID, thumbnail, canBumpFee from txmetadata where txid=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var txid, addr, memo, orderId, thumbnail string
 	var canBumpFee int

--- a/repo/db/txns_test.go
+++ b/repo/db/txns_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/hex"
-	"github.com/OpenBazaar/openbazaar-go/repo"
-	"github.com/OpenBazaar/wallet-interface"
-	"github.com/btcsuite/btcd/wire"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/OpenBazaar/openbazaar-go/repo"
+	"github.com/OpenBazaar/wallet-interface"
+	"github.com/btcsuite/btcd/wire"
 )
 
 var txdb repo.TransactionStore
@@ -32,6 +33,9 @@ func TestTxnsPut(t *testing.T) {
 		t.Error(err)
 	}
 	stmt, err := txdb.PrepareQuery("select tx, value, height, watchOnly from txns where txid=?")
+	if err != nil {
+		t.Error(err)
+	}
 	defer stmt.Close()
 	var ret []byte
 	var val int
@@ -139,9 +143,12 @@ func TestTxnsDB_UpdateHeight(t *testing.T) {
 	txHex := "0100000001cbfe4948ebc9113244b802a96e4940fa063c0455a16ca1f39a1e1db03837d9c701000000da004830450221008994e3dba54cb0ea23ca008d0e361b4339ee7b44b5e9101f6837e6a1a89ce044022051be859c68a547feaf60ffacc43f528cf2963c088bde33424d859274505e3f450147304402206cd4ef92cc7f2862c67810479013330fcafe4d468f1370563d4dff6be5bcbedc02207688a09163e615bc82299a29e987e1d718cb99a91d46a1ab13d18c0f6e616a1601475221024760c9ba5fa6241da6ee8601f0266f0e0592f53735703f0feaae23eda6673ae821038cfa8e97caaafbe21455803043618440c28c501ec32d6ece6865003165a0d4d152aeffffffff029ae2c700000000001976a914f72f20a739ec3c3df1a1fd7eff122d13bd5ca39188acb64784240000000017a9140be09225644b4cfdbb472028d8ccaf6df736025c8700000000"
 	raw, _ := hex.DecodeString(txHex)
 	r := bytes.NewReader(raw)
-	tx.Deserialize(r)
+	err := tx.Deserialize(r)
+	if err != nil {
+		t.Error(err)
+	}
 
-	err := txdb.Put(raw, tx.TxHash().String(), 0, 1, time.Now(), false)
+	err = txdb.Put(raw, tx.TxHash().String(), 0, 1, time.Now(), false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -150,6 +157,9 @@ func TestTxnsDB_UpdateHeight(t *testing.T) {
 		t.Error(err)
 	}
 	txn, err := txdb.Get(tx.TxHash())
+	if err != nil {
+		t.Error(err)
+	}
 	if txn.Height != -1 {
 		t.Error("Txn db failed to update height")
 	}

--- a/repo/migrations/Migration012_test.go
+++ b/repo/migrations/Migration012_test.go
@@ -129,6 +129,9 @@ func testMigration012_Setup(t *testing.T) func() {
 	}
 
 	db, err := migrations.OpenDB(testMigration012_datadir, "letmein", true)
+	if err != nil {
+		t.Error(err)
+	}
 
 	identityKey, err := base64.StdEncoding.DecodeString(testMigration012_IdentityPrivateKeyBase64)
 	if err != nil {


### PR DESCRIPTION
We have many places that do not check returned errors. In most cases an error would have occurred after on a later line of code, but not handling or propagating an error is always an error itself. In two cases the error was not visible because the associated returned pointer was allowed to be nil.

This change propagates those unchecked error the same way surrounding errors are populated.