### PR TITLE
[#1319] Separate spend and spendorder behavior

### DIFF
--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -52,6 +52,8 @@ func post(i *jsonAPIHandler, path string, w http.ResponseWriter, r *http.Request
 		i.POSTOrderFulfill(w, r)
 	case strings.HasPrefix(path, "/ob/ordercompletion"):
 		i.POSTOrderComplete(w, r)
+	case strings.HasPrefix(path, "/ob/orderspend"):
+		i.POSTSpendCoinsForOrder(w, r)
 	case strings.HasPrefix(path, "/ob/refund"):
 		i.POSTRefund(w, r)
 	case strings.HasPrefix(path, "/wallet/resyncblockchain"):

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -22,6 +22,7 @@ func put(i *jsonAPIHandler, path string, w http.ResponseWriter, r *http.Request)
 	}
 }
 
+//nolint:dupl
 func post(i *jsonAPIHandler, path string, w http.ResponseWriter, r *http.Request) {
 	switch {
 	case strings.HasPrefix(path, "/ob/listing"):
@@ -111,6 +112,7 @@ func post(i *jsonAPIHandler, path string, w http.ResponseWriter, r *http.Request
 	}
 }
 
+//nolint:dupl
 func get(i *jsonAPIHandler, path string, w http.ResponseWriter, r *http.Request) {
 	switch {
 	case strings.HasPrefix(path, "/ob/status"):

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -744,7 +744,7 @@ func (i *jsonAPIHandler) POSTSpendCoinsForOrder(w http.ResponseWriter, r *http.R
 	}
 
 	if spendArgs.OrderID == "" {
-		ErrorResponse(w, http.StatusBadRequest, "Missing order id")
+		ErrorResponse(w, http.StatusBadRequest, core.ErrOrderNotFound.Error())
 		return
 	}
 

--- a/core/currency.go
+++ b/core/currency.go
@@ -1,5 +1,141 @@
 package core
 
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/OpenBazaar/openbazaar-go/pb"
+	"github.com/OpenBazaar/openbazaar-go/repo"
+	wallet "github.com/OpenBazaar/wallet-interface"
+)
+
 // DefaultCurrencyDivisibility is the Divisibility of the Currency if not
 // defined otherwise
 const DefaultCurrencyDivisibility uint32 = 1e8
+
+type SpendRequest struct {
+	Wallet                 string `json:"wallet"`
+	Address                string `json:"address"`
+	Amount                 int64  `json:"amount"`
+	FeeLevel               string `json:"feeLevel"`
+	Memo                   string `json:"memo"`
+	OrderID                string `json:"orderID"`
+	RequireAssociatedOrder bool   `json:"requireOrder"`
+}
+
+type SpendResponse struct {
+	Txid               string    `json:"txid"`
+	Amount             int64     `json:"amount"`
+	ConfirmedBalance   int64     `json:"confirmedBalance"`
+	UnconfirmedBalance int64     `json:"unconfirmedBalance"`
+	Timestamp          time.Time `json:"timestamp"`
+	Memo               string    `json:"memo"`
+	OrderID            string    `json:"orderID"`
+}
+
+func (n *OpenBazaarNode) Spend(args *SpendRequest) (*SpendResponse, error) {
+	var (
+		feeLevel wallet.FeeLevel
+		contract *pb.RicardianContract
+	)
+
+	wal, err := n.Multiwallet.WalletForCurrencyCode(args.Wallet)
+	if err != nil {
+		return nil, ErrUnknownWallet
+	}
+
+	addr, err := wal.DecodeAddress(args.Address)
+	if err != nil {
+		return nil, ErrInvalidSpendAddress
+	}
+
+	if args.RequireAssociatedOrder {
+		var err error
+		contract, err = n.getOrderContractBySpendRequest(args)
+		if err != nil {
+			return nil, ErrOrderNotFound
+		}
+	}
+
+	switch strings.ToUpper(args.FeeLevel) {
+	case "PRIORITY":
+		feeLevel = wallet.PRIOIRTY
+	case "NORMAL":
+		feeLevel = wallet.NORMAL
+	case "ECONOMIC":
+		feeLevel = wallet.ECONOMIC
+	default:
+		feeLevel = wallet.NORMAL
+	}
+
+	txid, err := wal.Spend(args.Amount, addr, feeLevel, args.OrderID)
+	if err != nil {
+		switch {
+		case err == wallet.ErrorInsuffientFunds:
+			return nil, ErrInsufficientFunds
+		case err == wallet.ErrorDustAmount:
+			return nil, ErrSpendAmountIsDust
+		default:
+			return nil, err
+		}
+	}
+
+	var (
+		thumbnail string
+		title     string
+		memo      = args.Memo
+	)
+	if memo == "" && title != "" {
+		memo = title
+	}
+	if args.RequireAssociatedOrder {
+		if contract.VendorListings[0].Item != nil && len(contract.VendorListings[0].Item.Images) > 0 {
+			thumbnail = contract.VendorListings[0].Item.Images[0].Tiny
+			title = contract.VendorListings[0].Item.Title
+		}
+	}
+
+	if err := n.Datastore.TxMetadata().Put(repo.Metadata{
+		Txid:       txid.String(),
+		Address:    args.Address,
+		Memo:       memo,
+		OrderId:    args.OrderID,
+		Thumbnail:  thumbnail,
+		CanBumpFee: false,
+	}); err != nil {
+		return nil, fmt.Errorf("failed persisting transaction metadata: %s", err)
+	}
+
+	confirmed, unconfirmed := wal.Balance()
+	txn, err := wal.GetTransaction(*txid)
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving new wallet balance: %s", err)
+	}
+
+	return &SpendResponse{
+		Txid:               txid.String(),
+		ConfirmedBalance:   confirmed,
+		UnconfirmedBalance: unconfirmed,
+		Amount:             -(txn.Value),
+		Timestamp:          txn.Timestamp,
+		Memo:               memo,
+		OrderID:            args.OrderID,
+	}, nil
+}
+
+func (n *OpenBazaarNode) getOrderContractBySpendRequest(args *SpendRequest) (*pb.RicardianContract, error) {
+	if args.OrderID != "" {
+		contract, _, _, _, _, err := n.Datastore.Purchases().GetByOrderId(args.OrderID)
+		if err == nil && contract != nil {
+			return contract, nil
+		}
+	}
+	contract, _, _, _, _, err := n.Datastore.Purchases().GetByOrderId(args.Address)
+	if err == nil && contract != nil {
+		return contract, nil
+	}
+
+	return nil, errors.New("unable to find order from order id or spend address")
+}

--- a/core/currency.go
+++ b/core/currency.go
@@ -87,14 +87,14 @@ func (n *OpenBazaarNode) Spend(args *SpendRequest) (*SpendResponse, error) {
 		title     string
 		memo      = args.Memo
 	)
-	if memo == "" && title != "" {
-		memo = title
-	}
 	if args.RequireAssociatedOrder {
 		if contract.VendorListings[0].Item != nil && len(contract.VendorListings[0].Item.Images) > 0 {
 			thumbnail = contract.VendorListings[0].Item.Images[0].Tiny
 			title = contract.VendorListings[0].Item.Title
 		}
+	}
+	if memo == "" && title != "" {
+		memo = title
 	}
 
 	if err := n.Datastore.TxMetadata().Put(repo.Metadata{

--- a/core/errors.go
+++ b/core/errors.go
@@ -36,6 +36,21 @@ var (
 	ErrFulfillCryptocurrencyTXIDNotFound = errors.New("a transactionID is required to fulfill crypto listings")
 	// ErrFulfillCryptocurrencyTXIDTooLong - invalid txn id err
 	ErrFulfillCryptocurrencyTXIDTooLong = errors.New("transactionID should be no longer than " + strconv.Itoa(MaxTXIDSize))
+
+	// ErrUnknownWallet is returned when a wallet is not present on the node
+	ErrUnknownWallet = errors.New("Unknown wallet type")
+
+	// ErrInvalidSpendAddress is returned when the wallet is unable to decode the string address into a valid destination to send funds to
+	ErrInvalidSpendAddress = errors.New("ERROR_INVALID_ADDRESS")
+
+	// ErrInsufficientFunds is returned when the wallet is unable to send the amount specified due to the balance being too low
+	ErrInsufficientFunds = errors.New("ERROR_INSUFFICIENT_FUNDS")
+
+	// ErrSpendAmountIsDust is returned when the requested amount to spend out of the wallet would be considered "dust" by the network. This means the value is too low for the network to bother sending the amount and has a high likelihood of not being accepted or being outright rejected.
+	ErrSpendAmountIsDust = errors.New("ERROR_DUST_AMOUNT")
+
+	// ErrUnknownOrder is returned when the requested amount to spend is unable to be associated with the appropriate order
+	ErrOrderNotFound = errors.New("ERROR_ORDER_NOT_FOUND")
 )
 
 // CodedError is an error that is machine readable


### PR DESCRIPTION
This change adds a new possible error to `POST /ob/spendorder`. Our error handling is a little all over the place so it simply returns a string "ERROR_ORDER_NOT_FOUND" if the param is empty or if the order cannot be retrieved. Hopefully we can round back on to the error handling at some point.