### PR TITLE
Add spend all functionality to all wallets

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -33,91 +33,87 @@
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/bitcoin",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/bitcoincash",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/cache",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/client",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/client/blockbook",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
-		},
-		{
-			"ImportPath": "github.com/OpenBazaar/multiwallet/client/insight",
-			"Rev": "8202e0d9bae839a979baed94c480afad0c1de0c2"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/client/transport",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/config",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/datastore",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/keys",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/litecoin",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/litecoin/address",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/litecoin/params",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/model",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/service",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/util",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/zcash",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/zcash/address",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/spvwallet",
-			"Rev": "09e89cb80f4f71f74910ecec97dbabf912327d6f"
+			"Rev": "06f6037251780164889a046526b67b2c2be29107"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/spvwallet/exchangerates",
-			"Rev": "09e89cb80f4f71f74910ecec97dbabf912327d6f"
+			"Rev": "06f6037251780164889a046526b67b2c2be29107"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/wallet-interface",
-			"Rev": "90321224966c0c88e02e99f1f9d3cef18a77f399"
+			"Rev": "ed1c16b1331fc11f83a37810e2a693557c30e8ae"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/zcashd-wallet",
@@ -326,13 +322,13 @@
 		},
 		{
 			"ImportPath": "github.com/cpacia/BitcoinCash-Wallet",
-			"Comment": "v0.3.0-58-gba9295d",
-			"Rev": "ba9295daa6d43b4cbd3f88e925379f0cf025b6b9"
+			"Comment": "v0.3.0-59-g4c3046e",
+			"Rev": "4c3046e2214e1761986809a54c3179f9a1d9cfd5"
 		},
 		{
 			"ImportPath": "github.com/cpacia/BitcoinCash-Wallet/exchangerates",
-			"Comment": "v0.3.0-58-gba9295d",
-			"Rev": "ba9295daa6d43b4cbd3f88e925379f0cf025b6b9"
+			"Comment": "v0.3.0-59-g4c3046e",
+			"Rev": "4c3046e2214e1761986809a54c3179f9a1d9cfd5"
 		},
 		{
 			"ImportPath": "github.com/cpacia/bchutil",
@@ -2514,7 +2510,7 @@
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/client/errors",
-			"Rev": "00a64ca560adcc87cc0ffee0102f3c43f4a701bb"
+			"Rev": "5d687b8c67d127035479739cbf2258f7b275f3e7"
 		}
 	]
 }

