### PR TITLE
Fix json api keyname in setapicreds

### DIFF
--- a/cmd/setapicreds.go
+++ b/cmd/setapicreds.go
@@ -106,7 +106,7 @@ func (x *SetAPICreds) Execute(args []string) error {
 		apiCfg.AllowedIPs = []string{}
 	}
 
-	configJson["JSON_API"] = apiCfg
+	configJson["JSON-API"] = apiCfg
 
 	out, err := json.MarshalIndent(configJson, "", "    ")
 	if err != nil {


### PR DESCRIPTION
Currently `setapicreds` is broken as it just adds a section `JSON_API` to the configuration file that isn't read by the server. 

The server is supposed to read it back here:
https://github.com/OpenBazaar/openbazaar-go/blob/master/schema/configuration.go#L133