### PR TITLE
Update SPV wallets to init exchanges but do not run if disabled

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -94,11 +94,11 @@
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/spvwallet",
-			"Rev": "4da6964dfd36e87b8c963b68f34498c2ff71810b"
+			"Rev": "09e89cb80f4f71f74910ecec97dbabf912327d6f"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/spvwallet/exchangerates",
-			"Rev": "4da6964dfd36e87b8c963b68f34498c2ff71810b"
+			"Rev": "09e89cb80f4f71f74910ecec97dbabf912327d6f"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/wallet-interface",
@@ -268,13 +268,13 @@
 		},
 		{
 			"ImportPath": "github.com/cpacia/BitcoinCash-Wallet",
-			"Comment": "v0.3.0-56-g7bd3a60",
-			"Rev": "7bd3a60205212141115744bd79247c223cd9311e"
+			"Comment": "v0.3.0-58-gba9295d",
+			"Rev": "ba9295daa6d43b4cbd3f88e925379f0cf025b6b9"
 		},
 		{
 			"ImportPath": "github.com/cpacia/BitcoinCash-Wallet/exchangerates",
-			"Comment": "v0.3.0-56-g7bd3a60",
-			"Rev": "7bd3a60205212141115744bd79247c223cd9311e"
+			"Comment": "v0.3.0-58-gba9295d",
+			"Rev": "ba9295daa6d43b4cbd3f88e925379f0cf025b6b9"
 		},
 		{
 			"ImportPath": "github.com/cpacia/bchutil",

--- a/vendor/github.com/OpenBazaar/spvwallet/exchangerates/bitcoinprices.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/exchangerates/bitcoinprices.go
@@ -59,7 +59,6 @@ func NewBitcoinPriceFetcher(dialer proxy.Dialer) *BitcoinPriceFetcher {
 		{"https://blockchain.info/ticker", b.cache, client, BlockchainInfoDecoder{}},
 		{"https://api.bitcoincharts.com/v1/weighted_prices.json", b.cache, client, BitcoinChartsDecoder{}},
 	}
-	go b.run()
 	return &b
 }
 
@@ -141,7 +140,7 @@ func (provider *ExchangeRateProvider) fetch() (err error) {
 	return provider.decoder.decode(dataMap, provider.cache)
 }
 
-func (b *BitcoinPriceFetcher) run() {
+func (b *BitcoinPriceFetcher) Run() {
 	b.fetchCurrentRates()
 	ticker := time.NewTicker(time.Minute * 15)
 	for range ticker.C {

--- a/vendor/github.com/OpenBazaar/spvwallet/peers.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/peers.go
@@ -93,11 +93,11 @@ func NewPeerManager(config *PeerManagerConfig) (*PeerManager, error) {
 	}
 
 	pm := &PeerManager{
-		addrManager: addrmgr.New(config.AddressCacheDir, nil),
-		peerMutex:   new(sync.RWMutex),
-		sourceAddr:  wire.NewNetAddressIPPort(net.ParseIP("0.0.0.0"), defaultPort, 0),
-		trustedPeer: config.TrustedPeer,
-		proxy:       config.Proxy,
+		addrManager:            addrmgr.New(config.AddressCacheDir, nil),
+		peerMutex:              new(sync.RWMutex),
+		sourceAddr:             wire.NewNetAddressIPPort(net.ParseIP("0.0.0.0"), defaultPort, 0),
+		trustedPeer:            config.TrustedPeer,
+		proxy:                  config.Proxy,
 		recentlyTriedAddresses: make(map[string]bool),
 		connectedPeers:         make(map[uint64]*peer.Peer),
 		msgChan:                config.MsgChan,

--- a/vendor/github.com/OpenBazaar/spvwallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/wallet.go
@@ -100,8 +100,10 @@ func NewSPVWallet(config *Config) (*SPVWallet, error) {
 		mutex:         new(sync.RWMutex),
 	}
 
+	bpf := exchangerates.NewBitcoinPriceFetcher(config.Proxy)
+	w.exchangeRates = bpf
 	if !config.DisableExchangeRates {
-		w.exchangeRates = exchangerates.NewBitcoinPriceFetcher(config.Proxy)
+		go bpf.Run()
 	}
 
 	w.keyManager, err = NewKeyManager(config.DB.Keys(), w.params, w.masterPrivateKey)

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/exchangerates/exchangerates.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/exchangerates/exchangerates.go
@@ -52,7 +52,6 @@ func NewBitcoinCashPriceFetcher(dialer proxy.Dialer) *BitcoinCashPriceFetcher {
 		{"https://poloniex.com/public?command=returnTicker", b.cache, client, PoloniexDecoder{}},
 		{"https://api.kraken.com/0/public/Ticker?pair=BCHUSD", b.cache, client, KrakenDecoder{}},
 	}
-	go b.run()
 	return &b
 }
 
@@ -106,7 +105,7 @@ func (b *BitcoinCashPriceFetcher) fetchCurrentRates() error {
 	return errors.New("All exchange rate API queries failed")
 }
 
-func (b *BitcoinCashPriceFetcher) run() {
+func (b *BitcoinCashPriceFetcher) Run() {
 	b.fetchCurrentRates()
 	ticker := time.NewTicker(time.Minute * 15)
 	for range ticker.C {

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/peers.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/peers.go
@@ -94,11 +94,11 @@ func NewPeerManager(config *PeerManagerConfig) (*PeerManager, error) {
 	}
 
 	pm := &PeerManager{
-		addrManager: addrmgr.New(config.AddressCacheDir, nil),
-		peerMutex:   new(sync.RWMutex),
-		sourceAddr:  wire.NewNetAddressIPPort(net.ParseIP("0.0.0.0"), defaultPort, 0),
-		trustedPeer: config.TrustedPeer,
-		proxy:       config.Proxy,
+		addrManager:            addrmgr.New(config.AddressCacheDir, nil),
+		peerMutex:              new(sync.RWMutex),
+		sourceAddr:             wire.NewNetAddressIPPort(net.ParseIP("0.0.0.0"), defaultPort, 0),
+		trustedPeer:            config.TrustedPeer,
+		proxy:                  config.Proxy,
 		recentlyTriedAddresses: make(map[string]bool),
 		connectedPeers:         make(map[uint64]*peer.Peer),
 		msgChan:                config.MsgChan,

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/wallet.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/wallet.go
@@ -113,9 +113,10 @@ func NewSPVWallet(config *Config) (*SPVWallet, error) {
 		mutex:         new(sync.RWMutex),
 	}
 
+	er := exchangerates.NewBitcoinCashPriceFetcher(config.Proxy)
+	w.exchangeRates = er
 	if !config.DisableExchangeRates {
-		er := exchangerates.NewBitcoinCashPriceFetcher(config.Proxy)
-		w.exchangeRates = er
+		go er.Run()
 		w.feeProvider.exchangeRates = er
 	}
 


### PR DESCRIPTION
We at least need to initialize the exchange rate objects even if the disableexchangerates
option is used so that ob-go can access the UnitsPerCoin method.