### PR TITLE
Fix IPFS protocol identifier handling

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"gx/ipfs/QmQmhotPUzVrMEWNK3x1R5jQ5ZHWyL7tVUrmRPjrBrvyCb/go-ipfs-files"
+	files "gx/ipfs/QmQmhotPUzVrMEWNK3x1R5jQ5ZHWyL7tVUrmRPjrBrvyCb/go-ipfs-files"
 
 	"gx/ipfs/QmRxk6AUaGaKCfzS1xSNRojiAPd7h2ih8GuCdjJBF3Y6GK/go-libp2p"
-	"gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht/opts"
+	dhtopts "gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht/opts"
 	ma "gx/ipfs/QmTZBfrPJmjWsCvHEtX5FE6KimVJhsJg5sBbqEFYf4UZtL/go-multiaddr"
 	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
-	"gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
+	peer "gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
 	oniontp "gx/ipfs/QmYv2MbwHn7qcvAPFisZ94w85crQVpwUuv8G7TuUeBnfPb/go-onion-transport"
 	ipld "gx/ipfs/QmZ6nzCLwGLVfRzYLpD7pW6UNuBDKEcA2imJtVpbEx2rxy/go-ipld-format"
 	bitswap "gx/ipfs/QmcSPuzpSbVLU6UHU4e5PwZpm4fHbCn5SbNR5ZNL6Mj63G/go-bitswap/network"
