### PR TITLE
CI: Add govet to linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,8 @@ run:
 issues:
   max-per-linter: 999999
   max-same: 999999
+  exclude:
+    - composite literal uses unkeyed fields
 
 linters-settings:
   errcheck:
@@ -43,9 +45,9 @@ linters:
     - nakedret
     - lll
     - goconst
+    - govet
   disable:
     - errcheck
-    - govet
     - golint
     - megacheck
     - goimports

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -3607,7 +3607,9 @@ func (i *jsonAPIHandler) GETPeerInfo(w http.ResponseWriter, r *http.Request) {
 		ErrorResponse(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
 	pi, err := i.node.IpfsNode.Routing.FindPeer(ctx, pid)
 	if err != nil {
 		ErrorResponse(w, http.StatusNotFound, err.Error())

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -355,10 +355,12 @@ func RestoreDirectory(repoPath, directory string, nd *ipfscore.IpfsNode, id *cid
 		wg.Add(1)
 		go func(link *ipld.Link) {
 			defer wg.Done()
-			cctx, _ := context.WithTimeout(context.Background(), time.Second*30)
+			cctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
 			r, err := coreunix.Cat(cctx, nd, "/ipfs/"+link.Cid.String())
 			if err != nil {
-				PrintError(fmt.Sprintf("Error retrieving %s\n", path.Join(directory, l.Name)))
+				PrintError(fmt.Sprintf("Error retrieving %s\n", path.Join(directory, link.Name)))
 				return
 			}
 			fmt.Printf("Restoring %s/%s\n", directory, link.Name)

--- a/ipfs/cat.go
+++ b/ipfs/cat.go
@@ -13,7 +13,9 @@ import (
 
 // Fetch data from IPFS given the hash
 func Cat(n *core.IpfsNode, path string, timeout time.Duration) ([]byte, error) {
-	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	if !strings.HasPrefix(path, "/ipfs/") {
 		path = "/ipfs/" + path
 	}

--- a/ipfs/resolve.go
+++ b/ipfs/resolve.go
@@ -36,7 +36,9 @@ func Resolve(n *core.IpfsNode, p peer.ID, timeout time.Duration, usecache bool) 
 }
 
 func resolve(n *core.IpfsNode, p peer.ID, timeout time.Duration) (string, error) {
-	cctx, _ := context.WithTimeout(context.Background(), timeout)
+	cctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	pth, err := n.Namesys.Resolve(cctx, "/ipns/"+p.Pretty())
 	if err != nil {
 		return "", err
@@ -45,7 +47,9 @@ func resolve(n *core.IpfsNode, p peer.ID, timeout time.Duration) (string, error)
 }
 
 func ResolveAltRoot(n *core.IpfsNode, p peer.ID, altRoot string, timeout time.Duration) (string, error) {
-	cctx, _ := context.WithTimeout(context.Background(), timeout)
+	cctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	pth, err := n.Namesys.Resolve(cctx, "/ipns/"+p.Pretty()+":"+altRoot)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Add govet checks to linter to catch common issues.

Unkeyed composite literal errors are ignored. I prefer not having unkeyed literals but not everybody feels the same and it shouldn't necessarily be considered an error like most other checks. If we decide we want to remove unkeyed literals we can fix all the occurrences of them and remove the exception.

Also fixes uncancelled contexts caught by govet.