### PR TITLE
Revert data directory name to preserve identity and all other data after upgrade to v13

### DIFF
--- a/schema/path.go
+++ b/schema/path.go
@@ -39,9 +39,9 @@ func OpenbazaarPathTransform(basePath string, testModeEnabled bool) (path string
 }
 func directoryName(isTestnet bool) (directoryName string) {
 	if runtime.GOOS == "linux" {
-		directoryName = ".openbazaar"
+		directoryName = ".openbazaar2.0"
 	} else {
-		directoryName = "openbazaar"
+		directoryName = "openbazaar2.0"
 	}
 
 	if isTestnet {


### PR DESCRIPTION
After upgrading to server v13 I found I could not connect from my client any more, and even authenticated `curl` requests were failing, from both remote and local. After checking the server again I realized OB was not using any of my existing data! My onion key, API credentials, all were replaced with fresh new arguments in a brand new folder `~/.openbazaar`

This change was made here https://github.com/OpenBazaar/openbazaar-go/commit/0c9e934bac634a546efe3e7d0ef4f8d0e58cd328

Title of that PR is **"Change default data directory path for new node instances"** which makes sense, but in my case the migration to v13 never took place because the old data was not parsed.

I'm not sure how the v13 upgrade works for the bundled application, or what the motivation was to rename that data directory so I understand if this PR doesn't get merged, but just in case anyone else is running with separate server / client setups, they may run in to this problem after upgrade to v13 as well.

ping @placer14 thanks!
