### PR TITLE
update year in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 OpenBazaar Developers
+Copyright (c) 2016-2018 OpenBazaar Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The year in license is currently 2016. I've bumped it to 2018 in order to ensure that no copyright issues arise in the future