### PR TITLE
(#1907) Check for empty peer ID before adding to spendResponse

### DIFF
--- a/core/images.go
+++ b/core/images.go
@@ -5,11 +5,10 @@ import (
 	"encoding/base64"
 	"image"
 	_ "image/gif"
-	jpeg "image/jpeg"
+	"image/jpeg"
 	_ "image/png"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	netUrl "net/url"
 	"os"
@@ -18,7 +17,7 @@ import (
 	"time"
 
 	ipath "gx/ipfs/QmQAgv6Gaoe2tQpcabqwKXKChp2MZ7i3UXv9DqTTaxCaTR/go-path"
-	cid "gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
+	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
 
 	"github.com/OpenBazaar/openbazaar-go/ipfs"
 	"github.com/OpenBazaar/openbazaar-go/pb"
@@ -164,10 +163,9 @@ func (n *OpenBazaarNode) FetchImage(peerID string, imageType string, size string
 
 // GetBase64Image - fetch the image and return it as base64 encoded string
 func (n *OpenBazaarNode) GetBase64Image(url string) (base64ImageData, filename string, err error) {
-	dial := net.Dial
 	var client *http.Client
 	if n.TorDialer != nil {
-		dial = n.TorDialer.Dial
+		dial := n.TorDialer.Dial
 		tbTransport := &http.Transport{Dial: dial}
 		client = &http.Client{Transport: tbTransport, Timeout: time.Second * 30}
 	} else {

--- a/core/spend.go
+++ b/core/spend.go
@@ -88,11 +88,15 @@ func (n *OpenBazaarNode) Spend(args *SpendRequest) (*SpendResponse, error) {
 		thumbnail string
 		title     string
 		memo      = args.Memo
+		peerID    string
 	)
 	if contract != nil {
 		if contract.VendorListings[0].Item != nil && len(contract.VendorListings[0].Item.Images) > 0 {
 			thumbnail = contract.VendorListings[0].Item.Images[0].Tiny
 			title = contract.VendorListings[0].Item.Title
+		}
+		if contract.VendorListings[0].VendorID != nil {
+			peerID = contract.VendorListings[0].VendorID.PeerID
 		}
 	}
 	if memo == "" && title != "" {
@@ -124,6 +128,7 @@ func (n *OpenBazaarNode) Spend(args *SpendRequest) (*SpendResponse, error) {
 		Timestamp:          txn.Timestamp,
 		Memo:               memo,
 		OrderID:            args.OrderID,
+		PeerID:             peerID,
 	}, nil
 }
 

--- a/net/retriever/retriever.go
+++ b/net/retriever/retriever.go
@@ -13,7 +13,6 @@ import (
 	"gx/ipfs/QmerPMzPk1mJVowm8KgmoknWa4yCYvvugMPsgWmDNUvDLW/go-multihash"
 
 	"io/ioutil"
-	gonet "net"
 	"net/http"
 	"sync"
 	"time"
@@ -68,10 +67,9 @@ type offlineMessage struct {
 }
 
 func NewMessageRetriever(cfg MRConfig) *MessageRetriever {
-	dial := gonet.Dial
 	var client *http.Client
 	if cfg.Dialer != nil {
-		dial = cfg.Dialer.Dial
+		dial := cfg.Dialer.Dial
 		tbTransport := &http.Transport{Dial: dial}
 		client = &http.Client{Transport: tbTransport, Timeout: time.Second * 30}
 	} else {

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -328,7 +328,7 @@ func (service *OpenBazaarService) handleOrder(peer peer.ID, pmes *pb.Message, op
 		return errorResponse(err.Error()), err
 	}
 
-	pro, err := service.node.GetProfile()
+	pro, _ := service.node.GetProfile()
 	if !pro.Vendor {
 		log.Debugf("sending message to buyer that our store is not accepting orders")
 		return errorResponse("the vendor turned his store off and is not accepting orders at this time"), errors.New("store is turned off")


### PR DESCRIPTION
This is fixed in ethereum-master btw.

Fixes #1907 