### PR TITLE
1191 adjustable offline timeout

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -473,7 +473,7 @@ func (x *Start) Execute(args []string) error {
 	ctx := commands.Context{}
 	ctx.Online = true
 	ctx.ConfigRoot = repoPath
-	ctx.LoadConfig = func(path string) (*config.Config, error) {
+	ctx.LoadConfig = func(_ string) (*config.Config, error) {
 		return fsrepo.ConfigAt(repoPath)
 	}
 	ctx.ConstructNode = func() (*ipfscore.IpfsNode, error) {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -677,22 +677,23 @@ func (x *Start) Execute(args []string) error {
 
 	// OpenBazaar node setup
 	core.Node = &core.OpenBazaarNode{
-		IpfsNode:             nd,
-		RootHash:             ipath.Path(e.Value).String(),
-		RepoPath:             repoPath,
-		Datastore:            sqliteDB,
-		Multiwallet:          mw,
-		NameSystem:           ns,
+		AcceptStoreRequests:           dataSharing.AcceptStoreRequests,
+		BanManager:                    bm,
+		Datastore:                     sqliteDB,
+		IPNSBackupAPI:                 cfg.Ipns.BackUpAPI,
+		IpfsNode:                      nd,
+		MasterPrivateKey:              mPrivKey,
+		Multiwallet:                   mw,
+		NameSystem:                    ns,
+		OfflineMessageFailoverTimeout: 30 * time.Second,
+		Pubsub:               ps,
 		PushNodes:            pushNodes,
-		AcceptStoreRequests:  dataSharing.AcceptStoreRequests,
+		RegressionTestEnable: x.Regtest,
+		RepoPath:             repoPath,
+		RootHash:             ipath.Path(e.Value).String(),
+		TestnetEnable:        x.Testnet,
 		TorDialer:            torDialer,
 		UserAgent:            core.USERAGENT,
-		BanManager:           bm,
-		IPNSBackupAPI:        cfg.Ipns.BackUpAPI,
-		Pubsub:               ps,
-		TestnetEnable:        x.Testnet,
-		RegressionTestEnable: x.Regtest,
-		MasterPrivateKey:     mPrivKey,
 	}
 	core.PublishLock.Lock()
 

--- a/core/core.go
+++ b/core/core.go
@@ -74,6 +74,11 @@ type OpenBazaarNode struct {
 	// A service that periodically checks the dht for outstanding messages
 	MessageRetriever *ret.MessageRetriever
 
+	// OfflineMessageFailoverTimeout is the duration until the protocol
+	// will stop looking for the peer to send a direct message and failover to
+	// sending an offline message
+	OfflineMessageFailoverTimeout time.Duration
+
 	// A service that periodically republishes active pointers
 	PointerRepublisher *rep.PointerRepublisher
 

--- a/core/net.go
+++ b/core/net.go
@@ -35,7 +35,7 @@ func (n *OpenBazaarNode) sendMessage(peerID string, k *libp2p.PubKey, message pb
 	if err != nil {
 		return err
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), n.OfflineMessageFailoverTimeout)
 	defer cancel()
 	err = n.Service.SendMessage(ctx, p, &message)
 	if err != nil {

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -294,7 +294,7 @@ func (n *Node) startIPFSNode(repoPath string, config *ipfscore.BuildCfg) (*ipfsc
 
 	ctx.Online = true
 	ctx.ConfigRoot = repoPath
-	ctx.LoadConfig = func(path string) (*ipfsconfig.Config, error) {
+	ctx.LoadConfig = func(_ string) (*ipfsconfig.Config, error) {
 		return fsrepo.ConfigAt(repoPath)
 	}
 	ctx.ConstructNode = func() (*ipfscore.IpfsNode, error) {

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -264,14 +264,15 @@ func NewNodeWithConfig(config *NodeConfig, password string, mnemonic string) (*N
 
 	// OpenBazaar node setup
 	core.Node = &core.OpenBazaarNode{
-		RepoPath:         config.RepoPath,
-		Datastore:        sqliteDB,
-		Multiwallet:      mw,
-		NameSystem:       ns,
-		UserAgent:        core.USERAGENT,
-		PushNodes:        pushNodes,
-		BanManager:       bm,
-		MasterPrivateKey: mPrivKey,
+		BanManager:                    bm,
+		Datastore:                     sqliteDB,
+		MasterPrivateKey:              mPrivKey,
+		Multiwallet:                   mw,
+		NameSystem:                    ns,
+		OfflineMessageFailoverTimeout: 5 * time.Second,
+		PushNodes:                     pushNodes,
+		RepoPath:                      config.RepoPath,
+		UserAgent:                     core.USERAGENT,
 	}
 
 	if len(cfg.Addresses.Gateway) <= 0 {


### PR DESCRIPTION
Made the duration before the node stops waiting for the online peer to respond and resorts to an offline message a configurable option with hardcoded defaults for the desktop and mobile configurations. The configuration is carried by the `core.OpenBazaarNode` struct as a `time.Duration` and passed in the Context used to send online messages only.

Standard build default is 30 seconds.
Mobile build default is 5 seconds.