### PR TITLE
Fixed import error

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	routing "gx/ipfs/QmRaVcGchmC1stHHK7YhcgEuTk5k1JiGS568pfYWMgT91H/go-libp2p-kad-dht"
-	"gx/ipfs/QmTmqJGRQfuH8eKWD1FjThwPRipt1QhqJQNZ8MpzmfAAxo/go-ipfs-ds-help"
 	ps "gx/ipfs/QmXauCuJzmzapetmC6W4TuDJLL1yFFrVzSHoWv8YdbmnxH/go-libp2p-peerstore"
 	peer "gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
 	mh "gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"


### PR DESCRIPTION
Was receiving this error on the latest update:

```
api/jsonapi.go:30:2: dshelp redeclared as imported package name
        previous declaration at api/jsonapi.go:12:2
```
Removed unnecessary import package