@@ -26,7 +26,7 @@ import (
 	"syscall"
 	"time"
 
-	"gx/ipfs/QmXLwxifxwfc2bAwq6rdjbYqAsGzWsDE9RM5TWMGtykyj6/interface-go-ipfs-core"
+	iface "gx/ipfs/QmXLwxifxwfc2bAwq6rdjbYqAsGzWsDE9RM5TWMGtykyj6/interface-go-ipfs-core"
 
 	"github.com/ipfs/go-ipfs/core/coreapi"
 
@@ -221,15 +221,7 @@ func (x *Restore) Execute(args []string) error {
 		libp2p.DefaultTransports = transportOptions
 	}
 
-	ncfg := &ipfscore.BuildCfg{
-		Repo:   r,
-		Online: true,
-		ExtraOpts: map[string]bool{
-			"mplex":  true,
-			"ipnsps": true,
-		},
-		Routing: constructRouting,
-	}
+	ncfg := ipfs.PrepareIPFSConfig(r, schema.IPFSCachingRouterDefaultURI, false, false)
 	fmt.Println("Starting node...")
 	nd, err := ipfscore.NewNode(cctx, ncfg)
 	if err != nil {

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	files "gx/ipfs/QmQmhotPUzVrMEWNK3x1R5jQ5ZHWyL7tVUrmRPjrBrvyCb/go-ipfs-files"
+	"gx/ipfs/QmQmhotPUzVrMEWNK3x1R5jQ5ZHWyL7tVUrmRPjrBrvyCb/go-ipfs-files"
 
 	"gx/ipfs/QmRxk6AUaGaKCfzS1xSNRojiAPd7h2ih8GuCdjJBF3Y6GK/go-libp2p"
-	dhtopts "gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht/opts"
+	"gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht/opts"
 	ma "gx/ipfs/QmTZBfrPJmjWsCvHEtX5FE6KimVJhsJg5sBbqEFYf4UZtL/go-multiaddr"
 	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
-	peer "gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
+	"gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
 	oniontp "gx/ipfs/QmYv2MbwHn7qcvAPFisZ94w85crQVpwUuv8G7TuUeBnfPb/go-onion-transport"
 	ipld "gx/ipfs/QmZ6nzCLwGLVfRzYLpD7pW6UNuBDKEcA2imJtVpbEx2rxy/go-ipld-format"
 	bitswap "gx/ipfs/QmcSPuzpSbVLU6UHU4e5PwZpm4fHbCn5SbNR5ZNL6Mj63G/go-bitswap/network"
@@ -26,7 +26,7 @@ import (
 	"syscall"
 	"time"
 
-	iface "gx/ipfs/QmXLwxifxwfc2bAwq6rdjbYqAsGzWsDE9RM5TWMGtykyj6/interface-go-ipfs-core"
+	"gx/ipfs/QmXLwxifxwfc2bAwq6rdjbYqAsGzWsDE9RM5TWMGtykyj6/interface-go-ipfs-core"
 
 	"github.com/ipfs/go-ipfs/core/coreapi"
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -71,10 +71,7 @@ var fileLogFormat = logging.MustStringFormatter(
 	`%{time:15:04:05.000} [%{level}] [%{module}/%{shortfunc}] %{message}`,
 )
 
-var (
-	ErrNoGateways = errors.New("no gateway addresses configured")
-	apiRouterURI  string
-)
+var ErrNoGateways = errors.New("no gateway addresses configured")
 
 type Start struct {
 	Password             string   `short:"p" long:"password" description:"the encryption password if the database is encrypted"`

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
 	"io"
 	"io/ioutil"
 	"net"
@@ -105,6 +106,13 @@ type Start struct {
 }
 
 func (x *Start) Execute(args []string) error {
+
+	if x.Testnet || x.Regtest {
+		ipfscore.DHTOption = constructTestnetDHTRouting
+	} else {
+		ipfscore.DHTOption = constructDHTRouting
+	}
+
 	printSplashScreen(x.Verbose)
 
 	if x.Testnet && x.Regtest {
@@ -873,6 +881,17 @@ func constructDHTRouting(ctx context.Context, host p2phost.Host, dstore ds.Batch
 		ctx, host,
 		dhtopts.Datastore(dstore),
 		dhtopts.Validator(validator),
+	)
+}
+
+func constructTestnetDHTRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
+	testnetDHT := protocol.ID("/openbazaar/kad/testnet/1.0.0")
+	testnetApp := protocol.ID("/openbazaar/app/testnet/1.0.0")
+	return dht.New(
+		ctx, host,
+		dhtopts.Datastore(dstore),
+		dhtopts.Validator(validator),
+		dhtopts.Protocols(testnetDHT, testnetApp),
 	)
 }
 

--- a/ipfs/config.go
+++ b/ipfs/config.go
@@ -8,7 +8,6 @@ import (
 	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
 	p2phost "gx/ipfs/QmYrWiWM4qtrnCeT3R14jY3ZZyirDNJgwK57q4qFYePgbd/go-libp2p-host"
 	routing "gx/ipfs/QmYxUdYY9S6yg5tSPVin5GFTvtfsLauVcr7reHDD3dM8xf/go-libp2p-routing"
-	protocol "gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
 	record "gx/ipfs/QmbeHtaBy9nZsW4cHRcvgVY4CnDhXudE2Dr6qDxS7yg9rX/go-libp2p-record"
 	bitswap "gx/ipfs/QmcSPuzpSbVLU6UHU4e5PwZpm4fHbCn5SbNR5ZNL6Mj63G/go-bitswap/network"
 
@@ -22,13 +21,13 @@ var routerCacheURI string
 // which do not yet have an API to manage their configuration
 func UpdateIPFSGlobalProtocolVars(testnetEnable bool) {
 	if testnetEnable {
-		bitswap.ProtocolBitswap = "/openbazaar/bitswap/testnet/1.1.0"
-		bitswap.ProtocolBitswapOne = "/openbazaar/bitswap/testnet/1.0.0"
-		bitswap.ProtocolBitswapNoVers = "/openbazaar/bitswap/testnet"
+		bitswap.ProtocolBitswap = IPFSProtocolBitswapTestnetOneDotOne
+		bitswap.ProtocolBitswapOne = IPFSProtocolBitswapTestnetOne
+		bitswap.ProtocolBitswapNoVers = IPFSProtocolBitswapTestnetNoVers
 	} else {
-		bitswap.ProtocolBitswap = "/openbazaar/bitswap/1.1.0"
-		bitswap.ProtocolBitswapOne = "/openbazaar/bitswap/1.0.0"
-		bitswap.ProtocolBitswapNoVers = "/openbazaar/bitswap"
+		bitswap.ProtocolBitswap = IPFSProtocolBitswapMainnetOneDotOne
+		bitswap.ProtocolBitswapOne = IPFSProtocolBitswapMainnetOne
+		bitswap.ProtocolBitswapNoVers = IPFSProtocolBitswapMainnetNoVers
 	}
 }
 
@@ -60,6 +59,10 @@ func constructRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching
 		ctx, host,
 		dhtopts.Datastore(dstore),
 		dhtopts.Validator(validator),
+		dhtopts.Protocols(
+			IPFSProtocolKademliaMainnetOne,
+			IPFSProtocolDHTMainnetLegacy,
+		),
 	)
 	if err != nil {
 		return nil, err
@@ -74,18 +77,23 @@ func constructDHTRouting(ctx context.Context, host p2phost.Host, dstore ds.Batch
 		ctx, host,
 		dhtopts.Datastore(dstore),
 		dhtopts.Validator(validator),
+		dhtopts.Protocols(
+			IPFSProtocolKademliaMainnetOne,
+			IPFSProtocolDHTMainnetLegacy,
+		),
 	)
 }
 
 func constructTestnetDHTRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
 	var (
-		testnetDHT      = protocol.ID("/openbazaar/kad/testnet/1.0.0")
-		testnetApp      = protocol.ID("/openbazaar/app/testnet/1.0.0")
 		dhtRouting, err = dht.New(
 			ctx, host,
 			dhtopts.Datastore(dstore),
 			dhtopts.Validator(validator),
-			dhtopts.Protocols(testnetDHT, testnetApp),
+			dhtopts.Protocols(
+				IPFSProtocolKademliaTestnetOne,
+				IPFSProtocolAppTestnetOne,
+			),
 		)
 	)
 	if err != nil {

--- a/ipfs/config.go
+++ b/ipfs/config.go
@@ -10,12 +10,27 @@ import (
 	routing "gx/ipfs/QmYxUdYY9S6yg5tSPVin5GFTvtfsLauVcr7reHDD3dM8xf/go-libp2p-routing"
 	protocol "gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
 	record "gx/ipfs/QmbeHtaBy9nZsW4cHRcvgVY4CnDhXudE2Dr6qDxS7yg9rX/go-libp2p-record"
+	bitswap "gx/ipfs/QmcSPuzpSbVLU6UHU4e5PwZpm4fHbCn5SbNR5ZNL6Mj63G/go-bitswap/network"
 
 	ipfscore "github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/repo"
 )
 
 var routerCacheURI string
+
+// UpdateIPFSGlobalProtocolVars is a hack to manage custom protocol strings
+// which do not yet have an API to manage their configuration
+func UpdateIPFSGlobalProtocolVars(testnetEnable bool) {
+	if testnetEnable {
+		bitswap.ProtocolBitswap = "/openbazaar/bitswap/testnet/1.1.0"
+		bitswap.ProtocolBitswapOne = "/openbazaar/bitswap/testnet/1.0.0"
+		bitswap.ProtocolBitswapNoVers = "/openbazaar/bitswap/testnet"
+	} else {
+		bitswap.ProtocolBitswap = "/openbazaar/bitswap/1.1.0"
+		bitswap.ProtocolBitswapOne = "/openbazaar/bitswap/1.0.0"
+		bitswap.ProtocolBitswapNoVers = "/openbazaar/bitswap"
+	}
+}
 
 // PrepareIPFSConfig builds the configuration options for the internal
 // IPFS node.
@@ -63,13 +78,15 @@ func constructDHTRouting(ctx context.Context, host p2phost.Host, dstore ds.Batch
 }
 
 func constructTestnetDHTRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
-	testnetDHT := protocol.ID("/openbazaar/kad/testnet/1.0.0")
-	testnetApp := protocol.ID("/openbazaar/app/testnet/1.0.0")
-	dhtRouting, err := dht.New(
-		ctx, host,
-		dhtopts.Datastore(dstore),
-		dhtopts.Validator(validator),
-		dhtopts.Protocols(testnetDHT, testnetApp),
+	var (
+		testnetDHT      = protocol.ID("/openbazaar/kad/testnet/1.0.0")
+		testnetApp      = protocol.ID("/openbazaar/app/testnet/1.0.0")
+		dhtRouting, err = dht.New(
+			ctx, host,
+			dhtopts.Datastore(dstore),
+			dhtopts.Validator(validator),
+			dhtopts.Protocols(testnetDHT, testnetApp),
+		)
 	)
 	if err != nil {
 		return nil, err

--- a/ipfs/config.go
+++ b/ipfs/config.go
@@ -47,9 +47,9 @@ func PrepareIPFSConfig(r repo.Repo, routerAPIEndpoint string, testEnable, regtes
 	// regtest and test are never enabled together
 	ncfg.Routing = constructRouting
 	if regtestEnable {
-		ncfg.Routing = constructDHTRouting
+		ncfg.Routing = constructRegtestRouting
 	} else if testEnable {
-		ncfg.Routing = constructTestnetDHTRouting
+		ncfg.Routing = constructTestnetRouting
 	}
 	return ncfg
 }
@@ -72,7 +72,7 @@ func constructRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching
 	return cachingRouter, nil
 }
 
-func constructDHTRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
+func constructRegtestRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
 	return dht.New(
 		ctx, host,
 		dhtopts.Datastore(dstore),
@@ -84,7 +84,7 @@ func constructDHTRouting(ctx context.Context, host p2phost.Host, dstore ds.Batch
 	)
 }
 
-func constructTestnetDHTRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
+func constructTestnetRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
 	var (
 		dhtRouting, err = dht.New(
 			ctx, host,

--- a/ipfs/config.go
+++ b/ipfs/config.go
@@ -1,0 +1,80 @@
+package ipfs
+
+import (
+	"context"
+
+	dht "gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht"
+	dhtopts "gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht/opts"
+	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
+	p2phost "gx/ipfs/QmYrWiWM4qtrnCeT3R14jY3ZZyirDNJgwK57q4qFYePgbd/go-libp2p-host"
+	routing "gx/ipfs/QmYxUdYY9S6yg5tSPVin5GFTvtfsLauVcr7reHDD3dM8xf/go-libp2p-routing"
+	protocol "gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
+	record "gx/ipfs/QmbeHtaBy9nZsW4cHRcvgVY4CnDhXudE2Dr6qDxS7yg9rX/go-libp2p-record"
+
+	ipfscore "github.com/ipfs/go-ipfs/core"
+	"github.com/ipfs/go-ipfs/repo"
+)
+
+var routerCacheURI string
+
+// PrepareIPFSConfig builds the configuration options for the internal
+// IPFS node.
+func PrepareIPFSConfig(r repo.Repo, routerAPIEndpoint string, testEnable, regtestEnable bool) *ipfscore.BuildCfg {
+	routerCacheURI = routerAPIEndpoint
+	ncfg := &ipfscore.BuildCfg{
+		Repo:   r,
+		Online: true,
+		ExtraOpts: map[string]bool{
+			"mplex":  true,
+			"ipnsps": true,
+		},
+	}
+
+	// regtest and test are never enabled together
+	ncfg.Routing = constructRouting
+	if regtestEnable {
+		ncfg.Routing = constructDHTRouting
+	} else if testEnable {
+		ncfg.Routing = constructTestnetDHTRouting
+	}
+	return ncfg
+}
+
+func constructRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
+	dhtRouting, err := dht.New(
+		ctx, host,
+		dhtopts.Datastore(dstore),
+		dhtopts.Validator(validator),
+	)
+	if err != nil {
+		return nil, err
+	}
+	apiRouter := NewAPIRouter(routerCacheURI)
+	cachingRouter := NewCachingRouter(dhtRouting, &apiRouter)
+	return cachingRouter, nil
+}
+
+func constructDHTRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
+	return dht.New(
+		ctx, host,
+		dhtopts.Datastore(dstore),
+		dhtopts.Validator(validator),
+	)
+}
+
+func constructTestnetDHTRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
+	testnetDHT := protocol.ID("/openbazaar/kad/testnet/1.0.0")
+	testnetApp := protocol.ID("/openbazaar/app/testnet/1.0.0")
+	dhtRouting, err := dht.New(
+		ctx, host,
+		dhtopts.Datastore(dstore),
+		dhtopts.Validator(validator),
+		dhtopts.Protocols(testnetDHT, testnetApp),
+	)
+	if err != nil {
+		return nil, err
+	}
+	apiRouter := NewAPIRouter(routerCacheURI)
+	cachingRouter := NewCachingRouter(dhtRouting, &apiRouter)
+	return cachingRouter, nil
+}

--- a/ipfs/constants.go
+++ b/ipfs/constants.go
@@ -1,0 +1,19 @@
+package ipfs
+
+const (
+	IPFSProtocolAppMainnetOne = "/openbazaar/app/1.0.0"
+	IPFSProtocolAppTestnetOne = "/openbazaar/app/testnet/1.0.0"
+
+	IPFSProtocolBitswapMainnetNoVers    = "/openbazaar/bitswap"
+	IPFSProtocolBitswapMainnetOne       = "/openbazaar/bitswap/1.0.0"
+	IPFSProtocolBitswapMainnetOneDotOne = "/openbazaar/bitswap/1.1.0"
+	IPFSProtocolBitswapTestnetNoVers    = "/openbazaar/bitswap/testnet"
+	IPFSProtocolBitswapTestnetOne       = "/openbazaar/bitswap/testnet/1.0.0"
+	IPFSProtocolBitswapTestnetOneDotOne = "/openbazaar/bitswap/testnet/1.1.0"
+
+	IPFSProtocolDHTMainnetLegacy = "/openbazaar/dht"
+	IPFSProtocolDHTTestnetLegacy = "/openbazaar/dht/testnet"
+
+	IPFSProtocolKademliaMainnetOne = "/openbazaar/kad/1.0.0"
+	IPFSProtocolKademliaTestnetOne = "/openbazaar/kad/testnet/1.0.0"
+)

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	routinghelpers "gx/ipfs/QmRCrPXk2oUwpK1Cj2FXrUotRpddUxz56setkny2gz13Cx/go-libp2p-routing-helpers"
-	dht "gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht"
-	dhtopts "gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht/opts"
+	"gx/ipfs/QmRCrPXk2oUwpK1Cj2FXrUotRpddUxz56setkny2gz13Cx/go-libp2p-routing-helpers"
+	"gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht"
+	"gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht/opts"
 	ma "gx/ipfs/QmTZBfrPJmjWsCvHEtX5FE6KimVJhsJg5sBbqEFYf4UZtL/go-multiaddr"
 	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
-	peer "gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
+	"gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
 	p2phost "gx/ipfs/QmYrWiWM4qtrnCeT3R14jY3ZZyirDNJgwK57q4qFYePgbd/go-libp2p-host"
-	routing "gx/ipfs/QmYxUdYY9S6yg5tSPVin5GFTvtfsLauVcr7reHDD3dM8xf/go-libp2p-routing"
-	record "gx/ipfs/QmbeHtaBy9nZsW4cHRcvgVY4CnDhXudE2Dr6qDxS7yg9rX/go-libp2p-record"
-	manet "gx/ipfs/Qmc85NSvmSG4Frn9Vb2cBc1rMyULH6D3TNVEfCzSKoUpip/go-multiaddr-net"
+	"gx/ipfs/QmYxUdYY9S6yg5tSPVin5GFTvtfsLauVcr7reHDD3dM8xf/go-libp2p-routing"
+	"gx/ipfs/QmbeHtaBy9nZsW4cHRcvgVY4CnDhXudE2Dr6qDxS7yg9rX/go-libp2p-record"
+	"gx/ipfs/Qmc85NSvmSG4Frn9Vb2cBc1rMyULH6D3TNVEfCzSKoUpip/go-multiaddr-net"
 	"gx/ipfs/QmddjPSGZb3ieihSseFeCfVRpZzcqczPNsD2DvarSwnjJB/gogo-protobuf/proto"
 	"io/ioutil"
 	"net/http"
@@ -35,6 +35,7 @@ import (
 	"github.com/OpenBazaar/openbazaar-go/repo"
 	"github.com/OpenBazaar/openbazaar-go/repo/db"
 	"github.com/OpenBazaar/openbazaar-go/repo/migrations"
+	"github.com/OpenBazaar/openbazaar-go/schema"
 	apiSchema "github.com/OpenBazaar/openbazaar-go/schema"
 	"github.com/OpenBazaar/openbazaar-go/storage/selfhosted"
 	"github.com/OpenBazaar/openbazaar-go/wallet"
@@ -62,8 +63,6 @@ type Node struct {
 	ipfsConfig     *ipfscore.BuildCfg
 	apiConfig      *apiSchema.APIConfig
 }
-
-var apiRouterURI string
 
 // NewNode create the configuration file for a new node
 func NewNode(repoPath string, authenticationToken string, testnet bool, userAgent string, walletTrustedPeer string, password string, mnemonic string) *Node {
@@ -252,8 +251,28 @@ func NewNodeWithConfig(config *NodeConfig, password string, mnemonic string) (*N
 		return nil, errors.New("no gateway addresses configured")
 	}
 
-	ncfg := ipfs.PrepareIPFSConfig(r, ipnsExtraConfig.APIRouter, config.Testnet, config.Testnet)
+	// override with mobile routing config
+	ignoredURI := ""
+	ncfg := ipfs.PrepareIPFSConfig(r, ignoredURI, config.Testnet, config.Testnet)
+	ncfg.Routing = constructMobileRouting
+
 	return &Node{OpenBazaarNode: core.Node, config: *config, ipfsConfig: ncfg, apiConfig: apiConfig}, nil
+}
+
+func constructMobileRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
+	dhtRouting, err := dht.New(
+		ctx, host,
+		dhtopts.Client(true),
+		dhtopts.Datastore(dstore),
+		dhtopts.Validator(validator),
+	)
+	if err != nil {
+		return nil, err
+	}
+	apiRouter := ipfs.NewAPIRouter(schema.IPFSCachingRouterDefaultURI)
+	apiRouter.Start(nil)
+	cachingRouter := ipfs.NewCachingRouter(dhtRouting, &apiRouter)
+	return cachingRouter, nil
 }
 
 // startIPFSNode start the node
@@ -472,20 +491,4 @@ func newHTTPGateway(node *core.OpenBazaarNode, ctx commands.Context, authCookie 
 
 	// Create and return an API gateway
 	return api.NewGateway(node, authCookie, manet.NetListener(gwLis), config, logger, opts...)
-}
-
-func constructRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
-	dhtRouting, err := dht.New(
-		ctx, host,
-		dhtopts.Client(true),
-		dhtopts.Datastore(dstore),
-		dhtopts.Validator(validator),
-	)
-	if err != nil {
-		return nil, err
-	}
-	apiRouter := ipfs.NewAPIRouter(apiRouterURI)
-	apiRouter.Start(nil)
-	cachingRouter := ipfs.NewCachingRouter(dhtRouting, &apiRouter)
-	return cachingRouter, nil
 }

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"gx/ipfs/QmRCrPXk2oUwpK1Cj2FXrUotRpddUxz56setkny2gz13Cx/go-libp2p-routing-helpers"
-	"gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht"
-	"gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht/opts"
+	routinghelpers "gx/ipfs/QmRCrPXk2oUwpK1Cj2FXrUotRpddUxz56setkny2gz13Cx/go-libp2p-routing-helpers"
+	dht "gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht"
+	dhtopts "gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht/opts"
 	ma "gx/ipfs/QmTZBfrPJmjWsCvHEtX5FE6KimVJhsJg5sBbqEFYf4UZtL/go-multiaddr"
 	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
-	"gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
+	peer "gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
 	p2phost "gx/ipfs/QmYrWiWM4qtrnCeT3R14jY3ZZyirDNJgwK57q4qFYePgbd/go-libp2p-host"
-	"gx/ipfs/QmYxUdYY9S6yg5tSPVin5GFTvtfsLauVcr7reHDD3dM8xf/go-libp2p-routing"
-	"gx/ipfs/QmbeHtaBy9nZsW4cHRcvgVY4CnDhXudE2Dr6qDxS7yg9rX/go-libp2p-record"
-	"gx/ipfs/Qmc85NSvmSG4Frn9Vb2cBc1rMyULH6D3TNVEfCzSKoUpip/go-multiaddr-net"
+	routing "gx/ipfs/QmYxUdYY9S6yg5tSPVin5GFTvtfsLauVcr7reHDD3dM8xf/go-libp2p-routing"
+	record "gx/ipfs/QmbeHtaBy9nZsW4cHRcvgVY4CnDhXudE2Dr6qDxS7yg9rX/go-libp2p-record"
+	manet "gx/ipfs/Qmc85NSvmSG4Frn9Vb2cBc1rMyULH6D3TNVEfCzSKoUpip/go-multiaddr-net"
 	"gx/ipfs/QmddjPSGZb3ieihSseFeCfVRpZzcqczPNsD2DvarSwnjJB/gogo-protobuf/proto"
 	"io/ioutil"
 	"net/http"
@@ -24,7 +24,6 @@ import (
 
 	ipfsconfig "gx/ipfs/QmUAuYuiafnJRZxDDX7MuruMNsicYNuyub5vUeAcupUBNs/go-ipfs-config"
 	ipnspb "gx/ipfs/QmUwMnKKjH3JwGKNVZ3TcP37W93xzqNA4ECFFiMo6sXkkc/go-ipns/pb"
-	bitswap "gx/ipfs/QmcSPuzpSbVLU6UHU4e5PwZpm4fHbCn5SbNR5ZNL6Mj63G/go-bitswap/network"
 
 	"github.com/OpenBazaar/openbazaar-go/api"
 	"github.com/OpenBazaar/openbazaar-go/core"
@@ -131,7 +130,6 @@ func NewNodeWithConfig(config *NodeConfig, password string, mnemonic string) (*N
 	if err != nil {
 		return nil, err
 	}
-	apiRouterURI = ipnsExtraConfig.APIRouter
 
 	// Create user-agent file
 	userAgentBytes := []byte(core.USERAGENT + config.UserAgent)
@@ -161,28 +159,16 @@ func NewNodeWithConfig(config *NodeConfig, password string, mnemonic string) (*N
 
 	// Setup testnet
 	if config.Testnet {
+		// set testnet bootstrap addrs
 		testnetBootstrapAddrs, err := apiSchema.GetTestnetBootstrapAddrs(configFile)
 		if err != nil {
+			log.Error(err)
 			return nil, err
 		}
 		cfg.Bootstrap = testnetBootstrapAddrs
-		dhtopts.ProtocolDHT = "/openbazaar/kad/testnet/1.0.0"
-		bitswap.ProtocolBitswap = "/openbazaar/bitswap/testnet/1.1.0"
-		service.ProtocolOpenBazaar = "/openbazaar/app/testnet/1.0.0"
 
+		// don't use pushnodes on testnet
 		dataSharing.PushTo = []string{}
-	} else {
-		bitswap.ProtocolBitswap = "/openbazaar/bitswap/1.1.0"
-	}
-
-	ncfg := &ipfscore.BuildCfg{
-		Repo:   r,
-		Online: true,
-		ExtraOpts: map[string]bool{
-			"mplex":  true,
-			"ipnsps": true,
-		},
-		Routing: constructRouting,
 	}
 
 	// Mnemonic
@@ -266,6 +252,7 @@ func NewNodeWithConfig(config *NodeConfig, password string, mnemonic string) (*N
 		return nil, errors.New("no gateway addresses configured")
 	}
 
+	ncfg := ipfs.PrepareIPFSConfig(r, ipnsExtraConfig.APIRouter, config.Testnet, config.Testnet)
 	return &Node{OpenBazaarNode: core.Node, config: *config, ipfsConfig: ncfg, apiConfig: apiConfig}, nil
 }
 

--- a/net/service/messagesender.go
+++ b/net/service/messagesender.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	inet "gx/ipfs/QmY3ArotKMKaL7YGfbQfyDrib6RVraLqZYWXZvVgZktBxp/go-libp2p-net"
-	peer "gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
+	"gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
 	ggio "gx/ipfs/QmddjPSGZb3ieihSseFeCfVRpZzcqczPNsD2DvarSwnjJB/gogo-protobuf/io"
 	"math/rand"
 	"sync"

--- a/net/service/messagesender.go
+++ b/net/service/messagesender.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 	inet "gx/ipfs/QmY3ArotKMKaL7YGfbQfyDrib6RVraLqZYWXZvVgZktBxp/go-libp2p-net"
-	"gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
+	peer "gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
 	ggio "gx/ipfs/QmddjPSGZb3ieihSseFeCfVRpZzcqczPNsD2DvarSwnjJB/gogo-protobuf/io"
 	"math/rand"
 	"sync"
 	"time"
 
+	"github.com/OpenBazaar/openbazaar-go/ipfs"
 	"github.com/OpenBazaar/openbazaar-go/pb"
 )
 
@@ -102,7 +103,7 @@ func (ms *messageSender) prep() error {
 		return nil
 	}
 
-	nstr, err := ms.service.host.NewStream(ms.service.ctx, ms.p, ProtocolOpenBazaar)
+	nstr, err := ms.service.host.NewStream(ms.service.ctx, ms.p, ipfs.IPFSProtocolAppMainnetOne)
 	if err != nil {
 		return err
 	}

--- a/net/service/service.go
+++ b/net/service/service.go
@@ -16,15 +16,14 @@ import (
 	"time"
 
 	"github.com/OpenBazaar/openbazaar-go/core"
+	"github.com/OpenBazaar/openbazaar-go/ipfs"
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/openbazaar-go/repo"
-	"github.com/jbenet/go-context/io"
+	ctxio "github.com/jbenet/go-context/io"
 	"github.com/op/go-logging"
 )
 
 var log = logging.MustGetLogger("service")
-
-var ProtocolOpenBazaar protocol.ID = "/openbazaar/app/1.0.0"
 
 type OpenBazaarService struct {
 	host      host.Host
@@ -49,8 +48,8 @@ func New(node *core.OpenBazaarNode, datastore repo.Datastore) *OpenBazaarService
 		node:      node,
 		sender:    make(map[peer.ID]*messageSender),
 	}
-	node.IpfsNode.PeerHost.SetStreamHandler(ProtocolOpenBazaar, service.HandleNewStream)
-	log.Infof("OpenBazaar service running at %s", ProtocolOpenBazaar)
+	node.IpfsNode.PeerHost.SetStreamHandler(protocol.ID(ipfs.IPFSProtocolAppMainnetOne), service.HandleNewStream)
+	log.Infof("OpenBazaar service running at %s", ipfs.IPFSProtocolAppMainnetOne)
 	return service
 }
 

--- a/repo/init.go
+++ b/repo/init.go
@@ -176,7 +176,7 @@ func addConfigExtensions(repoRoot string) error {
 		}
 		ie = schema.IpnsExtraConfig{
 			DHTQuorumSize: 1,
-			APIRouter:     "https://routing.api.openbazaar.org",
+			APIRouter:     schema.IPFSCachingRouterDefaultURI,
 		}
 
 		t = schema.TorConfig{}

--- a/schema/constants.go
+++ b/schema/constants.go
@@ -52,6 +52,8 @@ const (
 	BootstrapNodeDefault_LeMarcheSerpette = "/ip4/107.170.133.32/tcp/4001/ipfs/QmUZRGLhcKXF1JyuaHgKm23LvqcoMYwtb9jmh8CkP4og3K"
 	BootstrapNodeDefault_BrixtonVillage   = "/ip4/139.59.174.197/tcp/4001/ipfs/QmZfTbnpvPwxCjpCG3CXJ7pfexgkBZ2kgChAiRJrTK1HsM"
 	BootstrapNodeDefault_Johari           = "/ip4/139.59.6.222/tcp/4001/ipfs/QmRDcEDK9gSViAevCHiE6ghkaBCU7rTuQj4BDpmCzRvRYg"
+
+	IPFSCachingRouterDefaultURI = "https://routing.api.openbazaar.org"
 	// End Configuration defaults
 )
 


### PR DESCRIPTION
Update: This PR also manages the other protocol strings the daemon uses (kademlia, dht legacy, app, and bitswap protocols).

Original Motivation:
So currently we are not setting our DHT routing options correctly for testnet nodes (AFAICT). This means that when publishing and resolving, our testnet nodes just use mainnet DHT and mainnet nodes to store data. This code actually changes that and makes it so we only use testnet nodes. The only problem right now is that there are actually not any nodes that speak this protocol at the moment so it seems like all our testnet nodes will need to upgrade to this code before we see it acting properly (including seed nodes). 

**This needs validation though**