### PR TITLE
(#1846) Unable to load legacy orders due to payment coin refactor

### DIFF
--- a/core/order.go
+++ b/core/order.go
@@ -68,7 +68,12 @@ func (n *OpenBazaarNode) GetOrder(orderID string) (*pb.OrderRespApi, error) {
 	resp.State = state
 
 	// TODO: Remove once broken contracts are migrated
-	lookupCoin := contract.BuyerOrder.Payment.AmountCurrency.Code
+	var lookupCoin string
+	if contract.BuyerOrder.Payment.AmountCurrency != nil {
+		lookupCoin = contract.BuyerOrder.Payment.AmountCurrency.Code
+	} else {
+		lookupCoin = contract.BuyerOrder.Payment.Coin
+	}
 	_, err = n.LookupCurrency(lookupCoin)
 	if err != nil {
 		log.Warningf("invalid BuyerOrder.Payment.Coin (%s) on order (%s)", lookupCoin, orderID)

--- a/repo/db/purchases.go
+++ b/repo/db/purchases.go
@@ -247,7 +247,13 @@ func (p *PurchasesDB) GetUnfunded() ([]repo.UnfundedOrder, error) {
 			if err != nil {
 				return ret, err
 			}
-			ret = append(ret, repo.UnfundedOrder{OrderId: orderID, Timestamp: time.Unix(int64(timestamp), 0), PaymentCoin: rc.BuyerOrder.Payment.AmountCurrency.Code, PaymentAddress: paymentAddr})
+			var paymentCoin string
+			if rc.BuyerOrder.Payment.AmountCurrency != nil {
+				paymentCoin = rc.BuyerOrder.Payment.AmountCurrency.Code
+			} else {
+				paymentCoin = rc.BuyerOrder.Payment.Coin
+			}
+			ret = append(ret, repo.UnfundedOrder{OrderId: orderID, Timestamp: time.Unix(int64(timestamp), 0), PaymentCoin: paymentCoin, PaymentAddress: paymentAddr})
 		}
 	}
 	return ret, nil

--- a/repo/db/purchases.go
+++ b/repo/db/purchases.go
@@ -247,13 +247,17 @@ func (p *PurchasesDB) GetUnfunded() ([]repo.UnfundedOrder, error) {
 			if err != nil {
 				return ret, err
 			}
-			var paymentCoin string
-			if rc.BuyerOrder.Payment.AmountCurrency != nil {
-				paymentCoin = rc.BuyerOrder.Payment.AmountCurrency.Code
-			} else {
-				paymentCoin = rc.BuyerOrder.Payment.Coin
+			v5Order, err := repo.ToV5Order(rc.BuyerOrder, repo.AllCurrencies().Lookup)
+			if err != nil {
+				log.Errorf("failed converting contract buyer order to v5 schema: %s", err.Error())
+				return nil, err
 			}
-			ret = append(ret, repo.UnfundedOrder{OrderId: orderID, Timestamp: time.Unix(int64(timestamp), 0), PaymentCoin: paymentCoin, PaymentAddress: paymentAddr})
+			ret = append(ret, repo.UnfundedOrder{
+				OrderId:        orderID,
+				Timestamp:      time.Unix(int64(timestamp), 0),
+				PaymentCoin:    v5Order.Payment.AmountCurrency.Code,
+				PaymentAddress: paymentAddr,
+			})
 		}
 	}
 	return ret, nil


### PR DESCRIPTION
I'm sure this is not a long term fix considering there should be a migration of pre-ETH contracts to the new payment refactor, but it does alleviate the panic when loading orders into the UI.

Fixes #1846 