### PR TITLE
Add referenceID to spend

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -740,7 +740,7 @@ func (i *jsonAPIHandler) POSTSpendCoins(w http.ResponseWriter, r *http.Request) 
 		Address  string `json:"address"`
 		Amount   int64  `json:"amount"`
 		FeeLevel string `json:"feeLevel"`
-		Memo     string `json:"memo"`
+		Memo     string `json:"memo"` /* memo must contain the orderID */
 	}
 	decoder := json.NewDecoder(r.Body)
 	var snd Send
@@ -770,7 +770,7 @@ func (i *jsonAPIHandler) POSTSpendCoins(w http.ResponseWriter, r *http.Request) 
 		ErrorResponse(w, http.StatusBadRequest, "ERROR_INVALID_ADDRESS")
 		return
 	}
-	txid, err := wal.Spend(snd.Amount, addr, feeLevel)
+	txid, err := wal.Spend(snd.Amount, addr, feeLevel, snd.Memo)
 	if err != nil {
 		switch {
 		case err == wallet.ErrorInsuffientFunds:
@@ -789,7 +789,7 @@ func (i *jsonAPIHandler) POSTSpendCoins(w http.ResponseWriter, r *http.Request) 
 	var thumbnail string
 	var memo string
 	var title string
-	contract, _, _, _, err := i.node.Datastore.Purchases().GetByPaymentAddress(addr)
+	contract, _, _, _, _, err := i.node.Datastore.Purchases().GetByOrderId(memo)
 	if contract != nil && err == nil {
 		orderID, _ = i.node.CalcOrderID(contract.BuyerOrder)
 		if contract.VendorListings[0].Item != nil && len(contract.VendorListings[0].Item.Images) > 0 {

--- a/core/refunds.go
+++ b/core/refunds.go
@@ -94,7 +94,7 @@ func (n *OpenBazaarNode) RefundOrder(contract *pb.RicardianContract, records []*
 		if err != nil {
 			return err
 		}
-		txid, err := wal.Spend(outValue, refundAddr, wallet.NORMAL)
+		txid, err := wal.Spend(outValue, refundAddr, wallet.NORMAL, orderID)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/OpenBazaar/multiwallet/bitcoin/wallet.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/bitcoin/wallet.go
@@ -223,7 +223,7 @@ func (w *BitcoinWallet) GetFeePerByte(feeLevel wi.FeeLevel) uint64 {
 	return w.fp.GetFeePerByte(feeLevel)
 }
 
-func (w *BitcoinWallet) Spend(amount int64, addr btc.Address, feeLevel wi.FeeLevel) (*chainhash.Hash, error) {
+func (w *BitcoinWallet) Spend(amount int64, addr btc.Address, feeLevel wi.FeeLevel, referenceID string) (*chainhash.Hash, error) {
 	tx, err := w.buildTx(amount, addr, feeLevel, nil)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/OpenBazaar/multiwallet/bitcoincash/wallet.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/bitcoincash/wallet.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/net/proxy"
 
 	"encoding/hex"
+
 	"github.com/OpenBazaar/multiwallet/client"
 	"github.com/OpenBazaar/multiwallet/config"
 	"github.com/OpenBazaar/multiwallet/keys"
@@ -220,7 +221,7 @@ func (w *BitcoinCashWallet) GetFeePerByte(feeLevel wi.FeeLevel) uint64 {
 	return w.fp.GetFeePerByte(feeLevel)
 }
 
-func (w *BitcoinCashWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel) (*chainhash.Hash, error) {
+func (w *BitcoinCashWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel, referenceID string) (*chainhash.Hash, error) {
 	tx, err := w.buildTx(amount, addr, feeLevel, nil)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/OpenBazaar/multiwallet/litecoin/wallet.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/litecoin/wallet.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/net/proxy"
 
 	"encoding/hex"
+
 	"github.com/OpenBazaar/multiwallet/cache"
 	"github.com/OpenBazaar/multiwallet/client"
 	"github.com/OpenBazaar/multiwallet/config"
@@ -218,7 +219,7 @@ func (w *LitecoinWallet) GetFeePerByte(feeLevel wi.FeeLevel) uint64 {
 	return w.fp.GetFeePerByte(feeLevel)
 }
 
-func (w *LitecoinWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel) (*chainhash.Hash, error) {
+func (w *LitecoinWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel, referenceID string) (*chainhash.Hash, error) {
 	tx, err := w.buildTx(amount, addr, feeLevel, nil)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/OpenBazaar/multiwallet/zcash/wallet.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/zcash/wallet.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/net/proxy"
 
 	"encoding/hex"
+
 	"github.com/OpenBazaar/multiwallet/cache"
 	"github.com/OpenBazaar/multiwallet/client"
 	"github.com/OpenBazaar/multiwallet/config"
@@ -223,7 +224,7 @@ func (w *ZCashWallet) GetFeePerByte(feeLevel wi.FeeLevel) uint64 {
 	return w.fp.GetFeePerByte(feeLevel)
 }
 
-func (w *ZCashWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel) (*chainhash.Hash, error) {
+func (w *ZCashWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel, referenceID string) (*chainhash.Hash, error) {
 	tx, err := w.buildTx(amount, addr, feeLevel, nil)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/OpenBazaar/spvwallet/sortsignsend.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/sortsignsend.go
@@ -9,6 +9,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec"
@@ -21,7 +23,6 @@ import (
 	"github.com/btcsuite/btcutil/txsort"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
-	"time"
 )
 
 func (s *SPVWallet) Broadcast(tx *wire.MsgTx) error {
@@ -92,7 +93,7 @@ func (w *SPVWallet) gatherCoins() map[coinset.Coin]*hd.ExtendedKey {
 	return m
 }
 
-func (w *SPVWallet) Spend(amount int64, addr btc.Address, feeLevel wallet.FeeLevel) (*chainhash.Hash, error) {
+func (w *SPVWallet) Spend(amount int64, addr btc.Address, feeLevel wallet.FeeLevel, referenceID string) (*chainhash.Hash, error) {
 	tx, err := w.buildTx(amount, addr, feeLevel, nil)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/OpenBazaar/wallet-interface/wallet.go
+++ b/vendor/github.com/OpenBazaar/wallet-interface/wallet.go
@@ -65,7 +65,7 @@ type Wallet interface {
 	GetFeePerByte(feeLevel FeeLevel) uint64
 
 	// Send bitcoins to an external wallet
-	Spend(amount int64, addr btc.Address, feeLevel FeeLevel) (*chainhash.Hash, error)
+	Spend(amount int64, addr btc.Address, feeLevel FeeLevel, referenceID string) (*chainhash.Hash, error)
 
 	// Bump the fee for the given transaction
 	BumpFee(txid chainhash.Hash) (*chainhash.Hash, error)

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/sortsignsend.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/sortsignsend.go
@@ -8,6 +8,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec"
@@ -21,7 +23,6 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/cpacia/bchutil"
-	"time"
 )
 
 func (s *SPVWallet) Broadcast(tx *wire.MsgTx) error {
@@ -102,7 +103,7 @@ func (w *SPVWallet) gatherCoins() map[coinset.Coin]*hd.ExtendedKey {
 	return m
 }
 
-func (w *SPVWallet) Spend(amount int64, addr btc.Address, feeLevel wallet.FeeLevel) (*chainhash.Hash, error) {
+func (w *SPVWallet) Spend(amount int64, addr btc.Address, feeLevel wallet.FeeLevel, referenceID string) (*chainhash.Hash, error) {
 	tx, err := w.buildTx(amount, addr, feeLevel, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
@cpacia - Changed the Spend calls in the jsonapi and refunds.
In jsonapi, the send struct will require memo to contain the referenceID/orderID to be passed from the invoker.