### PR TITLE
Create Migration021

### DIFF
--- a/repo/init.go
+++ b/repo/init.go
@@ -17,7 +17,7 @@ import (
 	"github.com/tyler-smith/go-bip39"
 )
 
-const RepoVersion = "21"
+const RepoVersion = "22"
 
 var log = logging.MustGetLogger("repo")
 var ErrRepoExists = errors.New("IPFS configuration file exists. Reinitializing would overwrite your keys. Use -f to force overwrite.")

--- a/repo/migration.go
+++ b/repo/migration.go
@@ -41,6 +41,7 @@ var (
 		migrations.Migration018{},
 		migrations.Migration019{},
 		migrations.Migration020{},
+		migrations.Migration021{},
 	}
 )
 

--- a/repo/migrations/Migration021.go
+++ b/repo/migrations/Migration021.go
@@ -1,0 +1,95 @@
+package migrations
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+// Migration021 migrates the config file to set the Swarm: EnableAutoRelay option
+// to true.
+type Migration021 struct{}
+
+func (Migration021) Up(repoPath, dbPassword string, testnet bool) error {
+	var (
+		configMap        = map[string]interface{}{}
+		configBytes, err = ioutil.ReadFile(path.Join(repoPath, "config"))
+	)
+	if err != nil {
+		return fmt.Errorf("reading config: %s", err.Error())
+	}
+
+	if err = json.Unmarshal(configBytes, &configMap); err != nil {
+		return fmt.Errorf("unmarshal config: %s", err.Error())
+	}
+
+	iSwarm, ok := configMap["Swarm"]
+	if !ok {
+		return fmt.Errorf("unmarshal config: missing swarm key")
+	}
+
+	swarm, ok := iSwarm.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unmarshal config: error type asserting swarm")
+	}
+
+	swarm["EnableAutoRelay"] = true
+	configMap["Swarm"] = swarm
+
+	newConfigBytes, err := json.MarshalIndent(configMap, "", "    ")
+	if err != nil {
+		return fmt.Errorf("marshal migrated config: %s", err.Error())
+	}
+
+	if err := ioutil.WriteFile(path.Join(repoPath, "config"), newConfigBytes, os.ModePerm); err != nil {
+		return fmt.Errorf("writing migrated config: %s", err.Error())
+	}
+
+	if err := writeRepoVer(repoPath, 22); err != nil {
+		return fmt.Errorf("bumping repover to 18: %s", err.Error())
+	}
+	return nil
+}
+
+func (Migration021) Down(repoPath, dbPassword string, testnet bool) error {
+	var (
+		configMap        = map[string]interface{}{}
+		configBytes, err = ioutil.ReadFile(path.Join(repoPath, "config"))
+	)
+	if err != nil {
+		return fmt.Errorf("reading config: %s", err.Error())
+	}
+
+	if err = json.Unmarshal(configBytes, &configMap); err != nil {
+		return fmt.Errorf("unmarshal config: %s", err.Error())
+	}
+
+	iSwarm, ok := configMap["Swarm"]
+	if !ok {
+		return fmt.Errorf("unmarshal config: missing swarm key")
+	}
+
+	swarm, ok := iSwarm.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unmarshal config: error type asserting swarm")
+	}
+
+	delete(swarm, "EnableAutoRelay")
+	configMap["Swarm"] = swarm
+
+	newConfigBytes, err := json.MarshalIndent(configMap, "", "    ")
+	if err != nil {
+		return fmt.Errorf("marshal migrated config: %s", err.Error())
+	}
+
+	if err := ioutil.WriteFile(path.Join(repoPath, "config"), newConfigBytes, os.ModePerm); err != nil {
+		return fmt.Errorf("writing migrated config: %s", err.Error())
+	}
+
+	if err := writeRepoVer(repoPath, 21); err != nil {
+		return fmt.Errorf("dropping repover to 16: %s", err.Error())
+	}
+	return nil
+}

--- a/repo/migrations/Migration021.go
+++ b/repo/migrations/Migration021.go
@@ -36,6 +36,7 @@ func (Migration021) Up(repoPath, dbPassword string, testnet bool) error {
 	}
 
 	swarm["EnableAutoRelay"] = true
