### PR TITLE
Removed temporary check of bitcoin cash address

### DIFF
--- a/core/disputes.go
+++ b/core/disputes.go
@@ -878,9 +878,7 @@ func (n *OpenBazaarNode) ValidateCaseContract(contract *pb.RicardianContract) []
 			return validationErrors
 		}
 
-		// TODO: the bitcoin cash check is temporary in case someone files a dispute for an order that was created when the prefix was still being used
-		// on the address. We can remove this 45 days after the release of 2.2.2 as it won't be possible for this condition to exist at this point.
-		if contract.BuyerOrder.Payment.Address != addr.EncodeAddress() && contract.BuyerOrder.Payment.Address != n.normalizeBitcoinCashAddress(addr.EncodeAddress()) {
+		if contract.BuyerOrder.Payment.Address != addr.EncodeAddress() {
 			validationErrors = append(validationErrors, "The calculated bitcoin address doesn't match the address in the order")
 		}
 

--- a/core/disputes.go
+++ b/core/disputes.go
@@ -8,7 +8,6 @@ import (
 	peer "gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
 	libp2p "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 

--- a/core/disputes.go
+++ b/core/disputes.go
@@ -1082,18 +1082,3 @@ func (n *OpenBazaarNode) ReleaseFunds(contract *pb.RicardianContract, records []
 
 	return nil
 }
-
-func (n *OpenBazaarNode) normalizeBitcoinCashAddress(addr string) string {
-	if NormalizeCurrencyCode(n.Wallet.CurrencyCode()) == "BCH" || NormalizeCurrencyCode(n.Wallet.CurrencyCode()) == "TBCH" {
-		prefix := "bitcoincash:"
-		if n.TestnetEnable {
-			prefix = "bchtest:"
-		} else if n.RegressionTestEnable {
-			prefix = "bchreg:"
-		}
-		if !strings.HasPrefix(addr, prefix) {
-			return prefix + addr
-		}
-	}
-	return addr
-}


### PR DESCRIPTION
The temporary check for the bitcoin cash address was added in 2.2.2, released 7/26/2018 and slated for removal no sooner than 45 days. It is now ready for removal from the code. Closes #1244.