### PR TITLE
[#1183] Migrate multiwallet config; Refactor multiwallet config handling

### DIFF
--- a/repo/init.go
+++ b/repo/init.go
@@ -17,7 +17,7 @@ import (
 	"github.com/tyler-smith/go-bip39"
 )
 
-const RepoVersion = "15"
+const RepoVersion = "16"
 
 var log = logging.MustGetLogger("repo")
 var ErrRepoExists = errors.New("IPFS configuration file exists. Reinitializing would overwrite your keys. Use -f to force overwrite.")

--- a/repo/init.go
+++ b/repo/init.go
@@ -159,56 +159,6 @@ func addConfigExtensions(repoRoot string) error {
 		return err
 	}
 	var (
-		ws = schema.WalletsConfig{
-			BTC: &schema.CoinConfig{
-				Type:             "API",
-				API:              "https://btc.blockbook.api.openbazaar.org/api",
-				APITestnet:       "https://tbtc.blockbook.api.openbazaar.org/api",
-				MaxFee:           200,
-				FeeAPI:           "https://btc.fees.openbazaar.org",
-				HighFeeDefault:   50,
-				MediumFeeDefault: 10,
-				LowFeeDefault:    1,
-			},
-			BCH: &schema.CoinConfig{
-				Type:             "API",
-				API:              "https://bch.blockbook.api.openbazaar.org/api",
-				APITestnet:       "https://tbch.blockbook.api.openbazaar.org/api",
-				MaxFee:           200,
-				HighFeeDefault:   10,
-				MediumFeeDefault: 5,
-				LowFeeDefault:    1,
-			},
-			LTC: &schema.CoinConfig{
-				Type:             "API",
-				API:              "https://ltc.blockbook.api.openbazaar.org/api",
-				APITestnet:       "https://tltc.blockbook.api.openbazaar.org/api",
-				MaxFee:           200,
-				HighFeeDefault:   20,
-				MediumFeeDefault: 10,
-				LowFeeDefault:    5,
-			},
-			ZEC: &schema.CoinConfig{
-				Type:             "API",
-				API:              "https://zec.blockbook.api.openbazaar.org/api",
-				APITestnet:       "https://tzec.blockbook.api.openbazaar.org/api",
-				MaxFee:           200,
-				HighFeeDefault:   20,
-				MediumFeeDefault: 10,
-				LowFeeDefault:    5,
-			},
-			ETH: &schema.CoinConfig{
-				Type:             "API",
-				API:              "https://rinkeby.infura.io",
-				APITestnet:       "https://rinkeby.infura.io",
-				MaxFee:           200,
-				HighFeeDefault:   30,
-				MediumFeeDefault: 15,
-				LowFeeDefault:    7,
-				WalletOptions:    schema.EthereumDefaultOptions(),
-			},
-		}
-
 		a = schema.APIConfig{
 			Enabled:     true,
 			AllowedIPs:  []string{},
@@ -226,7 +176,7 @@ func addConfigExtensions(repoRoot string) error {
 			Id: "https://resolver.onename.com/",
 		}
 	)
-	if err := r.SetConfigKey("Wallets", ws); err != nil {
+	if err := r.SetConfigKey("Wallets", schema.DefaultWalletsConfig()); err != nil {
 		return err
 	}
 	if err := r.SetConfigKey("DataSharing", ds); err != nil {

--- a/repo/migration.go
+++ b/repo/migration.go
@@ -31,6 +31,7 @@ var Migrations = []Migration{
 	migrations.Migration012{},
 	migrations.Migration013{},
 	migrations.Migration014{},
+	migrations.Migration015{},
 }
 
 // MigrateUp looks at the currently active migration version

--- a/repo/migrations/Migration015.go
+++ b/repo/migrations/Migration015.go
@@ -53,7 +53,7 @@ func migration015DefaultWalletConfig() *migration015WalletsConfig {
 			Type:             "API",
 			APIPool:          []string{"https://bch.api.openbazaar.org/api"},
 			APITestnetPool:   []string{"https://tbch.api.openbazaar.org/api"},
-			FeeAPI:           feeAPI,
+			FeeAPI:           "", // intentionally blank
 			LowFeeDefault:    1,
 			MediumFeeDefault: 5,
 			HighFeeDefault:   10,
@@ -64,7 +64,7 @@ func migration015DefaultWalletConfig() *migration015WalletsConfig {
 			Type:             "API",
 			APIPool:          []string{"https://ltc.api.openbazaar.org/api"},
 			APITestnetPool:   []string{"https://tltc.api.openbazaar.org/api"},
-			FeeAPI:           feeAPI,
+			FeeAPI:           "", // intentionally blank
 			LowFeeDefault:    5,
 			MediumFeeDefault: 10,
 			HighFeeDefault:   20,
@@ -75,7 +75,7 @@ func migration015DefaultWalletConfig() *migration015WalletsConfig {
 			Type:             "API",
 			APIPool:          []string{"https://zec.api.openbazaar.org/api"},
 			APITestnetPool:   []string{"https://tzec.api.openbazaar.org/api"},
-			FeeAPI:           feeAPI,
+			FeeAPI:           "", // intentionally blank
 			LowFeeDefault:    5,
 			MediumFeeDefault: 10,
 			HighFeeDefault:   20,
@@ -86,7 +86,7 @@ func migration015DefaultWalletConfig() *migration015WalletsConfig {
 			Type:             "API",
 			APIPool:          []string{"https://rinkeby.infura.io"},
 			APITestnetPool:   []string{"https://rinkeby.infura.io"},
-			FeeAPI:           feeAPI,
+			FeeAPI:           "", // intentionally blank
 			LowFeeDefault:    7,
 			MediumFeeDefault: 15,
 			HighFeeDefault:   30,

--- a/repo/migrations/Migration015.go
+++ b/repo/migrations/Migration015.go
@@ -1,0 +1,77 @@
+package migrations
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/OpenBazaar/openbazaar-go/schema"
+)
+
+type Migration015 struct{}
+
+func (Migration015) Up(repoPath, dbPassword string, testnet bool) error {
+	var (
+		configMap        = make(map[string]interface{})
+		configBytes, err = ioutil.ReadFile(path.Join(repoPath, "config"))
+	)
+	if err != nil {
+		return fmt.Errorf("reading config: %s", err.Error())
+	}
+
+	if err = json.Unmarshal(configBytes, &configMap); err != nil {
+		return fmt.Errorf("unmarshal config: %s", err.Error())
+	}
+
+	configMap["LegacyWallet"] = configMap["Wallet"]
+	delete(configMap, "Wallet")
+	configMap["Wallets"] = schema.DefaultWalletsConfig()
+
+	newConfigBytes, err := json.MarshalIndent(configMap, "", "    ")
+	if err != nil {
+		return fmt.Errorf("marshal migrated config: %s", err.Error())
+	}
+
+	if err := ioutil.WriteFile(path.Join(repoPath, "config"), newConfigBytes, os.ModePerm); err != nil {
+		return fmt.Errorf("writing migrated config: %s", err.Error())
+	}
+
+	if err := writeRepoVer(repoPath, 16); err != nil {
+		return fmt.Errorf("bumping repover to 16: %s", err.Error())
+	}
+	return nil
+}
+
+func (Migration015) Down(repoPath, dbPassword string, testnet bool) error {
+	var (
+		configMap        = make(map[string]interface{})
+		configBytes, err = ioutil.ReadFile(path.Join(repoPath, "config"))
+	)
+	if err != nil {
+		return fmt.Errorf("reading config: %s", err.Error())
+	}
+
+	if err = json.Unmarshal(configBytes, &configMap); err != nil {
+		return fmt.Errorf("unmarshal config: %s", err.Error())
+	}
+
+	configMap["Wallet"] = configMap["LegacyWallet"]
+	delete(configMap, "Wallets")
+	delete(configMap, "LegacyWallet")
+
+	newConfigBytes, err := json.MarshalIndent(configMap, "", "    ")
+	if err != nil {
+		return fmt.Errorf("marshal migrated config: %s", err.Error())
+	}
+
+	if err := ioutil.WriteFile(path.Join(repoPath, "config"), newConfigBytes, os.ModePerm); err != nil {
+		return fmt.Errorf("writing migrated config: %s", err.Error())
+	}
+
+	if err := writeRepoVer(repoPath, 15); err != nil {
+		return fmt.Errorf("bumping repover to 16: %s", err.Error())
+	}
+	return nil
+}

--- a/repo/migrations/Migration015.go
+++ b/repo/migrations/Migration015.go
@@ -6,9 +6,99 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-
-	"github.com/OpenBazaar/openbazaar-go/schema"
 )
+
+const (
+	migration015EthereumRegistryAddressMainnet = "0x403d907982474cdd51687b09a8968346159378f3"
+	migration015EthereumRegistryAddressRinkeby = "0x403d907982474cdd51687b09a8968346159378f3"
+	migration015EthereumRegistryAddressRopsten = "0x403d907982474cdd51687b09a8968346159378f3"
+)
+
+type migration015WalletsConfig struct {
+	BTC *migration015CoinConfig `json:"BTC"`
+	BCH *migration015CoinConfig `json:"BCH"`
+	LTC *migration015CoinConfig `json:"LTC"`
+	ZEC *migration015CoinConfig `json:"ZEC"`
+	ETH *migration015CoinConfig `json:"ETH"`
+}
+
+type migration015CoinConfig struct {
+	Type             string                 `json:"Type"`
+	APIPool          []string               `json:"API"`
+	APITestnetPool   []string               `json:"APITestnet"`
+	MaxFee           uint64                 `json:"MaxFee"`
+	FeeAPI           string                 `json:"FeeAPI"`
+	HighFeeDefault   uint64                 `json:"HighFeeDefault"`
+	MediumFeeDefault uint64                 `json:"MediumFeeDefault"`
+	LowFeeDefault    uint64                 `json:"LowFeeDefault"`
+	TrustedPeer      string                 `json:"TrustedPeer"`
+	WalletOptions    map[string]interface{} `json:"WalletOptions"`
+}
+
+func migration015DefaultWalletConfig() *migration015WalletsConfig {
+	var feeAPI = "https://btc.fees.openbazaar.org"
+	return &migration015WalletsConfig{
+		BTC: &migration015CoinConfig{
+			Type:             "API",
+			APIPool:          []string{"https://btc.api.openbazaar.org/api"},
+			APITestnetPool:   []string{"https://tbtc.api.openbazaar.org/api"},
+			FeeAPI:           feeAPI,
+			LowFeeDefault:    1,
+			MediumFeeDefault: 10,
+			HighFeeDefault:   50,
+			MaxFee:           200,
+			WalletOptions:    nil,
+		},
+		BCH: &migration015CoinConfig{
+			Type:             "API",
+			APIPool:          []string{"https://bch.api.openbazaar.org/api"},
+			APITestnetPool:   []string{"https://tbch.api.openbazaar.org/api"},
+			FeeAPI:           feeAPI,
+			LowFeeDefault:    1,
+			MediumFeeDefault: 5,
+			HighFeeDefault:   10,
+			MaxFee:           200,
+			WalletOptions:    nil,
+		},
+		LTC: &migration015CoinConfig{
+			Type:             "API",
+			APIPool:          []string{"https://ltc.api.openbazaar.org/api"},
+			APITestnetPool:   []string{"https://tltc.api.openbazaar.org/api"},
+			FeeAPI:           feeAPI,
+			LowFeeDefault:    5,
+			MediumFeeDefault: 10,
+			HighFeeDefault:   20,
+			MaxFee:           200,
+			WalletOptions:    nil,
+		},
+		ZEC: &migration015CoinConfig{
+			Type:             "API",
+			APIPool:          []string{"https://zec.api.openbazaar.org/api"},
+			APITestnetPool:   []string{"https://tzec.api.openbazaar.org/api"},
+			FeeAPI:           feeAPI,
+			LowFeeDefault:    5,
+			MediumFeeDefault: 10,
+			HighFeeDefault:   20,
+			MaxFee:           200,
+			WalletOptions:    nil,
+		},
+		ETH: &migration015CoinConfig{
+			Type:             "API",
+			APIPool:          []string{"https://rinkeby.infura.io"},
+			APITestnetPool:   []string{"https://rinkeby.infura.io"},
+			FeeAPI:           feeAPI,
+			LowFeeDefault:    7,
+			MediumFeeDefault: 15,
+			HighFeeDefault:   30,
+			MaxFee:           200,
+			WalletOptions: map[string]interface{}{
+				"RegistryAddress":        migration015EthereumRegistryAddressMainnet,
+				"RinkebyRegistryAddress": migration015EthereumRegistryAddressRinkeby,
+				"RopstenRegistryAddress": migration015EthereumRegistryAddressRopsten,
+			},
+		},
+	}
+}
 
 type Migration015 struct{}
 
@@ -27,7 +117,7 @@ func (Migration015) Up(repoPath, dbPassword string, testnet bool) error {
 
 	configMap["LegacyWallet"] = configMap["Wallet"]
 	delete(configMap, "Wallet")
-	configMap["Wallets"] = schema.DefaultWalletsConfig()
+	configMap["Wallets"] = migration015DefaultWalletConfig()
 
 	newConfigBytes, err := json.MarshalIndent(configMap, "", "    ")
 	if err != nil {

--- a/repo/migrations/Migration015_test.go
+++ b/repo/migrations/Migration015_test.go
@@ -1,0 +1,110 @@
+package migrations_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/OpenBazaar/openbazaar-go/repo/migrations"
+	"github.com/OpenBazaar/openbazaar-go/schema"
+)
+
+const preMigrationConfig = `{"Wallet":{
+	"Binary": "",
+	"FeeAPI": "https://btc.fees.openbazaar.org",
+	"HighFeeDefault": 160,
+	"LowFeeDefault": 20,
+	"MaxFee": 2000,
+	"MediumFeeDefault": 60,
+	"TrustedPeer": "",
+	"Type": "spvwallet"
+}}`
+
+func TestMigration015(t *testing.T) {
+	var testRepo, err = schema.NewCustomSchemaManager(schema.SchemaContext{
+		DataPath:        schema.GenerateTempPath(),
+		TestModeEnabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = testRepo.BuildSchemaDirectories(); err != nil {
+		t.Fatal(err)
+	}
+	defer testRepo.DestroySchemaDirectories()
+
+	var (
+		configPath  = testRepo.DataPathJoin("config")
+		repoverPath = testRepo.DataPathJoin("repover")
+	)
+	if err = ioutil.WriteFile(configPath, []byte(preMigrationConfig), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = ioutil.WriteFile(repoverPath, []byte("15"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	var m migrations.Migration015
+	err = m.Up(testRepo.DataPath(), "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configBytes, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var configInterface map[string]json.RawMessage
+	if err = json.Unmarshal(configBytes, &configInterface); err != nil {
+		t.Fatalf("unmarshaling invalid json after migration: %s", err.Error())
+	}
+
+	if _, ok := configInterface["Wallet"]; ok {
+		t.Error("expected 'Wallet' key to be present")
+	}
+
+	if _, ok := configInterface["Wallets"]; !ok {
+		t.Error("missing expected 'Wallets' key after migration")
+	}
+
+	if _, ok := configInterface["LegacyWallet"]; !ok {
+		t.Error("missing expected 'LegacyWallet' key after migration")
+	}
+
+	var actualWalletsConfig = new(schema.WalletsConfig)
+	if err = json.Unmarshal(configInterface["Wallets"], actualWalletsConfig); err != nil {
+		t.Fatalf("unmarshaling invalid multiwallet config: %s", err.Error())
+	}
+
+	assertCorrectRepoVer(t, repoverPath, "16")
+
+	err = m.Down(testRepo.DataPath(), "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configBytes, err = ioutil.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configInterface = make(map[string]json.RawMessage)
+	if err = json.Unmarshal(configBytes, &configInterface); err != nil {
+		t.Fatalf("unmarshaling invalid json after migration: %s", err.Error())
+	}
+
+	if _, ok := configInterface["Wallet"]; !ok {
+		t.Error("missing expected 'Wallet' key after reversing migration")
+	}
+
+	if _, ok := configInterface["Wallets"]; ok {
+		t.Error("expected 'Wallets' key to be removed")
+	}
+
+	if _, ok := configInterface["LegacyWallet"]; ok {
+		t.Error("expected 'LegacyWallet' key to be removed")
+	}
+	assertCorrectRepoVer(t, repoverPath, "15")
+}

--- a/schema/configuration.go
+++ b/schema/configuration.go
@@ -256,18 +256,13 @@ func GetAPIConfig(cfgBytes []byte) (*APIConfig, error) {
 }
 
 func GetWalletsConfig(cfgBytes []byte) (*WalletsConfig, error) {
-	var cfgIface interface{}
+	var cfgIface map[string]interface{}
 	err := json.Unmarshal(cfgBytes, &cfgIface)
 	if err != nil {
 		return nil, MalformedConfigError
 	}
 
-	cfg, ok := cfgIface.(map[string]interface{})
-	if !ok {
-		return nil, MalformedConfigError
-	}
-
-	walletIface, ok := cfg["Wallets"]
+	walletIface, ok := cfgIface["Wallets"]
 	if !ok {
 		return nil, MalformedConfigError
 	}

--- a/schema/configuration.go
+++ b/schema/configuration.go
@@ -75,7 +75,7 @@ func DefaultWalletsConfig() *WalletsConfig {
 			Type:             WalletTypeAPI,
 			APIPool:          CoinPoolBCH,
 			APITestnetPool:   CoinPoolTBCH,
-			FeeAPI:           feeAPI,
+			FeeAPI:           "", // intentionally blank
 			LowFeeDefault:    1,
 			MediumFeeDefault: 5,
 			HighFeeDefault:   10,
@@ -86,7 +86,7 @@ func DefaultWalletsConfig() *WalletsConfig {
 			Type:             WalletTypeAPI,
 			APIPool:          CoinPoolLTC,
 			APITestnetPool:   CoinPoolTLTC,
-			FeeAPI:           feeAPI,
+			FeeAPI:           "", // intentionally blank
 			LowFeeDefault:    5,
 			MediumFeeDefault: 10,
 			HighFeeDefault:   20,
@@ -97,7 +97,7 @@ func DefaultWalletsConfig() *WalletsConfig {
 			Type:             WalletTypeAPI,
 			APIPool:          CoinPoolZEC,
 			APITestnetPool:   CoinPoolTZEC,
-			FeeAPI:           feeAPI,
+			FeeAPI:           "", // intentionally blank
 			LowFeeDefault:    5,
 			MediumFeeDefault: 10,
 			HighFeeDefault:   20,
@@ -108,7 +108,7 @@ func DefaultWalletsConfig() *WalletsConfig {
 			Type:             WalletTypeAPI,
 			APIPool:          CoinPoolETH,
 			APITestnetPool:   CoinPoolTETH,
-			FeeAPI:           feeAPI,
+			FeeAPI:           "", // intentionally blank
 			LowFeeDefault:    7,
 			MediumFeeDefault: 15,
 			HighFeeDefault:   30,

--- a/schema/configuration.go
+++ b/schema/configuration.go
@@ -38,16 +38,16 @@ type WalletsConfig struct {
 }
 
 type CoinConfig struct {
-	Type             string
-	API              string
-	APITestnet       string
-	MaxFee           int
-	FeeAPI           string
-	HighFeeDefault   int
-	MediumFeeDefault int
-	LowFeeDefault    int
-	TrustedPeer      string
-	WalletOptions    map[string]interface{}
+	Type             string                 `json:"Type"`
+	APIPool          []string               `json:"API"`
+	APITestnetPool   []string               `json:"APITestnet"`
+	MaxFee           uint64                 `json:"MaxFee"`
+	FeeAPI           string                 `json:"FeeAPI"`
+	HighFeeDefault   uint64                 `json:"HighFeeDefault"`
+	MediumFeeDefault uint64                 `json:"MediumFeeDefault"`
+	LowFeeDefault    uint64                 `json:"LowFeeDefault"`
+	TrustedPeer      string                 `json:"TrustedPeer"`
+	WalletOptions    map[string]interface{} `json:"WalletOptions"`
 }
 
 type DataSharing struct {
@@ -56,6 +56,67 @@ type DataSharing struct {
 }
 
 var MalformedConfigError error = errors.New("config file is malformed")
+
+func DefaultWalletsConfig() *WalletsConfig {
+	var feeAPI = "https://btc.fees.openbazaar.org"
+	return &WalletsConfig{
+		BTC: &CoinConfig{
+			Type:             WalletTypeAPI,
+			APIPool:          CoinPoolBTC,
+			APITestnetPool:   CoinPoolTBTC,
+			FeeAPI:           feeAPI,
+			LowFeeDefault:    1,
+			MediumFeeDefault: 10,
+			HighFeeDefault:   50,
+			MaxFee:           200,
+			WalletOptions:    nil,
+		},
+		BCH: &CoinConfig{
+			Type:             WalletTypeAPI,
+			APIPool:          CoinPoolBCH,
+			APITestnetPool:   CoinPoolTBCH,
+			FeeAPI:           feeAPI,
+			LowFeeDefault:    1,
+			MediumFeeDefault: 5,
+			HighFeeDefault:   10,
+			MaxFee:           200,
+			WalletOptions:    nil,
+		},
+		LTC: &CoinConfig{
+			Type:             WalletTypeAPI,
+			APIPool:          CoinPoolLTC,
+			APITestnetPool:   CoinPoolTLTC,
+			FeeAPI:           feeAPI,
+			LowFeeDefault:    5,
+			MediumFeeDefault: 10,
+			HighFeeDefault:   20,
+			MaxFee:           200,
+			WalletOptions:    nil,
+		},
+		ZEC: &CoinConfig{
+			Type:             WalletTypeAPI,
+			APIPool:          CoinPoolZEC,
+			APITestnetPool:   CoinPoolTZEC,
+			FeeAPI:           feeAPI,
+			LowFeeDefault:    5,
+			MediumFeeDefault: 10,
+			HighFeeDefault:   20,
+			MaxFee:           200,
+			WalletOptions:    nil,
+		},
+		ETH: &CoinConfig{
+			Type:             WalletTypeAPI,
+			APIPool:          CoinPoolETH,
+			APITestnetPool:   CoinPoolTETH,
+			FeeAPI:           feeAPI,
+			LowFeeDefault:    7,
+			MediumFeeDefault: 15,
+			HighFeeDefault:   30,
+			MaxFee:           200,
+			WalletOptions:    EthereumDefaultOptions(),
+		},
+	}
+}
 
 func GetAPIConfig(cfgBytes []byte) (*APIConfig, error) {
 	var cfgIface interface{}

--- a/schema/configuration_test.go
+++ b/schema/configuration_test.go
@@ -51,7 +51,7 @@ func TestGetApiConfig(t *testing.T) {
 func TestGetWalletsConfig(t *testing.T) {
 	config, err := GetWalletsConfig(configFixture())
 	if err != nil {
-		t.Error("GetWalletsConfig threw an unexpected error")
+		t.Errorf("GetWalletsConfig threw an unexpected error: %s", err.Error())
 	}
 	if config.BTC.FeeAPI != "https://btc.fees.openbazaar.org" {
 		t.Error("FeeApi does not equal expected value")
@@ -59,11 +59,11 @@ func TestGetWalletsConfig(t *testing.T) {
 	if config.BTC.Type != "API" {
 		t.Error("Type does not equal expected value")
 	}
-	if config.BTC.API != "https://btc.bloqapi.net/insight-api" {
-		t.Error("Binary does not equal expected value")
+	if len(config.BTC.APIPool) == 0 || config.BTC.APIPool[0] != "https://btc.api.openbazaar.org/api" {
+		t.Error("BTC APIPool does not equal expected value")
 	}
-	if config.BTC.APITestnet != "https://test-insight.bitpay.com/api" {
-		t.Error("Binary does not equal expected value")
+	if len(config.BTC.APITestnetPool) == 0 || config.BTC.APITestnetPool[0] != "https://tbtc.api.openbazaar.org/api" {
+		t.Error("BTC APITestnetPool does not equal expected value")
 	}
 	if config.BTC.LowFeeDefault != 1 {
 		t.Error("Expected low to be 1, got ", config.BTC.LowFeeDefault)
@@ -81,11 +81,12 @@ func TestGetWalletsConfig(t *testing.T) {
 	if config.BCH.Type != "API" {
 		t.Error("Type does not equal expected value")
 	}
-	if config.BCH.API != "https://bch-insight.bitpay.com/api" {
-		t.Error("Binary does not equal expected value")
+	if len(config.BCH.APIPool) == 0 || config.BCH.APIPool[0] != "https://bch.api.openbazaar.org/api" {
+		t.Error("BCH APIPool does not equal expected value")
 	}
-	if config.BCH.APITestnet != "https://test-bch-insight.bitpay.com/api" {
-		t.Error("Binary does not equal expected value")
+	if len(config.BCH.APITestnetPool) == 0 || config.BCH.APITestnetPool[0] != "https://tbch.api.openbazaar.org/api" {
+
+		t.Error("BCH APITestnetPool does not equal expected value")
 	}
 	if config.BCH.LowFeeDefault != 1 {
 		t.Error("Expected low to be 1, got ", config.BCH.LowFeeDefault)
@@ -103,11 +104,11 @@ func TestGetWalletsConfig(t *testing.T) {
 	if config.LTC.Type != "API" {
 		t.Error("Type does not equal expected value")
 	}
-	if config.LTC.API != "https://insight.litecore.io/api" {
-		t.Error("Binary does not equal expected value")
+	if len(config.LTC.APIPool) == 0 || config.LTC.APIPool[0] != "https://ltc.api.openbazaar.org/api" {
+		t.Error("LTC APIPool does not equal expected value")
 	}
-	if config.LTC.APITestnet != "https://testnet.litecore.io/api" {
-		t.Error("Binary does not equal expected value")
+	if len(config.LTC.APITestnetPool) == 0 || config.LTC.APITestnetPool[0] != "https://tltc.api.openbazaar.org/api" {
+		t.Error("LTC APITestnetPool does not equal expected value")
 	}
 	if config.LTC.LowFeeDefault != 5 {
 		t.Error("Expected low to be 5, got ", config.LTC.LowFeeDefault)
@@ -125,11 +126,11 @@ func TestGetWalletsConfig(t *testing.T) {
 	if config.ZEC.Type != "API" {
 		t.Error("Type does not equal expected value")
 	}
-	if config.ZEC.API != "https://zcashnetwork.info/api" {
-		t.Error("Binary does not equal expected value")
+	if len(config.ZEC.APIPool) == 0 || config.ZEC.APIPool[0] != "https://zec.api.openbazaar.org/api" {
+		t.Error("ZEC APIPool does not equal expected value")
 	}
-	if config.ZEC.APITestnet != "https://explorer.testnet.z.cash/api" {
-		t.Error("Binary does not equal expected value")
+	if len(config.ZEC.APITestnetPool) == 0 || config.ZEC.APITestnetPool[0] != "https://tzec.api.openbazaar.org/api" {
+		t.Error("ZEC APITestnetPool does not equal expected value")
 	}
 	if config.ZEC.LowFeeDefault != 5 {
 		t.Error("Expected low to be 5, got ", config.ZEC.LowFeeDefault)
@@ -328,7 +329,7 @@ func configFixture() []byte {
   "Tour": {
     "Last": ""
   },
-  "Wallet": {
+  "LegacyWallet": {
     "Binary": "/path/to/bitcoind",
     "FeeAPI": "https://btc.fees.openbazaar.org",
     "HighFeeDefault": 60,
@@ -341,45 +342,89 @@ func configFixture() []byte {
     "Type": "spvwallet"
   },
   "Wallets": {
-    "BCH": {
-      "API": "https://bch-insight.bitpay.com/api",
-      "APITestnet": "https://test-bch-insight.bitpay.com/api",
-      "FeeAPI": "",
-      "HighFeeDefault": 10,
-      "LowFeeDefault": 1,
-      "MaxFee": 200,
-      "MediumFeeDefault": 5,
-      "Type": "API"
-    },
     "BTC": {
-      "API": "https://btc.bloqapi.net/insight-api",
-      "APITestnet": "https://test-insight.bitpay.com/api",
+      "Type": "API",
+      "API": [
+        "https://btc.api.openbazaar.org/api"
+      ],
+      "APITestnet": [
+        "https://tbtc.api.openbazaar.org/api"
+      ],
+      "MaxFee": 200,
       "FeeAPI": "https://btc.fees.openbazaar.org",
       "HighFeeDefault": 50,
-      "LowFeeDefault": 1,
-      "MaxFee": 200,
       "MediumFeeDefault": 10,
-      "Type": "API"
+      "LowFeeDefault": 1,
+      "TrustedPeer": "",
+      "WalletOptions": null
+    },
+    "BCH": {
+      "Type": "API",
+      "API": [
+        "https://bch.api.openbazaar.org/api"
+      ],
+      "APITestnet": [
+        "https://tbch.api.openbazaar.org/api"
+      ],
+      "MaxFee": 200,
+      "FeeAPI": "https://btc.fees.openbazaar.org",
+      "HighFeeDefault": 10,
+      "MediumFeeDefault": 5,
+      "LowFeeDefault": 1,
+      "TrustedPeer": "",
+      "WalletOptions": null
     },
     "LTC": {
-      "API": "https://insight.litecore.io/api",
-      "APITestnet": "https://testnet.litecore.io/api",
-      "FeeAPI": "",
-      "HighFeeDefault": 20,
-      "LowFeeDefault": 5,
+      "Type": "API",
+      "API": [
+        "https://ltc.api.openbazaar.org/api"
+      ],
+      "APITestnet": [
+        "https://tltc.api.openbazaar.org/api"
+      ],
       "MaxFee": 200,
+      "FeeAPI": "https://btc.fees.openbazaar.org",
+      "HighFeeDefault": 20,
       "MediumFeeDefault": 10,
-      "Type": "API"
+      "LowFeeDefault": 5,
+      "TrustedPeer": "",
+      "WalletOptions": null
     },
     "ZEC": {
-      "API": "https://zcashnetwork.info/api",
-      "APITestnet": "https://explorer.testnet.z.cash/api",
-      "FeeAPI": "",
-      "HighFeeDefault": 20,
-      "LowFeeDefault": 5,
+      "Type": "API",
+      "API": [
+        "https://zec.api.openbazaar.org/api"
+      ],
+      "APITestnet": [
+        "https://tzec.api.openbazaar.org/api"
+      ],
       "MaxFee": 200,
+      "FeeAPI": "https://btc.fees.openbazaar.org",
+      "HighFeeDefault": 20,
       "MediumFeeDefault": 10,
-      "Type": "API"
+      "LowFeeDefault": 5,
+      "TrustedPeer": "",
+      "WalletOptions": null
+    },
+    "ETH": {
+      "Type": "API",
+      "API": [
+        "https://rinkeby.infura.io"
+      ],
+      "APITestnet": [
+        "https://rinkeby.infura.io"
+      ],
+      "MaxFee": 200,
+      "FeeAPI": "https://btc.fees.openbazaar.org",
+      "HighFeeDefault": 30,
+      "MediumFeeDefault": 15,
+      "LowFeeDefault": 7,
+      "TrustedPeer": "",
+      "WalletOptions": {
+        "RegistryAddress": "0x403d907982474cdd51687b09a8968346159378f3",
+        "RinkebyRegistryAddress": "0x403d907982474cdd51687b09a8968346159378f3",
+        "RopstenRegistryAddress": "0x403d907982474cdd51687b09a8968346159378f3"
+      }
     }
   }
 }`)

--- a/schema/constants.go
+++ b/schema/constants.go
@@ -81,3 +81,35 @@ func EthereumDefaultOptions() map[string]interface{} {
 		"RopstenRegistryAddress": EthereumRegistryAddressRopsten,
 	}
 }
+
+const (
+	WalletTypeAPI = "API"
+	WalletTypeSPV = "SPV"
+)
+
+const (
+	CoinAPIOpenBazaarBTC = "https://btc.api.openbazaar.org/api"
+	CoinAPIOpenBazaarBCH = "https://bch.api.openbazaar.org/api"
+	CoinAPIOpenBazaarLTC = "https://ltc.api.openbazaar.org/api"
+	CoinAPIOpenBazaarZEC = "https://zec.api.openbazaar.org/api"
+	CoinAPIOpenBazaarETH = "https://rinkeby.infura.io"
+
+	CoinAPIOpenBazaarTBTC = "https://tbtc.api.openbazaar.org/api"
+	CoinAPIOpenBazaarTBCH = "https://tbch.api.openbazaar.org/api"
+	CoinAPIOpenBazaarTLTC = "https://tltc.api.openbazaar.org/api"
+	CoinAPIOpenBazaarTZEC = "https://tzec.api.openbazaar.org/api"
+)
+
+var (
+	CoinPoolBTC = []string{CoinAPIOpenBazaarBTC}
+	CoinPoolBCH = []string{CoinAPIOpenBazaarBCH}
+	CoinPoolLTC = []string{CoinAPIOpenBazaarLTC}
+	CoinPoolZEC = []string{CoinAPIOpenBazaarZEC}
+	CoinPoolETH = []string{CoinAPIOpenBazaarETH}
+
+	CoinPoolTBTC = []string{CoinAPIOpenBazaarTBTC}
+	CoinPoolTBCH = []string{CoinAPIOpenBazaarTBCH}
+	CoinPoolTLTC = []string{CoinAPIOpenBazaarTLTC}
+	CoinPoolTZEC = []string{CoinAPIOpenBazaarTZEC}
+	CoinPoolTETH = []string{CoinAPIOpenBazaarETH}
+)

--- a/schema/path.go
+++ b/schema/path.go
@@ -39,9 +39,9 @@ func OpenbazaarPathTransform(basePath string, testModeEnabled bool) (path string
 }
 func directoryName(isTestnet bool) (directoryName string) {
 	if runtime.GOOS == "linux" {
-		directoryName = ".openbazaar2.0"
+		directoryName = ".openbazaar"
 	} else {
-		directoryName = "OpenBazaar2.0"
+		directoryName = "openbazaar"
 	}
 
 	if isTestnet {

--- a/wallet/builder.go
+++ b/wallet/builder.go
@@ -146,13 +146,6 @@ func prepareCoinConfig(coin wallet.CoinType, override *schema.CoinConfig, wallet
 		testnet          = walletConfig.Params.Name != chaincfg.MainNetParams.Name
 	)
 
-	if testnet {
-		overrideWalletEndpoints = override.APITestnetPool
-		defaultWalletEndpoints = defaultConfig.APITestnetPool
-	} else {
-		overrideWalletEndpoints = override.APIPool
-		defaultWalletEndpoints = defaultConfig.APIPool
-	}
 	switch coin {
 	case wallet.Bitcoin:
 		defaultConfig = defaultConfigSet.BTC
@@ -165,6 +158,14 @@ func prepareCoinConfig(coin wallet.CoinType, override *schema.CoinConfig, wallet
 	case wallet.Ethereum:
 		defaultConfig = defaultConfigSet.ETH
 		defaultCoinOptions = schema.EthereumDefaultOptions()
+	}
+
+	if testnet {
+		overrideWalletEndpoints = override.APITestnetPool
+		defaultWalletEndpoints = defaultConfig.APITestnetPool
+	} else {
+		overrideWalletEndpoints = override.APIPool
+		defaultWalletEndpoints = defaultConfig.APIPool
 	}
 
 	var preparedConfig = &mwConfig.CoinConfig{

--- a/wallet/builder.go
+++ b/wallet/builder.go
@@ -352,7 +352,7 @@ func prepareAPICoinConfig(coin wallet.CoinType, override *schema.CoinConfig, wal
 	if len(preparedConfig.ClientAPIs) == 0 {
 		preparedConfig.ClientAPIs = defaultWalletEndpoints
 	}
-	if preparedConfig.FeeAPI == "" {
+	if preparedConfig.CoinType == wallet.Bitcoin && preparedConfig.FeeAPI == "" {
 		preparedConfig.FeeAPI = "https://btc.fees.openbazaar.org"
 	}
 	if len(preparedConfig.Options) == 0 {

--- a/wallet/builder.go
+++ b/wallet/builder.go
@@ -30,19 +30,30 @@ import (
 
 const InvalidCoinType wallet.CoinType = wallet.CoinType(^uint32(0))
 
+// ErrTrustedPeerRequired is returned when the config is missing the TrustedPeer field
+var ErrTrustedPeerRequired = errors.New("trusted peer required in spv wallet config during regtest use")
+
+// WalletConfig describes the options needed to create a MultiWallet
 type WalletConfig struct {
-	ConfigFile           *schema.WalletsConfig
-	RepoPath             string
-	Logger               logging.Backend
-	DB                   *db.DB
-	Mnemonic             string
-	WalletCreationDate   time.Time
-	Params               *chaincfg.Params
-	Proxy                proxy.Dialer
+	// ConfigFile contains the options of each native wallet
+	ConfigFile *schema.WalletsConfig
+	// RepoPath is the base path which contains the nodes data directory
+	RepoPath string
+	// Logger is an interface to support internal wallet logging
+	Logger logging.Backend
+	// DB is an interface to support internal transaction persistance
+	DB *db.DB
+	// Mnemonic is the string entropy used to generate the wallet's BIP39-compliant seed
+	Mnemonic string
+	// WalletCreationDate represents the time when new transactions were added by this wallet
+	WalletCreationDate time.Time
+	// Params describe the desired blockchain params to enforce on joining the network
+	Params *chaincfg.Params
+	// Proxy is an interface which allows traffic for the wallet to proxied
+	Proxy proxy.Dialer
+	// DisableExchangeRates will disable usage of the internal exchange rate API
 	DisableExchangeRates bool
 }
-
-var ErrTrustedPeerRequired = errors.New("trusted peer required in spv wallet config during regtest use")
 
 // NewMultiWallet returns a functional set of wallets using the provided WalletConfig.
 // The value of schema.WalletsConfig.<COIN>.Type must be "API" or will be ignored. BTC

--- a/wallet/builder.go
+++ b/wallet/builder.go
@@ -24,6 +24,7 @@ import (
 	"github.com/OpenBazaar/spvwallet"
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/chaincfg"
+	bchspv "github.com/cpacia/BitcoinCash-Wallet"
 	"github.com/op/go-logging"
 	"golang.org/x/net/proxy"
 )
@@ -183,36 +184,115 @@ func createSPVWallet(coin wallet.CoinType, coinConfigOverrides *schema.CoinConfi
 		notMainnet         = cfg.Params.Name != chaincfg.MainNetParams.Name
 		usingRegnet        = cfg.Params.Name == chaincfg.RegressionNetParams.Name
 		missingTrustedPeer = coinConfigOverrides.TrustedPeer == ""
+		defaultConfigSet   = schema.DefaultWalletsConfig()
 	)
 
 	if usingRegnet && missingTrustedPeer {
 		return InvalidCoinType, nil, ErrTrustedPeerRequired
 	}
 
-	coinConfig, err := prepareSPVCoinConfig(coin, coinConfigOverrides, cfg)
+	trustedPeer, err := net.ResolveTCPAddr("tcp", coinConfigOverrides.TrustedPeer)
 	if err != nil {
-		return InvalidCoinType, nil, err
+		return InvalidCoinType, nil, fmt.Errorf("resolving tcp address %s: %s", coinConfigOverrides.TrustedPeer, err.Error())
+	}
+	feeAPI, err := url.Parse(coinConfigOverrides.FeeAPI)
+	if err != nil {
+		return InvalidCoinType, nil, fmt.Errorf("parsing fee api: %s", err.Error())
+	}
+	walletRepoPath, err := ensureWalletRepoPath(cfg.RepoPath, coin, "ob1")
+	if err != nil {
+		return InvalidCoinType, nil, fmt.Errorf("creating wallet repository: %s", err.Error())
 	}
 
 	switch coin {
 	case wallet.Bitcoin:
+		defaultConfig := defaultConfigSet.BTC
+		preparedConfig := &spvwallet.Config{
+			Mnemonic:             cfg.Mnemonic,
+			Params:               cfg.Params,
+			MaxFee:               uint64(coinConfigOverrides.MaxFee),
+			LowFee:               uint64(coinConfigOverrides.LowFeeDefault),
+			MediumFee:            uint64(coinConfigOverrides.MediumFeeDefault),
+			HighFee:              uint64(coinConfigOverrides.HighFeeDefault),
+			FeeAPI:               *feeAPI,
+			RepoPath:             walletRepoPath,
+			CreationDate:         cfg.WalletCreationDate,
+			DB:                   CreateWalletDB(cfg.DB, coin),
+			UserAgent:            "OpenBazaar",
+			TrustedPeer:          trustedPeer,
+			Proxy:                cfg.Proxy,
+			Logger:               cfg.Logger,
+			DisableExchangeRates: cfg.DisableExchangeRates,
+		}
+		if preparedConfig.HighFee == 0 {
+			preparedConfig.HighFee = defaultConfig.HighFeeDefault
+		}
+		if preparedConfig.MediumFee == 0 {
+			preparedConfig.MediumFee = defaultConfig.MediumFeeDefault
+		}
+		if preparedConfig.LowFee == 0 {
+			preparedConfig.LowFee = defaultConfig.LowFeeDefault
+		}
+		if preparedConfig.MaxFee == 0 {
+			preparedConfig.MaxFee = defaultConfig.MaxFee
+		}
+
+		newSPVWallet, err := spvwallet.NewSPVWallet(preparedConfig)
+		if err != nil {
+			return InvalidCoinType, nil, err
+		}
+
 		if notMainnet {
 			actualCoin = wallet.TestnetBitcoin
 		} else {
 			actualCoin = wallet.Bitcoin
 		}
+		return actualCoin, newSPVWallet, nil
 	case wallet.BitcoinCash:
+		defaultConfig := defaultConfigSet.BCH
+		preparedConfig := &bchspv.Config{
+			Mnemonic:             cfg.Mnemonic,
+			Params:               cfg.Params,
+			MaxFee:               uint64(coinConfigOverrides.MaxFee),
+			LowFee:               uint64(coinConfigOverrides.LowFeeDefault),
+			MediumFee:            uint64(coinConfigOverrides.MediumFeeDefault),
+			HighFee:              uint64(coinConfigOverrides.HighFeeDefault),
+			FeeAPI:               *feeAPI,
+			RepoPath:             walletRepoPath,
+			CreationDate:         cfg.WalletCreationDate,
+			DB:                   CreateWalletDB(cfg.DB, coin),
+			UserAgent:            "OpenBazaar",
+			TrustedPeer:          trustedPeer,
+			Proxy:                cfg.Proxy,
+			Logger:               cfg.Logger,
+			DisableExchangeRates: cfg.DisableExchangeRates,
+		}
+		if preparedConfig.HighFee == 0 {
+			preparedConfig.HighFee = defaultConfig.HighFeeDefault
+		}
+		if preparedConfig.MediumFee == 0 {
+			preparedConfig.MediumFee = defaultConfig.MediumFeeDefault
+		}
+		if preparedConfig.LowFee == 0 {
+			preparedConfig.LowFee = defaultConfig.LowFeeDefault
+		}
+		if preparedConfig.MaxFee == 0 {
+			preparedConfig.MaxFee = defaultConfig.MaxFee
+		}
+
+		newSPVWallet, err := bchspv.NewSPVWallet(preparedConfig)
+		if err != nil {
+			return InvalidCoinType, nil, err
+		}
+
 		if notMainnet {
 			actualCoin = wallet.TestnetBitcoinCash
 		} else {
 			actualCoin = wallet.BitcoinCash
 		}
+		return actualCoin, newSPVWallet, nil
 	}
-	newSPVWallet, err := spvwallet.NewSPVWallet(coinConfig)
-	if err != nil {
-		return InvalidCoinType, nil, err
-	}
-	return actualCoin, newSPVWallet, nil
+	return InvalidCoinType, nil, fmt.Errorf("unable to create wallet for unknown coin %s", coin)
 }
 
 func ensureWalletRepoPath(repoPath string, coin wallet.CoinType, devGUID string) (string, error) {
@@ -233,63 +313,6 @@ func walletPath(coin wallet.CoinType, devGUID string) string {
 		trimmedCoin = strings.Replace(lowerCoin, " ", "", -1)
 	)
 	return trimmedCoin
-}
-
-func prepareSPVCoinConfig(coin wallet.CoinType, override *schema.CoinConfig, walletConfig *WalletConfig) (*spvwallet.Config, error) {
-	var (
-		defaultConfig    *schema.CoinConfig
-		defaultConfigSet = schema.DefaultWalletsConfig()
-	)
-
-	switch coin {
-	case wallet.Bitcoin:
-		defaultConfig = defaultConfigSet.BTC
-	case wallet.BitcoinCash:
-		defaultConfig = defaultConfigSet.BCH
-	}
-
-	trustedPeer, err := net.ResolveTCPAddr("tcp", override.TrustedPeer)
-	if err != nil {
-		return nil, fmt.Errorf("resolving tcp address %s: %s", override.TrustedPeer, err.Error())
-	}
-	feeAPI, err := url.Parse(override.FeeAPI)
-	if err != nil {
-		return nil, fmt.Errorf("parsing fee api: %s", err.Error())
-	}
-	walletRepoPath, err := ensureWalletRepoPath(walletConfig.RepoPath, coin, "ob1")
-	if err != nil {
-		return nil, fmt.Errorf("creating wallet repository: %s", err.Error())
-	}
-	preparedConfig := &spvwallet.Config{
-		Mnemonic:             walletConfig.Mnemonic,
-		Params:               walletConfig.Params,
-		MaxFee:               uint64(override.MaxFee),
-		LowFee:               uint64(override.LowFeeDefault),
-		MediumFee:            uint64(override.MediumFeeDefault),
-		HighFee:              uint64(override.HighFeeDefault),
-		FeeAPI:               *feeAPI,
-		RepoPath:             walletRepoPath,
-		CreationDate:         walletConfig.WalletCreationDate,
-		DB:                   CreateWalletDB(walletConfig.DB, coin),
-		UserAgent:            "OpenBazaar",
-		TrustedPeer:          trustedPeer,
-		Proxy:                walletConfig.Proxy,
-		Logger:               walletConfig.Logger,
-		DisableExchangeRates: walletConfig.DisableExchangeRates,
-	}
-	if preparedConfig.HighFee == 0 {
-		preparedConfig.HighFee = defaultConfig.HighFeeDefault
-	}
-	if preparedConfig.MediumFee == 0 {
-		preparedConfig.MediumFee = defaultConfig.MediumFeeDefault
-	}
-	if preparedConfig.LowFee == 0 {
-		preparedConfig.LowFee = defaultConfig.LowFeeDefault
-	}
-	if preparedConfig.MaxFee == 0 {
-		preparedConfig.MaxFee = defaultConfig.MaxFee
-	}
-	return preparedConfig, nil
 }
 
 func prepareAPICoinConfig(coin wallet.CoinType, override *schema.CoinConfig, walletConfig *WalletConfig) *mwConfig.CoinConfig {

--- a/wallet/builder.go
+++ b/wallet/builder.go
@@ -175,7 +175,7 @@ func createAPIWallet(coin wallet.CoinType, coinConfigOverrides *schema.CoinConfi
 		}
 		return actualCoin, w, nil
 	}
-	return InvalidCoinType, nil, fmt.Errorf("unable to create wallet for unknown coin %s", coin)
+	return InvalidCoinType, nil, fmt.Errorf("unable to create wallet for unknown coin %s", coin.String())
 }
 
 func createSPVWallet(coin wallet.CoinType, coinConfigOverrides *schema.CoinConfig, cfg *WalletConfig) (wallet.CoinType, wallet.Wallet, error) {
@@ -210,10 +210,10 @@ func createSPVWallet(coin wallet.CoinType, coinConfigOverrides *schema.CoinConfi
 		preparedConfig := &spvwallet.Config{
 			Mnemonic:             cfg.Mnemonic,
 			Params:               cfg.Params,
-			MaxFee:               uint64(coinConfigOverrides.MaxFee),
-			LowFee:               uint64(coinConfigOverrides.LowFeeDefault),
-			MediumFee:            uint64(coinConfigOverrides.MediumFeeDefault),
-			HighFee:              uint64(coinConfigOverrides.HighFeeDefault),
+			MaxFee:               coinConfigOverrides.MaxFee,
+			LowFee:               coinConfigOverrides.LowFeeDefault,
+			MediumFee:            coinConfigOverrides.MediumFeeDefault,
+			HighFee:              coinConfigOverrides.HighFeeDefault,
 			FeeAPI:               *feeAPI,
 			RepoPath:             walletRepoPath,
 			CreationDate:         cfg.WalletCreationDate,
@@ -253,10 +253,10 @@ func createSPVWallet(coin wallet.CoinType, coinConfigOverrides *schema.CoinConfi
 		preparedConfig := &bchspv.Config{
 			Mnemonic:             cfg.Mnemonic,
 			Params:               cfg.Params,
-			MaxFee:               uint64(coinConfigOverrides.MaxFee),
-			LowFee:               uint64(coinConfigOverrides.LowFeeDefault),
-			MediumFee:            uint64(coinConfigOverrides.MediumFeeDefault),
-			HighFee:              uint64(coinConfigOverrides.HighFeeDefault),
+			MaxFee:               coinConfigOverrides.MaxFee,
+			LowFee:               coinConfigOverrides.LowFeeDefault,
+			MediumFee:            coinConfigOverrides.MediumFeeDefault,
+			HighFee:              coinConfigOverrides.HighFeeDefault,
 			FeeAPI:               *feeAPI,
 			RepoPath:             walletRepoPath,
 			CreationDate:         cfg.WalletCreationDate,
@@ -292,7 +292,7 @@ func createSPVWallet(coin wallet.CoinType, coinConfigOverrides *schema.CoinConfi
 		}
 		return actualCoin, newSPVWallet, nil
 	}
-	return InvalidCoinType, nil, fmt.Errorf("unable to create wallet for unknown coin %s", coin)
+	return InvalidCoinType, nil, fmt.Errorf("unable to create wallet for unknown coin %s", coin.String())
 }
 
 func ensureWalletRepoPath(repoPath string, coin wallet.CoinType, devGUID string) (string, error) {


### PR DESCRIPTION
- Reconcile schema.DefaultWalletsConfig()
- Migrate legacy "Wallet" config key to "LegacyWallet" which is ignored
by config handling
- Migrate default "Wallets" config key to contain default multiwallet
settings. Ignores prior fee defaults, but legacy config is intact should
the user decide to restore their prior settings.
- A failure to create a single wallet will no longer impact other
wallets
- Removal of the coin key under the "Wallets" key will disable that
wallet. Alternatively, changing the Type to a value other than "API" and
"SPV" will also disable that coin.