### PR TITLE
Add GET /wallet/currencies

### DIFF
--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -129,6 +129,8 @@ func get(i *jsonAPIHandler, path string, w http.ResponseWriter, r *http.Request)
 		i.GETPeers(w, r)
 	case strings.HasPrefix(path, "/ob/config"):
 		i.GETConfig(w, r)
+	case strings.HasPrefix(path, "/wallet/currencies"):
+		i.GETWalletCurrencyDictionary(w, r)
 	case strings.HasPrefix(path, "/wallet/address"):
 		i.GETAddress(w, r)
 	case strings.HasPrefix(path, "/wallet/mnemonic"):

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -674,6 +674,24 @@ func (i *jsonAPIHandler) POSTUnfollow(w http.ResponseWriter, r *http.Request) {
 	SanitizedResponse(w, `{}`)
 }
 
+func (i *jsonAPIHandler) GETWalletCurrencyDictionary(w http.ResponseWriter, r *http.Request) {
+	type response struct {
+		Entries repo.CurrencyDictionary `json:"entries"`
+	}
+	var (
+		resp = response{
+			Entries: repo.LoadCurrencyDefinitions(),
+		}
+		out, err = json.MarshalIndent(resp, "", "    ")
+	)
+	if err != nil {
+		ErrorResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SanitizedResponse(w, string(out))
+}
+
 func (i *jsonAPIHandler) GETAddress(w http.ResponseWriter, r *http.Request) {
 	_, coinType := path.Split(r.URL.Path)
 	if coinType == "address" {

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -676,23 +676,21 @@ func (i *jsonAPIHandler) POSTUnfollow(w http.ResponseWriter, r *http.Request) {
 
 func (i *jsonAPIHandler) GETWalletCurrencyDictionary(w http.ResponseWriter, r *http.Request) {
 	type response struct {
-		Entries repo.CurrencyDictionary `json:"entries"`
+		Entries map[string]*repo.CurrencyDefinition `json:"entries"`
 	}
 	var (
 		resp      = response{}
 		_, lookup = path.Split(r.URL.Path)
 	)
 	if lookup == "currencies" {
-		resp.Entries = repo.LoadCurrencyDefinitions()
+		resp.Entries = repo.LoadCurrencyDefinitions().All()
 	} else {
 		def, err := repo.LoadCurrencyDefinitions().Lookup(lookup)
 		if err != nil {
 			ErrorResponse(w, http.StatusNotFound, fmt.Sprintf("unknown definition for %s", lookup))
 			return
 		}
-		resp.Entries = repo.CurrencyDictionary{
-			lookup: def,
-		}
+		resp.Entries = map[string]*repo.CurrencyDefinition{lookup: def}
 	}
 	out, err := json.MarshalIndent(resp, "", "    ")
 	if err != nil {

--- a/api/jsonapi_data_test.go
+++ b/api/jsonapi_data_test.go
@@ -334,20 +334,22 @@ const walletBalanceJSONResponse = `{
         "confirmed": {
             "amount": "0",
             "currency": {
-                "code": "TBCH",
+                "code": "BCH",
                 "currencyType": "crypto",
                 "divisibility": 8,
-                "name": "Bitcoin Cash"
+                "name": "Bitcoin Cash",
+                "testnetCode": "TBCH"
             }
         },
         "height": 0,
         "unconfirmed": {
             "amount": "0",
             "currency": {
-                "code": "TBCH",
+                "code": "BCH",
                 "currencyType": "crypto",
                 "divisibility": 8,
-                "name": "Bitcoin Cash"
+                "name": "Bitcoin Cash",
+                "testnetCode": "TBCH"
             }
         }
     },
@@ -355,20 +357,22 @@ const walletBalanceJSONResponse = `{
         "confirmed": {
             "amount": "0",
             "currency": {
-                "code": "TBTC",
+                "code": "BTC",
                 "currencyType": "crypto",
                 "divisibility": 8,
-                "name": "Bitcoin"
+                "name": "Bitcoin",
+                "testnetCode": "TBTC"
             }
         },
         "height": 0,
         "unconfirmed": {
             "amount": "0",
             "currency": {
-                "code": "TBTC",
+                "code": "BTC",
                 "currencyType": "crypto",
                 "divisibility": 8,
-                "name": "Bitcoin"
+                "name": "Bitcoin",
+                "testnetCode": "TBTC"
             }
         }
     },
@@ -376,20 +380,22 @@ const walletBalanceJSONResponse = `{
         "confirmed": {
             "amount": "0",
             "currency": {
-                "code": "TLTC",
+                "code": "LTC",
                 "currencyType": "crypto",
                 "divisibility": 8,
-                "name": "Litecoin"
+                "name": "Litecoin",
+                "testnetCode": "TLTC"
             }
         },
         "height": 0,
         "unconfirmed": {
             "amount": "0",
             "currency": {
-                "code": "TLTC",
+                "code": "LTC",
                 "currencyType": "crypto",
                 "divisibility": 8,
-                "name": "Litecoin"
+                "name": "Litecoin",
+                "testnetCode": "TLTC"
             }
         }
     },
@@ -397,20 +403,22 @@ const walletBalanceJSONResponse = `{
         "confirmed": {
             "amount": "0",
             "currency": {
-                "code": "TZEC",
+                "code": "ZEC",
                 "currencyType": "crypto",
                 "divisibility": 8,
-                "name": "Zcash"
+                "name": "Zcash",
+                "testnetCode": "TZEC"
             }
         },
         "height": 0,
         "unconfirmed": {
             "amount": "0",
             "currency": {
-                "code": "TZEC",
+                "code": "ZEC",
                 "currencyType": "crypto",
                 "divisibility": 8,
-                "name": "Zcash"
+                "name": "Zcash",
+                "testnetCode": "TZEC"
             }
         }
     }

--- a/api/jsonapi_test.go
+++ b/api/jsonapi_test.go
@@ -498,6 +498,25 @@ func TestWallet(t *testing.T) {
 	})
 }
 
+func TestWalletCurrencyDictionary(t *testing.T) {
+	type dictionaryResponse struct {
+		Entries repo.CurrencyDictionary `json:"entries"`
+	}
+	var (
+		resp = dictionaryResponse{
+			Entries: repo.LoadCurrencyDefinitions(),
+		}
+		expectedResponse, err = json.MarshalIndent(resp, "", "    ")
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runAPITests(t, apiTests{
+		{"GET", "/wallet/currencies", "", 200, string(expectedResponse)},
+	})
+}
+
 func TestExchangeRates(t *testing.T) {
 	runAPITests(t, apiTests{
 		{"GET", "/ob/exchangerates", "", 500, invalidCoinJSON},

--- a/api/jsonapi_test.go
+++ b/api/jsonapi_test.go
@@ -501,11 +501,11 @@ func TestWallet(t *testing.T) {
 
 func TestWalletCurrencyDictionary(t *testing.T) {
 	type dictionaryResponse struct {
-		Entries repo.CurrencyDictionary `json:"entries"`
+		Entries map[string]*repo.CurrencyDefinition `json:"entries"`
 	}
 	var (
 		resp = dictionaryResponse{
-			Entries: repo.LoadCurrencyDefinitions(),
+			Entries: repo.LoadCurrencyDefinitions().All(),
 		}
 		expectedResponse, err = json.MarshalIndent(resp, "", "    ")
 	)
@@ -520,10 +520,10 @@ func TestWalletCurrencyDictionary(t *testing.T) {
 
 func TestWalletCurrencyDictionaryLookup(t *testing.T) {
 	type dictionaryResponse struct {
-		Entries repo.CurrencyDictionary `json:"entries"`
+		Entries map[string]*repo.CurrencyDefinition `json:"entries"`
 	}
 	var randomLookup string
-	for currency := range repo.LoadCurrencyDefinitions() {
+	for currency := range repo.LoadCurrencyDefinitions().All() {
 		// pick any currency string from the dictionary
 		randomLookup = currency
 		break
@@ -533,10 +533,8 @@ func TestWalletCurrencyDictionaryLookup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error looking up (%s): %s", randomLookup, err.Error())
 	}
-	resp := dictionaryResponse{
-		Entries: repo.CurrencyDictionary{randomLookup: def},
-	}
-	expectedResponse, err := json.MarshalIndent(resp, "", "    ")
+	entries := map[string]*repo.CurrencyDefinition{randomLookup: def}
+	expectedResponse, err := json.MarshalIndent(dictionaryResponse{Entries: entries}, "", "    ")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/jsonapi_test.go
+++ b/api/jsonapi_test.go
@@ -500,15 +500,7 @@ func TestWallet(t *testing.T) {
 }
 
 func TestWalletCurrencyDictionary(t *testing.T) {
-	type dictionaryResponse struct {
-		Entries map[string]*repo.CurrencyDefinition `json:"entries"`
-	}
-	var (
-		resp = dictionaryResponse{
-			Entries: repo.LoadCurrencyDefinitions().All(),
-		}
-		expectedResponse, err = json.MarshalIndent(resp, "", "    ")
-	)
+	var expectedResponse, err = json.MarshalIndent(repo.LoadCurrencyDefinitions().All(), "", "    ")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -519,9 +511,6 @@ func TestWalletCurrencyDictionary(t *testing.T) {
 }
 
 func TestWalletCurrencyDictionaryLookup(t *testing.T) {
-	type dictionaryResponse struct {
-		Entries map[string]*repo.CurrencyDefinition `json:"entries"`
-	}
 	var randomLookup string
 	for currency := range repo.LoadCurrencyDefinitions().All() {
 		// pick any currency string from the dictionary
@@ -534,7 +523,7 @@ func TestWalletCurrencyDictionaryLookup(t *testing.T) {
 		t.Fatalf("error looking up (%s): %s", randomLookup, err.Error())
 	}
 	entries := map[string]*repo.CurrencyDefinition{randomLookup: def}
-	expectedResponse, err := json.MarshalIndent(dictionaryResponse{Entries: entries}, "", "    ")
+	expectedResponse, err := json.MarshalIndent(entries, "", "    ")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repo/currency.go
+++ b/repo/currency.go
@@ -45,12 +45,7 @@ func (c *CurrencyValue) MarshalJSON() ([]byte, error) {
 	}
 
 	if c.Currency != nil {
-		c0.Currency = CurrencyDefinition{
-			Code:         c.Currency.Code,
-			Divisibility: c.Currency.Divisibility,
-			Name:         c.Currency.Name,
-			CurrencyType: c.Currency.CurrencyType,
-		}
+		c0.Currency = *c.Currency
 	}
 
 	return json.Marshal(c0)

--- a/repo/currency_definition.go
+++ b/repo/currency_definition.go
@@ -164,7 +164,7 @@ var (
 		"TJS": {Name: "Somoni", Code: CurrencyCode("TJS"), CurrencyType: Fiat, Divisibility: 2},
 		"TMT": {Name: "Turkmenistan New Manat", Code: CurrencyCode("TMT"), CurrencyType: Fiat, Divisibility: 2},
 		"TND": {Name: "Tunisian Dinar", Code: CurrencyCode("TND"), CurrencyType: Fiat, Divisibility: 2},
-		"TOP": {Name: "Pa\"anga", Code: CurrencyCode("TOP"), CurrencyType: Fiat, Divisibility: 2},
+		"TOP": {Name: "Paanga", Code: CurrencyCode("TOP"), CurrencyType: Fiat, Divisibility: 2},
 		"TRY": {Name: "Turkish Lira", Code: CurrencyCode("TRY"), CurrencyType: Fiat, Divisibility: 2},
 		"TTD": {Name: "Trinidad and Tobago Dollar", Code: CurrencyCode("TTD"), CurrencyType: Fiat, Divisibility: 2},
 		"TWD": {Name: "New Taiwan Dollar", Code: CurrencyCode("TWD"), CurrencyType: Fiat, Divisibility: 2},

--- a/repo/currency_definition_test.go
+++ b/repo/currency_definition_test.go
@@ -190,7 +190,7 @@ func TestCurrencyDictionaryLookup(t *testing.T) {
 		},
 		{ // testnet lookup
 			lookup:      testnetCode,
-			expected:    expected.AsTestnet(),
+			expected:    expected,
 			expectedErr: nil,
 		},
 		{ // undefined key

--- a/repo/currency_definition_test.go
+++ b/repo/currency_definition_test.go
@@ -2,6 +2,7 @@ package repo_test
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/OpenBazaar/openbazaar-go/repo"
@@ -159,38 +160,45 @@ func TestCurrencyDefinitionValidation(t *testing.T) {
 
 func TestCurrencyDictionaryLookup(t *testing.T) {
 	var (
-		expected = factory.NewCurrencyDefinition("ABC")
-		dict     = repo.CurrencyDictionary{
+		code        = "ABC"
+		testnetCode = "XYZ"
+		expected    = factory.NewCurrencyDefinition(code)
+		defs        = map[string]*repo.CurrencyDefinition{
 			expected.Code.String(): expected,
 		}
-
-		examples = []struct {
-			lookup      string
-			expected    *repo.CurrencyDefinition
-			expectedErr error
-		}{
-			{ // upcase lookup
-				lookup:      "ABC",
-				expected:    expected,
-				expectedErr: nil,
-			},
-			{ // lowercase lookup
-				lookup:      "abc",
-				expected:    expected,
-				expectedErr: nil,
-			},
-			{ // testnet lookup
-				lookup:      "TABC",
-				expected:    factory.NewCurrencyDefinition("TABC"),
-				expectedErr: nil,
-			},
-			{ // undefined key
-				lookup:      "FAIL",
-				expected:    nil,
-				expectedErr: repo.ErrCurrencyDefinitionUndefined,
-			},
-		}
 	)
+	expected.TestnetCode = repo.CurrencyCode(testnetCode)
+	dict, err := repo.NewCurrencyDictionary(defs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var examples = []struct {
+		lookup      string
+		expected    *repo.CurrencyDefinition
+		expectedErr error
+	}{
+		{ // upcase lookup
+			lookup:      code,
+			expected:    expected,
+			expectedErr: nil,
+		},
+		{ // lowercase lookup
+			lookup:      strings.ToLower(code),
+			expected:    expected,
+			expectedErr: nil,
+		},
+		{ // testnet lookup
+			lookup:      testnetCode,
+			expected:    expected.AsTestnet(),
+			expectedErr: nil,
+		},
+		{ // undefined key
+			lookup:      "FAIL",
+			expected:    nil,
+			expectedErr: repo.ErrCurrencyDefinitionUndefined,
+		},
+	}
 
 	for _, e := range examples {
 		var def, err = dict.Lookup(e.lookup)
@@ -215,13 +223,16 @@ func TestCurrencyDictionaryLookup(t *testing.T) {
 }
 
 func TestCurrencyDictionaryValid(t *testing.T) {
-	var (
-		valid      = factory.NewCurrencyDefinition("BTC")
-		invalidOne = factory.NewCurrencyDefinition("LTC")
-		invalidTwo = factory.NewCurrencyDefinition("BCH")
-	)
+	valid := factory.NewCurrencyDefinition("BTC")
+	// invalidOne is invalid because the divisibility is 0
+	invalidOne := factory.NewCurrencyDefinition("LTC")
 	invalidOne.Divisibility = 0
+	// invalidTwo is invalid because the code is too short
+	invalidTwo := factory.NewCurrencyDefinition("BCH")
 	invalidTwo.Code = "X"
+	// colliding is invalid because the testnet code collides with BTC above
+	colliding := factory.NewCurrencyDefinition("COL")
+	colliding.TestnetCode = repo.CurrencyCode("BTC")
 
 	errOne := invalidOne.Valid()
 	if errOne == nil {
@@ -233,12 +244,14 @@ func TestCurrencyDictionaryValid(t *testing.T) {
 	}
 
 	expectedErrs := map[string]error{
-		invalidOne.Code.String(): errOne,
-		invalidTwo.Code.String(): errTwo,
-		"DIF":                    repo.ErrDictionaryIndexMismatchedCode,
+		invalidOne.Code.String():       errOne,
+		invalidTwo.Code.String():       errTwo,
+		colliding.TestnetCode.String(): repo.ErrDictionaryCurrencyCodeCollision,
+		"DIF":                          repo.ErrDictionaryIndexMismatchedCode,
 	}
 	_, err := repo.NewCurrencyDictionary(map[string]*repo.CurrencyDefinition{
 		valid.Code.String():      valid,
+		colliding.Code.String():  colliding,
 		invalidOne.Code.String(): invalidOne,
 		invalidTwo.Code.String(): invalidTwo,
 		"DIF":                    valid,

--- a/repo/currency_definitions_validity_test.go
+++ b/repo/currency_definitions_validity_test.go
@@ -3,7 +3,7 @@ package repo
 import "testing"
 
 func TestMainnetCurrencyDictionaryIsValid(t *testing.T) {
-	if _, err := NewCurrencyDictionary(mainnetCurrencyDefinitions); err != nil {
+	if _, err := NewCurrencyDictionary(allCurrencyDefinitions); err != nil {
 		var mappedErrs = map[string]error(err.(CurrencyDictionaryProcessingError))
 		t.Logf("invalid currencies: %s", mappedErrs)
 		t.Fatal(err)

--- a/test/factory/currency.go
+++ b/test/factory/currency.go
@@ -22,6 +22,7 @@ func NewCurrencyDefinition(code string) *repo.CurrencyDefinition {
 	return &repo.CurrencyDefinition{
 		Name:         fmt.Sprintf("%scoin", code),
 		Code:         repo.CurrencyCode(code),
+		TestnetCode:  repo.CurrencyCode(fmt.Sprintf("T%s", code)),
 		Divisibility: 8,
 		CurrencyType: repo.Crypto,
 	}


### PR DESCRIPTION
Work towards completion of #1586.

Some example output:
```
[1586-currency-dictionary][mg@io:~/go/src/github.com/OpenBazaar/openbazaar-go]
[10:04:41] $ curl -I 0.0.0.0:4002/wallet/currencies/BCH
HTTP/1.1 200 OK
Content-Type: application/json
Date: Tue, 27 Aug 2019 14:04:51 GMT
Content-Length: 184

[1586-currency-dictionary][mg@io:~/go/src/github.com/OpenBazaar/openbazaar-go]
[10:04:52] $ curl -I 0.0.0.0:4002/wallet/currencies/INVALID
HTTP/1.1 404 Not Found
Content-Type: application/json
Date: Tue, 27 Aug 2019 14:04:58 GMT
Content-Length: 72

[1586-currency-dictionary][mg@io:~/go/src/github.com/OpenBazaar/openbazaar-go]
[10:06:07] $ curl 0.0.0.0:4002/wallet/currencies/INVALID
{
    "success": false,
    "reason": "unknown definition for INVALID"
}
```

Full dictionary response: https://gist.github.com/placer14/09e7cebce2b04551eec216e5d4880e42