### PR TITLE
#1524 CRYPTO LISTING UPDATE #1535 SERVER DAEMON LOG

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1009,7 +1009,7 @@ func printSplashScreen(verbose bool) {
 	blue.DisableColor()
 	white.DisableColor()
 	fmt.Println("")
-	fmt.Println("OpenBazaar Server v" + core.VERSION)
+	log.Info("\nOpenBazaar Server v" + core.VERSION)
 	if !verbose {
 		fmt.Println("[Press Ctrl+C to exit]")
 	}

--- a/core/listings.go
+++ b/core/listings.go
@@ -261,11 +261,6 @@ func (n *OpenBazaarNode) SignListing(listing *pb.Listing) (*pb.SignedListing, er
 /*SetListingInventory Sets the inventory for the listing in the database. Does some basic validation
   to make sure the inventory uses the correct variants. */
 func (n *OpenBazaarNode) SetListingInventory(listing *pb.Listing) error {
-	err := validateListingSkus(listing)
-	if err != nil {
-		return err
-	}
-
 	// Grab current inventory
 	currentInv, err := n.Datastore.Inventory().Get(listing.Slug)
 	if err != nil {
@@ -273,6 +268,9 @@ func (n *OpenBazaarNode) SetListingInventory(listing *pb.Listing) error {
 	}
 	// Update inventory
 	for i, s := range listing.Item.Skus {
+		if s.Quantity < 1 {
+			continue
+		}
 		err = n.Datastore.Inventory().Put(listing.Slug, i, s.Quantity)
 		if err != nil {
 			return err

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -1242,12 +1242,17 @@ func (service *OpenBazaarService) handleChat(p peer.ID, pmes *pb.Message, option
 		return nil, errors.New("chat message over max characters")
 	}
 
+	log.Infof("chat message is %s", chat.Message)
+
 	// Use correct timestamp
 	offline, _ := options.(bool)
+
 	var t time.Time
 	if !offline {
+		log.Debug("currently online")
 		t = time.Now()
 	} else {
+		log.Debug("currently online")
 		if chat.Timestamp == nil {
 			return nil, errors.New("invalid timestamp")
 		}

--- a/repo/db/chat.go
+++ b/repo/db/chat.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -47,7 +48,7 @@ func (c *ChatDB) Put(messageId string, peerId string, subject string, message st
 		subject,
 		message,
 		readInt,
-		int(timestamp.Unix()),
+		int64(timestamp.UnixNano()),
 		outgoingInt,
 	)
 	if err != nil {
@@ -93,7 +94,7 @@ func (c *ChatDB) GetConversations() []repo.ChatConversation {
 		if outInt > 0 {
 			outgoing = true
 		}
-		timestamp := time.Unix(int64(ts), 0)
+		timestamp := time.Unix(0, int64(ts))
 		convo := repo.ChatConversation{
 			PeerId:    peerId,
 			Unread:    count,
@@ -145,7 +146,7 @@ func (c *ChatDB) GetMessages(peerID string, subject string, offsetId string, lim
 		if outgoingInt == 1 {
 			outgoing = true
 		}
-		timestamp := time.Unix(int64(timestampInt), 0)
+		timestamp := time.Unix(0, int64(timestampInt))
 		chatMessage := repo.ChatMessage{
 			PeerId:    pid,
 			MessageId: msgID,


### PR DESCRIPTION

Allow for the editing of crypto listing when inventory is 0. Currently when the crypto listing is zero the store owner can't update any of the crypto listing info. 