+	swarm["EnableAutoNATService"] = false
 	configMap["Swarm"] = swarm
 
 	newConfigBytes, err := json.MarshalIndent(configMap, "", "    ")
@@ -77,6 +78,7 @@ func (Migration021) Down(repoPath, dbPassword string, testnet bool) error {
 	}
 
 	delete(swarm, "EnableAutoRelay")
+	delete(swarm, "EnableAutoNATService")
 	configMap["Swarm"] = swarm
 
 	newConfigBytes, err := json.MarshalIndent(configMap, "", "    ")

--- a/repo/migrations/Migration021_test.go
+++ b/repo/migrations/Migration021_test.go
@@ -1,0 +1,106 @@
+package migrations_test
+
+import (
+	"github.com/OpenBazaar/openbazaar-go/repo/migrations"
+	"github.com/OpenBazaar/openbazaar-go/schema"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"testing"
+)
+
+const preMigration021Config = `{
+	"Swarm": {
+		"AddrFilters": null,
+     	 	"ConnMgr": {
+         		"GracePeriod": "",
+         		"HighWater": 0,
+         		"LowWater": 0,
+         		"Type": ""
+      		},
+		"DisableBandwidthMetrics": false,
+      		"DisableNatPortMap": false,
+      		"DisableRelay": false,
+      		"EnableRelayHop": false
+   	}
+}`
+
+const postMigration021Config = `{
+	"Swarm": {
+		"AddrFilters": null,
+     	 	"ConnMgr": {
+         		"GracePeriod": "",
+         		"HighWater": 0,
+         		"LowWater": 0,
+         		"Type": ""
+      		},
+		"DisableBandwidthMetrics": false,
+      		"DisableNatPortMap": false,
+      		"DisableRelay": false,
+		"EnableAutoRelay": true,
+      		"EnableRelayHop": false
+   	}
+}`
+
+func TestMigration021(t *testing.T) {
+	var testRepo, err = schema.NewCustomSchemaManager(schema.SchemaContext{
+		DataPath:        schema.GenerateTempPath(),
+		TestModeEnabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = testRepo.BuildSchemaDirectories(); err != nil {
+		t.Fatal(err)
+	}
+	defer testRepo.DestroySchemaDirectories()
+
+	var (
+		configPath  = testRepo.DataPathJoin("config")
+		repoverPath = testRepo.DataPathJoin("repover")
+	)
+	if err = ioutil.WriteFile(configPath, []byte(preMigration021Config), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = ioutil.WriteFile(repoverPath, []byte("15"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	var m migrations.Migration021
+	err = m.Up(testRepo.DataPath(), "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configBytes, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var re = regexp.MustCompile(`\s`)
+	if re.ReplaceAllString(string(configBytes), "") != re.ReplaceAllString(string(postMigration021Config), "") {
+		t.Logf("actual: %s", re.ReplaceAllString(string(configBytes), ""))
+		t.Fatal("incorrect post-migration config")
+	}
+
+	assertCorrectRepoVer(t, repoverPath, "22")
+
+	err = m.Down(testRepo.DataPath(), "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configBytes, err = ioutil.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if re.ReplaceAllString(string(configBytes), "") != re.ReplaceAllString(string(preMigration021Config), "") {
+		t.Logf("actual: %s", re.ReplaceAllString(string(configBytes), ""))
+		t.Fatal("incorrect post-migration config")
+	}
+
+	assertCorrectRepoVer(t, repoverPath, "21")
+}

--- a/repo/migrations/Migration021_test.go
+++ b/repo/migrations/Migration021_test.go
@@ -37,6 +37,7 @@ const postMigration021Config = `{
 		"DisableBandwidthMetrics": false,
       		"DisableNatPortMap": false,
       		"DisableRelay": false,
+		"EnableAutoNATService": false,
 		"EnableAutoRelay": true,
       		"EnableRelayHop": false
    	}


### PR DESCRIPTION
This migration migrates the config file to include the EnableAutoRelay option
in the Swarm config. This will allow the node to automatically detect if it's
behind a restricted NAT, automatically find relay nodes, and set their own
swarm addresses to use the relays.

closes #1531 