### PR TITLE
(#1835) Fix cryptolisting price calculation for ETH payments

### DIFF
--- a/core/order.go
+++ b/core/order.go
@@ -1344,11 +1344,16 @@ func (n *OpenBazaarNode) getMarketPriceInSatoshis(pricingCurrency, currencyCode 
 	if err != nil {
 		return big.NewInt(0), err
 	}
-	r, _ := big.NewFloat(rate).Int(nil)
-	if r.Int64() == 0 {
-		return big.NewInt(0), errors.New("invalid rate of zero value")
+
+	cv, err := repo.NewCurrencyValue(amount.String(), currencyDef)
+	if err != nil {
+		return nil, err
 	}
-	return new(big.Int).Div(amount, r), nil
+	newCV, _, err := cv.ConvertTo(pricingDef, 1/rate)
+	if err != nil {
+		return nil, err
+	}
+	return newCV.Amount, nil
 }
 
 func verifySignaturesOnOrder(contract *pb.RicardianContract) error {


### PR DESCRIPTION
The crypto listing total calculation code was not adjusting for the payment
coin's level of precision and thus was returning only a few digits when
paying with eth instead of the full precision.

closes #1835

Sadly our code does not allow any easy way to test this without hitting the exchange rate API. We need much more refactoring, if not a whole sale change to the wallet interface and exchange rate design to improve. 

But for the sake of manual testing you can use this function:

```go
func TestCryptoListingTotal(t *testing.T) {
	node, err := test.NewNode()
	if err != nil {
		t.Fatal(err)
	}

	contract := &pb.RicardianContract{
		VendorListings:          []*pb.Listing{
			{
				Slug:                 "test",
				Metadata:             &pb.Listing_Metadata{
					Version:              5,
					ContractType:         pb.Listing_Metadata_CRYPTOCURRENCY,
					Format:               pb.Listing_Metadata_MARKET_PRICE,
					AcceptedCurrencies:   []string{"TBCH"},
					CryptoCurrencyCode:   "BAT",
					CryptoDivisibility:   8,
				},
				Item:                 &pb.Listing_Item{
					Title:                "bat",
					PriceModifier:        3,
				},
			},
		},
	}

	ser, err := proto.Marshal(contract.VendorListings[0])
	if err != nil {
		t.Fatal(err)
	}
	listingID, err := ipfs.EncodeCID(ser)
	if err != nil {
		t.Fatal(err)
	}

	contract.BuyerOrder = &pb.Order{
		Items:                []*pb.Order_Item{
			{
				ListingHash:          listingID.String(),
				BigQuantity:          "150000000",
			},
		},
		Payment:              &pb.Order_Payment{
			AmountCurrency:       &pb.CurrencyDefinition{
				Code:                 "TBCH",
				Divisibility:         18,
			},
		},
	}

	total, err := node.CalculateOrderTotal(contract)
	if err != nil {
		t.Fatal(err)
	}
	fmt.Println(total, len(total.String()))
}
```