### PR TITLE
Add a blurb about min Golang version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can either pull in remote changes as normal or run `go get -u github.com/Ope
 
 ## Usage
 
-You can run the server with `go run openbazaard.go start`.
+You can run the server with `go run openbazaard.go start`. Ensure you are using at least version `1.10` of Golang, otherwise you might get errors while running.
 
 ### Options
 


### PR DESCRIPTION
The default golang version on AWS images utilizing `yum install go` point to 1.9 which causes errors during runtime. Adding this blurb should help people resolve this issue.

Here is a sample of the errors if running 1.9
```
go run openbazaard.go start
# github.com/OpenBazaar/openbazaar-go/vendor/github.com/OpenBazaar/multiwallet/service
vendor/github.com/OpenBazaar/multiwallet/service/wallet_service.go:153:28: undefined: math.Round
vendor/github.com/OpenBazaar/multiwallet/service/wallet_service.go:428:14: undefined: math.Round
vendor/github.com/OpenBazaar/multiwallet/service/wallet_service.go:464:14: undefined: math.Round
# github.com/OpenBazaar/openbazaar-go/vendor/gx/ipfs/QmT4U94DnD8FRfqr21obWY32HLM5VExccPKMjQHofeYqr9/go-multiaddr
vendor/gx/ipfs/QmT4U94DnD8FRfqr21obWY32HLM5VExccPKMjQHofeYqr9/go-multiaddr/codec.go:141:10: undefined: strings.Builder
vendor/gx/ipfs/QmT4U94DnD8FRfqr21obWY32HLM5VExccPKMjQHofeYqr9/go-multiaddr/component.go:69:8: undefined: strings.Builder
vendor/gx/ipfs/QmT4U94DnD8FRfqr21obWY32HLM5VExccPKMjQHofeYqr9/go-multiaddr/component.go:76:32: undefined: strings.Builder
```