### PR TITLE
Update go-onion-transport to fix bug with dualstack mode

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -24,11 +24,9 @@ import (
 	dhtopts "gx/ipfs/QmPpYHPRGVpSJTkQDQDwTYZ1cYUR2NM4HS6M3iAXi8aoUa/go-libp2p-kad-dht/opts"
 	ma "gx/ipfs/QmT4U94DnD8FRfqr21obWY32HLM5VExccPKMjQHofeYqr9/go-multiaddr"
 	peer "gx/ipfs/QmTRhk7cgjUf2gfQ3p2M9KPECNZEW9XUrmHcFCgog4cPgB/go-libp2p-peer"
-	tcp "gx/ipfs/QmTkKN1x5Jvhc5Np55gJzD3PQ6GL74aKm9145t9WbvJyrB/go-tcp-transport"
 	libp2p "gx/ipfs/QmUDTcnDp2WssbmiDLC6aYurUeyt7QeRakHUQMxA2mZ5iB/go-libp2p"
 	oniontp "gx/ipfs/QmVSfWChGxC5AkUhM6ZyZxbcBmZoPrUmrPuW6BnHU3YDA9/go-onion-transport"
 	routinghelpers "gx/ipfs/QmX3syBjwRd12qJGaKbFBWFfrBinKsaTC43ry3PsgiXCLK/go-libp2p-routing-helpers"
-	ws "gx/ipfs/QmY957dCFYVPKpj21xRs6KA3XAGA9tBt73UE5kfUGdNgD9/go-ws-transport"
 	ipfslogging "gx/ipfs/QmZChCsSt8DctjceaL56Eibc29CVQq4dGKRXC5JRZ6Ppae/go-log/writer"
 	record "gx/ipfs/Qma9Eqp16mNHDX1EL73pcxhFfzbyXVcAYtaDd1xdmDRDtL/go-libp2p-record"
 	ipnspb "gx/ipfs/QmaRFtZhVAwXBk4Z3zEsvjScH9fjsDZmhXfa1Gm8eMb9cg/go-ipns/pb"
@@ -379,11 +377,7 @@ func (x *Start) Execute(args []string) error {
 		if usingClearnet {
 			transportOptions = libp2p.ChainOptions(
 				transportOptions,
-				libp2p.Transport(ws.New),
-			)
-			transportOptions = libp2p.ChainOptions(
-				transportOptions,
-				libp2p.Transport(tcp.NewTCPTransport),
+				libp2p.DefaultTransports,
 			)
 		}
 		libp2p.DefaultTransports = transportOptions

--- a/vendor/gx/ipfs/QmVSfWChGxC5AkUhM6ZyZxbcBmZoPrUmrPuW6BnHU3YDA9/go-onion-transport/onion_transport.go
+++ b/vendor/gx/ipfs/QmVSfWChGxC5AkUhM6ZyZxbcBmZoPrUmrPuW6BnHU3YDA9/go-onion-transport/onion_transport.go
@@ -264,7 +264,11 @@ func (t *OnionTransport) CanDial(a ma.Multiaddr) bool {
 
 // Protocols returns the list of terminal protocols this transport can dial.
 func (t *OnionTransport) Protocols() []int {
-	return []int{ma.P_ONION, ma.P_TCP}
+	if !t.onlyOnion {
+		return []int{ma.P_ONION, ma.P_TCP}
+	} else {
+		return []int{ma.P_ONION}
+	}
 }
 
 // Proxy always returns false for the onion transport.


### PR DESCRIPTION
There was a conflict registering the TCP protocol in both the onion and tcp
transports when using dualstack mode. This fix makes it so when in dual stack
mode the onion transaction does not register that it can route tcp, only onion.