### PR TITLE
Create and use repo.APITime to guarantee timestamp formatting in API

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -3272,12 +3272,12 @@ func (i *jsonAPIHandler) POSTBumpFee(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	type response struct {
-		Txid               string    `json:"txid"`
-		Amount             int64     `json:"amount"`
-		ConfirmedBalance   int64     `json:"confirmedBalance"`
-		UnconfirmedBalance int64     `json:"unconfirmedBalance"`
-		Timestamp          time.Time `json:"timestamp"`
-		Memo               string    `json:"memo"`
+		Txid               string        `json:"txid"`
+		Amount             int64         `json:"amount"`
+		ConfirmedBalance   int64         `json:"confirmedBalance"`
+		UnconfirmedBalance int64         `json:"unconfirmedBalance"`
+		Timestamp          *repo.APITime `json:"timestamp"`
+		Memo               string        `json:"memo"`
 	}
 	confirmed, unconfirmed := wal.Balance()
 	txn, err := wal.GetTransaction(*newTxid)
@@ -3285,12 +3285,13 @@ func (i *jsonAPIHandler) POSTBumpFee(w http.ResponseWriter, r *http.Request) {
 		ErrorResponse(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	t := repo.APITime(txn.Timestamp)
 	resp := &response{
 		Txid:               newTxid.String(),
 		ConfirmedBalance:   confirmed,
 		UnconfirmedBalance: unconfirmed,
 		Amount:             -(txn.Value),
-		Timestamp:          txn.Timestamp,
+		Timestamp:          &t,
 		Memo:               fmt.Sprintf("Fee bump of %s", txid),
 	}
 	ser, err := json.MarshalIndent(resp, "", "    ")

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -3285,13 +3285,13 @@ func (i *jsonAPIHandler) POSTBumpFee(w http.ResponseWriter, r *http.Request) {
 		ErrorResponse(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	t := repo.APITime(txn.Timestamp)
+	t := repo.NewAPITime(txn.Timestamp)
 	resp := &response{
 		Txid:               newTxid.String(),
 		ConfirmedBalance:   confirmed,
 		UnconfirmedBalance: unconfirmed,
 		Amount:             -(txn.Value),
-		Timestamp:          &t,
+		Timestamp:          t,
 		Memo:               fmt.Sprintf("Fee bump of %s", txid),
 	}
 	ser, err := json.MarshalIndent(resp, "", "    ")

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -2867,18 +2867,18 @@ func (i *jsonAPIHandler) GETTransactions(w http.ResponseWriter, r *http.Request)
 	}
 	offsetID := r.URL.Query().Get("offsetId")
 	type Tx struct {
-		Txid          string    `json:"txid"`
-		Value         int64     `json:"value"`
-		Address       string    `json:"address"`
-		Status        string    `json:"status"`
-		ErrorMessage  string    `json:"errorMessage"`
-		Memo          string    `json:"memo"`
-		Timestamp     time.Time `json:"timestamp"`
-		Confirmations int32     `json:"confirmations"`
-		Height        int32     `json:"height"`
-		OrderID       string    `json:"orderId"`
-		Thumbnail     string    `json:"thumbnail"`
-		CanBumpFee    bool      `json:"canBumpFee"`
+		Txid          string        `json:"txid"`
+		Value         int64         `json:"value"`
+		Address       string        `json:"address"`
+		Status        string        `json:"status"`
+		ErrorMessage  string        `json:"errorMessage"`
+		Memo          string        `json:"memo"`
+		Timestamp     *repo.APITime `json:"timestamp"`
+		Confirmations int32         `json:"confirmations"`
+		Height        int32         `json:"height"`
+		OrderID       string        `json:"orderId"`
+		Thumbnail     string        `json:"thumbnail"`
+		CanBumpFee    bool          `json:"canBumpFee"`
 	}
 	wal, err := i.node.Multiwallet.WalletForCurrencyCode(coinType)
 	if err != nil {
@@ -2902,7 +2902,7 @@ func (i *jsonAPIHandler) GETTransactions(w http.ResponseWriter, r *http.Request)
 		tx := Tx{
 			Txid:          t.Txid,
 			Value:         t.Value,
-			Timestamp:     t.Timestamp,
+			Timestamp:     repo.NewAPITime(t.Timestamp),
 			Confirmations: int32(t.Confirmations),
 			Height:        t.Height,
 			Status:        string(t.Status),

--- a/api/jsonapi_test.go
+++ b/api/jsonapi_test.go
@@ -482,7 +482,7 @@ func TestWallet(t *testing.T) {
 		{"GET", "/wallet/address", "", 200, walletAddressJSONResponse},
 		{"GET", "/wallet/balance", "", 200, walletBalanceJSONResponse},
 		{"GET", "/wallet/mnemonic", "", 200, walletMneumonicJSONResponse},
-		{"POST", "/wallet/spend/", spendJSON, 400, insuffientFundsJSON},
+		{"POST", "/wallet/spend", spendJSON, 400, insuffientFundsJSON},
 		// TODO: Test successful spend on regnet with coins
 	})
 }

--- a/api/jsonapi_test.go
+++ b/api/jsonapi_test.go
@@ -796,7 +796,7 @@ func TestNotificationsAreReturnedInExpectedOrder(t *testing.T) {
 		createdAt = time.Unix(837645345, 0)
 		notif1    = &repo.Notification{
 			ID:           "notif1",
-			CreatedAt:    createdAt,
+			CreatedAt:    repo.NewAPITime(createdAt),
 			NotifierType: repo.NotifierTypeFollowNotification,
 			NotifierData: &repo.FollowNotification{
 				ID:     "notif1",
@@ -806,7 +806,7 @@ func TestNotificationsAreReturnedInExpectedOrder(t *testing.T) {
 		}
 		notif2 = &repo.Notification{
 			ID:           "notif2",
-			CreatedAt:    createdAt,
+			CreatedAt:    repo.NewAPITime(createdAt),
 			NotifierType: repo.NotifierTypeFollowNotification,
 			NotifierData: &repo.FollowNotification{
 				ID:     "notif2",
@@ -816,7 +816,7 @@ func TestNotificationsAreReturnedInExpectedOrder(t *testing.T) {
 		}
 		notif3 = &repo.Notification{
 			ID:           "notif3",
-			CreatedAt:    createdAt,
+			CreatedAt:    repo.NewAPITime(createdAt),
 			NotifierType: repo.NotifierTypeFollowNotification,
 			NotifierData: &repo.FollowNotification{
 				ID:     "notif3",

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -1272,12 +1272,12 @@ func (service *OpenBazaarService) handleChat(p peer.ID, pmes *pb.Message, option
 	}
 
 	// Push to websocket
-	n := repo.ChatMessage{
+	n := repo.ChatMessageNotification{
 		MessageId: chat.MessageId,
 		PeerId:    p.Pretty(),
 		Subject:   chat.Subject,
 		Message:   chat.Message,
-		Timestamp: t,
+		Timestamp: repo.NewAPITime(t),
 	}
 	service.broadcast <- n
 	log.Debugf("Received CHAT message from %s", p.Pretty())

--- a/repo/api_time.go
+++ b/repo/api_time.go
@@ -10,15 +10,23 @@ var ErrUnknownAPITimeFormat = errors.New("unknown api time format")
 
 const JSONAPITimeFormat = `"2006-01-02T15:04:05.999999999Z07:00"` // time.RFC3339Nano
 
-type APITime time.Time
+type APITime struct {
+	time.Time
+}
+
+// NewAPITime returns a pointer to a new APITime instance
+func NewAPITime(t time.Time) *APITime {
+	var val = APITime{t}
+	return &val
+}
 
 func (t APITime) MarshalJSON() ([]byte, error) {
-	return []byte(time.Time(t).Format(JSONAPITimeFormat)), nil
+	return []byte(t.Time.Format(JSONAPITimeFormat)), nil
 }
 
 func (t *APITime) UnmarshalJSON(b []byte) error {
 	if value, err := time.Parse(q(time.RFC3339), string(b)); err == nil {
-		*t = APITime(value)
+		*t = APITime{value}
 		return nil
 	}
 	return ErrUnknownAPITimeFormat
@@ -29,5 +37,5 @@ func q(format string) string {
 }
 
 func (t APITime) String() string {
-	return time.Time(t).String()
+	return t.Time.String()
 }

--- a/repo/api_time.go
+++ b/repo/api_time.go
@@ -1,0 +1,33 @@
+package repo
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+var ErrUnknownAPITimeFormat = errors.New("unknown api time format")
+
+const JSONAPITimeFormat = `"2006-01-02T15:04:05.999999999Z07:00"` // time.RFC3339Nano
+
+type APITime time.Time
+
+func (t APITime) MarshalJSON() ([]byte, error) {
+	return []byte(time.Time(t).Format(JSONAPITimeFormat)), nil
+}
+
+func (t *APITime) UnmarshalJSON(b []byte) error {
+	if value, err := time.Parse(q(time.RFC3339), string(b)); err == nil {
+		*t = APITime(value)
+		return nil
+	}
+	return ErrUnknownAPITimeFormat
+}
+
+func q(format string) string {
+	return fmt.Sprintf(`"%s"`, format)
+}
+
+func (t APITime) String() string {
+	return time.Time(t).String()
+}

--- a/repo/api_time_test.go
+++ b/repo/api_time_test.go
@@ -38,8 +38,8 @@ func TestAPITimeUnmarshalJSONSupportsRFC3339(t *testing.T) {
 		t.Logf("output: %s", string(marshaledExample))
 		t.Fatal(err)
 	}
-	if !when.Equal(time.Time(actual)) {
-		t.Errorf("expected (%s) to equal (%s), but did not when using format (%s)", time.Time(actual), when, format)
+	if !when.Equal(actual.Time) {
+		t.Errorf("expected (%s) to equal (%s), but did not when using format (%s)", actual.Time, when, format)
 	}
 }
 
@@ -55,13 +55,13 @@ func TestAPITimeUnmarshalJSONSupportsRFC3339Nano(t *testing.T) {
 		t.Logf("output: %s", string(marshaledExample))
 		t.Fatal(err)
 	}
-	if !when.Equal(time.Time(actual)) {
-		t.Errorf("expected (%s) to equal (%s), but did not when using format (%s)", time.Time(actual), when, format)
+	if !when.Equal(actual.Time) {
+		t.Errorf("expected (%s) to equal (%s), but did not when using format (%s)", actual.Time, when, format)
 	}
 }
 
 func TestAPITimeMarshalIsReciprocal(t *testing.T) {
-	var when = repo.APITime(time.Now())
+	var when = repo.NewAPITime(time.Now())
 	subjectBytes, err := json.Marshal(&when)
 	if err != nil {
 		t.Fatal(err)
@@ -72,7 +72,7 @@ func TestAPITimeMarshalIsReciprocal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !time.Time(when).Equal(time.Time(actual)) {
+	if !when.Equal(actual.Time) {
 		t.Errorf("expected (%s) to equal (%s), but did not", actual, when)
 	}
 }

--- a/repo/api_time_test.go
+++ b/repo/api_time_test.go
@@ -1,0 +1,78 @@
+package repo_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/OpenBazaar/openbazaar-go/repo"
+	"github.com/OpenBazaar/openbazaar-go/test/factory"
+)
+
+func TestAPITimeMarshalJSON(t *testing.T) {
+	var (
+		when     = time.Now()
+		subject  = factory.NewAPITime(when)
+		expected = []byte(when.Format(fmt.Sprintf(`"%s"`, time.RFC3339Nano)))
+	)
+	actual, err := json.Marshal(&subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(actual, expected) {
+		t.Errorf("expected (%s) to equal (%s), but did not", actual, expected)
+	}
+}
+
+func TestAPITimeUnmarshalJSONSupportsRFC3339(t *testing.T) {
+	var (
+		when             = time.Now().Truncate(time.Second)
+		format           = time.RFC3339
+		marshaledExample = []byte(fmt.Sprintf(`"%s"`, when.Format(format)))
+
+		actual repo.APITime
+	)
+	if err := json.Unmarshal(marshaledExample, &actual); err != nil {
+		t.Logf("output: %s", string(marshaledExample))
+		t.Fatal(err)
+	}
+	if !when.Equal(time.Time(actual)) {
+		t.Errorf("expected (%s) to equal (%s), but did not when using format (%s)", time.Time(actual), when, format)
+	}
+}
+
+func TestAPITimeUnmarshalJSONSupportsRFC3339Nano(t *testing.T) {
+	var (
+		when             = time.Now().Add(1 * time.Nanosecond)
+		format           = time.RFC3339Nano
+		marshaledExample = []byte(fmt.Sprintf(`"%s"`, when.Format(format)))
+
+		actual repo.APITime
+	)
+	if err := json.Unmarshal(marshaledExample, &actual); err != nil {
+		t.Logf("output: %s", string(marshaledExample))
+		t.Fatal(err)
+	}
+	if !when.Equal(time.Time(actual)) {
+		t.Errorf("expected (%s) to equal (%s), but did not when using format (%s)", time.Time(actual), when, format)
+	}
+}
+
+func TestAPITimeMarshalIsReciprocal(t *testing.T) {
+	var when = repo.APITime(time.Now())
+	subjectBytes, err := json.Marshal(&when)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var actual repo.APITime
+	if err := json.Unmarshal(subjectBytes, &actual); err != nil {
+		t.Fatal(err)
+	}
+
+	if !time.Time(when).Equal(time.Time(actual)) {
+		t.Errorf("expected (%s) to equal (%s), but did not", actual, when)
+	}
+}

--- a/repo/chat_message.go
+++ b/repo/chat_message.go
@@ -1,0 +1,25 @@
+package repo
+
+type ChatMessage struct {
+	MessageId string   `json:"messageId"`
+	PeerId    string   `json:"peerId"`
+	Subject   string   `json:"subject"`
+	Message   string   `json:"message"`
+	Read      bool     `json:"read"`
+	Outgoing  bool     `json:"outgoing"`
+	Timestamp *APITime `json:"timestamp"`
+}
+
+type ChatConversation struct {
+	PeerId    string   `json:"peerId"`
+	Unread    int      `json:"unread"`
+	Last      string   `json:"lastMessage"`
+	Timestamp *APITime `json:"timestamp"`
+	Outgoing  bool     `json:"outgoing"`
+}
+
+type GroupChatMessage struct {
+	PeerIds []string `json:"peerIds"`
+	Subject string   `json:"subject"`
+	Message string   `json:"message"`
+}

--- a/repo/db/chat.go
+++ b/repo/db/chat.go
@@ -101,7 +101,7 @@ func (c *ChatDB) GetConversations() []repo.ChatConversation {
 		if outInt > 0 {
 			outgoing = true
 		}
-		timestamp := time.Unix(0, ts)
+		timestamp := repo.NewAPITime(time.Unix(0, ts))
 		convo := repo.ChatConversation{
 			PeerId:    peerId,
 			Unread:    count,
@@ -142,7 +142,6 @@ func (c *ChatDB) GetMessages(peerID string, subject string, offsetId string, lim
 			message      string
 			readInt      int
 			timestampInt int64
-			timestamp    time.Time
 			outgoingInt  int
 		)
 		if err := rows.Scan(&msgID, &pid, &message, &readInt, &timestampInt, &outgoingInt); err != nil {
@@ -156,7 +155,7 @@ func (c *ChatDB) GetMessages(peerID string, subject string, offsetId string, lim
 		if outgoingInt == 1 {
 			outgoing = true
 		}
-		timestamp = time.Unix(0, timestampInt)
+		timestamp := repo.NewAPITime(time.Unix(0, timestampInt))
 		chatMessage := repo.ChatMessage{
 			PeerId:    pid,
 			MessageId: msgID,

--- a/repo/db/chat_test.go
+++ b/repo/db/chat_test.go
@@ -498,6 +498,6 @@ func TestChatDB_DeterministicNanosecondOrdering_Issue1545(t *testing.T) {
 			t.Fatalf("expected the messages to return in decending timestamp order, but were not")
 			t.Logf("\tmessages recieved: %+v", messages)
 		}
-		latestTime = m.Timestamp
+		latestTime = m.Timestamp.Time
 	}
 }

--- a/repo/db/notifications.go
+++ b/repo/db/notifications.go
@@ -117,7 +117,7 @@ func (n *NotficationsDB) GetAll(offsetId string, limit int, typeFilter []string)
 			read = true
 		}
 		notification.IsRead = read
-		notification.CreatedAt = time.Unix(int64(timestampInt), 0).UTC()
+		notification.CreatedAt = repo.NewAPITime(time.Unix(int64(timestampInt), 0).UTC())
 		// END
 
 		ret = append(ret, notification)

--- a/repo/models.go
+++ b/repo/models.go
@@ -53,20 +53,6 @@ type Coupon struct {
 	Hash string
 }
 
-type GroupChatMessage struct {
-	PeerIds []string `json:"peerIds"`
-	Subject string   `json:"subject"`
-	Message string   `json:"message"`
-}
-
-type ChatConversation struct {
-	PeerId    string    `json:"peerId"`
-	Unread    int       `json:"unread"`
-	Last      string    `json:"lastMessage"`
-	Timestamp time.Time `json:"timestamp"`
-	Outgoing  bool      `json:"outgoing"`
-}
-
 type Metadata struct {
 	Txid       string
 	Address    string

--- a/repo/notification.go
+++ b/repo/notification.go
@@ -39,7 +39,7 @@ type Notifier interface {
 func NewNotification(n Notifier, createdAt time.Time, isRead bool) *Notification {
 	return &Notification{
 		ID:           n.GetID(),
-		CreatedAt:    createdAt.UTC(),
+		CreatedAt:    NewAPITime(createdAt.UTC()),
 		IsRead:       isRead,
 		NotifierData: n,
 		NotifierType: n.GetType(),
@@ -55,7 +55,7 @@ func NewNotification(n Notifier, createdAt time.Time, isRead bool) *Notification
 // serializations to match in the Notifications Datastore
 type Notification struct {
 	ID           string           `json:"-"`
-	CreatedAt    time.Time        `json:"timestamp"`
+	CreatedAt    *APITime         `json:"timestamp"`
 	IsRead       bool             `json:"read"`
 	NotifierData Notifier         `json:"notification"`
 	NotifierType NotificationType `json:"-"`
@@ -77,7 +77,7 @@ func (n *Notification) Data() ([]byte, error)          { return json.MarshalInde
 func (n *Notification) WebsocketData() ([]byte, error) { return n.Data() }
 
 type notificationTransporter struct {
-	CreatedAt    time.Time        `json:"timestamp"`
+	CreatedAt    *APITime         `json:"timestamp"`
 	IsRead       bool             `json:"read"`
 	NotifierData json.RawMessage  `json:"notification"`
 	NotifierType NotificationType `json:"type"`

--- a/repo/notification.go
+++ b/repo/notification.go
@@ -804,21 +804,16 @@ func (n StatusNotification) GetID() string                               { retur
 func (n StatusNotification) GetType() NotificationType                   { return NotifierTypeStatusUpdateNotification }
 func (n StatusNotification) GetSMTPTitleAndBody() (string, string, bool) { return "", "", false }
 
-type ChatMessage struct {
-	MessageId string    `json:"messageId"`
-	PeerId    string    `json:"peerId"`
-	Subject   string    `json:"subject"`
-	Message   string    `json:"message"`
-	Read      bool      `json:"read"`
-	Outgoing  bool      `json:"outgoing"`
-	Timestamp time.Time `json:"timestamp"`
-}
+// ChatMessageNotification handles serialization of ChatMessages for notifications
+type ChatMessageNotification ChatMessage
 
-func (n ChatMessage) Data() ([]byte, error)                       { return json.MarshalIndent(messageWrapper{n}, "", "    ") }
-func (n ChatMessage) WebsocketData() ([]byte, error)              { return n.Data() }
-func (n ChatMessage) GetID() string                               { return "" } // Not persisted, ID is ignored
-func (n ChatMessage) GetType() NotificationType                   { return NotifierTypeChatMessage }
-func (n ChatMessage) GetSMTPTitleAndBody() (string, string, bool) { return "", "", false }
+func (n ChatMessageNotification) Data() ([]byte, error) {
+	return json.MarshalIndent(messageWrapper{n}, "", "    ")
+}
+func (n ChatMessageNotification) WebsocketData() ([]byte, error)              { return n.Data() }
+func (n ChatMessageNotification) GetID() string                               { return "" } // Not persisted, ID is ignored
+func (n ChatMessageNotification) GetType() NotificationType                   { return NotifierTypeChatMessage }
+func (n ChatMessageNotification) GetSMTPTitleAndBody() (string, string, bool) { return "", "", false }
 
 type ChatRead struct {
 	MessageId string `json:"messageId"`

--- a/test/factory/api_time.go
+++ b/test/factory/api_time.go
@@ -1,0 +1,11 @@
+package factory
+
+import (
+	"time"
+
+	"github.com/OpenBazaar/openbazaar-go/repo"
+)
+
+func NewAPITime(t time.Time) repo.APITime {
+	return repo.APITime(t)
+}

--- a/test/factory/api_time.go
+++ b/test/factory/api_time.go
@@ -6,6 +6,6 @@ import (
 	"github.com/OpenBazaar/openbazaar-go/repo"
 )
 
-func NewAPITime(t time.Time) repo.APITime {
-	return repo.APITime(t)
+func NewAPITime(t time.Time) *repo.APITime {
+	return repo.NewAPITime(t)
 }


### PR DESCRIPTION
In order to guarantee the formatting and marshaling of timestamp formats, I created `repo.APITime` to protect inputs matching `time.RFC3339` and `time.RFC3339Nano` formats while also having a pattern to follow for future flexibility around time presentation in our JSON API.

Closes #1571