### PR TITLE
[#1160] Reorder write to {data}/root/user_agent

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -208,14 +208,6 @@ func (x *Start) Execute(args []string) error {
 		return err
 	}
 
-	// Create user-agent file
-	userAgentBytes := []byte(core.USERAGENT + x.UserAgent)
-	err = ioutil.WriteFile(path.Join(repoPath, "root", "user_agent"), userAgentBytes, os.ModePerm)
-	if err != nil {
-		log.Error("write user_agent:", err)
-		return err
-	}
-
 	ct := wi.Bitcoin
 	cfgf, err := ioutil.ReadFile(path.Join(repoPath, "config"))
 	if err == nil {
@@ -238,6 +230,14 @@ func (x *Start) Execute(args []string) error {
 	migrations.WalletCoinType = ct
 	sqliteDB, err := InitializeRepo(repoPath, x.Password, "", isTestnet, time.Now(), ct)
 	if err != nil && err != repo.ErrRepoExists {
+		return err
+	}
+
+	// Create user-agent file
+	userAgentBytes := []byte(core.USERAGENT + x.UserAgent)
+	err = ioutil.WriteFile(path.Join(repoPath, "root", "user_agent"), userAgentBytes, os.ModePerm)
+	if err != nil {
+		log.Error("write user_agent:", err)
 		return err
 	}
 


### PR DESCRIPTION
When starting a fresh node without an initialized schema, the user_agent
will not be written to the schema properly.