### PR TITLE
Override travis default install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ env:
 before_install:
   - go get -u github.com/axw/gocov/gocov github.com/mattn/goveralls github.com/tcnksm/ghr
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.10
-
+install:
+  - echo "No external dependencies required. Skipping travis default library dependency setup to use vendors..."
 script:
   - $GOPATH/bin/golangci-lint run
   - cd $TRAVIS_BUILD_DIR && go test -i && ./test_compile.sh
-  - goveralls -coverprofile=coverage.out -service travis-ci
+  - goveralls -coverprofile=coverage.out -service travis-ci -repotoken $COVERALLS_TOKEN
 after_success:
   - ./deploy.sh


### PR DESCRIPTION
Travis changed it's default `install` behavior to automatically attempt restoring the dependencies defined by `Godep.json`. Since we vendor our dependencies to not require this step, we are replacing the default behavior with a no-op.