### PR TITLE
(#1834) Do not allow purchases if amount is lower than the wallet's dust amount

### DIFF
--- a/core/order.go
+++ b/core/order.go
@@ -162,6 +162,10 @@ func (n *OpenBazaarNode) Purchase(data *repo.PurchaseData) (orderID string, paym
 		return "", "", retCurrency, false, err
 	}
 
+	if wal.IsDust(*total) {
+		return "", "", retCurrency, false, ErrSpendAmountIsDust
+	}
+
 	payment.BigAmount = total.String()
 
 	contract, err = n.SignOrder(contract)


### PR DESCRIPTION
Fixes #1834.