### PR TITLE
Fix migration counting; Add datadir path hint to Migration014

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -203,9 +203,9 @@ func (x *Start) Execute(args []string) error {
 	}
 
 	ct := wi.Bitcoin
-	if x.BitcoinCash {
+	if x.BitcoinCash || strings.Contains(repoPath, "-bitcoincash") {
 		ct = wi.BitcoinCash
-	} else if x.ZCash != "" {
+	} else if x.ZCash != "" || strings.Contains(repoPath, "-zcash") {
 		ct = wi.Zcash
 	}
 

--- a/repo/migration.go
+++ b/repo/migration.go
@@ -55,12 +55,12 @@ func MigrateUp(repoPath, dbPassword string, testnet bool) error {
 		return err
 	}
 	if v > len(Migrations) {
-		log.Errorf("binary can migrate schemas up to version %03d but this schema is already at %03d", len(Migrations)-1, v)
+		log.Errorf("binary can migrate schemas up to version %03d but this schema is already at %03d", len(Migrations), v)
 		return ErrUnknownSchema
 	}
 	x := v
-	for i, m := range Migrations[v:] {
-		log.Noticef("running migration %03d changing schema to version %03d...\n", i, x+1)
+	for _, m := range Migrations[v:] {
+		log.Noticef("running migration %03d changing schema to version %03d...\n", x, x+1)
 		err := m.Up(repoPath, dbPassword, testnet)
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
Migration counting up always started at 0 instead of on the current migration. Also indicate which schema version is being reached at the end of the migration.

Example:
```
________                      __________
\_____  \ ______   ____   ____\______   \_____  _____________  _____ _______
 /   |   \\____ \_/ __ \ /    \|    |  _/\__  \ \___   /\__  \ \__  \\_  __ \
/    |    \  |_> >  ___/|   |  \    |   \ / __ \_/    /  / __ \_/ __ \|  | \/
\_______  /   __/ \___  >___|  /______  /(____  /_____ \(____  (____  /__|
        \/|__|        \/     \/       \/      \/      \/     \/     \/

OpenBazaar Server v0.13.0
06:23:15.119 [DEBUG] [core/CheckAndSetUlimit] Did not change ulimit
06:23:15.166 [NOTICE] [repo/MigrateUp] running migration 007 changing schema to version 008...
06:23:15.320 [NOTICE] [repo/MigrateUp] running migration 008 changing schema to version 009...
06:23:15.491 [NOTICE] [repo/MigrateUp] running migration 009 changing schema to version 010...
06:23:15.605 [NOTICE] [repo/MigrateUp] running migration 010 changing schema to version 011...
06:23:15.697 [NOTICE] [repo/MigrateUp] running migration 011 changing schema to version 012...
06:23:15.704 [NOTICE] [repo/MigrateUp] running migration 012 changing schema to version 013...
06:23:15.712 [NOTICE] [repo/MigrateUp] running migration 013 changing schema to version 014...
06:23:15.788 [NOTICE] [repo/MigrateUp] running migration 014 changing schema to version 015...
06:23:16.048 [NOTICE] [repo/MigrateUp] running migration 015 changing schema to version 016...
06:23:16.115 [NOTICE] [repo/MigrateUp] running migration 016 changing schema to version 017...
```