### PR TITLE
(#1836) Only validate divisibility in sales listener if not crypto listing

### DIFF
--- a/wallet/listeners/transaction_listener.go
+++ b/wallet/listeners/transaction_listener.go
@@ -226,12 +226,14 @@ func (l *TransactionListener) processSalePayment(txid string, output wallet.Tran
 		}
 
 		// update divisibility from contract listing
-		customDivisibility := currencyDivisibilityFromContract(l.multiwallet, contract)
-		if customDivisibility != currencyValue.Currency.Divisibility {
-			currencyValue.Currency.Divisibility = customDivisibility
-			if err := currencyValue.Valid(); err != nil {
-				log.Errorf("Invalid currency divisibility (%d) found in contract (%s): %s", customDivisibility, orderId, err.Error())
-				return
+		if contract.VendorListings[0].Metadata.ContractType != pb.Listing_Metadata_CRYPTOCURRENCY {
+			customDivisibility := currencyDivisibilityFromContract(l.multiwallet, contract)
+			if customDivisibility != currencyValue.Currency.Divisibility {
+				currencyValue.Currency.Divisibility = customDivisibility
+				if err := currencyValue.Valid(); err != nil {
+					log.Errorf("Invalid currency divisibility (%d) found in contract (%s): %s", customDivisibility, orderId, err.Error())
+					return
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixed #1836 

The problem in this issue is that we're trying to validate the buyer's provided divisibility against the listing's divisibility but that field is not used in the listing for crypto listings causing a panic. 

Question for @placer14: 

This comment
> // TODO: this comparison needs to consider the possibility of different divisibilities

Doesn't seem to apply here right as if we skip the code block which assigns a custom divisibility in the crypto listing case then we're never using a custom divisibility. It's always using the divisibility from the lookup() right?