### PR TITLE
#1527 Added Method check for HEAD to validat undefined endpoint

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -176,6 +176,8 @@ func (i *jsonAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		deleter(i, u.String(), w, r)
 	case "PATCH":
 		patch(i, u.String(), w, r)
+	case "HEAD":
+		get(i, u.String(), w, r)
 	}
 }
 


### PR DESCRIPTION
When making the request curl localhost:4002/ob/blah -I the method being passed was HEAD. Added this to the switch case and passed as a get request.

Fixes #1527 