### PR TITLE
IPNS improvements to prevent panic

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -29,6 +29,7 @@ import (
 	peer "gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
 	routing "gx/ipfs/QmYxUdYY9S6yg5tSPVin5GFTvtfsLauVcr7reHDD3dM8xf/go-libp2p-routing"
 	ps "gx/ipfs/QmaCTz9RkrU13bm9kMB54f7atgqM4qkjDZpRwRoJiWXEqs/go-libp2p-peerstore"
+	ggproto "gx/ipfs/QmddjPSGZb3ieihSseFeCfVRpZzcqczPNsD2DvarSwnjJB/gogo-protobuf/proto"
 	mh "gx/ipfs/QmerPMzPk1mJVowm8KgmoknWa4yCYvvugMPsgWmDNUvDLW/go-multihash"
 
 	"github.com/OpenBazaar/jsonpb"
@@ -44,7 +45,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/ipfs/go-ipfs/core/coreapi"
-	"github.com/ipfs/go-ipfs/namesys"
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
 )
 
@@ -3786,7 +3786,7 @@ func (i *jsonAPIHandler) GETIPNS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	val, err := ipfsStore.Get(namesys.IpnsDsKey(pid))
+	peerIPNSRecord, err := ipfs.GetCachedIPNSRecord(ipfsStore, pid)
 	if err != nil { // No record in datastore
 		ErrorResponse(w, http.StatusNotFound, err.Error())
 		return
@@ -3813,8 +3813,13 @@ func (i *jsonAPIHandler) GETIPNS(w http.ResponseWriter, r *http.Request) {
 		Pubkey string `json:"pubkey"`
 		Record string `json:"record"`
 	}
+	peerIPNSBytes, err := ggproto.Marshal(peerIPNSRecord)
+	if err != nil {
+		ErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("marshaling IPNS record: %s", err.Error()))
+		return
+	}
 
