### PR TITLE
Retry failed STORE against push nodes

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -222,15 +222,19 @@ func (n *OpenBazaarNode) sendToPushNodes(hash string) error {
 		}
 	}
 	for _, p := range n.PushNodes {
-		go n.retryableSeedStoreToPeer(p, graph)
+		go n.retryableSeedStoreToPeer(p, hash, graph)
 	}
 
 	return nil
 }
 
-func (n *OpenBazaarNode) retryableSeedStoreToPeer(pid peer.ID, graph []cid.Cid) {
+func (n *OpenBazaarNode) retryableSeedStoreToPeer(pid peer.ID, graphHash string, graph []cid.Cid) {
 	var retryTimeout = 2 * time.Second
 	for {
+		if graphHash != n.RootHash {
+			log.Errorf("root hash has changed, aborting push to %s", pid.Pretty())
+			return
+		}
 		err := n.SendStore(pid.Pretty(), graph)
 		if err != nil {
 			if retryTimeout > 60*time.Second {

--- a/core/net.go
+++ b/core/net.go
@@ -634,16 +634,20 @@ func (n *OpenBazaarNode) SendStore(peerID string, ids []cid.Cid) error {
 		return err
 	}
 	if len(resp.Cids) == 0 {
-		log.Debugf("Peer %s requested no blocks", peerID)
+		log.Debugf("peer %s requested no blocks", peerID)
 		return nil
 	}
 	log.Debugf("Sending %d blocks to %s", len(resp.Cids), peerID)
 	for _, id := range resp.Cids {
 		decoded, err := cid.Decode(id)
 		if err != nil {
+			log.Debugf("failed decoding store block (%s) for peer (%s)", id, peerID)
 			continue
 		}
-		n.SendBlock(peerID, *decoded)
+		if err := n.SendBlock(peerID, *decoded); err != nil {
+			log.Debugf("failed sending store block (%s) to peer (%s)", id, peerID)
+			continue
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #1276. Retry storing initial update with push node via exponential backoff and a little bit of logging.