### PR TITLE
Attempt to protect the bitswap protocol strings in mobile package

### DIFF
--- a/mobile/node_test.go
+++ b/mobile/node_test.go
@@ -1,0 +1,83 @@
+package mobile_test
+
+import (
+	"testing"
+
+	"github.com/OpenBazaar/openbazaar-go/ipfs"
+	"github.com/OpenBazaar/openbazaar-go/mobile"
+	"github.com/OpenBazaar/openbazaar-go/schema"
+	bitswap "gx/ipfs/QmcSPuzpSbVLU6UHU4e5PwZpm4fHbCn5SbNR5ZNL6Mj63G/go-bitswap/network"
+)
+
+func TestNewNodeSetsIPFSGlobalAsSideEffectTestnet(t *testing.T) {
+	var s, err = schema.NewCustomSchemaManager(schema.SchemaContext{
+		DataPath:        schema.GenerateTempPath(),
+		TestModeEnabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.DestroySchemaDirectories()
+
+	if err := s.BuildSchemaDirectories(); err != nil {
+		t.Fatal(err)
+	}
+
+	config := &mobile.NodeConfig{
+		RepoPath:             s.DataPath(),
+		DisableWallet:        true,
+		DisableExchangerates: true,
+		Testnet:              true,
+	}
+	n, err := mobile.NewNodeWithConfig(config, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer n.Stop()
+
+	if bitswap.ProtocolBitswap != ipfs.IPFSProtocolBitswapTestnetOneDotOne {
+		t.Errorf("expected bitswap protocol latest to be set to '%s' when using testnet, but was not", ipfs.IPFSProtocolBitswapTestnetOneDotOne)
+	}
+	if bitswap.ProtocolBitswapOne != ipfs.IPFSProtocolBitswapTestnetOne {
+		t.Errorf("expected bitswap protocol v1 to be set to '%s' when using testnet, but was not", ipfs.IPFSProtocolBitswapTestnetOne)
+	}
+	if bitswap.ProtocolBitswapNoVers != ipfs.IPFSProtocolBitswapTestnetNoVers {
+		t.Errorf("expected bitswap protocol nover to be set to '%s' when using testnet, but was not", ipfs.IPFSProtocolBitswapTestnetNoVers)
+	}
+}
+
+//s2, err := schema.NewCustomSchemaManager(schema.SchemaContext{
+//DataPath:        schema.GenerateTempPath(),
+//TestModeEnabled: true,
+//})
+//if err != nil {
+//t.Fatal(err)
+//}
+
+//if err := s.BuildSchemaDirectories(); err != nil {
+//t.Fatal(err)
+//}
+//defer s2.DestroySchemaDirectories()
+
+//config = &mobile.NodeConfig{
+//RepoPath:             s2.DataPath(),
+//DisableWallet:        true,
+//DisableExchangerates: true,
+//Testnet:              false,
+//}
+//n2, err := mobile.NewNodeWithConfig(config, "", "")
+//if err != nil {
+//t.Fatal(err)
+//}
+//defer n2.Stop()
+
+//if bitswap.ProtocolBitswap != ipfs.IPFSProtocolBitswapMainnetOneDotOne {
+//t.Errorf("expected bitswap protocol latest to be set to '%s' when using mainnet, but was not", ipfs.IPFSProtocolBitswapMainnetOneDotOne)
+//}
+//if bitswap.ProtocolBitswapOne != ipfs.IPFSProtocolBitswapMainnetOne {
+//t.Errorf("expected bitswap protocol v1 to be set to '%s' when using mainnet, but was not", ipfs.IPFSProtocolBitswapMainnetOne)
+//}
+//if bitswap.ProtocolBitswapNoVers != ipfs.IPFSProtocolBitswapMainnetNoVers {
+//t.Errorf("expected bitswap protocol nover to be set to '%s' when using mainnet, but was not", ipfs.IPFSProtocolBitswapMainnetNoVers)
+//}
+//}


### PR DESCRIPTION
@cpacia This was an attempt to protect the mobile package's bitswap protocol strings, but there seems to be a race condition which sometimes causes fsrepo to deadlock. The tests are currently failing, but illustrate the idea. Can you see about getting these tests passing as part of your other PR? This is what the goroutines look like when attempting to run the included tests:

```
  Goroutine 1 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/testing/testing.go:879 testing.(*T).Run (0x4144aea)
  Goroutine 2 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 3 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 4 - User: ./vendor/gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log/writer/writer.go:76 github.com/OpenBazaar/openbazaar-go/vendor/gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4
HB7BGF/go-log/writer.(*MirrorWriter).logRoutine (0x44d8125)
  Goroutine 5 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/sigqueue.go:139 os/signal.signal_recv (0x404b5ef)
  Goroutine 8 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/asm_amd64.s:623 runtime.asmcgocall (0x4065302)
  Goroutine 9 - User: ./vendor/github.com/rjeczalik/notify/tree_recursive.go:125 github.com/OpenBazaar/openbazaar-go/vendor/github.com/rjeczalik/notify.(*recursiveTree).dispatch (0x555f8b4)
  Goroutine 10 - User: _cgo_gotypes.go:224 github.com/OpenBazaar/openbazaar-go/vendor/github.com/rjeczalik/notify._Cfunc_CFRunLoopRun (0x5565551)
  Goroutine 11 - User: ./vendor/github.com/OpenBazaar/multiwallet/service/wallet_service.go:97 github.com/OpenBazaar/openbazaar-go/vendor/github.com/OpenBazaar/multiwallet/service.(*WalletService).Stop (0
x50a7fee)
  Goroutine 18 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 19 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 20 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 21 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 22 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 23 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 24 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 34 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 35 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 36 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 37 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 51 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/asm_amd64.s:623 runtime.asmcgocall (0x4065302)
  Goroutine 66 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/asm_amd64.s:623 runtime.asmcgocall (0x4065302)
  Goroutine 89 - User: ./vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/db_compaction.go:90 github.com/OpenBazaar/openbazaar-go/vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPv
MJ6qbD8AMjYYvPRw1g/goleveldb/leveldb.(*DB).compactionError (0x4e2d483)
  Goroutine 90 - User: ./vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/db_state.go:97 github.com/OpenBazaar/openbazaar-go/vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qb
D8AMjYYvPRw1g/goleveldb/leveldb.(*DB).mpoolDrain (0x4e394b0)
  Goroutine 91 - User: ./vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/db_compaction.go:804 github.com/OpenBazaar/openbazaar-go/vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FP
vMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb.(*DB).tCompaction (0x4e347a9)
  Goroutine 92 - User: ./vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/db_compaction.go:751 github.com/OpenBazaar/openbazaar-go/vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FP
vMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb.(*DB).mCompaction (0x4e33dfc)
  Goroutine 93 - User: ./vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/db_write.go:37 github.com/OpenBazaar/openbazaar-go/vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qb
D8AMjYYvPRw1g/goleveldb/leveldb.(*DB).jWriter (0x4e3dbca)
  Goroutine 129 - User: ./vendor/gx/ipfs/QmcjM6sfVtgGFBCCJaZo33HNi7K4rPkrUQAzLewgWTNkeg/go-ds-flatfs/flatfs.go:876 github.com/OpenBazaar/openbazaar-go/vendor/gx/ipfs/QmcjM6sfVtgGFBCCJaZo33HNi7K4rPkrUQAzLe
wgWTNkeg/go-ds-flatfs.(*Datastore).checkpointLoop (0x4dcfb30)
  Goroutine 130 - User: /usr/local/Cellar/go@1.11/1.11.6/libexec/src/runtime/proc.go:303 runtime.gopark (0x40350a4)
  Goroutine 146 - User: ./vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/util/buffer_pool.go:206 github.com/OpenBazaar/openbazaar-go/vendor/gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9
Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/util.(*BufferPool).drain (0x4debebc)
```

If we can find an easy way to include this protect, that would be better than no protection offered in #1576. If we can't get this to reliably pass, we can ignore the test and merge #1576 as-is.