### PR TITLE
PeerID is not included in SpendResponse

### DIFF
--- a/core/spend.go
+++ b/core/spend.go
@@ -124,6 +124,7 @@ func (n *OpenBazaarNode) Spend(args *SpendRequest) (*SpendResponse, error) {
 		Timestamp:          txn.Timestamp,
 		Memo:               memo,
 		OrderID:            args.OrderID,
+		PeerID:             contract.VendorListings[0].VendorID.PeerID,
 	}, nil
 }
 


### PR DESCRIPTION
For some reason, the spendresponse struct never included the vendor’s peer id and caused the payment message to never be sent.