### PR TITLE
Improve documentation of ob-go start flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ OpenBazaar Server Daemon in Go
 [![Coverage Status](https://coveralls.io/repos/github/OpenBazaar/openbazaar-go/badge.svg?branch=master)](https://coveralls.io/github/OpenBazaar/openbazaar-go?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/OpenBazaar/openbazaar-go)](https://goreportcard.com/report/github.com/OpenBazaar/openbazaar-go)
 
-This repository contains the OpenBazaar server daemon which handles the heavy lifting for the [OpenBazaar](https://openbazaar.org/) desktop application. The server combines several technologies: A modified [IPFS](https://ipfs.io) node, which itself combines ideas from Git, BitTorrent, and Kademlia. A lightweight SPV Bitcoin wallet for interacting with the Bitcoin network. And a JSON API which can be used by a user interface to control the node and browse the network. If you are looking for the OpenBazaar user interface code see [here](https://github.com/OpenBazaar/openbazaar-desktop).
+This repository contains the OpenBazaar server daemon which handles the heavy lifting for the [OpenBazaar](https://openbazaar.org/) desktop application. The server combines several technologies: A modified [IPFS](https://ipfs.io) node, which itself combines ideas from Git, BitTorrent, and Kademlia. A lightweight wallet for interacting with several cryptocurrency networks. And a JSON API which can be used by a user interface to control the node and browse the network. Find the user interface for the server at [github.com/OpenBazaar/openbazaar-desktop](https://github.com/OpenBazaar/openbazaar-desktop).
 
 ## Table of Contents
 
@@ -65,32 +65,32 @@ Help Options:
   -h, --help                      Show this help message
 
 [start command options]
-      -p, --password=             the encryption password if the database is
-                                  encrypted
+      -p, --password=             the encryption password if the database is encrypted
       -t, --testnet               use the test network
       -r, --regtest               run in regression test mode
-      -l, --loglevel=             set the logging level [debug, info, notice,
-                                  warning, error, critical]
+      -l, --loglevel=             set the logging level [debug, info, notice, warning, error, critical]
+                                  (default: debug)
+      -f, --nologfiles            save logs on disk
       -a, --allowip=              only allow API connections from these IPs
       -s, --stun                  use stun on µTP IPv4
       -d, --datadir=              specify the data directory to be used
-      -c, --authcookie=           turn on API authentication and use this
-                                  specific cookie
+      -c, --authcookie=           turn on API authentication and use this specific cookie
       -u, --useragent=            add a custom user-agent field
-          --torpassword=          Set the tor control password. This will
-                                  override the tor password in the config.
-          --tor                   Automatically configure the daemon to run as
-                                  a Tor hidden service and use Tor exclusively.
-                                  Requires Tor to be running.
-          --dualstack             Automatically configure the daemon to run as
-                                  a Tor hidden service IN ADDITION to using the
-                                  clear internet. Requires Tor to be running.
+      -v, --verbose               print openbazaar logs to stdout
+          --torpassword=          Set the tor control password. This will override the tor password in
+                                  the config.
+          --tor                   Automatically configure the daemon to run as a Tor hidden service and
+                                  use Tor exclusively. Requires Tor to be running.
+          --dualstack             Automatically configure the daemon to run as a Tor hidden service IN
+                                  ADDITION to using the clear internet. Requires Tor to be running.
                                   WARNING: this mode is not private
           --disablewallet         disable the wallet functionality of the node
-          --disableexchangerates  disable the exchange rate service to prevent
-                                  api queries
-          --storage=              set the outgoing message storage option
-                                  [self-hosted, dropbox] default=self-hosted
+          --disableexchangerates  disable the exchange rate service to prevent api queries
+          --storage=              set the outgoing message storage option [self-hosted, dropbox]
+                                  (default=self-hosted)
+          --bitcoincash           use a Bitcoin Cash wallet in a dedicated data directory
+          --zcash=                use a ZCash wallet in a dedicated data directory. To use this you must
+                                  pass in the location of the zcashd binary.
 ```
 
 ## Documentation


### PR DESCRIPTION
Noticed start flags were slightly out of date. Update to latest. Will need to update this again with the 2.3 release.