--- a/core/refunds.go
+++ b/core/refunds.go
@@ -94,7 +94,7 @@ func (n *OpenBazaarNode) RefundOrder(contract *pb.RicardianContract, records []*
 		if err != nil {
 			return err
 		}
-		txid, err := wal.Spend(outValue, refundAddr, wallet.NORMAL, orderID)
+		txid, err := wal.Spend(outValue, refundAddr, wallet.NORMAL, orderID, false)
 		if err != nil {
 			return err
 		}

--- a/core/spend.go
+++ b/core/spend.go
@@ -26,6 +26,7 @@ type SpendRequest struct {
 	OrderID                string `json:"orderId"`
 	RequireAssociatedOrder bool   `json:"requireOrder"`
 	Wallet                 string `json:"wallet"`
+	SpendAll               bool   `json:"spendAll"`
 }
 
 type SpendResponse struct {
@@ -70,7 +71,7 @@ func (n *OpenBazaarNode) Spend(args *SpendRequest) (*SpendResponse, error) {
 		feeLevel = wallet.NORMAL
 	}
 
-	txid, err := wal.Spend(args.Amount, addr, feeLevel, args.OrderID)
+	txid, err := wal.Spend(args.Amount, addr, feeLevel, args.OrderID, args.SpendAll)
 	if err != nil {
 		switch {
 		case err == wallet.ErrorInsuffientFunds:

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
@@ -410,7 +410,7 @@ func (wallet *EthereumWallet) GetFeePerByte(feeLevel wi.FeeLevel) uint64 {
 }
 
 // Spend - Send ether to an external wallet
-func (wallet *EthereumWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel, referenceID string) (*chainhash.Hash, error) {
+func (wallet *EthereumWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel, referenceID string, spendAll bool) (*chainhash.Hash, error) {
 
 	var hash common.Hash
 	var h *chainhash.Hash

--- a/vendor/github.com/OpenBazaar/multiwallet/bitcoin/sign.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/bitcoin/sign.go
@@ -129,6 +129,67 @@ func (w *BitcoinWallet) buildTx(amount int64, addr btc.Address, feeLevel wi.FeeL
 	return authoredTx.Tx, nil
 }
 
+func (w *BitcoinWallet) buildSpendAllTx(addr btc.Address, feeLevel wi.FeeLevel) (*wire.MsgTx, error) {
+	tx := wire.NewMsgTx(1)
+
+	height, _ := w.ws.ChainTip()
+	utxos, err := w.db.Utxos().GetAll()
+	if err != nil {
+		return nil, err
+	}
+	coinMap := util.GatherCoins(height, utxos, w.ScriptToAddress, w.km.GetKeyForScript)
+
+	totalIn, _, additionalPrevScripts, additionalKeysByAddress := util.LoadAllInputs(tx, coinMap, w.params)
+
+	// outputs
+	script, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the fee
+	feePerByte := int64(w.GetFeePerByte(feeLevel))
+	estimatedSize := EstimateSerializeSize(1, []*wire.TxOut{wire.NewTxOut(0, script)}, false, P2PKH)
+	fee := int64(estimatedSize) * feePerByte
+
+	// Check for dust output
+	if txrules.IsDustAmount(btc.Amount(totalIn-fee), len(script), txrules.DefaultRelayFeePerKb) {
+		return nil, wi.ErrorDustAmount
+	}
+
+	// Build the output
+	out := wire.NewTxOut(totalIn-fee, script)
+	tx.TxOut = append(tx.TxOut, out)
+
+	// BIP 69 sorting
+	txsort.InPlaceSort(tx)
+
+	// Sign
+	getKey := txscript.KeyClosure(func(addr btc.Address) (*btcec.PrivateKey, bool, error) {
+		addrStr := addr.EncodeAddress()
+		wif, ok := additionalKeysByAddress[addrStr]
+		if !ok {
+			return nil, false, errors.New("key not found")
+		}
+		return wif.PrivKey, wif.CompressPubKey, nil
+	})
+	getScript := txscript.ScriptClosure(func(
+		addr btc.Address) ([]byte, error) {
+		return []byte{}, nil
+	})
+	for i, txIn := range tx.TxIn {
+		prevOutScript := additionalPrevScripts[txIn.PreviousOutPoint]
+		script, err := txscript.SignTxOutput(w.params,
+			tx, i, prevOutScript, txscript.SigHashAll, getKey,
+			getScript, txIn.SignatureScript)
+		if err != nil {
+			return nil, errors.New("failed to sign transaction")
+		}
+		txIn.SignatureScript = script
+	}
+	return tx, nil
+}
+
 func newUnsignedTransaction(outputs []*wire.TxOut, feePerKb btc.Amount, fetchInputs txauthor.InputSource, fetchChange txauthor.ChangeSource) (*txauthor.AuthoredTx, error) {
 
 	var targetAmount btc.Amount

--- a/vendor/github.com/OpenBazaar/multiwallet/bitcoin/wallet.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/bitcoin/wallet.go
@@ -224,11 +224,23 @@ func (w *BitcoinWallet) GetFeePerByte(feeLevel wi.FeeLevel) uint64 {
 	return w.fp.GetFeePerByte(feeLevel)
 }
 
-func (w *BitcoinWallet) Spend(amount int64, addr btc.Address, feeLevel wi.FeeLevel, referenceID string) (*chainhash.Hash, error) {
-	tx, err := w.buildTx(amount, addr, feeLevel, nil)
-	if err != nil {
-		return nil, err
+func (w *BitcoinWallet) Spend(amount int64, addr btc.Address, feeLevel wi.FeeLevel, referenceID string, spendAll bool) (*chainhash.Hash, error) {
+	var (
+		tx  *wire.MsgTx
+		err error
+	)
+	if spendAll {
+		tx, err = w.buildSpendAllTx(addr, feeLevel)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		tx, err = w.buildTx(amount, addr, feeLevel, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	if err := w.Broadcast(tx); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/OpenBazaar/multiwallet/bitcoincash/sign.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/bitcoincash/sign.go
@@ -135,6 +135,67 @@ func (w *BitcoinCashWallet) buildTx(amount int64, addr btc.Address, feeLevel wi.
 	return authoredTx.Tx, nil
 }
 
+func (w *BitcoinCashWallet) buildSpendAllTx(addr btc.Address, feeLevel wi.FeeLevel) (*wire.MsgTx, error) {
+	tx := wire.NewMsgTx(1)
+
+	height, _ := w.ws.ChainTip()
+	utxos, err := w.db.Utxos().GetAll()
+	if err != nil {
+		return nil, err
+	}
+	coinMap := util.GatherCoins(height, utxos, w.ScriptToAddress, w.km.GetKeyForScript)
+
+	totalIn, inVals, additionalPrevScripts, additionalKeysByAddress := util.LoadAllInputs(tx, coinMap, w.params)
+
+	// outputs
+	script, err := bchutil.PayToAddrScript(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the fee
+	feePerByte := int64(w.GetFeePerByte(feeLevel))
+	estimatedSize := EstimateSerializeSize(1, []*wire.TxOut{wire.NewTxOut(0, script)}, false, P2PKH)
+	fee := int64(estimatedSize) * feePerByte
+
+	// Check for dust output
+	if txrules.IsDustAmount(btc.Amount(totalIn-fee), len(script), txrules.DefaultRelayFeePerKb) {
+		return nil, wi.ErrorDustAmount
+	}
+
+	// Build the output
+	out := wire.NewTxOut(totalIn-fee, script)
+	tx.TxOut = append(tx.TxOut, out)
+
+	// BIP 69 sorting
+	txsort.InPlaceSort(tx)
+
+	// Sign
+	getKey := txscript.KeyClosure(func(addr btc.Address) (*btcec.PrivateKey, bool, error) {
+		addrStr := addr.EncodeAddress()
+		wif, ok := additionalKeysByAddress[addrStr]
+		if !ok {
+			return nil, false, errors.New("key not found")
+		}
+		return wif.PrivKey, wif.CompressPubKey, nil
+	})
+	getScript := txscript.ScriptClosure(func(
+		addr btc.Address) ([]byte, error) {
+		return []byte{}, nil
+	})
+	for i, txIn := range tx.TxIn {
+		prevOutScript := additionalPrevScripts[txIn.PreviousOutPoint]
+		script, err := bchutil.SignTxOutput(w.params,
+			tx, i, prevOutScript, txscript.SigHashAll, getKey,
+			getScript, txIn.SignatureScript, inVals[txIn.PreviousOutPoint])
+		if err != nil {
+			return nil, errors.New("failed to sign transaction")
+		}
+		txIn.SignatureScript = script
+	}
+	return tx, nil
+}
+
 func newUnsignedTransaction(outputs []*wire.TxOut, feePerKb btc.Amount, fetchInputs txauthor.InputSource, fetchChange txauthor.ChangeSource) (*txauthor.AuthoredTx, error) {
 
 	var targetAmount btc.Amount

--- a/vendor/github.com/OpenBazaar/multiwallet/bitcoincash/wallet.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/bitcoincash/wallet.go
@@ -220,11 +220,23 @@ func (w *BitcoinCashWallet) GetFeePerByte(feeLevel wi.FeeLevel) uint64 {
 	return w.fp.GetFeePerByte(feeLevel)
 }
 
-func (w *BitcoinCashWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel, referenceID string) (*chainhash.Hash, error) {
-	tx, err := w.buildTx(amount, addr, feeLevel, nil)
-	if err != nil {
-		return nil, err
+func (w *BitcoinCashWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel, referenceID string, spendAll bool) (*chainhash.Hash, error) {
+	var (
+		tx  *wire.MsgTx
+		err error
+	)
+	if spendAll {
+		tx, err = w.buildSpendAllTx(addr, feeLevel)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		tx, err = w.buildTx(amount, addr, feeLevel, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	// Broadcast
 	if err := w.Broadcast(tx); err != nil {
 		return nil, err

--- a/vendor/github.com/OpenBazaar/multiwallet/litecoin/sign.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/litecoin/sign.go
@@ -134,6 +134,67 @@ func (w *LitecoinWallet) buildTx(amount int64, addr btc.Address, feeLevel wi.Fee
 	return authoredTx.Tx, nil
 }
 
+func (w *LitecoinWallet) buildSpendAllTx(addr btc.Address, feeLevel wi.FeeLevel) (*wire.MsgTx, error) {
+	tx := wire.NewMsgTx(1)
+
+	height, _ := w.ws.ChainTip()
+	utxos, err := w.db.Utxos().GetAll()
+	if err != nil {
+		return nil, err
+	}
+	coinMap := util.GatherCoins(height, utxos, w.ScriptToAddress, w.km.GetKeyForScript)
+
+	totalIn, _, additionalPrevScripts, additionalKeysByAddress := util.LoadAllInputs(tx, coinMap, w.params)
+
+	// outputs
+	script, err := laddr.PayToAddrScript(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the fee
+	feePerByte := int64(w.GetFeePerByte(feeLevel))
+	estimatedSize := EstimateSerializeSize(1, []*wire.TxOut{wire.NewTxOut(0, script)}, false, P2PKH)
+	fee := int64(estimatedSize) * feePerByte
+
+	// Check for dust output
+	if txrules.IsDustAmount(ltcutil.Amount(totalIn-fee), len(script), txrules.DefaultRelayFeePerKb) {
+		return nil, wi.ErrorDustAmount
+	}
+
+	// Build the output
+	out := wire.NewTxOut(totalIn-fee, script)
+	tx.TxOut = append(tx.TxOut, out)
+
+	// BIP 69 sorting
+	txsort.InPlaceSort(tx)
+
+	// Sign
+	getKey := txscript.KeyClosure(func(addr btc.Address) (*btcec.PrivateKey, bool, error) {
+		addrStr := addr.EncodeAddress()
+		wif, ok := additionalKeysByAddress[addrStr]
+		if !ok {
+			return nil, false, errors.New("key not found")
+		}
+		return wif.PrivKey, wif.CompressPubKey, nil
+	})
+	getScript := txscript.ScriptClosure(func(
+		addr btc.Address) ([]byte, error) {
+		return []byte{}, nil
+	})
+	for i, txIn := range tx.TxIn {
+		prevOutScript := additionalPrevScripts[txIn.PreviousOutPoint]
+		script, err := txscript.SignTxOutput(w.params,
+			tx, i, prevOutScript, txscript.SigHashAll, getKey,
+			getScript, txIn.SignatureScript)
+		if err != nil {
+			return nil, errors.New("failed to sign transaction")
+		}
+		txIn.SignatureScript = script
+	}
+	return tx, nil
+}
+
 func newUnsignedTransaction(outputs []*wire.TxOut, feePerKb btc.Amount, fetchInputs txauthor.InputSource, fetchChange txauthor.ChangeSource) (*txauthor.AuthoredTx, error) {
 
 	var targetAmount btc.Amount

--- a/vendor/github.com/OpenBazaar/multiwallet/litecoin/wallet.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/litecoin/wallet.go
@@ -218,11 +218,23 @@ func (w *LitecoinWallet) GetFeePerByte(feeLevel wi.FeeLevel) uint64 {
 	return w.fp.GetFeePerByte(feeLevel)
 }
 
-func (w *LitecoinWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel, referenceID string) (*chainhash.Hash, error) {
-	tx, err := w.buildTx(amount, addr, feeLevel, nil)
-	if err != nil {
-		return nil, err
+func (w *LitecoinWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel, referenceID string, spendAll bool) (*chainhash.Hash, error) {
+	var (
+		tx  *wire.MsgTx
+		err error
+	)
+	if spendAll {
+		tx, err = w.buildSpendAllTx(addr, feeLevel)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		tx, err = w.buildTx(amount, addr, feeLevel, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	// Broadcast
 	if err := w.Broadcast(tx); err != nil {
 		return nil, err

--- a/vendor/github.com/OpenBazaar/multiwallet/zcash/sign.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/zcash/sign.go
@@ -159,6 +159,76 @@ func (w *ZCashWallet) buildTx(amount int64, addr btc.Address, feeLevel wi.FeeLev
 	return authoredTx.Tx, nil
 }
 
+func (w *ZCashWallet) buildSpendAllTx(addr btc.Address, feeLevel wi.FeeLevel) (*wire.MsgTx, error) {
+	tx := wire.NewMsgTx(1)
+
+	height, _ := w.ws.ChainTip()
+	utxos, err := w.db.Utxos().GetAll()
+	if err != nil {
+		return nil, err
+	}
+	coinMap := util.GatherCoins(height, utxos, w.ScriptToAddress, w.km.GetKeyForScript)
+
+	totalIn, inVals, additionalPrevScripts, additionalKeysByAddress := util.LoadAllInputs(tx, coinMap, w.params)
+
+	// outputs
+	script, err := zaddr.PayToAddrScript(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the fee
+	feePerByte := int64(w.GetFeePerByte(feeLevel))
+	estimatedSize := EstimateSerializeSize(1, []*wire.TxOut{wire.NewTxOut(0, script)}, false, P2PKH)
+	fee := int64(estimatedSize) * feePerByte
+
+	// Check for dust output
+	if txrules.IsDustAmount(btc.Amount(totalIn-fee), len(script), txrules.DefaultRelayFeePerKb) {
+		return nil, wi.ErrorDustAmount
+	}
+
+	// Build the output
+	out := wire.NewTxOut(totalIn-fee, script)
+	tx.TxOut = append(tx.TxOut, out)
+
+	// BIP 69 sorting
+	txsort.InPlaceSort(tx)
+
+	// Sign
+	getKey := txscript.KeyClosure(func(addr btc.Address) (*btcec.PrivateKey, bool, error) {
+		addrStr := addr.EncodeAddress()
+		wif, ok := additionalKeysByAddress[addrStr]
+		if !ok {
+			return nil, false, errors.New("key not found")
+		}
+		return wif.PrivKey, wif.CompressPubKey, nil
+	})
+	for i, txIn := range tx.TxIn {
+		prevOutScript := additionalPrevScripts[txIn.PreviousOutPoint]
+		_, addrs, _, err := txscript.ExtractPkScriptAddrs(prevOutScript, w.params)
+		if err != nil {
+			return nil, err
+		}
+		key, _, err := getKey(addrs[0])
+		if err != nil {
+			return nil, err
+		}
+		sig, err := rawTxInSignature(tx, i, prevOutScript, txscript.SigHashAll, key, inVals[txIn.PreviousOutPoint])
+		if err != nil {
+			return nil, errors.New("failed to sign transaction")
+		}
+		builder := txscript.NewScriptBuilder()
+		builder.AddData(sig)
+		builder.AddData(key.PubKey().SerializeCompressed())
+		script, err := builder.Script()
+		if err != nil {
+			return nil, err
+		}
+		txIn.SignatureScript = script
+	}
+	return tx, nil
+}
+
 func newUnsignedTransaction(outputs []*wire.TxOut, feePerKb btc.Amount, fetchInputs txauthor.InputSource, fetchChange txauthor.ChangeSource) (*txauthor.AuthoredTx, []btc.Amount, error) {
 
 	var targetAmount btc.Amount

--- a/vendor/github.com/OpenBazaar/multiwallet/zcash/wallet.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/zcash/wallet.go
@@ -222,10 +222,21 @@ func (w *ZCashWallet) GetFeePerByte(feeLevel wi.FeeLevel) uint64 {
 	return w.fp.GetFeePerByte(feeLevel)
 }
 
-func (w *ZCashWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel, referenceID string) (*chainhash.Hash, error) {
-	tx, err := w.buildTx(amount, addr, feeLevel, nil)
-	if err != nil {
-		return nil, err
+func (w *ZCashWallet) Spend(amount int64, addr btcutil.Address, feeLevel wi.FeeLevel, referenceID string, spendAll bool) (*chainhash.Hash, error) {
+	var (
+		tx  *wire.MsgTx
+		err error
+	)
+	if spendAll {
+		tx, err = w.buildSpendAllTx(addr, feeLevel)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		tx, err = w.buildTx(amount, addr, feeLevel, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
 	// Broadcast
 	txid, err := w.Broadcast(tx)

--- a/vendor/github.com/OpenBazaar/spvwallet/blockchain.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/blockchain.go
@@ -5,15 +5,14 @@ package spvwallet
 
 import (
 	"errors"
-	"math/big"
-	"sort"
-	"sync"
-	"time"
-
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"math/big"
+	"sort"
+	"sync"
+	"time"
 )
 
 // Blockchain settings.  These are kindof Bitcoin specific, but not contained in

--- a/vendor/github.com/OpenBazaar/spvwallet/checkpoints.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/checkpoints.go
@@ -1,11 +1,10 @@
 package spvwallet
 
 import (
-	"time"
-
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"time"
 )
 
 type Checkpoint struct {

--- a/vendor/github.com/OpenBazaar/spvwallet/config.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/config.go
@@ -1,18 +1,17 @@
 package spvwallet
 
 import (
+	"github.com/OpenBazaar/wallet-interface"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/mitchellh/go-homedir"
+	"github.com/op/go-logging"
+	"golang.org/x/net/proxy"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"time"
-
-	"github.com/OpenBazaar/wallet-interface"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/mitchellh/go-homedir"
-	"github.com/op/go-logging"
-	"golang.org/x/net/proxy"
 )
 
 type Config struct {

--- a/vendor/github.com/OpenBazaar/spvwallet/eight333.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/eight333.go
@@ -1,13 +1,12 @@
 package spvwallet
 
 import (
-	"net"
-	"time"
-
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	peerpkg "github.com/btcsuite/btcd/peer"
 	"github.com/btcsuite/btcd/wire"
+	"net"
+	"time"
 )
 
 const (

--- a/vendor/github.com/OpenBazaar/spvwallet/exchangerates/bitcoinprices.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/exchangerates/bitcoinprices.go
@@ -10,10 +10,9 @@ import (
 	"sync"
 	"time"
 
-	"strings"
-
 	"github.com/op/go-logging"
 	"golang.org/x/net/proxy"
+	"strings"
 )
 
 const SatoshiPerBTC = 100000000

--- a/vendor/github.com/OpenBazaar/spvwallet/fees.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/fees.go
@@ -2,12 +2,11 @@ package spvwallet
 
 import (
 	"encoding/json"
+	"github.com/OpenBazaar/wallet-interface"
+	"golang.org/x/net/proxy"
 	"net"
 	"net/http"
 	"time"
-
-	"github.com/OpenBazaar/wallet-interface"
-	"golang.org/x/net/proxy"
 )
 
 type httpClient interface {

--- a/vendor/github.com/OpenBazaar/spvwallet/headers.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/headers.go
@@ -11,12 +11,11 @@ import (
 	"sort"
 	"sync"
 
-	"strings"
-
 	"github.com/boltdb/bolt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/cevaris/ordered_map"
+	"strings"
 )
 
 const (

--- a/vendor/github.com/OpenBazaar/spvwallet/mblock.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/mblock.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"errors"
-
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 )

--- a/vendor/github.com/OpenBazaar/spvwallet/mock.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/mock.go
@@ -4,15 +4,14 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
-	"sort"
-	"strconv"
-	"testing"
-	"time"
-
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
 )
 
 type MockDatastore struct {

--- a/vendor/github.com/OpenBazaar/spvwallet/peers.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/peers.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"fmt"
-
 	"github.com/btcsuite/btcd/addrmgr"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -94,11 +93,11 @@ func NewPeerManager(config *PeerManagerConfig) (*PeerManager, error) {
 	}
 
 	pm := &PeerManager{
-		addrManager: addrmgr.New(config.AddressCacheDir, nil),
-		peerMutex:   new(sync.RWMutex),
-		sourceAddr:  wire.NewNetAddressIPPort(net.ParseIP("0.0.0.0"), defaultPort, 0),
-		trustedPeer: config.TrustedPeer,
-		proxy:       config.Proxy,
+		addrManager:            addrmgr.New(config.AddressCacheDir, nil),
+		peerMutex:              new(sync.RWMutex),
+		sourceAddr:             wire.NewNetAddressIPPort(net.ParseIP("0.0.0.0"), defaultPort, 0),
+		trustedPeer:            config.TrustedPeer,
+		proxy:                  config.Proxy,
 		recentlyTriedAddresses: make(map[string]bool),
 		connectedPeers:         make(map[uint64]*peer.Peer),
 		msgChan:                config.MsgChan,

--- a/vendor/github.com/OpenBazaar/spvwallet/txstore.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/txstore.go
@@ -6,9 +6,6 @@ package spvwallet
 import (
 	"bytes"
 	"errors"
-	"sync"
-	"time"
-
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -17,6 +14,8 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/bloom"
+	"sync"
+	"time"
 )
 
 type TxStore struct {

--- a/vendor/github.com/OpenBazaar/spvwallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/spvwallet/wallet.go
@@ -2,10 +2,6 @@ package spvwallet
 
 import (
 	"errors"
-	"io"
-	"sync"
-	"time"
-
 	"github.com/OpenBazaar/spvwallet/exchangerates"
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/btcec"
@@ -18,6 +14,9 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/op/go-logging"
 	b39 "github.com/tyler-smith/go-bip39"
+	"io"
+	"sync"
+	"time"
 )
 
 type SPVWallet struct {

--- a/vendor/github.com/OpenBazaar/wallet-interface/datastore.go
+++ b/vendor/github.com/OpenBazaar/wallet-interface/datastore.go
@@ -2,11 +2,10 @@ package wallet
 
 import (
 	"bytes"
-	"time"
-
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"time"
 )
 
 type Coin interface {
@@ -23,11 +22,11 @@ const (
 	BitcoinCash          = 145
 	Ethereum             = 60
 
-	TestnetBitcoin     = 1000000
-	TestnetLitecoin    = 1000001
-	TestnetZcash       = 1000133
-	TestnetBitcoinCash = 1000145
-	TestnetEthereum    = 1000060
+	TestnetBitcoin       = 1000000
+	TestnetLitecoin      = 1000001
+	TestnetZcash         = 1000133
+	TestnetBitcoinCash   = 1000145
+	TestnetEthereum      = 1000060
 )
 
 func (c *CoinType) String() string {

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/blockchain.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/blockchain.go
@@ -6,15 +6,14 @@ package bitcoincash
 import (
 	"errors"
 	"fmt"
-	"math/big"
-	"sort"
-	"sync"
-	"time"
-
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"math/big"
+	"sort"
+	"sync"
+	"time"
 )
 
 // Blockchain settings.  These are kindof Bitcoin specific, but not contained in

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/checkpoints.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/checkpoints.go
@@ -1,11 +1,10 @@
 package bitcoincash
 
 import (
-	"time"
-
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"time"
 )
 
 type Checkpoint struct {

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/config.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/config.go
@@ -1,18 +1,17 @@
 package bitcoincash
 
 import (
+	"github.com/OpenBazaar/wallet-interface"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/mitchellh/go-homedir"
+	"github.com/op/go-logging"
+	"golang.org/x/net/proxy"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"time"
-
-	"github.com/OpenBazaar/wallet-interface"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/mitchellh/go-homedir"
-	"github.com/op/go-logging"
-	"golang.org/x/net/proxy"
 )
 
 type Config struct {

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/eight333.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/eight333.go
@@ -1,13 +1,12 @@
 package bitcoincash
 
 import (
-	"net"
-	"time"
-
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	peerpkg "github.com/btcsuite/btcd/peer"
 	"github.com/btcsuite/btcd/wire"
+	"net"
+	"time"
 )
 
 const (

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/exchangerates/exchangerates.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/exchangerates/exchangerates.go
@@ -4,14 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"golang.org/x/net/proxy"
 	"net"
 	"net/http"
 	"reflect"
 	"strconv"
 	"sync"
 	"time"
-
-	"golang.org/x/net/proxy"
 )
 
 type ExchangeRateProvider struct {

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/fees.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/fees.go
@@ -1,10 +1,9 @@
 package bitcoincash
 
 import (
+	"github.com/OpenBazaar/wallet-interface"
 	"net/http"
 	"time"
-
-	"github.com/OpenBazaar/wallet-interface"
 )
 
 type httpClient interface {

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/headers.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/headers.go
@@ -11,12 +11,11 @@ import (
 	"sort"
 	"sync"
 
-	"strings"
-
 	"github.com/boltdb/bolt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/cevaris/ordered_map"
+	"strings"
 )
 
 const (

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/mblock.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/mblock.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"errors"
-
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 )

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/mock.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/mock.go
@@ -4,15 +4,14 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
-	"sort"
-	"strconv"
-	"testing"
-	"time"
-
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
 )
 
 type MockDatastore struct {

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/peers.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/peers.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"fmt"
-
 	"github.com/btcsuite/btcd/addrmgr"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -95,11 +94,11 @@ func NewPeerManager(config *PeerManagerConfig) (*PeerManager, error) {
 	}
 
 	pm := &PeerManager{
-		addrManager: addrmgr.New(config.AddressCacheDir, nil),
-		peerMutex:   new(sync.RWMutex),
-		sourceAddr:  wire.NewNetAddressIPPort(net.ParseIP("0.0.0.0"), defaultPort, 0),
-		trustedPeer: config.TrustedPeer,
-		proxy:       config.Proxy,
+		addrManager:            addrmgr.New(config.AddressCacheDir, nil),
+		peerMutex:              new(sync.RWMutex),
+		sourceAddr:             wire.NewNetAddressIPPort(net.ParseIP("0.0.0.0"), defaultPort, 0),
+		trustedPeer:            config.TrustedPeer,
+		proxy:                  config.Proxy,
 		recentlyTriedAddresses: make(map[string]bool),
 		connectedPeers:         make(map[uint64]*peer.Peer),
 		msgChan:                config.MsgChan,

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/sortsignsend.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/sortsignsend.go
@@ -103,16 +103,28 @@ func (w *SPVWallet) gatherCoins() map[coinset.Coin]*hd.ExtendedKey {
 	return m
 }
 
-func (w *SPVWallet) Spend(amount int64, addr btc.Address, feeLevel wallet.FeeLevel, referenceID string) (*chainhash.Hash, error) {
-	tx, err := w.buildTx(amount, addr, feeLevel, nil)
-	if err != nil {
-		return nil, err
+func (w *SPVWallet) Spend(amount int64, addr btc.Address, feeLevel wallet.FeeLevel, referenceID string, spendAll bool) (*chainhash.Hash, error) {
+	var (
+		tx  *wire.MsgTx
+		err error
+	)
+	if spendAll {
+		tx, err = w.buildSpendAllTx(addr, feeLevel)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		tx, err = w.buildTx(amount, addr, feeLevel, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	// Broadcast
-	err = w.Broadcast(tx)
-	if err != nil {
+	if err := w.Broadcast(tx); err != nil {
 		return nil, err
 	}
+
 	ch := tx.TxHash()
 	return &ch, nil
 }
@@ -698,6 +710,86 @@ func (w *SPVWallet) buildTx(amount int64, addr btc.Address, feeLevel wallet.FeeL
 		txIn.SignatureScript = script
 	}
 	return authoredTx.Tx, nil
+}
+
+func (w *SPVWallet) buildSpendAllTx(addr btc.Address, feeLevel wallet.FeeLevel) (*wire.MsgTx, error) {
+	tx := wire.NewMsgTx(1)
+
+	coinMap := w.gatherCoins()
+
+	inVals := make(map[wire.OutPoint]int64)
+	totalIn := int64(0)
+	additionalPrevScripts := make(map[wire.OutPoint][]byte)
+	additionalKeysByAddress := make(map[string]*btc.WIF)
+
+	for coin, key := range coinMap {
+		outpoint := wire.NewOutPoint(coin.Hash(), coin.Index())
+		in := wire.NewTxIn(outpoint, nil, nil)
+		additionalPrevScripts[*outpoint] = coin.PkScript()
+		tx.TxIn = append(tx.TxIn, in)
+		val := int64(coin.Value().ToUnit(btc.AmountSatoshi))
+		totalIn += val
+		inVals[*outpoint] = val
+
+		addr, err := key.Address(w.params)
+		if err != nil {
+			continue
+		}
+		privKey, err := key.ECPrivKey()
+		if err != nil {
+			continue
+		}
+		wif, _ := btc.NewWIF(privKey, w.params, true)
+		additionalKeysByAddress[addr.EncodeAddress()] = wif
+	}
+
+	// outputs
+	script, err := bchutil.PayToAddrScript(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the fee
+	feePerByte := int64(w.GetFeePerByte(feeLevel))
+	estimatedSize := EstimateSerializeSize(1, []*wire.TxOut{wire.NewTxOut(0, script)}, false, P2PKH)
+	fee := int64(estimatedSize) * feePerByte
+
+	// Check for dust output
+	if txrules.IsDustAmount(btc.Amount(totalIn-fee), len(script), txrules.DefaultRelayFeePerKb) {
+		return nil, wallet.ErrorDustAmount
+	}
+
+	// Build the output
+	out := wire.NewTxOut(totalIn-fee, script)
+	tx.TxOut = append(tx.TxOut, out)
+
+	// BIP 69 sorting
+	txsort.InPlaceSort(tx)
+
+	// Sign
+	getKey := txscript.KeyClosure(func(addr btc.Address) (*btcec.PrivateKey, bool, error) {
+		addrStr := addr.EncodeAddress()
+		wif, ok := additionalKeysByAddress[addrStr]
+		if !ok {
+			return nil, false, errors.New("key not found")
+		}
+		return wif.PrivKey, wif.CompressPubKey, nil
+	})
+	getScript := txscript.ScriptClosure(func(
+		addr btc.Address) ([]byte, error) {
+		return []byte{}, nil
+	})
+	for i, txIn := range tx.TxIn {
+		prevOutScript := additionalPrevScripts[txIn.PreviousOutPoint]
+		script, err := bchutil.SignTxOutput(w.params,
+			tx, i, prevOutScript, txscript.SigHashAll, getKey,
+			getScript, txIn.SignatureScript, inVals[txIn.PreviousOutPoint])
+		if err != nil {
+			return nil, errors.New("failed to sign transaction")
+		}
+		txIn.SignatureScript = script
+	}
+	return tx, nil
 }
 
 func NewUnsignedTransaction(outputs []*wire.TxOut, feePerKb btc.Amount, fetchInputs txauthor.InputSource, fetchChange txauthor.ChangeSource) (*txauthor.AuthoredTx, error) {

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/txstore.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/txstore.go
@@ -6,9 +6,6 @@ package bitcoincash
 import (
 	"bytes"
 	"errors"
-	"sync"
-	"time"
-
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -17,6 +14,8 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/bloom"
+	"sync"
+	"time"
 )
 
 type TxStore struct {

--- a/vendor/github.com/cpacia/BitcoinCash-Wallet/wallet.go
+++ b/vendor/github.com/cpacia/BitcoinCash-Wallet/wallet.go
@@ -2,10 +2,6 @@ package bitcoincash
 
 import (
 	"errors"
-	"io"
-	"sync"
-	"time"
-
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -18,6 +14,9 @@ import (
 	"github.com/cpacia/bchutil"
 	"github.com/op/go-logging"
 	b39 "github.com/tyler-smith/go-bip39"
+	"io"
+	"sync"
+	"time"
 )
 
 func setupNetworkParams(params *chaincfg.Params) {


### PR DESCRIPTION
This commit updates the wallet-interface, multiwallet, spvwallet, and
bch spvwallet to add a spendAll bool to the spend interface method that will
allow us to sweep all funds from the wallet. Currently to remove all funds you
need to try to guess what fee the wallet will use and substract that from the
amount you're trying to spend. The spendAll option will subtract the fee from
the amount you're sending rather than adding it. Improving the UX in this regard.

A new bool is added to the spend POST JSON body.

closes #929