### PR TITLE
(#1815) Add currency value to refundAddressTransaction

### DIFF
--- a/core/refunds.go
+++ b/core/refunds.go
@@ -104,6 +104,7 @@ func (n *OpenBazaarNode) RefundOrder(contract *pb.RicardianContract, records []*
 		txinfo := new(pb.Refund_TransactionInfo)
 		txinfo.Txid = txid.String()
 		txinfo.BigValue = outValue.String()
+		txinfo.ValueCurrency = contract.BuyerOrder.Payment.AmountCurrency
 		refundMsg.RefundTransaction = txinfo
 	}
 	contract.Refund = refundMsg


### PR DESCRIPTION
This should close #1815.

I was unable to reproduce the missing data part of the issue though Rob did say the data eventually came in. Afaict this is the only place where the CurrencyValue is set (and it was missing) so I'm not sure how Rob was able to see it set in another context. 