### PR TITLE
Fix bug detecting resolved dispute

### DIFF
--- a/wallet/listeners/transaction_listener.go
+++ b/wallet/listeners/transaction_listener.go
@@ -9,7 +9,6 @@ import (
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/openbazaar-go/repo"
 	"github.com/OpenBazaar/wallet-interface"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	btc "github.com/btcsuite/btcutil"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
@@ -100,14 +99,9 @@ func (l *TransactionListener) OnTransactionReceived(cb wallet.TransactionCallbac
 			continue
 		}
 
-		outpointHash, err := chainhash.NewHash(input.OutpointHash)
-		if err != nil {
-			continue
-		}
-
 		fundsReleased := true
 		for i, r := range records {
-			if r.Txid == outpointHash.String() && r.Index == input.OutpointIndex {
+			if input.LinkedAddress.String() == r.Address {
 				records[i].Spent = true
 			}
 			if records[i].Value > 0 && !records[i].Spent {


### PR DESCRIPTION
closes #1315 

The listener wasn't switched over to make use of the new input.LinkedAddress field. 