### PR TITLE
Update docs to complete 1.11 upgrade

### DIFF
--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -12,13 +12,13 @@ sudo apt-get install build-essential git -y
 ### Install Go
 These are some condensed steps which will get you started quickly, but we recommend following the installation steps at [https://golang.org/doc/install](https://golang.org/doc/install).
 
-Download Go 1.10 and extract executeables:
+Download Go 1.11 and extract executeables:
 ```
-wget https://storage.googleapis.com/golang/go1.10.7.linux-amd64.tar.gz
-sudo tar -zxvf  go1.10.7.linux-amd64.tar.gz -C /usr/local/
+wget https://storage.googleapis.com/golang/go1.11.5.linux-amd64.tar.gz
+sudo tar -zxvf  go1.11.5.linux-amd64.tar.gz -C /usr/local/
 ```
 
-Note: OpenBazaar has not been tested on v1.11 and may cause problems
+Note: OpenBazaar has not been tested on v1.12 and may cause problems
 
 ### Setup Go
 
@@ -54,7 +54,7 @@ It will use git to checkout the source code into `$GOPATH/src/github.com/OpenBaz
 
 Checkout a release version:
 ```
-git checkout v0.12.4
+git checkout v0.13.2
 ```
 
 Note: `go get` leaves the repo pointing at `master` which is a branch used for active development. Running OpenBazaar from `master` is NOT recommended. Check the [release versions](https://github.com/OpenBazaar/openbazaar-go/releases) for the available versions that you use in checkout.

--- a/docs/install-osx.md
+++ b/docs/install-osx.md
@@ -12,9 +12,9 @@ brew install git
 ### Install Go
 These are some condensed steps which will get you started quickly, but we recommend following the installation steps at [https://golang.org/doc/install](https://golang.org/doc/install).
 
-Use brew to install Go 1.10:
+Use brew to install Go 1.11:
 ```
-brew install go@1.10
+brew install go@1.11
 ```
 
 Go may also be installed following the directions at [https://golang.org/doc/install](https://golang.org/doc/install).
@@ -56,7 +56,7 @@ It will use git to checkout the source code into `$GOPATH/src/github.com/OpenBaz
 
 Checkout a release version:
 ```
-git checkout v0.12.4
+git checkout v0.13.2
 ```
 
 Note: `go get` leaves the repo pointing at `master` which is a branch used for active development. Running OpenBazaar from `master` is NOT recommended. Check the [release versions](https://github.com/OpenBazaar/openbazaar-go/releases) for the available versions that you use in checkout.

--- a/docs/install-pi3.md
+++ b/docs/install-pi3.md
@@ -14,10 +14,10 @@ sudo apt-get install build-essential git -y
 
 These are some condensed steps which will get you started quickly, but we recommend following the installation steps at [https://golang.org/doc/install](https://golang.org/doc/install).
 
-Download Go 1.10 and extract executeables:
+Download Go 1.11 and extract executeables:
 ```
-wget https://storage.googleapis.com/golang/go1.10.7.linux-armv6l.tar.gz
-sudo tar -zxvf go1.10.7.linux-armv6l.tar.gz -C /usr/local/
+wget https://storage.googleapis.com/golang/go1.11.5.linux-armv6l.tar.gz
+sudo tar -zxvf go1.11.5.linux-armv6l.tar.gz -C /usr/local/
 ```
 
 Note: OpenBazaar has not been tested on v1.11 and may cause problems
@@ -57,7 +57,7 @@ It will use git to checkout the source code into `$GOPATH/src/github.com/OpenBaz
 
 Checkout a release version:
 ```
-git checkout v0.12.4
+git checkout v0.13.2
 ```
 
 Note: `go get` leaves the repo pointing at `master` which is a branch used for active development. Running OpenBazaar from `master` is NOT recommended. Check the [release versions](https://github.com/OpenBazaar/openbazaar-go/releases) for the available versions that you use iin checkout.

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -5,9 +5,9 @@ WINDOWS INSTALL NOTES
 
 You need to have Go, Git, and GCC installed to compile and run the OpenBazaar-Go daemon.
 
-- **Go v1.10**
+- **Go v1.11**
     + https://golang.org/dl
-    + Note: OpenBazaar has not been tested on v1.11 and may cause problems
+    + Note: OpenBazaar has not been tested on v1.12 and may cause problems
 - **Git**
     + https://git-scm.com/download/win
 - **TDM-GCC/MinGW-w64**
@@ -27,7 +27,7 @@ Create a directory to store all your Go projects (e.g. `C:\goprojects`):
 - Install `openbazaar-go`:
     + Open the command prompt and run: `go get github.com/OpenBazaar/openbazaar-go`. This will use git to checkout the source code into `%GOPATH%\src\github.com\OpenBazaar\openbazaar-go`.
 - Checkout an OpenBazaar release:
-    + Run `git checkout v0.12.4` to checkout a release version.
+    + Run `git checkout v0.13.2` to checkout a release version.
     + Note: `go get` leaves the repo pointing at `master` which is a branch used for active development. Running OpenBazaar from `master` is NOT recommended. Check the [release versions](https://github.com/OpenBazaar/openbazaar-go/releases) for the available versions that you use in checkout.
 - To compile and run `openbazaar-go`:
     + Open the command prompt and navigate the source directory: `cd %GOPATH%\src\github.com\OpenBazaar\openbazaar-go` 

--- a/docs/multipleInstances.md
+++ b/docs/multipleInstances.md
@@ -6,7 +6,8 @@ Install and Run Multiple Servers
 In your server directory, use the datadir option to init the server with a new data directory. This will create the data directory if it doesn't already exist, and generate all the files needed to run the server from that directory. 
 
 Example:
-`go run openbazaard.go init -d=c://Users/Username/OpenBazaar2.0StoreB`
+Windows: `go run openbazaard.go init -d=c://path/to/data/directory`
+Linux/MacOS: `go run openbazaard.go init -d=/path/to/data/directory`
 
 ### Change the Ports in the Config File
 
@@ -31,4 +32,5 @@ Example:
 You can now run an instance of the server from the new data directory with the daradir option. Multiple instances can be run simultaneously, one for each data directory you've created.
 
 Example:
-`go run openbazaard.go start -d=c://Users/Username/OpenBazaar2.0StoreB`
+Windows: `go run openbazaard.go start -d=c://path/to/data/directory`
+Linux/MacOS: `go run openbazaard.go start -d=/path/to/data/directory`


### PR DESCRIPTION
Adds missing documentation from updating to ob-go project to use go v1.11.5.
Closes #1339 