### PR TITLE
(ob-desktop #1825) Use ethereum transaction hash as is

### DIFF
--- a/core/spend.go
+++ b/core/spend.go
@@ -115,6 +115,7 @@ func (n *OpenBazaarNode) Spend(args *SpendRequest) (*SpendResponse, error) {
 
 	txn, err := wal.GetTransaction(*txid)
 	if err != nil {
+		log.Errorf("get txn failed : %v", err.Error())
 		return nil, fmt.Errorf("failed retrieving new wallet balance: %s", err)
 	}
 

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -1132,7 +1132,7 @@ func (service *OpenBazaarService) handleOrderCompletion(p peer.ID, pmes *pb.Mess
 		outValue := big.NewInt(0)
 		for _, r := range records {
 			if !r.Spent && r.Value.Cmp(big.NewInt(0)) > 0 {
-				outpointHash, err := hex.DecodeString(ut.NormalizeAddress(r.Txid))
+				outpointHash, err := hex.DecodeString(r.Txid)
 				if err != nil {
 					return nil, err
 				}

--- a/vendor/github.com/OpenBazaar/go-ethwallet/util/util.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/util/util.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"log"
 	"math/big"
 	"reflect"
 	"regexp"
@@ -13,8 +12,11 @@ import (
 	"github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/op/go-logging"
 	"github.com/shopspring/decimal"
 )
+
+var log = logging.MustGetLogger("ethwallet-util")
 
 // ExtractChaincode used to get the chaincode out of extended key
 func ExtractChaincode(key *hdkeychain.ExtendedKey) []byte {
@@ -136,14 +138,11 @@ func EnsureCorrectPrefix(str string) string {
 // letting the 0x prefix hinder the chainhash generation
 func CreateChainHash(str string) (*chainhash.Hash, error) {
 	hash, err := chainhash.NewHashFromStr(str)
-	if err.Error() == "max hash string length is 64 bytes" {
+	if err == chainhash.ErrHashStrSize {
 		hash, err = chainhash.NewHashFromStr(strings.TrimPrefix(str, "0x"))
 		if err != nil {
-			hash, err = chainhash.NewHashFromStr("")
-			if err != nil {
-				log.Println("err : ", err.Error())
-				return hash, err
-			}
+			log.Errorf("err creating chainhash : %v", err)
+			return nil, err
 		}
 	}
 	return hash, nil

--- a/vendor/github.com/OpenBazaar/go-ethwallet/util/util.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/util/util.go
@@ -1,12 +1,14 @@
 package util
 
 import (
+	"log"
 	"math/big"
 	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/ethereum/go-ethereum/common"
@@ -127,4 +129,22 @@ func EnsureCorrectPrefix(str string) string {
 		return str
 	}
 	return "0x" + str
+}
+
+// CreateChainHash is a wrapper to the chainhash.new hash function
+// this allows for a cleaner way to check if we are not in any way
+// letting the 0x prefix hinder the chainhash generation
+func CreateChainHash(str string) (*chainhash.Hash, error) {
+	hash, err := chainhash.NewHashFromStr(str)
+	if err.Error() == "max hash string length is 64 bytes" {
+		hash, err = chainhash.NewHashFromStr(strings.TrimPrefix(str, "0x"))
+		if err != nil {
+			hash, err = chainhash.NewHashFromStr("")
+			if err != nil {
+				log.Println("err : ", err.Error())
+				return hash, err
+			}
+		}
+	}
+	return hash, nil
 }

--- a/vendor/github.com/OpenBazaar/go-ethwallet/util/util.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/util/util.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/btcsuite/btcutil/hdkeychain"
@@ -118,4 +119,12 @@ func SigRSV(isig interface{}) ([32]byte, [32]byte, uint8) {
 	V := uint8(vI + 27)
 
 	return R, S, V
+}
+
+// EnsureCorrectPrefix ensures we have 0x prefix
+func EnsureCorrectPrefix(str string) string {
+	if strings.HasPrefix(str, "0x") {
+		return str
+	}
+	return "0x" + str
 }

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/account.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/account.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	log "github.com/sirupsen/logrus"
 	"github.com/tyler-smith/go-bip39"
 )
 

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/erc20_wallet.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/erc20_wallet.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/proxy"
 
 	"github.com/OpenBazaar/go-ethwallet/util"

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/service.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/service.go
@@ -7,7 +7,6 @@ import (
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/ethereum/go-ethereum/ethclient"
-	log "github.com/sirupsen/logrus"
 )
 
 // Service - used to represent WalletService

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
@@ -34,7 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	log "github.com/sirupsen/logrus"
+	"github.com/op/go-logging"
 	"golang.org/x/net/proxy"
 	"gopkg.in/yaml.v2"
 
@@ -52,6 +52,7 @@ var (
 		Code:         "ETH",
 		Divisibility: 18,
 	}
+	log = logging.MustGetLogger("ethwallet")
 )
 
 // EthConfiguration - used for eth specific configuration
@@ -558,6 +559,7 @@ func (wallet *EthereumWallet) GetTransaction(txid chainhash.Hash) (wi.Txn, error
 
 // ChainTip - Get the height and best hash of the blockchain
 func (wallet *EthereumWallet) ChainTip() (uint32, chainhash.Hash) {
+
 	num, hash, err := wallet.client.GetLatestBlock()
 	h, _ := chainhash.NewHashFromStr("")
 	if err != nil {
@@ -566,6 +568,10 @@ func (wallet *EthereumWallet) ChainTip() (uint32, chainhash.Hash) {
 	h, err = util.CreateChainHash(hash.Hex())
 	if err != nil {
 		log.Error(err)
+		h, err = chainhash.NewHashFromStr("")
+		if err != nil {
+			log.Errorf("err creating empty chainhash : %v", err)
+		}
 	}
 	return num, *h
 }

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
@@ -47,6 +47,8 @@ const (
 )
 
 var (
+	emptyChainHash *chainhash.Hash
+
 	// EthCurrencyDefinition is eth defaults
 	EthCurrencyDefinition = wi.CurrencyDefinition{
 		Code:         "ETH",
@@ -54,6 +56,18 @@ var (
 	}
 	log = logging.MustGetLogger("ethwallet")
 )
+
+func init() {
+	mustInitEmptyChainHash()
+}
+
+func mustInitEmptyChainHash() {
+	hash, err := chainhash.NewHashFromStr("")
+	if err != nil {
+		panic(fmt.Sprintf("creating emptyChainHash: %s", err.Error()))
+	}
+	emptyChainHash = hash
+}
 
 // EthConfiguration - used for eth specific configuration
 type EthConfiguration struct {
@@ -559,19 +573,14 @@ func (wallet *EthereumWallet) GetTransaction(txid chainhash.Hash) (wi.Txn, error
 
 // ChainTip - Get the height and best hash of the blockchain
 func (wallet *EthereumWallet) ChainTip() (uint32, chainhash.Hash) {
-
 	num, hash, err := wallet.client.GetLatestBlock()
-	h, _ := chainhash.NewHashFromStr("")
 	if err != nil {
-		return 0, *h
+		return 0, *emptyChainHash
 	}
-	h, err = util.CreateChainHash(hash.Hex())
+	h, err := util.CreateChainHash(hash.Hex())
 	if err != nil {
 		log.Error(err)
-		h, err = chainhash.NewHashFromStr("")
-		if err != nil {
-			log.Errorf("err creating empty chainhash : %v", err)
-		}
+		h = emptyChainHash
 	}
 	return num, *h
 }

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
@@ -563,7 +563,10 @@ func (wallet *EthereumWallet) ChainTip() (uint32, chainhash.Hash) {
 	if err != nil {
 		return 0, *h
 	}
-	h, _ = chainhash.NewHashFromStr(hash.Hex()[2:])
+	h, err = util.CreateChainHash(hash.Hex())
+	if err != nil {
+		log.Error(err)
+	}
 	return num, *h
 }
 
@@ -706,7 +709,7 @@ func (wallet *EthereumWallet) Spend(amount big.Int, addr btcutil.Address, feeLev
 	}
 
 	if err == nil {
-		h, err = chainhash.NewHashFromStr(util.EnsureCorrectPrefix(hash.Hex()))
+		h, err = util.CreateChainHash(hash.Hex())
 	}
 	return h, err
 }
@@ -769,7 +772,7 @@ func (wallet *EthereumWallet) CheckTxnRcpt(hash *common.Hash, data []byte) (*com
 		// but valid txn like some contract condition causing revert
 		if rcpt.Status > 0 {
 			// all good to update order state
-			chash, err := chainhash.NewHashFromStr((*hash).Hex())
+			chash, err := util.CreateChainHash((*hash).Hex())
 			if err != nil {
 				return nil, err
 			}
@@ -789,7 +792,7 @@ func (wallet *EthereumWallet) CheckTxnRcpt(hash *common.Hash, data []byte) (*com
 
 // BumpFee - Bump the fee for the given transaction
 func (wallet *EthereumWallet) BumpFee(txid chainhash.Hash) (*chainhash.Hash, error) {
-	return chainhash.NewHashFromStr(txid.String())
+	return util.CreateChainHash(txid.String())
 }
 
 // EstimateFee - Calculates the estimated size of the transaction and returns the total fee for the given feePerByte
@@ -845,7 +848,7 @@ func (wallet *EthereumWallet) SweepAddress(utxos []wi.TransactionInput, address 
 
 	hash := common.BytesToHash(data)
 
-	return chainhash.NewHashFromStr(hash.Hex()[2:])
+	return util.CreateChainHash(hash.Hex())
 }
 
 // ExchangeRates - return the exchangerates


### PR DESCRIPTION
Earlier, there were places where the `0x` prefix was being trimmed before being sent to ob-go. This is not removed. All the txn ids/hashes/addresses will not be trimmed of their `0x` prefix. 