### PR TITLE
Sign Verify Content with IPFS Key

### DIFF
--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -71,6 +71,10 @@ func post(i *jsonAPIHandler, path string, w http.ResponseWriter, r *http.Request
 		blockingStartupMiddleware(i, w, r, i.POSTReleaseEscrow)
 	case strings.HasPrefix(path, "/ob/chat"):
 		blockingStartupMiddleware(i, w, r, i.POSTChat)
+	case strings.HasPrefix(path, "/ob/signmessage"):
+		i.POSTSignMessage(w, r)
+	case strings.HasPrefix(path, "/ob/verifymessage"):
+		i.POSTVerifyMessage(w, r)
 	case strings.HasPrefix(path, "/ob/groupchat"):
 		blockingStartupMiddleware(i, w, r, i.POSTGroupChat)
 	case strings.HasPrefix(path, "/ob/markchatasread"):

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"gx/ipfs/QmPvyPwuCgJ7pDmrKDxRtsScJgBaM5h4EpRL2qQJsmXf4n/go-libp2p-crypto"
 
 	"gx/ipfs/QmPSQnBKM9g7BaUcZCvswUJVscQ1ipjmwxN5PXCjkp9EQ7/go-cid"
 	mh "gx/ipfs/QmPnFwZ2JXKnXgMw8CdBPxn7FWh6LLdjUjxV1fKHuJnkr8/go-multihash"

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -2281,7 +2281,7 @@ func (i *jsonAPIHandler) POSTSignMessage(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	keyBytes, err := i.node.IpfsNode.PrivateKey.Bytes()
+	keyBytes, err := i.node.IpfsNode.Identity.ExtractPublicKey().Bytes()
 	if err != nil {
 		ErrorResponse(w, http.StatusBadRequest, err.Error())
 		return

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -2327,7 +2327,7 @@ func (i *jsonAPIHandler) POSTVerifyMessage(w http.ResponseWriter, r *http.Reques
 	}
 
 	if generatedPeer.Pretty() != msg.PeerId {
-		ErrorResponse(w, http.StatusBadRequest, "submitted peerId does not belong to the pubkey")
+		SanitizedResponse(w, `{"error":"PEER_ID_PUBKEY_MISMATCH"}`)
 		return
 	}
 
@@ -2343,11 +2343,10 @@ func (i *jsonAPIHandler) POSTVerifyMessage(w http.ResponseWriter, r *http.Reques
 	}
 	_, err = pubkey.Verify(contentBytes, sigBytes)
 	if err != nil {
-		ErrorResponse(w, http.StatusBadRequest, err.Error())
+		SanitizedResponse(w, `{"error":"VERIFICATION_FAILED"}`)
 		return
 	}
-
-	SanitizedResponse(w, fmt.Sprintf(`{"peerId":"%s"}`, msg.PeerId))
+	SanitizedResponse(w, fmt.Sprintf(`{"error":"","peerId":"%s"}`, msg.PeerId))
 }
 
 func (i *jsonAPIHandler) POSTChat(w http.ResponseWriter, r *http.Request) {

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -2277,11 +2277,20 @@ func (i *jsonAPIHandler) POSTSignMessage(w http.ResponseWriter, r *http.Request)
 
 	sig, err := i.node.IpfsNode.PrivateKey.Sign([]byte(msg.Content))
 	if err != nil {
-		ErrorResponse(w, http.StatusBadRequest, "there was an error signing the submitted content")
+		ErrorResponse(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	SanitizedResponse(w, fmt.Sprintf(`{"signature": "%s"}`, hex.EncodeToString(sig)))
+	keyBytes, err := i.node.IpfsNode.PrivateKey.Bytes()
+	if err != nil {
+		ErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	SanitizedResponse(w, fmt.Sprintf(`{"signature": "%s","pubkey":"%s","peerId":"%s"}`,
+		hex.EncodeToString(sig),
+		hex.EncodeToString(keyBytes),
+		i.node.IpfsNode.Identity.Pretty()))
 }
 
 func (i *jsonAPIHandler) POSTVerifyMessage(w http.ResponseWriter, r *http.Request) {

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -2281,7 +2281,7 @@ func (i *jsonAPIHandler) POSTSignMessage(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	keyBytes, err := i.node.IpfsNode.Identity.ExtractPublicKey().Bytes()
+	keyBytes, err := i.node.IpfsNode.PrivateKey.GetPublic().Bytes()
 	if err != nil {
 		ErrorResponse(w, http.StatusBadRequest, err.Error())
 		return

--- a/api/jsonapi_data_test.go
+++ b/api/jsonapi_data_test.go
@@ -172,7 +172,8 @@ const signMessageJSON = `{
 const verifyMessageJSON = `{
 	"content": "74657374",
 	"signature": "fac9dec1ce872c931bda1af85f9107e8733b42ed6401bc989a84b6b53ad263290d9bd9d470f046024884f502ecb7af50de2fea11268e82dcb1c72d50753c330a",
-	"pubkey": "080112203f94c7707af68ede9ddd24a16edd813146550df565eda8fb81114476ccfe6b78"
+	"pubkey": "080112203f94c7707af68ede9ddd24a16edd813146550df565eda8fb81114476ccfe6b78",
+	"peerId": "QmRmisSghsxUMrTQZ5vmqFroxxuCXJqXwXoTc21q5cefmM"
 }`
 
 //

--- a/api/jsonapi_data_test.go
+++ b/api/jsonapi_data_test.go
@@ -164,6 +164,17 @@ const settingsAlreadyExistsJSON = `{
     "reason": "Settings is already set. Use PUT."
 }`
 
+// Sign Verify Messages
+const signMessageJSON = `{
+	"content": "test"
+}`
+
+const verifyMessageJSON = `{
+	"content": "74657374",
+	"signature": "fac9dec1ce872c931bda1af85f9107e8733b42ed6401bc989a84b6b53ad263290d9bd9d470f046024884f502ecb7af50de2fea11268e82dcb1c72d50753c330a",
+	"pubkey": "080112203f94c7707af68ede9ddd24a16edd813146550df565eda8fb81114476ccfe6b78"
+}`
+
 //
 // Profile
 //

--- a/api/jsonapi_test.go
+++ b/api/jsonapi_test.go
@@ -137,6 +137,13 @@ func TestModerator(t *testing.T) {
 	})
 }
 
+func TestMessageSignVerify(t *testing.T) {
+	runAPITests(t, apiTests{
+		{"POST", "/ob/signmessage", signMessageJSON, 200, anyResponseJSON},
+		{"POST", "/ob/verifymessage", verifyMessageJSON, 200, anyResponseJSON},
+	})
+}
+
 func TestListingsAcceptedCurrencies(t *testing.T) {
 	runAPITests(t, apiTests{
 		{"POST", "/ob/listing", jsonFor(t, factory.NewListing("ron-swanson-tshirt")), 200, anyResponseJSON},


### PR DESCRIPTION
Per @drwasho's request I whipped up a quick PR to kick this request off, but please be aware this needs conversation and I am not positive it even meets the requirements. 

**/ob/signmessage** -
Input: `{ "content": "<string_content>" }`
Output: `{ "signature": "<hex_encoded_sig>, "pubkey": "<hex_encoded_pubkey>", "peerId": "<peer_id>" }`

**/ob/verifymessage** -
Input: `{ "content": "<string_content>", "signature": "<hex_encoded_sig>", "pubkey": "<hex_encoded_pubkey>", "peerId": "<peerId>" }`
Output: `{ "error": "<empty, PEER_ID_PUBKEY_MISMATCH, or VERIFICATION_FAILED>", "peerId": "<submitted_peerId>" }`




