### PR TITLE
[WIP] Revert custom transports to default transports

### DIFF
--- a/core/images.go
+++ b/core/images.go
@@ -168,11 +168,15 @@ func (n *OpenBazaarNode) FetchImage(peerID string, imageType string, size string
 // GetBase64Image - fetch the image and return it as base64 encoded string
 func (n *OpenBazaarNode) GetBase64Image(url string) (base64ImageData, filename string, err error) {
 	dial := net.Dial
+	var client *http.Client
 	if n.TorDialer != nil {
 		dial = n.TorDialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		client = &http.Client{Transport: tbTransport, Timeout: time.Second * 30}
+	} else {
+		client = &http.Client{Timeout: time.Second * 30}
 	}
-	tbTransport := &http.Transport{Dial: dial}
-	client := &http.Client{Transport: tbTransport, Timeout: time.Second * 30}
+
 	resp, err := client.Get(url)
 	if err != nil {
 		return "", "", err

--- a/net/retriever/retriever.go
+++ b/net/retriever/retriever.go
@@ -69,12 +69,15 @@ type offlineMessage struct {
 
 func NewMessageRetriever(cfg MRConfig) *MessageRetriever {
 	dial := gonet.Dial
+	var client *http.Client
 	if cfg.Dialer != nil {
 		dial = cfg.Dialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		client = &http.Client{Transport: tbTransport, Timeout: time.Second * 30}
+	} else {
+		client = &http.Client{Timeout: time.Second * 30}
 	}
 
-	tbTransport := &http.Transport{Dial: dial}
-	client := &http.Client{Transport: tbTransport, Timeout: time.Second * 30}
 	mr := MessageRetriever{
 		db:         cfg.Db,
 		node:       cfg.IPFSNode,

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/exchange_rates.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/exchange_rates.go
@@ -3,7 +3,6 @@ package wallet
 import (
 	"encoding/json"
 	"errors"
-	"net"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -57,12 +56,14 @@ func NewEthereumPriceFetcher(dialer proxy.Dialer) *EthereumPriceFetcher {
 	z := EthereumPriceFetcher{
 		cache: make(map[string]float64),
 	}
-	dial := net.Dial
+	var client *http.Client
 	if dialer != nil {
-		dial = dialer.Dial
+		dial := dialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		client = &http.Client{Transport: tbTransport, Timeout: time.Minute}
+	} else {
+		client = &http.Client{Timeout: time.Minute}
 	}
-	tbTransport := &http.Transport{Dial: dial}
-	client := &http.Client{Transport: tbTransport, Timeout: time.Minute}
 
 	z.providers = []*ExchangeRateProvider{
 		{"https://api.kraken.com/0/public/Ticker?pair=ETHXBT", z.cache, client, KrakenDecoder{}, bp},

--- a/vendor/github.com/OpenBazaar/multiwallet/bitcoincash/exchange_rates.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/bitcoincash/exchange_rates.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"reflect"
 	"sync"
@@ -37,12 +36,16 @@ func NewBitcoinCashPriceFetcher(dialer proxy.Dialer) *BitcoinCashPriceFetcher {
 	b := BitcoinCashPriceFetcher{
 		cache: make(map[string]float64),
 	}
-	dial := net.Dial
+
+	var client *http.Client
 	if dialer != nil {
-		dial = dialer.Dial
+		dial := dialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		client = &http.Client{Transport: tbTransport, Timeout: time.Minute}
+	} else {
+		client = &http.Client{Timeout: time.Minute}
 	}
-	tbTransport := &http.Transport{Dial: dial}
-	client := &http.Client{Transport: tbTransport, Timeout: time.Minute}
+
 
 	b.providers = []*ExchangeRateProvider{
 		{"https://ticker.openbazaar.org/api", b.cache, client, OpenBazaarDecoder{}},

--- a/vendor/github.com/OpenBazaar/multiwallet/client/blockbook/client.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/client/blockbook/client.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -122,16 +121,20 @@ func NewBlockBookClient(apiUrl string, proxyDialer proxy.Dialer) (*BlockBookClie
 		return nil, err
 	}
 
-	dial := net.Dial
+	var customClient http.Client
 	if proxyDialer != nil {
-		dial = proxyDialer.Dial
+		dial := proxyDialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		customClient = http.Client{Timeout: time.Second * 30, Transport: tbTransport}
+	} else {
+		customClient = http.Client{Timeout: time.Second * 30}
 	}
 
 	bch := make(chan model.Block)
 	tch := make(chan model.Transaction)
-	tbTransport := &http.Transport{Dial: dial}
+
 	ic := &BlockBookClient{
-		HTTPClient:      http.Client{Timeout: time.Second * 30, Transport: tbTransport},
+		HTTPClient:      customClient,
 		apiUrl:          u,
 		proxyDialer:     proxyDialer,
 		blockNotifyChan: bch,

--- a/vendor/github.com/OpenBazaar/multiwallet/litecoin/exchange_rates.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/litecoin/exchange_rates.go
@@ -3,7 +3,6 @@ package litecoin
 import (
 	"encoding/json"
 	"errors"
-	"net"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -44,12 +43,16 @@ func NewLitecoinPriceFetcher(dialer proxy.Dialer) *LitecoinPriceFetcher {
 	z := LitecoinPriceFetcher{
 		cache: make(map[string]float64),
 	}
-	dial := net.Dial
+
+	var client *http.Client
 	if dialer != nil {
-		dial = dialer.Dial
+		dial := dialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		client = &http.Client{Transport: tbTransport, Timeout: time.Minute}
+	} else {
+		client = &http.Client{Timeout: time.Minute}
 	}
-	tbTransport := &http.Transport{Dial: dial}
-	client := &http.Client{Transport: tbTransport, Timeout: time.Minute}
+
 
 	z.providers = []*ExchangeRateProvider{
 		{"https://ticker.openbazaar.org/api", z.cache, client, OpenBazaarDecoder{}, nil},

--- a/vendor/github.com/OpenBazaar/multiwallet/zcash/exchange_rates.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/zcash/exchange_rates.go
@@ -3,7 +3,6 @@ package zcash
 import (
 	"encoding/json"
 	"errors"
-	"net"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -45,12 +44,15 @@ func NewZcashPriceFetcher(dialer proxy.Dialer) *ZcashPriceFetcher {
 	z := ZcashPriceFetcher{
 		cache: make(map[string]float64),
 	}
-	dial := net.Dial
+
+	var client *http.Client
 	if dialer != nil {
-		dial = dialer.Dial
+		dial := dialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		client = &http.Client{Transport: tbTransport, Timeout: time.Minute}
+	} else {
+		client = &http.Client{Timeout: time.Minute}
 	}
-	tbTransport := &http.Transport{Dial: dial}
-	client := &http.Client{Transport: tbTransport, Timeout: time.Minute}
 
 	z.providers = []*ExchangeRateProvider{
 		{"https://ticker.openbazaar.org/api", z.cache, client, OpenBazaarDecoder{}, nil},


### PR DESCRIPTION
This is a WIP experiment to mitigate against the multiple timeout issues we're seeing when many requests are being made at once by any specific http.Client. We have anecdotal evidence that removal of the default `net.Dial` used with `http.Client{Transport}` has created some connectivity issues with many requests in-flight at once.

Will consider this for merge after running internal tests with this changeset.