### PR TITLE
Added relay messages to MessageProcessingOrder

### DIFF
--- a/net/retriever/retriever.go
+++ b/net/retriever/retriever.go
@@ -430,6 +430,7 @@ var MessageProcessingOrder = []pb.Message_MessageType{
 	pb.Message_MODERATOR_ADD,
 	pb.Message_MODERATOR_REMOVE,
 	pb.Message_OFFLINE_ACK,
+	pb.Message_OFFLINE_RELAY,
 }
 
 // processQueuedMessages loads all the saved messaged from the database for processing. For each message it sorts them into a


### PR DESCRIPTION
This fixes the issue that if messages came from an offline relay out-of-order they would never end up getting processed.