### PR TITLE
Update message sender to respect context timeout when sending messages

### DIFF
--- a/core/net.go
+++ b/core/net.go
@@ -64,6 +64,7 @@ func (n *OpenBazaarNode) SendOfflineMessage(p peer.ID, k *libp2p.PubKey, m *pb.M
 	if merr != nil {
 		return merr
 	}
+	// TODO: this function blocks if the recipient's public key is not on the local machine
 	ciphertext, cerr := n.EncryptMessage(p, k, messageBytes)
 	if cerr != nil {
 		return cerr

--- a/core/net.go
+++ b/core/net.go
@@ -38,9 +38,11 @@ func (n *OpenBazaarNode) sendMessage(peerID string, k *libp2p.PubKey, message pb
 	defer cancel()
 	err = n.Service.SendMessage(ctx, p, &message)
 	if err != nil {
-		if err := n.SendOfflineMessage(p, k, &message); err != nil {
-			return err
-		}
+		go func() {
+			if err := n.SendOfflineMessage(p, k, &message); err != nil {
+				log.Errorf("Error sending offline message %s", err.Error())
+			}
+		}()
 	}
 	return nil
 }

--- a/net/service/messagesender.go
+++ b/net/service/messagesender.go
@@ -90,7 +90,6 @@ func (ms *messageSender) ctxPrepOrInvalidate(ctx context.Context) error {
 		ms.invalidate()
 		return ErrWriteTimeout
 	}
-	return nil
 }
 
 func (ms *messageSender) prep() error {

--- a/net/service/messagesender.go
+++ b/net/service/messagesender.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	inet "gx/ipfs/QmXfkENeeBvh3zYA51MaSdGUdBjhQ99cP5WQe8zgr6wchG/go-libp2p-net"
 	ggio "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/io"
-	peer "gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
+	"gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
 	"math/rand"
 	"sync"
 	"time"
@@ -28,8 +28,9 @@ type messageSender struct {
 
 var ReadMessageTimeout = time.Minute * 5
 var ErrReadTimeout = fmt.Errorf("timed out reading response")
+var ErrWriteTimeout = fmt.Errorf("timed out writing message")
 
-func (service *OpenBazaarService) messageSenderForPeer(p peer.ID) (*messageSender, error) {
+func (service *OpenBazaarService) messageSenderForPeer(ctx context.Context, p peer.ID) (*messageSender, error) {
 	service.senderlk.Lock()
 	ms, ok := service.sender[p]
 	if ok {
@@ -40,7 +41,7 @@ func (service *OpenBazaarService) messageSenderForPeer(p peer.ID) (*messageSende
 	service.sender[p] = ms
 	service.senderlk.Unlock()
 
-	if err := ms.prepOrInvalidate(); err != nil {
+	if err := ms.ctxPrepOrInvalidate(ctx); err != nil {
 		service.senderlk.Lock()
 		defer service.senderlk.Unlock()
 
@@ -72,12 +73,22 @@ func (ms *messageSender) invalidate() {
 	}
 }
 
-func (ms *messageSender) prepOrInvalidate() error {
+func (ms *messageSender) ctxPrepOrInvalidate(ctx context.Context) error {
 	ms.lk.Lock()
 	defer ms.lk.Unlock()
-	if err := ms.prep(); err != nil {
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- ms.prep()
+	}()
+
+	select {
+	case err := <-errCh:
 		ms.invalidate()
 		return err
+	case <-ctx.Done():
+		ms.invalidate()
+		return ErrWriteTimeout
 	}
 	return nil
 }
@@ -116,7 +127,15 @@ func (ms *messageSender) SendMessage(ctx context.Context, pmes *pb.Message) erro
 			return err
 		}
 
-		if err := ms.w.WriteMsg(pmes); err != nil {
+		err := ms.ctxWriteMsg(ctx, pmes)
+		switch err {
+		case ErrWriteTimeout:
+			ms.s.Reset()
+			ms.s = nil
+			return err
+		case nil:
+			break
+		default:
 			ms.s.Reset()
 			ms.s = nil
 
@@ -156,7 +175,15 @@ func (ms *messageSender) SendRequest(ctx context.Context, pmes *pb.Message) (*pb
 			return nil, err
 		}
 
-		if err := ms.w.WriteMsg(pmes); err != nil {
+		err := ms.ctxWriteMsg(ctx, pmes)
+		switch err {
+		case ErrWriteTimeout:
+			ms.s.Reset()
+			ms.s = nil
+			return nil, err
+		case nil:
+			break
+		default:
 			ms.s.Reset()
 			ms.s = nil
 
@@ -208,5 +235,19 @@ func (ms *messageSender) ctxReadMsg(ctx context.Context, returnChan chan *pb.Mes
 		return nil, ctx.Err()
 	case <-t.C:
 		return nil, ErrReadTimeout
+	}
+}
+
+func (ms *messageSender) ctxWriteMsg(ctx context.Context, pmes *pb.Message) error {
+	errCh := make(chan error)
+	go func() {
+		errCh <- ms.w.WriteMsg(pmes)
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ErrWriteTimeout
 	}
 }

--- a/net/service/service.go
+++ b/net/service/service.go
@@ -82,7 +82,7 @@ func (service *OpenBazaarService) handleNewMessage(s inet.Stream) {
 		return
 	}
 
-	ms, err := service.messageSenderForPeer(mPeer)
+	ms, err := service.messageSenderForPeer(service.ctx, mPeer)
 	if err != nil {
 		log.Error("Error getting message sender")
 		return
@@ -161,7 +161,7 @@ func (service *OpenBazaarService) handleNewMessage(s inet.Stream) {
 
 func (service *OpenBazaarService) SendRequest(ctx context.Context, p peer.ID, pmes *pb.Message) (*pb.Message, error) {
 	log.Debugf("Sending %s request to %s", pmes.MessageType.String(), p.Pretty())
-	ms, err := service.messageSenderForPeer(p)
+	ms, err := service.messageSenderForPeer(ctx, p)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (service *OpenBazaarService) SendMessage(ctx context.Context, p peer.ID, pm
 	if pmes.MessageType != pb.Message_BLOCK {
 		log.Debugf("Sending %s message to %s", pmes.MessageType.String(), p.Pretty())
 	}
-	ms, err := service.messageSenderForPeer(p)
+	ms, err := service.messageSenderForPeer(ctx, p)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes the message sending so that it respects the timeout provided with the context.