### PR TITLE
Improve NoRepoError message in setapicreds

### DIFF
--- a/cmd/setapicreds.go
+++ b/cmd/setapicreds.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -32,6 +33,12 @@ func (x *SetAPICreds) Execute(args []string) error {
 		repoPath = x.DataDir
 	}
 	r, err := fsrepo.Open(repoPath)
+	if _, ok := err.(fsrepo.NoRepoError); ok {
+		return errors.New(fmt.Sprintf(
+					"IPFS repo in the data directory '%s' has not been initialized." +
+					"\nRun openbazaar with the 'start' command to initialize.",
+					repoPath));
+	}
 	if err != nil {
 		log.Error(err)
 		return err


### PR DESCRIPTION
Override ipfs error in `setapicreds`. 

The original error message misled me into spending time figuring out how to set up ipfs, until I realized openbazaar has built in its own verison of it.

This changes the error from:

```
$ go run openbazaard.go setapicreds
2019/02/28 14:01:45 no IPFS repo found in /home/dagurval/.openbazaar.
please run: 'ipfs init'
no IPFS repo found in /home/dagurval/.openbazaar.
please run: 'ipfs init'
exit status 1
```

to:

```
$ go run openbazaard.go setapicreds
The data directory '/home/dagurval/.openbazaar' has not been initialized.
Run openbazaar with the 'start' command to initialize.
exit status 1
```
