### PR TITLE
Fix requirements.txt operators

### DIFF
--- a/qa/requirements.txt
+++ b/qa/requirements.txt
@@ -1,2 +1,2 @@
-requests=2.18.4
-python-bitcoinlib=0.8.0
+requests==2.18.4
+python-bitcoinlib==0.8.0


### PR DESCRIPTION
Change to fix `requirements.txt` so that I can run `pip` against it when building a QA environment.

This is what happens when you run `pip` against the file now:
```
# pip install -r requirements.txt
Invalid requirement: 'requests=2.18.4'
= is not a valid operator. Did you mean == ?
```