### PR TITLE
[#1220] Currencies in profile no longer duplicate on update

### DIFF
--- a/core/listings_test.go
+++ b/core/listings_test.go
@@ -69,8 +69,8 @@ func TestValidShippingRegionUsingDefinedCountryCodes(t *testing.T) {
 func TestListingProtobufAlias(t *testing.T) {
 	countrycodes := []pb.CountryCode{
 		pb.CountryCode(212),
-		pb.CountryCode(pb.CountryCode_SWAZILAND),
-		pb.CountryCode(pb.CountryCode_ESWATINI),
+		pb.CountryCode_SWAZILAND,
+		pb.CountryCode_ESWATINI,
 	}
 	for _, cc := range countrycodes {
 		var (

--- a/core/profile.go
+++ b/core/profile.go
@@ -74,21 +74,21 @@ func (n *OpenBazaarNode) UpdateProfile(profile *pb.Profile) error {
 		OrigName:     false,
 	}
 
-	var currencies []string
+	var acceptedCurrencies []string
 	settingsData, _ := n.Datastore.Settings().Get()
 	if settingsData.PreferredCurrencies != nil {
-		currencies = append(currencies, *settingsData.PreferredCurrencies...)
+		for _, ct := range *settingsData.PreferredCurrencies {
+			acceptedCurrencies = append(acceptedCurrencies, NormalizeCurrencyCode(ct))
+		}
 	} else {
 		for ct := range n.Multiwallet {
-			currencies = append(currencies, ct.CurrencyCode())
+			acceptedCurrencies = append(acceptedCurrencies, NormalizeCurrencyCode(ct.CurrencyCode()))
 		}
 	}
 
-	for _, cc := range currencies {
-		profile.Currencies = append(profile.Currencies, NormalizeCurrencyCode(cc))
-		if profile.ModeratorInfo != nil {
-			profile.ModeratorInfo.AcceptedCurrencies = append(profile.ModeratorInfo.AcceptedCurrencies, NormalizeCurrencyCode(cc))
-		}
+	profile.Currencies = acceptedCurrencies
+	if profile.ModeratorInfo != nil {
+		profile.ModeratorInfo.AcceptedCurrencies = acceptedCurrencies
 	}
 
 	profile.PeerID = n.IpfsNode.Identity.Pretty()

--- a/core/profile.go
+++ b/core/profile.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
+	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
 	"io/ioutil"
 	"os"
 	"path"

--- a/test/factory/listing.go
+++ b/test/factory/listing.go
@@ -115,7 +115,7 @@ func NewListingWithShippingRegions(slug string) *pb.Listing {
 		{
 			Name:    "usps",
 			Type:    pb.Listing_ShippingOption_FIXED_PRICE,
-			Regions: []pb.CountryCode{pb.CountryCode(pb.CountryCode_UNITED_KINGDOM)},
+			Regions: []pb.CountryCode{pb.CountryCode_UNITED_KINGDOM},
 			Services: []*pb.Listing_ShippingOption_Service{
 				{
 					Name:              "standard",

--- a/wallet/builder.go
+++ b/wallet/builder.go
@@ -2,6 +2,13 @@ package wallet
 
 import (
 	"errors"
+	"net"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"time"
+
 	"github.com/OpenBazaar/multiwallet"
 	"github.com/OpenBazaar/multiwallet/config"
 	"github.com/OpenBazaar/openbazaar-go/repo"
@@ -13,12 +20,6 @@ import (
 	"github.com/cpacia/BitcoinCash-Wallet"
 	"github.com/op/go-logging"
 	"golang.org/x/net/proxy"
-	"net"
-	"net/url"
-	"os"
-	"path"
-	"strings"
-	"time"
 )
 
 type WalletConfig struct {

--- a/wallet/resync/resync_manager.go
+++ b/wallet/resync/resync_manager.go
@@ -1,12 +1,12 @@
 package resync
 
 import (
+	"strings"
 	"time"
 
 	"github.com/OpenBazaar/multiwallet"
 	"github.com/OpenBazaar/openbazaar-go/repo"
 	"github.com/op/go-logging"
-	"strings"
 )
 
 var log = logging.MustGetLogger("ResyncManager")


### PR DESCRIPTION
`core.UpdateProfile` was causing currency lists in the profile to become duplicated. Manually verified this fix works for the case illustrated in #1220.