### PR TITLE
(#1572) Record aging improvements

### DIFF
--- a/core/record_aging_notifier.go
+++ b/core/record_aging_notifier.go
@@ -179,7 +179,11 @@ func (notifier *recordAgingNotifier) generateSellerDisputeNotifications() (*noti
 	if err = notifier.datastore.Sales().UpdateSalesLastDisputeTimeoutNotifiedAt(updatedSales); err != nil {
 		return nil, fmt.Errorf("update sales disputeTimeoutNotifiedAt: %s", err.Error())
 	}
-	return &notifierResult{len(notificationsToAdd), len(updatedSales), "sales"}, nil
+	return &notifierResult{
+		notificationsMade: len(notificationsToAdd),
+		recordsUpdated:    len(updatedSales),
+		subject:           "sales",
+	}, nil
 }
 
 func (notifier *recordAgingNotifier) generateBuyerDisputeTimeoutNotifications() (*notifierResult, error) {
@@ -258,7 +262,11 @@ func (notifier *recordAgingNotifier) generateBuyerDisputeTimeoutNotifications() 
 	if err = notifier.datastore.Purchases().UpdatePurchasesLastDisputeTimeoutNotifiedAt(updatedPurchases); err != nil {
 		return nil, fmt.Errorf("updating lastDisputeTimeoutNotifiedAt on purchases: %s", err.Error())
 	}
-	return &notifierResult{len(notificationsToAdd), len(updatedPurchases), "purchaseTimeout"}, nil
+	return &notifierResult{
+		notificationsMade: len(notificationsToAdd),
+		recordsUpdated:    len(updatedPurchases),
+		subject:           "purchaseTimeout",
+	}, nil
 }
 
 func (notifier *recordAgingNotifier) generateBuyerDisputeExpiryNotifications() (*notifierResult, error) {
@@ -333,7 +341,11 @@ func (notifier *recordAgingNotifier) generateBuyerDisputeExpiryNotifications() (
 	if err = notifier.datastore.Purchases().UpdatePurchasesLastDisputeExpiryNotifiedAt(updatedPurchases); err != nil {
 		return nil, fmt.Errorf("updating lastDisputeExpiryNotifiedAt on purchases: %s", err.Error())
 	}
-	return &notifierResult{len(notificationsToAdd), len(updatedPurchases), "purchaseExpire"}, nil
+	return &notifierResult{
+		notificationsMade: len(notificationsToAdd),
+		recordsUpdated:    len(updatedPurchases),
+		subject:           "purchaseExpire",
+	}, nil
 }
 
 func (notifier *recordAgingNotifier) generateModeratorDisputeExpiryNotifications() (*notifierResult, error) {
@@ -412,5 +424,9 @@ func (notifier *recordAgingNotifier) generateModeratorDisputeExpiryNotifications
 	if err = notifier.datastore.Cases().UpdateDisputesLastDisputeExpiryNotifiedAt(updatedDisputes); err != nil {
 		return nil, fmt.Errorf("updating lastDisputeExpiryNotifiedAt on disputes: %s", err.Error())
 	}
-	return &notifierResult{len(notificationsToAdd), len(updatedDisputes), "dispute"}, nil
+	return &notifierResult{
+		notificationsMade: len(notificationsToAdd),
+		recordsUpdated:    len(updatedDisputes),
+		subject:           "dispute",
+	}, nil
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -104,19 +104,9 @@ func (n *OpenBazaarNode) BuildTransactionRecords(contract *pb.RicardianContract,
 	return paymentRecords, refundRecord, nil
 }
 
-// LookupCurrency looks up the CurrencyDefinition, first by crypto for the current network
-// (mainnet or testnet) and then by fiat code
+// LookupCurrency looks up the CurrencyDefinition from available currencies
 func (n *OpenBazaarNode) LookupCurrency(currencyCode string) (repo.CurrencyDefinition, error) {
-	if n.TestnetEnable || n.RegressionTestEnable {
-		if def, err := repo.TestnetCurrencies().Lookup(currencyCode); err == nil {
-			return def, nil
-		}
-	} else {
-		if def, err := repo.MainnetCurrencies().Lookup(currencyCode); err == nil {
-			return def, nil
-		}
-	}
-	return repo.FiatCurrencies().Lookup(currencyCode)
+	return repo.AllCurrencies().Lookup(currencyCode)
 }
 
 // exchangeRateCode strips the T off the currency code if we are on testnet or regtest.

--- a/repo/db/cases.go
+++ b/repo/db/cases.go
@@ -31,17 +31,13 @@ func (c *CasesDB) PutRecord(dispute *repo.DisputeCaseRecord) error {
 		buyerOpenedInt = 1
 	}
 
-	tx, err := c.db.Begin()
-	if err != nil {
-		return err
-	}
 	stm := `insert or replace into cases(caseID, state, read, timestamp, buyerOpened, claim, buyerPayoutAddress, vendorPayoutAddress, paymentCoin, coinType) values(?,?,?,?,?,?,?,?,?,?)`
-	stmt, err := tx.Prepare(stm)
+	stmt, err := c.PrepareQuery(stm)
 	if err != nil {
 		return err
 	}
-
 	defer stmt.Close()
+
 	_, err = stmt.Exec(
 		dispute.CaseID,
 		int(dispute.OrderState),
@@ -55,14 +51,10 @@ func (c *CasesDB) PutRecord(dispute *repo.DisputeCaseRecord) error {
 		dispute.CoinType,
 	)
 	if err != nil {
-		rErr := tx.Rollback()
-		if rErr != nil {
-			return fmt.Errorf("case put fail: %s\nand rollback failed: %s\n", err.Error(), rErr.Error())
-		}
-		return err
+		return fmt.Errorf("update dispute case: %s", err.Error())
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 func (c *CasesDB) Put(caseID string, state pb.OrderState, buyerOpened bool, claim string, paymentCoin string, coinType string) error {
@@ -321,21 +313,24 @@ func (c *CasesDB) GetAll(stateFilter []pb.OrderState, searchTerm string, sortByA
 func (c *CasesDB) GetCaseMetadata(caseID string) (buyerContract, vendorContract *pb.RicardianContract, buyerValidationErrors, vendorValidationErrors []string, state pb.OrderState, read bool, timestamp time.Time, buyerOpened bool, claim string, resolution *pb.DisputeResolution, err error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	stmt, err := c.db.Prepare("select buyerContract, vendorContract, buyerValidationErrors, vendorValidationErrors, state, read, timestamp, buyerOpened, claim, disputeResolution from cases where caseID=?")
+	stmt, err := c.PrepareQuery("select buyerContract, vendorContract, buyerValidationErrors, vendorValidationErrors, state, read, timestamp, buyerOpened, claim, disputeResolution from cases where caseID=?")
 	if err != nil {
 		return nil, nil, []string{}, []string{}, pb.OrderState(0), false, time.Time{}, false, "", nil, err
 	}
 	defer stmt.Close()
-	var buyerCon []byte
-	var vendorCon []byte
-	var buyerErrors []byte
-	var vendorErrors []byte
-	var stateInt int
-	var readInt *int
-	var ts int
-	var buyerOpenedInt int
-	var disputResolution []byte
-	err = stmt.QueryRow(caseID).Scan(&buyerCon, &vendorCon, &buyerErrors, &vendorErrors, &stateInt, &readInt, &ts, &buyerOpenedInt, &claim, &disputResolution)
+
+	var (
+		buyerCon          []byte
+		vendorCon         []byte
+		buyerErrors       []byte
+		vendorErrors      []byte
+		stateInt          int
+		readInt           *int
+		ts                int
+		buyerOpenedInt    int
+		disputeResolution []byte
+	)
+	err = stmt.QueryRow(caseID).Scan(&buyerCon, &vendorCon, &buyerErrors, &vendorErrors, &stateInt, &readInt, &ts, &buyerOpenedInt, &claim, &disputeResolution)
 	if err != nil {
 		return nil, nil, []string{}, []string{}, pb.OrderState(0), false, time.Time{}, false, "", nil, err
 	}
@@ -371,21 +366,21 @@ func (c *CasesDB) GetCaseMetadata(caseID string) (buyerContract, vendorContract 
 	if string(buyerErrors) != "" {
 		err = json.Unmarshal(buyerErrors, &berr)
 		if err != nil {
-			return nil, nil, []string{}, []string{}, pb.OrderState(0), false, time.Time{}, false, "", nil, err
+			return nil, nil, []string{}, []string{}, pb.OrderState(0), false, time.Time{}, false, "", nil, fmt.Errorf("unmarshal dispute case: %s", err.Error())
 		}
 	}
 	var verr []string
 	if string(vendorErrors) != "" {
 		err = json.Unmarshal(vendorErrors, &verr)
 		if err != nil {
-			return nil, nil, []string{}, []string{}, pb.OrderState(0), false, time.Time{}, false, "", nil, err
+			return nil, nil, []string{}, []string{}, pb.OrderState(0), false, time.Time{}, false, "", nil, fmt.Errorf("unmarshal dispute vendor errors: %s", err.Error())
 		}
 	}
 	resolution = new(pb.DisputeResolution)
-	if string(disputResolution) != "" {
-		err = jsonpb.UnmarshalString(string(disputResolution), resolution)
+	if string(disputeResolution) != "" {
+		err = jsonpb.UnmarshalString(string(disputeResolution), resolution)
 		if err != nil {
-			return nil, nil, []string{}, []string{}, pb.OrderState(0), false, time.Time{}, false, "", nil, err
+			return nil, nil, []string{}, []string{}, pb.OrderState(0), false, time.Time{}, false, "", nil, fmt.Errorf("unmarhsal dispute case resolution: %s", err.Error())
 		}
 	} else {
 		resolution = nil
@@ -411,10 +406,12 @@ func (c *CasesDB) GetByCaseID(caseID string) (*repo.DisputeCaseRecord, error) {
 		vendorOuts       []byte
 	)
 
-	stmt, err := c.db.Prepare("select buyerContract, vendorContract, buyerPayoutAddress, vendorPayoutAddress, buyerOutpoints, vendorOutpoints, state, buyerOpened, timestamp, paymentCoin from cases where caseID=?")
+	stmt, err := c.PrepareQuery("select buyerContract, vendorContract, buyerPayoutAddress, vendorPayoutAddress, buyerOutpoints, vendorOutpoints, state, buyerOpened, timestamp, paymentCoin from cases where caseID=?")
 	if err != nil {
 		return nil, err
 	}
+	defer stmt.Close()
+
 	err = stmt.QueryRow(caseID).Scan(&buyerCon, &vendorCon, &buyerAddr, &vendorAddr, &buyerOuts, &vendorOuts, &stateInt, &isBuyerInitiated, &createdAt, &paymentCoin)
 	if err != nil {
 		return nil, err
@@ -566,18 +563,24 @@ func (c *CasesDB) UpdateDisputesLastDisputeExpiryNotifiedAt(disputeCases []*repo
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	tx, err := c.db.Begin()
+	tx, err := c.BeginTransaction()
 	if err != nil {
 		return fmt.Errorf("begin update disputes transaction: %s", err.Error())
 	}
 	for _, d := range disputeCases {
 		_, err = tx.Exec("update cases set lastDisputeExpiryNotifiedAt = ? where caseID = ?", int(d.LastDisputeExpiryNotifiedAt.Unix()), d.CaseID)
 		if err != nil {
+			if rErr := tx.Rollback(); rErr != nil {
+				return fmt.Errorf("update dispute case: (%s) w rollback error: (%s)", err.Error(), rErr.Error())
+			}
 			return fmt.Errorf("update dispute case: %s", err.Error())
 		}
 	}
 	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("commit update disputes transaction: %s", err.Error())
+		if rErr := tx.Rollback(); rErr != nil {
+			return fmt.Errorf("commit dispute case: (%s) w rollback error: (%s)", err.Error(), rErr.Error())
+		}
+		return fmt.Errorf("commit disputes case: %s", err.Error())
 	}
 
 	return nil

--- a/repo/db/coupons.go
+++ b/repo/db/coupons.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 	"sync"
 
 	"github.com/OpenBazaar/openbazaar-go/repo"
@@ -18,22 +19,24 @@ func NewCouponStore(db *sql.DB, lock *sync.Mutex) repo.CouponStore {
 func (c *CouponDB) Put(coupons []repo.Coupon) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	tx, _ := c.db.Begin()
+	tx, _ := c.BeginTransaction()
 	for _, coupon := range coupons {
 		stmt, _ := tx.Prepare("insert or replace into coupons(slug, code, hash) values(?,?,?)")
 		defer stmt.Close()
+
 		_, err := stmt.Exec(coupon.Slug, coupon.Code, coupon.Hash)
 		if err != nil {
-			err = tx.Rollback()
-			if err != nil {
-				log.Error(err)
+			if rErr := tx.Rollback(); rErr != nil {
+				return fmt.Errorf("add coupon: (%s) w rollback error: (%s)", err.Error(), rErr.Error())
 			}
-			return err
+			return fmt.Errorf("add coupon: %s", err.Error())
 		}
 	}
-	err := tx.Commit()
-	if err != nil {
-		log.Error(err)
+	if err := tx.Commit(); err != nil {
+		if rErr := tx.Rollback(); rErr != nil {
+			return fmt.Errorf("commit coupon: (%s) w rollback error: (%s)", err.Error(), rErr.Error())
+		}
+		return fmt.Errorf("commit coupon: %s", err.Error())
 	}
 	return nil
 }

--- a/repo/db/keys.go
+++ b/repo/db/keys.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"strconv"
 	"sync"
 
@@ -24,26 +25,15 @@ func NewKeyStore(db *sql.DB, lock *sync.Mutex, coinType wallet.CoinType) repo.Ke
 func (k *KeysDB) Put(scriptAddress []byte, keyPath wallet.KeyPath) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	tx, err := k.db.Begin()
+	stmt, err := k.PrepareQuery("insert into keys(coin, scriptAddress, purpose, keyIndex, used) values(?,?,?,?,?)")
 	if err != nil {
-		return err
-	}
-	stmt, err := tx.Prepare("insert into keys(coin, scriptAddress, purpose, keyIndex, used) values(?,?,?,?,?)")
-	if err != nil {
-		return err
+		return fmt.Errorf("prepare key sql: %s", err.Error())
 	}
 	defer stmt.Close()
+
 	_, err = stmt.Exec(k.coinType.CurrencyCode(), hex.EncodeToString(scriptAddress), int(keyPath.Purpose), keyPath.Index, 0)
 	if err != nil {
-		err0 := tx.Rollback()
-		if err0 != nil {
-			log.Error(err0)
-		}
-		return err
-	}
-	err = tx.Commit()
-	if err != nil {
-		log.Error(err)
+		return fmt.Errorf("commit key: %s", err.Error())
 	}
 	return nil
 }
@@ -51,26 +41,14 @@ func (k *KeysDB) Put(scriptAddress []byte, keyPath wallet.KeyPath) error {
 func (k *KeysDB) ImportKey(scriptAddress []byte, key *btcec.PrivateKey) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	tx, err := k.db.Begin()
+	stmt, err := k.PrepareQuery("insert into keys(coin, scriptAddress, purpose, used, key) values(?,?,?,?,?)")
 	if err != nil {
-		return err
-	}
-	stmt, err := tx.Prepare("insert into keys(coin, scriptAddress, purpose, used, key) values(?,?,?,?,?)")
-	if err != nil {
-		return err
+		return fmt.Errorf("prepare key sql: %s", err.Error())
 	}
 	defer stmt.Close()
 	_, err = stmt.Exec(k.coinType.CurrencyCode(), hex.EncodeToString(scriptAddress), -1, 0, hex.EncodeToString(key.Serialize()))
 	if err != nil {
-		err0 := tx.Rollback()
-		if err0 != nil {
-			log.Error(err0)
-		}
-		return err
-	}
-	err = tx.Commit()
-	if err != nil {
-		log.Error(err)
+		return fmt.Errorf("commit key: %s", err.Error())
 	}
 	return nil
 }
@@ -78,27 +56,15 @@ func (k *KeysDB) ImportKey(scriptAddress []byte, key *btcec.PrivateKey) error {
 func (k *KeysDB) MarkKeyAsUsed(scriptAddress []byte) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	tx, err := k.db.Begin()
+	stmt, err := k.PrepareQuery("update keys set used=1 where scriptAddress=? and coin=?")
 	if err != nil {
-		return err
+		return fmt.Errorf("prepare key sql: %s", err.Error())
 	}
-	stmt, err := tx.Prepare("update keys set used=1 where scriptAddress=? and coin=?")
-	if err != nil {
-		return err
-	}
-
 	defer stmt.Close()
+
 	_, err = stmt.Exec(hex.EncodeToString(scriptAddress), k.coinType.CurrencyCode())
 	if err != nil {
-		err0 := tx.Rollback()
-		if err0 != nil {
-			log.Error(err0)
-		}
-		return err
-	}
-	err = tx.Commit()
-	if err != nil {
-		log.Error(err)
+		return fmt.Errorf("commit key update: %s", err.Error())
 	}
 	return nil
 }

--- a/repo/db/notifications.go
+++ b/repo/db/notifications.go
@@ -134,24 +134,15 @@ func (n *NotficationsDB) GetAll(offsetId string, limit int, typeFilter []string)
 func (n *NotficationsDB) MarkAsRead(notifID string) error {
 	n.lock.Lock()
 	defer n.lock.Unlock()
-	tx, err := n.db.Begin()
+	stmt, err := n.PrepareQuery("update notifications set read=1 where notifID=?")
 	if err != nil {
-		return err
+		return fmt.Errorf("prepare notification sql: %s", err.Error())
 	}
-	stmt, _ := tx.Prepare("update notifications set read=1 where notifID=?")
-
 	defer stmt.Close()
+
 	_, err = stmt.Exec(notifID)
 	if err != nil {
-		err0 := tx.Rollback()
-		if err0 != nil {
-			log.Error(err0)
-		}
-		return err
-	}
-	err = tx.Commit()
-	if err != nil {
-		log.Error(err)
+		return fmt.Errorf("commit notification as read: %s", err.Error())
 	}
 	return nil
 }

--- a/repo/db/purchases.go
+++ b/repo/db/purchases.go
@@ -330,9 +330,11 @@ func (p *PurchasesDB) GetByOrderId(orderId string) (*pb.RicardianContract, pb.Or
 		return nil, pb.OrderState(0), false, nil, false, nil, fmt.Errorf("validating payment coin: %s", err.Error())
 	}
 	var records []*wallet.TransactionRecord
-	err = json.Unmarshal(serializedTransactions, &records)
-	if err != nil {
-		return nil, pb.OrderState(0), false, nil, false, nil, fmt.Errorf("unmarshal purchase transactions: %s", err.Error())
+	if len(serializedTransactions) > 0 {
+		err = json.Unmarshal(serializedTransactions, &records)
+		if err != nil {
+			return nil, pb.OrderState(0), false, nil, false, nil, fmt.Errorf("unmarshal purchase transactions: %s", err.Error())
+		}
 	}
 	cc := def.CurrencyCode()
 	return rc, pb.OrderState(stateInt), funded, records, read, &cc, nil

--- a/repo/db/purchases.go
+++ b/repo/db/purchases.go
@@ -41,15 +41,12 @@ func (p *PurchasesDB) Put(orderID string, contract pb.RicardianContract, state p
 		return err
 	}
 
-	tx, err := p.db.Begin()
-	if err != nil {
-		return err
-	}
 	stm := `insert or replace into purchases(orderID, contract, state, read, timestamp, total, thumbnail, vendorID, vendorHandle, title, shippingName, shippingAddress, paymentAddr, paymentCoin, coinType, funded, transactions, disputedAt) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,(select funded from purchases where orderID="` + orderID + `"),(select transactions from purchases where orderID="` + orderID + `"),?)`
-	stmt, err := tx.Prepare(stm)
+	stmt, err := p.db.Prepare(stm)
 	if err != nil {
 		return err
 	}
+	defer stmt.Close()
 	var (
 		paymentAddr, shippingName, shippingAddress string
 		disputedAt                                 int
@@ -70,8 +67,6 @@ func (p *PurchasesDB) Put(orderID string, contract pb.RicardianContract, state p
 	if dispute != nil {
 		disputedAt = int(dispute.Timestamp.Seconds)
 	}
-
-	defer stmt.Close()
 	_, err = stmt.Exec(
 		orderID,
 		out,
@@ -91,13 +86,9 @@ func (p *PurchasesDB) Put(orderID string, contract pb.RicardianContract, state p
 		disputedAt,
 	)
 	if err != nil {
-		err0 := tx.Rollback()
-		if err0 != nil {
-			log.Error(err0)
-		}
-		return err
+		return fmt.Errorf("commit purchase: %s", err.Error())
 	}
-	return tx.Commit()
+	return nil
 }
 
 func (p *PurchasesDB) MarkAsRead(orderID string) error {
@@ -341,7 +332,7 @@ func (p *PurchasesDB) GetByOrderId(orderId string) (*pb.RicardianContract, pb.Or
 	var records []*wallet.TransactionRecord
 	err = json.Unmarshal(serializedTransactions, &records)
 	if err != nil {
-		log.Error(err)
+		return nil, pb.OrderState(0), false, nil, false, nil, fmt.Errorf("unmarshal purchase transactions: %s", err.Error())
 	}
 	cc := def.CurrencyCode()
 	return rc, pb.OrderState(stateInt), funded, records, read, &cc, nil
@@ -354,7 +345,8 @@ func (p *PurchasesDB) Count() int {
 	var count int
 	err := row.Scan(&count)
 	if err != nil {
-		log.Error(err)
+		log.Errorf("failed scanning purchase count: %s", err.Error())
+		return 0
 	}
 	return count
 }
@@ -463,17 +455,23 @@ func (p *PurchasesDB) UpdatePurchasesLastDisputeTimeoutNotifiedAt(purchases []*r
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	tx, err := p.db.Begin()
+	tx, err := p.BeginTransaction()
 	if err != nil {
 		return fmt.Errorf("begin update purchase transaction: %s", err.Error())
 	}
 	for _, p := range purchases {
 		_, err = tx.Exec("update purchases set lastDisputeTimeoutNotifiedAt = ? where orderID = ?", int(p.LastDisputeTimeoutNotifiedAt.Unix()), p.OrderID)
 		if err != nil {
+			if rErr := tx.Rollback(); rErr != nil {
+				return fmt.Errorf("update purchase: (%s) w rollback error: (%s)", err.Error(), rErr.Error())
+			}
 			return fmt.Errorf("update purchase: %s", err.Error())
 		}
 	}
 	if err = tx.Commit(); err != nil {
+		if rErr := tx.Rollback(); rErr != nil {
+			return fmt.Errorf("commit purchase: (%s) w rollback error: (%s)", err.Error(), rErr.Error())
+		}
 		return fmt.Errorf("commit update purchase transaction: %s", err.Error())
 	}
 
@@ -488,17 +486,23 @@ func (p *PurchasesDB) UpdatePurchasesLastDisputeExpiryNotifiedAt(purchases []*re
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	tx, err := p.db.Begin()
+	tx, err := p.BeginTransaction()
 	if err != nil {
 		return fmt.Errorf("begin update purchase transaction: %s", err.Error())
 	}
 	for _, p := range purchases {
 		_, err = tx.Exec("update purchases set lastDisputeExpiryNotifiedAt = ? where orderID = ?", int(p.LastDisputeExpiryNotifiedAt.Unix()), p.OrderID)
 		if err != nil {
+			if rErr := tx.Rollback(); rErr != nil {
+				return fmt.Errorf("update purchase error: (%s) w rollback error: (%s)", err.Error(), rErr.Error())
+			}
 			return fmt.Errorf("update purchase: %s", err.Error())
 		}
 	}
 	if err = tx.Commit(); err != nil {
+		if rErr := tx.Rollback(); rErr != nil {
+			return fmt.Errorf("commit purchase error: (%s) w rollback error: (%s)", err.Error(), rErr.Error())
+		}
 		return fmt.Errorf("commit update purchase transaction: %s", err.Error())
 	}
 

--- a/repo/db/sales.go
+++ b/repo/db/sales.go
@@ -46,15 +46,12 @@ func (s *SalesDB) Put(orderID string, contract pb.RicardianContract, state pb.Or
 		return err
 	}
 
-	tx, err := s.db.Begin()
-	if err != nil {
-		return err
-	}
 	stm := `insert or replace into sales(orderID, contract, state, read, timestamp, total, thumbnail, buyerID, buyerHandle, title, shippingName, shippingAddress, paymentAddr, paymentCoin, coinType, funded, transactions) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,(select funded from sales where orderID="` + orderID + `"),(select transactions from sales where orderID="` + orderID + `"))`
-	stmt, err := tx.Prepare(stm)
+	stmt, err := s.db.Prepare(stm)
 	if err != nil {
-		return err
+		return fmt.Errorf("prepare sale sql: %s", err.Error())
 	}
+	defer stmt.Close()
 
 	handle := contract.BuyerOrder.BuyerID.Handle
 	shippingName := ""
@@ -70,7 +67,6 @@ func (s *SalesDB) Put(orderID string, contract pb.RicardianContract, state pb.Or
 		address = contract.VendorOrderConfirmation.PaymentAddress
 	}
 
-	defer stmt.Close()
 	_, err = stmt.Exec(
 		orderID,
 		out,
@@ -89,14 +85,10 @@ func (s *SalesDB) Put(orderID string, contract pb.RicardianContract, state pb.Or
 		CoinTypeForContract(&contract),
 	)
 	if err != nil {
-		err0 := tx.Rollback()
-		if err0 != nil {
-			log.Error(err0)
-		}
-		return err
+		return fmt.Errorf("commit sale: %s", err.Error())
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 func (s *SalesDB) MarkAsRead(orderID string) error {
@@ -420,18 +412,24 @@ func (s *SalesDB) UpdateSalesLastDisputeTimeoutNotifiedAt(sales []*repo.SaleReco
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	tx, err := s.db.Begin()
+	tx, err := s.BeginTransaction()
 	if err != nil {
 		return fmt.Errorf("begin update sale transaction: %s", err.Error())
 	}
 	for _, sale := range sales {
 		_, err = tx.Exec("update sales set lastDisputeTimeoutNotifiedAt = ? where orderID = ?", int(sale.LastDisputeTimeoutNotifiedAt.Unix()), sale.OrderID)
 		if err != nil {
+			if rErr := tx.Rollback(); rErr != nil {
+				return fmt.Errorf("update sale: (%s) w rollback error: (%s)", err.Error(), rErr.Error())
+			}
 			return fmt.Errorf("update sale: %s", err.Error())
 		}
 	}
 	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("commit update sale transaction: %s", err.Error())
+		if rErr := tx.Rollback(); rErr != nil {
+			return fmt.Errorf("commit sale: (%s) w rollback error: (%s)", err.Error(), rErr.Error())
+		}
+		return fmt.Errorf("commit sale: %s", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
Help improve #1572 but was not able to find the root cause for the unmarshal error. @amangale if you can provide more insight, I might be able to reproduce it but I was not able to.

This PR mainly removes unused transactions on the database and uses the `modelStore` interface methods instead of reaching into each datastore's private variable. It also does not use the node state to deteremine which currencies are accessible via the `OpenBazaarNode.CurrencyLookup()` method.

Closes #1572