### PR TITLE
Fix transports for message retriever and images

### DIFF
--- a/core/images.go
+++ b/core/images.go
@@ -165,11 +165,15 @@ func (n *OpenBazaarNode) FetchImage(peerID string, imageType string, size string
 // GetBase64Image - fetch the image and return it as base64 encoded string
 func (n *OpenBazaarNode) GetBase64Image(url string) (base64ImageData, filename string, err error) {
 	dial := net.Dial
+	var client *http.Client
 	if n.TorDialer != nil {
 		dial = n.TorDialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		client = &http.Client{Transport: tbTransport, Timeout: time.Second * 30}
+	} else {
+		client = &http.Client{Timeout: time.Second * 30}
 	}
-	tbTransport := &http.Transport{Dial: dial}
-	client := &http.Client{Transport: tbTransport, Timeout: time.Second * 30}
+
 	resp, err := client.Get(url)
 	if err != nil {
 		return "", "", err

--- a/net/retriever/retriever.go
+++ b/net/retriever/retriever.go
@@ -69,12 +69,14 @@ type offlineMessage struct {
 
 func NewMessageRetriever(cfg MRConfig) *MessageRetriever {
 	dial := gonet.Dial
+	var client *http.Client
 	if cfg.Dialer != nil {
 		dial = cfg.Dialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		client = &http.Client{Transport: tbTransport, Timeout: time.Second * 30}
+	} else {
+		client = &http.Client{Timeout: time.Second * 30}
 	}
-
-	tbTransport := &http.Transport{Dial: dial}
-	client := &http.Client{Transport: tbTransport, Timeout: time.Second * 30}
 	mr := MessageRetriever{
 		db:         cfg.Db,
 		node:       cfg.IPFSNode,


### PR DESCRIPTION
Revert back to original transports for the message retriever and image retrieval.