### PR TITLE
Enforce golang version during build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,5 +6,5 @@ export CGO_ENABLED=1
 docker pull karalabe/xgo-latest
 go get github.com/karalabe/xgo
 mkdir dist && cd dist/
-xgo --targets=$TARGETS ../
+xgo -go=1.10 --targets=$TARGETS ../
 chmod +x *


### PR DESCRIPTION
Enforce a specific golang environment when building the server binaries as allowing the latest version was causing the build to fail when attempting to set the ulimit values. `error setting ulimit: invalid argument`