### PR TITLE
Remove unused Python modules in qa/chat.py

### DIFF
--- a/qa/chat.py
+++ b/qa/chat.py
@@ -1,7 +1,5 @@
 import requests
 import json
-import time
-from collections import OrderedDict
 from test_framework.test_framework import OpenBazaarTestFramework, TestFailure
 
 


### PR DESCRIPTION
Hello,

In my opinion, No time, OrderedDict Python module are required.

Because it is not used.

What do you think of it?

Thanks.