### PR TITLE
Add date to the timestamps in Haven logging

### DIFF
--- a/mobile/node.go
+++ b/mobile/node.go
@@ -70,7 +70,7 @@ type Node struct {
 
 var (
 	fileLogFormat = logging.MustStringFormatter(
-		`%{time:15:04:05.000} [%{level}] [%{module}/%{shortfunc}] %{message}`,
+		`%{time:2006-01-02 15:04:05.000} [%{level}] [%{module}/%{shortfunc}] %{message}`,
 	)
 	publishUnlocked    = false
 	mainLoggingBackend logging.Backend


### PR DESCRIPTION
Currently we just output the time and this makes it hard to find certain days in the log files.