### PR TITLE
Add dates to timestamps for desktop server

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -61,11 +61,11 @@ import (
 )
 
 var stdoutLogFormat = logging.MustStringFormatter(
-	`%{color:reset}%{color}%{time:15:04:05.000} [%{level}] [%{module}/%{shortfunc}] %{message}`,
+	`%{color:reset}%{color}%{time:2006-01-02 15:04:05.000} [%{level}] [%{module}/%{shortfunc}] %{message}`,
 )
 
 var fileLogFormat = logging.MustStringFormatter(
-	`%{time:15:04:05.000} [%{level}] [%{module}/%{shortfunc}] %{message}`,
+	`%{time:2006-01-02 15:04:05.000} [%{level}] [%{module}/%{shortfunc}] %{message}`,
 )
 
 var ErrNoGateways = errors.New("no gateway addresses configured")


### PR DESCRIPTION
This adds date to timestamps in the logs for the desktop server.