### PR TITLE
BUGFIX: Fix build on Windows

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -241,7 +241,7 @@ func (x *Start) Execute(args []string) error {
 	if sqliteDB.Config().IsEncrypted() {
 		sqliteDB.Close()
 		fmt.Print("Database is encrypted, enter your password: ")
-		bytePassword, _ := terminal.ReadPassword(syscall.Stdin)
+		bytePassword, _ := terminal.ReadPassword(int(syscall.Stdin))
 		fmt.Println("")
 		pw := string(bytePassword)
 		sqliteDB, err = InitializeRepo(repoPath, pw, "", isTestnet, time.Now(), ct)


### PR DESCRIPTION
This reverts commit f8640a39cc754a21c94b0ea77a406fbd508b2b67.

It was discovered that syscall.Stdin on Windows is not an int
like on other systems, so it must be converted here.