### PR TITLE
Improve OrderConfirmation failure recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ dist
 .tags*
 *.sw?
 openbazaar-go*
+config_*
 
 # macOS
 .DS_Store

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -1579,7 +1579,7 @@ func (i *jsonAPIHandler) POSTOrderConfirmation(w http.ResponseWriter, r *http.Re
 		return
 	}
 	if !conf.Reject {
-		err := i.node.ConfirmOfflineOrder(contract, records)
+		err := i.node.ConfirmOfflineOrder(state, contract, records)
 		if err != nil {
 			ErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -494,10 +494,16 @@ func (service *OpenBazaarService) handleOrderConfirmation(p peer.ID, pmes *pb.Me
 
 	if funded {
 		// Set message state to AWAITING_FULFILLMENT
-		service.datastore.Purchases().Put(orderId, *contract, pb.OrderState_AWAITING_FULFILLMENT, false)
+		err := service.datastore.Purchases().Put(orderId, *contract, pb.OrderState_AWAITING_FULFILLMENT, false)
+		if err != nil {
+			log.Errorf("failed setting order (%) to AWAITING_FULFILLMENT: %s", orderId, err.Error())
+		}
 	} else {
 		// Set message state to AWAITING_PAYMENT
-		service.datastore.Purchases().Put(orderId, *contract, pb.OrderState_AWAITING_PAYMENT, false)
+		err := service.datastore.Purchases().Put(orderId, *contract, pb.OrderState_AWAITING_PAYMENT, false)
+		if err != nil {
+			log.Errorf("failed setting order (%) to AWAITING_PAYMENT: %s", orderId, err.Error())
+		}
 	}
 
 	var thumbnailTiny string


### PR DESCRIPTION
OrderConfirmation has lots of opportunities to be left in a bad state. This makes some changes which help recover some unexpected side-effect when failing mid-way through transition with a TODO to follow up on later.

Fixes #1668 and then some.

Note: This is built off the `numprec` branch and will merge onto the precision work to avoid annoying reconciliation later.