-	ret := KeyAndRecord{hex.EncodeToString(keyBytes), string(val)}
+	ret := KeyAndRecord{hex.EncodeToString(keyBytes), string(peerIPNSBytes)}
 	retBytes, err := json.MarshalIndent(ret, "", "    ")
 	if err != nil {
 		ErrorResponse(w, http.StatusInternalServerError, err.Error())
@@ -3839,9 +3844,14 @@ func (i *jsonAPIHandler) GETResolveIPNS(w http.ResponseWriter, r *http.Request) 
 	var response = respType{PeerID: peerID}
 
 	if i.node.IpfsNode.Identity.Pretty() == peerID {
-		ipnsBytes, err := i.node.IpfsNode.Repo.Datastore().Get(namesys.IpnsDsKey(i.node.IpfsNode.Identity))
+		rec, err := ipfs.GetCachedIPNSRecord(i.node.IpfsNode.Repo.Datastore(), i.node.IpfsNode.Identity)
 		if err != nil {
-			ErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("retrieving self from datastore: %s", err))
+			ErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("retrieving self: %s", err))
+			return
+		}
+		ipnsBytes, err := proto.Marshal(rec)
+		if err != nil {
+			ErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("marshaling self: %s", err))
 			return
 		}
 		response.Record.Hex = hex.EncodeToString(ipnsBytes)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -23,12 +23,10 @@ import (
 	dht "gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht"
 	ma "gx/ipfs/QmTZBfrPJmjWsCvHEtX5FE6KimVJhsJg5sBbqEFYf4UZtL/go-multiaddr"
 	config "gx/ipfs/QmUAuYuiafnJRZxDDX7MuruMNsicYNuyub5vUeAcupUBNs/go-ipfs-config"
-	ipnspb "gx/ipfs/QmUwMnKKjH3JwGKNVZ3TcP37W93xzqNA4ECFFiMo6sXkkc/go-ipns/pb"
 	peer "gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
 	oniontp "gx/ipfs/QmYv2MbwHn7qcvAPFisZ94w85crQVpwUuv8G7TuUeBnfPb/go-onion-transport"
 	ipfslogging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log/writer"
 	manet "gx/ipfs/Qmc85NSvmSG4Frn9Vb2cBc1rMyULH6D3TNVEfCzSKoUpip/go-multiaddr-net"
-	proto "gx/ipfs/QmddjPSGZb3ieihSseFeCfVRpZzcqczPNsD2DvarSwnjJB/gogo-protobuf/proto"
 
 	"github.com/OpenBazaar/openbazaar-go/api"
 	"github.com/OpenBazaar/openbazaar-go/core"
@@ -53,7 +51,6 @@ import (
 	"github.com/ipfs/go-ipfs/commands"
 	ipfscore "github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/core/corehttp"
-	"github.com/ipfs/go-ipfs/namesys"
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
 	"github.com/natefinch/lumberjack"
 	"github.com/op/go-logging"
@@ -416,21 +413,19 @@ func (x *Start) Execute(args []string) error {
 	}
 
 	// Get current directory root hash
-	ipnskey := namesys.IpnsDsKey(nd.Identity)
-	ival, hasherr := nd.Repo.Datastore().Get(ipnskey)
+	cachedIPNSRecord, hasherr := ipfs.GetCachedIPNSRecord(nd.Repo.Datastore(), nd.Identity)
 	if hasherr != nil {
-		log.Error("get ipns key:", hasherr)
-	}
-	ourIpnsRecord := new(ipnspb.IpnsEntry)
-	err = proto.Unmarshal(ival, ourIpnsRecord)
-	if err != nil {
-		log.Error("unmarshal record value", err)
-		nd.Repo.Datastore().Delete(ipnskey)
+		log.Warning(err)
+		if err := ipfs.DeleteCachedIPNSRecord(nd.Repo.Datastore(), nd.Identity); err != nil {
+			log.Errorf("deleting invalid IPNS record: %s", err.Error())
+		}
 	}
 
 	if x.ForceKeyCachePurge {
 		log.Infof("forcing key purge from namesys cache...")
-		nd.Repo.Datastore().Delete(ipnskey)
+		if err := ipfs.DeleteCachedIPNSRecord(nd.Repo.Datastore(), nd.Identity); err != nil {
+			log.Errorf("force-purging IPNS record: %s", err.Error())
+		}
 	}
 
 	// Wallet
@@ -583,6 +578,11 @@ func (x *Start) Execute(args []string) error {
 	subscriber := ipfs.NewPubsubSubscriber(context.Background(), nd.PeerHost, nd.Routing, nd.Repo.Datastore(), nd.PubSub)
 	ps := ipfs.Pubsub{Publisher: publisher, Subscriber: subscriber}
 
+	var rootHash string
+	if cachedIPNSRecord != nil {
+		rootHash = string(cachedIPNSRecord.Value)
+	}
+
 	// OpenBazaar node setup
 	core.Node = &core.OpenBazaarNode{
 		AcceptStoreRequests:           dataSharing.AcceptStoreRequests,
@@ -597,7 +597,7 @@ func (x *Start) Execute(args []string) error {
 		PushNodes:                     pushNodes,
 		RegressionTestEnable:          x.Regtest,
 		RepoPath:                      repoPath,
-		RootHash:                      string(ourIpnsRecord.Value),
+		RootHash:                      rootHash,
 		TestnetEnable:                 x.Testnet,
 		TorDialer:                     torDialer,
 		UserAgent:                     core.USERAGENT,

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -407,12 +407,8 @@ func (x *Start) Execute(args []string) error {
 	}
 	var dhtRouting *dht.IpfsDHT
 	for _, router := range tiered.Routers {
-		if r, ok := router.(*ipfs.CachingRouter); ok {
-			r.APIRouter().Start(torDialer)
-			dhtRouting, err = r.DHT()
-			if err != nil {
-				return err
-			}
+		if r, ok := router.(*dht.IpfsDHT); ok {
+			dhtRouting = r
 		}
 	}
 	if dhtRouting == nil {

--- a/core/core.go
+++ b/core/core.go
@@ -10,7 +10,6 @@ import (
 	libp2p "gx/ipfs/QmTW4SdgBWq9GjsBsHeUx8WuGxzhgzAf88UMH2w62PC8yK/go-libp2p-crypto"
 	ma "gx/ipfs/QmTZBfrPJmjWsCvHEtX5FE6KimVJhsJg5sBbqEFYf4UZtL/go-multiaddr"
 	cid "gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
-	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
 	peer "gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
 	routing "gx/ipfs/QmYxUdYY9S6yg5tSPVin5GFTvtfsLauVcr7reHDD3dM8xf/go-libp2p-routing"
 
@@ -332,8 +331,11 @@ func (n *OpenBazaarNode) EncryptMessage(peerID peer.ID, peerKey *libp2p.PubKey, 
 	ctx, cancel := context.WithTimeout(context.Background(), n.OfflineMessageFailoverTimeout)
 	defer cancel()
 	if peerKey == nil {
-		var pubKey libp2p.PubKey
-		keyval, err := n.IpfsNode.Repo.Datastore().Get(datastore.NewKey(KeyCachePrefix + peerID.Pretty()))
+		var (
+			pubKey libp2p.PubKey
+			store  = n.IpfsNode.Repo.Datastore()
+		)
+		keyval, err := ipfs.GetCachedPubkey(store, peerID.Pretty())
 		if err != nil {
 			pubKey, err = routing.GetPublicKey(n.IpfsNode.Routing, ctx, peerID)
 			if err != nil {

--- a/core/net.go
+++ b/core/net.go
@@ -122,7 +122,7 @@ func (n *OpenBazaarNode) SendOfflineMessage(p peer.ID, k *libp2p.PubKey, m *pb.M
 	go func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		err := n.Pubsub.Publisher.Publish(ctx, ipfs.MessageTopicPrefix+pointer.Cid.String(), ciphertext)
+		err := n.Pubsub.Publisher.Publish(ctx, pointer.Cid.String(), ciphertext)
 		if err != nil {
 			log.Error(err)
 		}

--- a/core/profile.go
+++ b/core/profile.go
@@ -24,9 +24,6 @@ import (
 	"github.com/imdario/mergo"
 )
 
-// KeyCachePrefix - cache prefix for public key
-const KeyCachePrefix = "/pubkey/"
-
 // ErrorProfileNotFound - profile not found error
 var ErrorProfileNotFound = errors.New("profile not found")
 

--- a/ipfs/config.go
+++ b/ipfs/config.go
@@ -55,7 +55,7 @@ func PrepareIPFSConfig(r repo.Repo, routerAPIEndpoint string, testEnable, regtes
 }
 
 func constructRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
-	dhtRouting, err := dht.New(
+	return dht.New(
 		ctx, host,
 		dhtopts.Datastore(dstore),
 		dhtopts.Validator(validator),
@@ -64,12 +64,6 @@ func constructRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching
 			IPFSProtocolDHTMainnetLegacy,
 		),
 	)
-	if err != nil {
-		return nil, err
-	}
-	apiRouter := NewAPIRouter(routerCacheURI, dhtRouting.Validator)
-	cachingRouter := NewCachingRouter(dhtRouting, &apiRouter)
-	return cachingRouter, nil
 }
 
 func constructRegtestRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
@@ -85,21 +79,13 @@ func constructRegtestRouting(ctx context.Context, host p2phost.Host, dstore ds.B
 }
 
 func constructTestnetRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
-	var (
-		dhtRouting, err = dht.New(
-			ctx, host,
-			dhtopts.Datastore(dstore),
-			dhtopts.Validator(validator),
-			dhtopts.Protocols(
-				IPFSProtocolKademliaTestnetOne,
-				IPFSProtocolAppTestnetOne,
-			),
-		)
+	return dht.New(
+		ctx, host,
+		dhtopts.Datastore(dstore),
+		dhtopts.Validator(validator),
+		dhtopts.Protocols(
+			IPFSProtocolKademliaTestnetOne,
+			IPFSProtocolAppTestnetOne,
+		),
 	)
-	if err != nil {
-		return nil, err
-	}
-	apiRouter := NewAPIRouter(routerCacheURI, dhtRouting.Validator)
-	cachingRouter := NewCachingRouter(dhtRouting, &apiRouter)
-	return cachingRouter, nil
 }

--- a/ipfs/pubsub.go
+++ b/ipfs/pubsub.go
@@ -16,12 +16,7 @@ import (
 	"time"
 )
 
-const (
-	globalIPNSTopic    = "IPNS"
-	globalBlockTopic   = "BLOCK"
-	globalCIDTopic     = "CID"
-	messageTopicPrefix = "/offlinemessage/"
-)
+const messageTopicPrefix = "/offlinemessage/"
 
 type Pubsub struct {
 	Subscriber *PubsubSubscriber

--- a/ipfs/pubsub.go
+++ b/ipfs/pubsub.go
@@ -17,10 +17,10 @@ import (
 )
 
 const (
-	MessageTopicPrefix = "/offlinemessage/"
-	GlobalIPNSTopic    = "IPNS"
-	GlobalBlockTopic   = "BLOCK"
-	GlobalCIDTopic     = "CID"
+	globalIPNSTopic    = "IPNS"
+	globalBlockTopic   = "BLOCK"
+	globalCIDTopic     = "CID"
+	messageTopicPrefix = "/offlinemessage/"
 )
 
 type Pubsub struct {
@@ -79,40 +79,42 @@ func NewPubsubSubscriber(ctx context.Context, host p2phost.Host, cr routing.Cont
 
 func (p *PubsubPublisher) Publish(ctx context.Context, topic string, data []byte) error {
 	p.mx.Lock()
-	_, ok := p.subs[topic]
+	id := messageTopicPrefix + topic
+	_, ok := p.subs[id]
 
 	if !ok {
-		p.subs[topic] = struct{}{}
+		p.subs[id] = struct{}{}
 		p.mx.Unlock()
 
-		bootstrapPubsub(p.ctx, p.cr, p.host, topic)
+		bootstrapPubsub(p.ctx, p.cr, p.host, id)
 	} else {
 		p.mx.Unlock()
 	}
 
-	log.Debugf("PubsubPublish: publish data for %s", topic)
-	return p.ps.Publish(topic, data)
+	log.Debugf("PubsubPublish: publish data for %s", id)
+	return p.ps.Publish(id, data)
 }
 
 func (r *PubsubSubscriber) Subscribe(ctx context.Context, topic string) (chan []byte, error) {
 	r.mx.Lock()
 	// see if we already have a pubsub subscription; if not, subscribe
-	_, ok := r.subs[topic]
+	id := messageTopicPrefix + topic
+	_, ok := r.subs[id]
 	resp := make(chan []byte)
 	if !ok {
-		sub, err := r.ps.Subscribe(topic)
+		sub, err := r.ps.Subscribe(id)
 		if err != nil {
 			r.mx.Unlock()
 			return nil, err
 		}
 
-		log.Debugf("PubsubSubscribe: subscribed to %s", topic)
+		log.Debugf("PubsubSubscribe: subscribed to %s", id)
 
-		r.subs[topic] = sub
+		r.subs[id] = sub
 
 		ctx, cancel := context.WithCancel(r.ctx)
-		go r.handleSubscription(sub, topic, resp, cancel)
-		go bootstrapPubsub(ctx, r.cr, r.host, topic)
+		go r.handleSubscription(sub, id, resp, cancel)
+		go bootstrapPubsub(ctx, r.cr, r.host, id)
 	}
 	r.mx.Unlock()
 	return resp, nil

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -19,14 +19,12 @@ import (
 	ma "gx/ipfs/QmTZBfrPJmjWsCvHEtX5FE6KimVJhsJg5sBbqEFYf4UZtL/go-multiaddr"
 	ipfsconfig "gx/ipfs/QmUAuYuiafnJRZxDDX7MuruMNsicYNuyub5vUeAcupUBNs/go-ipfs-config"
 	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
-	ipnspb "gx/ipfs/QmUwMnKKjH3JwGKNVZ3TcP37W93xzqNA4ECFFiMo6sXkkc/go-ipns/pb"
 	"gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
 	p2phost "gx/ipfs/QmYrWiWM4qtrnCeT3R14jY3ZZyirDNJgwK57q4qFYePgbd/go-libp2p-host"
 	"gx/ipfs/QmYxUdYY9S6yg5tSPVin5GFTvtfsLauVcr7reHDD3dM8xf/go-libp2p-routing"
 	"gx/ipfs/QmbeHtaBy9nZsW4cHRcvgVY4CnDhXudE2Dr6qDxS7yg9rX/go-libp2p-record"
 	ipfslogging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log/writer"
 	"gx/ipfs/Qmc85NSvmSG4Frn9Vb2cBc1rMyULH6D3TNVEfCzSKoUpip/go-multiaddr-net"
-	"gx/ipfs/QmddjPSGZb3ieihSseFeCfVRpZzcqczPNsD2DvarSwnjJB/gogo-protobuf/proto"
 
 	"github.com/OpenBazaar/openbazaar-go/api"
 	"github.com/OpenBazaar/openbazaar-go/core"
@@ -49,7 +47,6 @@ import (
 	"github.com/ipfs/go-ipfs/commands"
 	ipfscore "github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/core/corehttp"
-	"github.com/ipfs/go-ipfs/namesys"
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
 	"github.com/natefinch/lumberjack"
 	"github.com/op/go-logging"
@@ -385,17 +382,15 @@ func (n *Node) start() error {
 	n.OpenBazaarNode.DHT = dhtRouting
 
 	// Get current directory root hash
-	ipnskey := namesys.IpnsDsKey(nd.Identity)
-	ival, hasherr := nd.Repo.Datastore().Get(ipnskey)
-	if hasherr != nil {
-		log.Error("get ipns key:", hasherr)
-	}
-	ourIpnsRecord := new(ipnspb.IpnsEntry)
-	err = proto.Unmarshal(ival, ourIpnsRecord)
+	rec, err := ipfs.GetCachedIPNSRecord(nd.Repo.Datastore(), nd.Identity)
 	if err != nil {
-		log.Error("unmarshal record value", err)
+		log.Warning(err)
+		if err := ipfs.DeleteCachedIPNSRecord(nd.Repo.Datastore(), nd.Identity); err != nil {
+			log.Errorf("deleting invalid IPNS record: %s", err.Error())
+		}
+	} else {
+		n.OpenBazaarNode.RootHash = string(rec.Value)
 	}
-	n.OpenBazaarNode.RootHash = string(ourIpnsRecord.Value)
 
 	configFile, err := ioutil.ReadFile(path.Join(n.OpenBazaarNode.RepoPath, "config"))
 	if err != nil {

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -38,7 +38,6 @@ import (
 	"github.com/OpenBazaar/openbazaar-go/repo"
 	"github.com/OpenBazaar/openbazaar-go/repo/db"
 	"github.com/OpenBazaar/openbazaar-go/repo/migrations"
-	"github.com/OpenBazaar/openbazaar-go/schema"
 	apiSchema "github.com/OpenBazaar/openbazaar-go/schema"
 	"github.com/OpenBazaar/openbazaar-go/storage/selfhosted"
 	"github.com/OpenBazaar/openbazaar-go/wallet"
@@ -307,19 +306,12 @@ func NewNodeWithConfig(config *NodeConfig, password string, mnemonic string) (*N
 }
 
 func constructMobileRouting(ctx context.Context, host p2phost.Host, dstore ds.Batching, validator record.Validator) (routing.IpfsRouting, error) {
-	dhtRouting, err := dht.New(
+	return dht.New(
 		ctx, host,
 		dhtopts.Client(true),
 		dhtopts.Datastore(dstore),
 		dhtopts.Validator(validator),
 	)
-	if err != nil {
-		return nil, err
-	}
-	apiRouter := ipfs.NewAPIRouter(schema.IPFSCachingRouterDefaultURI, dhtRouting.Validator)
-	apiRouter.Start(nil)
-	cachingRouter := ipfs.NewCachingRouter(dhtRouting, &apiRouter)
-	return cachingRouter, nil
 }
 
 // startIPFSNode start the node

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -9,11 +9,11 @@ import (
 
 	libp2p "gx/ipfs/QmTW4SdgBWq9GjsBsHeUx8WuGxzhgzAf88UMH2w62PC8yK/go-libp2p-crypto"
 	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
-	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
 	peer "gx/ipfs/QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h/go-libp2p-peer"
 	blocks "gx/ipfs/QmYYLnAzR28nAQ4U5MFniLprnktu6eTFKibeNt96V21EZK/go-block-format"
 
 	"github.com/OpenBazaar/openbazaar-go/core"
+	"github.com/OpenBazaar/openbazaar-go/ipfs"
 	"github.com/OpenBazaar/openbazaar-go/net"
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/openbazaar-go/repo"
@@ -258,9 +258,9 @@ func (service *OpenBazaarService) handleOfflineRelay(p peer.ID, pmes *pb.Message
 	if err != nil {
 		log.Errorf("handleOfflineRelayError: %s", err.Error())
 	}
-	err = service.node.IpfsNode.Repo.Datastore().Put(datastore.NewKey(core.KeyCachePrefix+id.Pretty()), env.Pubkey)
-	if err != nil {
-		log.Errorf("handleOfflineRelayError: %s", err.Error())
+	store := service.node.IpfsNode.Repo.Datastore()
+	if err := ipfs.PutCachedPubkey(store, id.Pretty(), env.Pubkey); err != nil {
+		log.Errorf("caching pubkey: %s", err.Error())
 	}
 
 	// Get handler for this message type

--- a/repo/migration.go
+++ b/repo/migration.go
@@ -46,6 +46,7 @@ var (
 		migrations.Migration023{},
 		migrations.Migration024{},
 		migrations.Migration025{},
+		migrations.Migration026{},
 	}
 )
 

--- a/repo/migrations/Migration026.go
+++ b/repo/migrations/Migration026.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
 	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
@@ -49,6 +50,9 @@ func (cleanIPNSRecordsFromDatastore) Up(repoPath, databasePassword string, testn
 
 	log.Debugf("found %d IPNS records to cull...", len(results))
 	for _, rawResult := range results {
+		if strings.HasPrefix(rawResult.Key, "/ipns/persistentcache") {
+			continue
+		}
 		rec := new(ipnspb.IpnsEntry)
 		if err = proto.Unmarshal(rawResult.Value, rec); err != nil {
 			log.Warningf("failed unmarshaling record (%s): %s", rawResult.Key, err.Error())

--- a/repo/migrations/Migration026.go
+++ b/repo/migrations/Migration026.go
@@ -1,0 +1,72 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-ipfs/repo/fsrepo"
+	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
+	dsq "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/query"
+	ipnspb "gx/ipfs/QmUwMnKKjH3JwGKNVZ3TcP37W93xzqNA4ECFFiMo6sXkkc/go-ipns/pb"
+	"gx/ipfs/QmddjPSGZb3ieihSseFeCfVRpZzcqczPNsD2DvarSwnjJB/gogo-protobuf/proto"
+)
+
+var cleanIPNSMigrationNumber = 26 // should match name
+
+type (
+	cleanIPNSRecordsFromDatastore struct{}
+	Migration026                  struct {
+		cleanIPNSRecordsFromDatastore
+	}
+)
+
+// Should we ever update these packages (which functionally changes their
+// behavior) the migrations should be made into a no-op.
+func (cleanIPNSRecordsFromDatastore) Up(repoPath, databasePassword string, testnetEnabled bool) error {
+	r, err := fsrepo.Open(repoPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			log.Errorf("closing repo: %s", err.Error())
+		}
+	}()
+
+	resultCh, err := r.Datastore().Query(dsq.Query{Prefix: "/ipns/"})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resultCh.Close(); err != nil {
+			log.Errorf("closing result channel: %s", err.Error())
+		}
+	}()
+
+	results, err := resultCh.Rest()
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("found %d IPNS records to cull...", len(results))
+	for _, rawResult := range results {
+		rec := new(ipnspb.IpnsEntry)
+		if err = proto.Unmarshal(rawResult.Value, rec); err != nil {
+			log.Warningf("failed unmarshaling record (%s): %s", rawResult.Key, err.Error())
+			if err := r.Datastore().Delete(ds.NewKey(rawResult.Key)); err != nil {
+				log.Errorf("failed dropping cached record (%s): %s", rawResult.Key, err.Error())
+			}
+		}
+	}
+
+	if err := writeRepoVer(repoPath, cleanIPNSMigrationNumber+1); err != nil {
+		return fmt.Errorf("updating repover to %d: %s", cleanIPNSMigrationNumber+1, err.Error())
+	}
+	return nil
+}
+
+func (cleanIPNSRecordsFromDatastore) Down(repoPath, databasePassword string, testnetEnabled bool) error {
+	if err := writeRepoVer(repoPath, cleanIPNSMigrationNumber); err != nil {
+		return fmt.Errorf("updating repover to %d: %s", cleanIPNSMigrationNumber, err.Error())
+	}
+	return nil
+}

--- a/repo/migrations/Migration026_test.go
+++ b/repo/migrations/Migration026_test.go
@@ -1,0 +1,84 @@
+package migrations
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/OpenBazaar/openbazaar-go/schema"
+	"github.com/ipfs/go-ipfs/repo/fsrepo"
+
+	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
+)
+
+func TestCleanIPNSRecordsMigration(t *testing.T) {
+	var (
+		basePath  = schema.GenerateTempPath()
+		ipnsKey   = "/ipns/shoulddelete"
+		otherKey  = "/ipfs/shouldNOTdelete"
+		migration = cleanIPNSRecordsFromDatastore{}
+
+		testRepoPath, err = schema.OpenbazaarPathTransform(basePath, true)
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	appSchema, err := schema.NewCustomSchemaManager(schema.SchemaContext{DataPath: testRepoPath, TestModeEnabled: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = appSchema.BuildSchemaDirectories(); err != nil {
+		t.Fatal(err)
+	}
+	defer appSchema.DestroySchemaDirectories()
+
+	if err := fsrepo.Init(appSchema.DataPath(), schema.MustDefaultConfig()); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := fsrepo.Open(testRepoPath)
+	if err != nil {
+		t.Fatalf("opening repo: %s", err.Error())
+	}
+
+	err = r.Datastore().Put(ds.NewKey(ipnsKey), []byte("randomdata"))
+	if err != nil {
+		t.Fatal("unable to put ipns record")
+	}
+	err = r.Datastore().Put(ds.NewKey(otherKey), []byte("randomdata"))
+	if err != nil {
+		t.Fatal("unable to put other record")
+	}
+
+	// run migration up
+	if err := migration.Up(appSchema.DataPath(), "", true); err != nil {
+		t.Fatal(err)
+	}
+
+	// validate state
+	if _, err := r.Datastore().Get(ds.NewKey(ipnsKey)); err != ds.ErrNotFound {
+		t.Errorf("expected the IPNS record to be removed, but was not")
+	}
+	if val, err := r.Datastore().Get(ds.NewKey(otherKey)); err != nil {
+		t.Errorf("expected the other record to be present, but was not")
+	} else {
+		if !bytes.Equal([]byte("randomdata"), val) {
+			t.Errorf("expected the other record data to be intact, but was not")
+		}
+	}
+
+	if err = appSchema.VerifySchemaVersion("27"); err != nil {
+		t.Fatal(err)
+	}
+
+	// run migration down
+	if err := migration.Down(appSchema.DataPath(), "", true); err != nil {
+		t.Fatal(err)
+	}
+
+	// validate state
+	if err = appSchema.VerifySchemaVersion("26"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/repo/migrations/log.go
+++ b/repo/migrations/log.go
@@ -1,0 +1,5 @@
+package migrations
+
+import logging "github.com/op/go-logging"
+
+var log = logging.MustGetLogger("migrations")


### PR DESCRIPTION
Fixes #1800 

Some observations from this work:
- ob-go does not put full IpnsEntry records into the IPFS Repo Datastore. If there invalid data being injected, it's by another system.
- Migration020 migrates IPNS records to key other than what we use for lookups in ipfs.Resolve (bug?) (see the difference in the keys used in Migration020 and the ones defined in `nativeIPNSRecordCacheKey` vs `obIPNSCacheKey`)