### PR TITLE
[WIP] Bulk update coupons [Relies on PR #1423]

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Help Options:
 
 Documentation of the OpenBazaar protocol has not been formalized yet. If you would like to help, please reach out on [Slack](https://openbazaar.slack.com/) or via a new issue on GitHub.
 
-`openbazaar-go` exposes an HTTP API which permits high-level interactions on the network and the internal wallet. Find the HTTP API documentation at [https://api.openbazaar.org](https://api.openbazaar.org).
+`openbazaar-go` exposes an HTTP API which permits high-level interactions on the network and the internal wallet. Find the HTTP API documentation at [https://api.docs.openbazaar.org](https://api.docs.openbazaar.org).
 
 ## Contributing
 

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -109,6 +109,8 @@ func post(i *jsonAPIHandler, path string, w http.ResponseWriter, r *http.Request
 		i.POSTPost(w, r)
 	case strings.HasPrefix(path, "/ob/bulkupdatecurrency"):
 		i.POSTBulkUpdateCurrency(w, r)
+	case strings.HasPrefix(path, "/ob/bulkupdatecoupons"):
+		i.POSTBulkUpdateCoupons(w, r)
 	default:
 		ErrorResponse(w, http.StatusNotFound, "Not Found")
 	}

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -107,6 +107,8 @@ func post(i *jsonAPIHandler, path string, w http.ResponseWriter, r *http.Request
 		i.POSTTestEmailNotifications(w, r)
 	case strings.HasPrefix(path, "/ob/post"):
 		i.POSTPost(w, r)
+	case strings.HasPrefix(path, "/ob/bulkupdatecurrency"):
+		i.POSTBulkUpdateCurrency(w, r)
 	default:
 		ErrorResponse(w, http.StatusNotFound, "Not Found")
 	}

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -3805,8 +3805,13 @@ func (i *jsonAPIHandler) POSTBulkUpdateCurrency(w http.ResponseWriter, r *http.R
 		http.Error(w, err.Error(), 400)
 		return
 	}
+
 	log.Info("Updating currencies for all listings to: ", bulkUpdate.Currencies)
-	i.node.SetCurrencyOnListings(bulkUpdate.Currencies)
+	err = i.node.SetCurrencyOnListings(bulkUpdate.Currencies)
+	if err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
 
 	SanitizedResponse(w, `{"success": "true"}`)
 }

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -3793,6 +3793,24 @@ func (i *jsonAPIHandler) GETPeerInfo(w http.ResponseWriter, r *http.Request) {
 	SanitizedResponse(w, string(out))
 }
 
+func (i *jsonAPIHandler) POSTBulkUpdateCurrency(w http.ResponseWriter, r *http.Request) {
+	// Retrieve attribute and values to update
+	type BulkUpdateRequest struct {
+		Currencies []string `json:"currencies"`
+	}
+
+	var bulkUpdate BulkUpdateRequest
+	err := json.NewDecoder(r.Body).Decode(&bulkUpdate)
+	if err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	log.Info("Updating currencies for all listings to: ", bulkUpdate.Currencies)
+	i.node.SetCurrencyOnListings(bulkUpdate.Currencies)
+
+	SanitizedResponse(w, `{"success": "true"}`)
+}
+
 // POSTS
 
 // Post a post

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -3886,7 +3886,7 @@ func (i *jsonAPIHandler) POSTBulkUpdateCoupons(w http.ResponseWriter, r *http.Re
 			}
 
 			couponDiscount := &pb.Listing_Coupon_PercentDiscount{
-				PercentDiscount: float32(coupon.PercentDiscount),
+				PercentDiscount: coupon.PercentDiscount,
 			}
 			newCoupon = &pb.Listing_Coupon{
 				Title:    coupon.Title,

--- a/core/moderation.go
+++ b/core/moderation.go
@@ -213,6 +213,41 @@ func (n *OpenBazaarNode) SetCurrencyOnListings(currencies []string) error {
 	return nil
 }
 
+// SetCouponOnListings - set coupons for listings
+func (n *OpenBazaarNode) SetCouponsOnListings(coupons []*pb.Listing_Coupon) error {
+	absPath, err := filepath.Abs(path.Join(n.RepoPath, "root", "listings"))
+	if err != nil {
+		return err
+	}
+
+	walkpath := func(p string, f os.FileInfo, err error) error {
+		if !f.IsDir() && filepath.Ext(p) == ".json" {
+			file, err := ioutil.ReadFile(p)
+			if err != nil {
+				return err
+			}
+			sl := new(pb.SignedListing)
+			err = jsonpb.UnmarshalString(string(file), sl)
+			if err != nil {
+				return err
+			}
+
+			sl.Listing.Coupons = coupons
+			n.UpdateListing(sl.Listing)
+
+			return nil
+		}
+		return nil
+	}
+
+	err = filepath.Walk(absPath, walkpath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // SetModeratorsOnListings - set moderators for a listing
 func (n *OpenBazaarNode) SetModeratorsOnListings(moderators []string) error {
 	absPath, err := filepath.Abs(path.Join(n.RepoPath, "root", "listings"))

--- a/core/moderation.go
+++ b/core/moderation.go
@@ -186,7 +186,7 @@ func (n *OpenBazaarNode) SetCurrencyOnListings(currencies []string) error {
 	}
 	hashes := make(map[string]string)
 	walkpath := func(p string, f os.FileInfo, err error) error {
-		if !f.IsDir() {
+		if !f.IsDir() && filepath.Ext(p) == ".json" {
 			file, err := ioutil.ReadFile(p)
 			if err != nil {
 				return err

--- a/core/moderation.go
+++ b/core/moderation.go
@@ -184,7 +184,7 @@ func (n *OpenBazaarNode) SetCurrencyOnListings(currencies []string) error {
 	if err != nil {
 		return err
 	}
-	hashes := make(map[string]string)
+
 	walkpath := func(p string, f os.FileInfo, err error) error {
 		if !f.IsDir() && filepath.Ext(p) == ".json" {
 			file, err := ioutil.ReadFile(p)
@@ -210,15 +210,7 @@ func (n *OpenBazaarNode) SetCurrencyOnListings(currencies []string) error {
 		return err
 	}
 
-	// Update accepted currencies and hashes on index
-	updater := func(listing *ListingData) error {
-		listing.AcceptedCurrencies = currencies
-		if hash, ok := hashes[listing.Slug]; ok {
-			listing.Hash = hash
-		}
-		return nil
-	}
-	return n.UpdateEachListingOnIndex(updater)
+	return nil
 }
 
 // SetModeratorsOnListings - set moderators for a listing

--- a/core/moderation.go
+++ b/core/moderation.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	ma "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
-	multihash "gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"
+	"gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"
 	"io/ioutil"
 	"os"
 	"path"
@@ -198,32 +198,7 @@ func (n *OpenBazaarNode) SetCurrencyOnListings(currencies []string) error {
 			}
 
 			sl.Listing.Metadata.AcceptedCurrencies = currencies
-			sl, err = n.SignListing(sl.Listing)
-			if err != nil {
-				return err
-			}
-			m := jsonpb.Marshaler{
-				EnumsAsInts:  false,
-				EmitDefaults: false,
-				Indent:       "    ",
-				OrigName:     false,
-			}
-			fi, err := os.Create(p)
-			if err != nil {
-				return err
-			}
-			out, err := m.MarshalToString(sl)
-			if err != nil {
-				return err
-			}
-			if _, err := fi.WriteString(out); err != nil {
-				return err
-			}
-			hash, err := ipfs.GetHashOfFile(n.IpfsNode, p)
-			if err != nil {
-				return err
-			}
-			hashes[sl.Listing.Slug] = hash
+			n.UpdateListing(sl.Listing)
 
 			return nil
 		}


### PR DESCRIPTION
This relies on PR #1423 getting merged first.

Here is the Bulk Update Coupons.

It accepts an array of coupon codes and replaces all coupon codes on all listings.

*POST* http://127.0.0.1:4002/ob/bulkupdatecoupons

Example Payload:
```
{"coupons": 
  [ 
    { "title": "test", "code": "test2",  "percentDiscount": 99 },
    { "title": "test", "code": "test23",  "percentDiscount": 32 } 
  ] 
}
```