### PR TITLE
Removes numeric reference to pb.CountryCode

### DIFF
--- a/core/listings.go
+++ b/core/listings.go
@@ -1220,9 +1220,7 @@ func validatePhysicalListing(listing *pb.Listing) error {
 			if int(region) == 0 {
 				return errors.New("Shipping region cannot be NA")
 			} else {
-				if val, ok := proto.EnumValueMap("CountryCode")[region.String()]; ok {
-					log.Debugf("Region %s:%d in pb.CountryCode", region, val)
-				} else {
+				if val, ok := proto.EnumValueMap("CountryCode")[region.String()]; !ok {
 					return fmt.Errorf("Invalid shipping region [ %s ]: ", region)
 				}
 			}

--- a/core/listings.go
+++ b/core/listings.go
@@ -1219,10 +1219,13 @@ func validatePhysicalListing(listing *pb.Listing) error {
 		for _, region := range shippingOption.Regions {
 			if int(region) == 0 {
 				return errors.New("Shipping region cannot be NA")
-			} else if int(region) > 247 && int(region) != 500 {
-				return errors.New("Invalid shipping region")
+			} else {
+				if val, ok := proto.EnumValueMap("CountryCode")[region.String()]; ok {
+					log.Debugf("Region %s:%d in pb.CountryCode", region, val)
+				} else {
+					return fmt.Errorf("Invalid shipping region [ %s ]: ", region)
+				}
 			}
-
 		}
 		if len(shippingOption.Regions) > MaxCountryCodes {
 			return fmt.Errorf("Number of shipping regions is greater than the max of %d", MaxCountryCodes)

--- a/core/listings.go
+++ b/core/listings.go
@@ -1220,7 +1220,7 @@ func validatePhysicalListing(listing *pb.Listing) error {
 			if int(region) == 0 {
 				return errors.New("Shipping region cannot be NA")
 			} else {
-				if val, ok := proto.EnumValueMap("CountryCode")[region.String()]; !ok {
+				if _, ok := proto.EnumValueMap("CountryCode")[region.String()]; !ok {
 					return fmt.Errorf("Invalid shipping region [ %s ]: ", region)
 				}
 			}

--- a/core/listings_test.go
+++ b/core/listings_test.go
@@ -1,11 +1,11 @@
 package core_test
 
 import (
-	"testing"
 	"reflect"
+	"testing"
 
-	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/openbazaar-go/core"
+	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/openbazaar-go/test/factory"
 )
 
@@ -16,7 +16,7 @@ func TestFactoryCryptoListingCoinDivisibilityMatchesConst(t *testing.T) {
 }
 
 func TestValidShippingRegion(t *testing.T) {
-	check := map[int32]bool {
+	check := map[int32]bool{
 		// NA
 		0: true,
 		// continents
@@ -33,7 +33,7 @@ func TestValidShippingRegion(t *testing.T) {
 		510: true,
 		511: true,
 		// some random numbers
-		5678: true,
+		5678:   true,
 		123456: true,
 	}
 	// skip NA, continents, a few random numbers
@@ -62,7 +62,7 @@ func TestValidShippingRegion(t *testing.T) {
 	}
 	count := 0
 	m := make(map[int]bool)
-	for n, _ := range check {
+	for n := range check {
 		cc := pb.CountryCode(n)
 		listing := factory.NewShippingRegionListing("asdfasdf", cc)
 		for _, shippingOption := range listing.ShippingOptions {

--- a/core/listings_test.go
+++ b/core/listings_test.go
@@ -2,7 +2,9 @@ package core_test
 
 import (
 	"testing"
+	"reflect"
 
+	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/openbazaar-go/core"
 	"github.com/OpenBazaar/openbazaar-go/test/factory"
 )
@@ -10,5 +12,79 @@ import (
 func TestFactoryCryptoListingCoinDivisibilityMatchesConst(t *testing.T) {
 	if factory.NewCryptoListing("blu").Metadata.CoinDivisibility != core.DefaultCoinDivisibility {
 		t.Fatal("DefaultCoinDivisibility constant has changed. Please update factory value.")
+	}
+}
+
+func TestValidShippingRegion(t *testing.T) {
+	check := map[int32]bool {
+		// NA
+		0: true,
+		// continents
+		501: true,
+		502: true,
+		503: true,
+		504: true,
+		505: true,
+		506: true,
+		507: true,
+		508: true,
+		// !exist
+		509: true,
+		510: true,
+		511: true,
+		// some random numbers
+		5678: true,
+		123456: true,
+	}
+	// skip NA, continents, a few random numbers
+	for _, v := range pb.CountryCode_value {
+		if !check[v] {
+			cc := pb.CountryCode(v)
+			listing := factory.NewShippingRegionListing("asdfasdf", cc)
+			for _, shippingOption := range listing.ShippingOptions {
+				if ok := core.ValidShippingRegion(shippingOption); ok > 0 {
+					t.Fatalf("Something has changed with valid shipping regions: %d %d", ok, v)
+				}
+			}
+		}
+	}
+	// DONT skip NA, continents, a few random numbers
+	for _, v := range pb.CountryCode_value {
+		if check[v] {
+			cc := pb.CountryCode(v)
+			listing := factory.NewShippingRegionListing("asdfasdf", cc)
+			for _, shippingOption := range listing.ShippingOptions {
+				if ok := core.ValidShippingRegion(shippingOption); ok > 0 {
+					t.Logf("Should error: %d %d", ok, v)
+				}
+			}
+		}
+	}
+	count := 0
+	m := make(map[int]bool)
+	for n, _ := range check {
+		cc := pb.CountryCode(n)
+		listing := factory.NewShippingRegionListing("asdfasdf", cc)
+		for _, shippingOption := range listing.ShippingOptions {
+			if ok := core.ValidShippingRegion(shippingOption); ok > 0 {
+				if ok == 2 {
+					t.Logf("Should error2: %d %d", ok, n)
+				}
+				m[ok] = true
+				count++
+			}
+		}
+	}
+	if count != 14 {
+		t.Fatalf("Something has changed with valid shipping regions: counted %d", count)
+	}
+	errorCodes := map[int]bool{
+		1: true, // NA
+		2: true, // continent
+		3: true, // !Exist
+	}
+	same := reflect.DeepEqual(m, errorCodes)
+	if !same {
+		t.Errorf("New/Unseen Shipping Region Error Code %v", same)
 	}
 }

--- a/test/factory/listing.go
+++ b/test/factory/listing.go
@@ -108,3 +108,22 @@ func NewCryptoListing(slug string) *pb.Listing {
 	listing.Coupons = nil
 	return listing
 }
+
+func NewShippingRegionListing(slug string, countrycode pb.CountryCode) *pb.Listing {
+	listing := NewListing(slug)
+	listing.ShippingOptions = []*pb.Listing_ShippingOption{
+			{
+				Name:    "usps",
+				Type:    pb.Listing_ShippingOption_FIXED_PRICE,
+				Regions: []pb.CountryCode{countrycode},
+				Services: []*pb.Listing_ShippingOption_Service{
+					{
+						Name:              "standard",
+						Price:             20,
+						EstimatedDelivery: "3 days",
+					},
+				},
+			},
+		}
+	return listing
+}

--- a/test/factory/listing.go
+++ b/test/factory/listing.go
@@ -112,18 +112,18 @@ func NewCryptoListing(slug string) *pb.Listing {
 func NewShippingRegionListing(slug string, countrycode pb.CountryCode) *pb.Listing {
 	listing := NewListing(slug)
 	listing.ShippingOptions = []*pb.Listing_ShippingOption{
-			{
-				Name:    "usps",
-				Type:    pb.Listing_ShippingOption_FIXED_PRICE,
-				Regions: []pb.CountryCode{countrycode},
-				Services: []*pb.Listing_ShippingOption_Service{
-					{
-						Name:              "standard",
-						Price:             20,
-						EstimatedDelivery: "3 days",
-					},
+		{
+			Name:    "usps",
+			Type:    pb.Listing_ShippingOption_FIXED_PRICE,
+			Regions: []pb.CountryCode{countrycode},
+			Services: []*pb.Listing_ShippingOption_Service{
+				{
+					Name:              "standard",
+					Price:             20,
+					EstimatedDelivery: "3 days",
 				},
 			},
-		}
+		},
+	}
 	return listing
 }


### PR DESCRIPTION
Removes numeric reference to pb.CountryCode / Region using 
`proto.EnumValueMap("CountryCode")[region.String()]`.

#1177 