### PR TITLE
Close stream to peer when the peer is banned

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -852,6 +852,7 @@ func (i *jsonAPIHandler) POSTSettings(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			blockedIds = append(blockedIds, id)
+			i.node.Service.DisconnectFromPeer(id)
 		}
 		i.node.BanManager.SetBlockedIds(blockedIds)
 	}
@@ -908,6 +909,7 @@ func (i *jsonAPIHandler) PUTSettings(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			blockedIds = append(blockedIds, id)
+			i.node.Service.DisconnectFromPeer(id)
 		}
 		i.node.BanManager.SetBlockedIds(blockedIds)
 	}
@@ -989,6 +991,7 @@ func (i *jsonAPIHandler) PATCHSettings(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			blockedIds = append(blockedIds, id)
+			i.node.Service.DisconnectFromPeer(id)
 		}
 		i.node.BanManager.SetBlockedIds(blockedIds)
 	}
@@ -3182,6 +3185,7 @@ func (i *jsonAPIHandler) POSTBlockNode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	i.node.BanManager.AddBlockedId(pid)
+	i.node.Service.DisconnectFromPeer(pid)
 	SanitizedResponse(w, `{}`)
 }
 

--- a/net/networkservice.go
+++ b/net/networkservice.go
@@ -29,7 +29,7 @@ type NetworkService interface {
 	SendMessage(ctx context.Context, p peer.ID, pmes *pb.Message) error
 
 	// Disconnect from the given peer
-	DisconnectFromPeer(p peer.ID) error
+	DisconnectFromPeer(p peer.ID)
 
 	// Block until the service is available
 	WaitForReady()

--- a/net/service/service.go
+++ b/net/service/service.go
@@ -58,19 +58,18 @@ func (service *OpenBazaarService) WaitForReady() {
 	<-service.node.DHT.BootstrapChan
 }
 
-func (service *OpenBazaarService) DisconnectFromPeer(p peer.ID) error {
+func (service *OpenBazaarService) DisconnectFromPeer(p peer.ID) {
 	log.Debugf("Disconnecting from %s", p.Pretty())
 	service.senderlk.Lock()
 	defer service.senderlk.Unlock()
 	ms, ok := service.sender[p]
 	if !ok {
-		return nil
+		return
 	}
 	if ms != nil && ms.s != nil {
 		ms.s.Close()
 	}
 	delete(service.sender, p)
-	return nil
 }
 
 func (service *OpenBazaarService) HandleNewStream(s inet.Stream) {


### PR DESCRIPTION
The ban manager only checks to see if a peer is banned if that peer tries to
open a new stream. If there is an existing stream to that peer the messages
would otherwise still get through. This commit changes the behavior to close
the streams to any banned peers which should have the effect of preventing
further communication from them.