### PR TITLE
(#1881) Check for non nil moderator fixed fee amount

### DIFF
--- a/core/profile.go
+++ b/core/profile.go
@@ -215,8 +215,12 @@ func (n *OpenBazaarNode) PatchProfile(patch map[string]interface{}) error {
 		return fmt.Errorf("building profile for validation: %s", err.Error())
 	}
 
-	if err := repoProfile.Valid(); err != nil {
-		return fmt.Errorf("invalid profile: %s", err.Error())
+	if repoProfile.IsModerationEnabled() {
+		validatedFees, err := repoProfile.ToValidModeratorFee()
+		if err != nil {
+			return err
+		}
+		p.ModeratorInfo.Fee = validatedFees
 	}
 
 	return n.UpdateProfile(p)

--- a/repo/profile.go
+++ b/repo/profile.go
@@ -135,7 +135,7 @@ func (p *Profile) validateModeratorFees() error {
 		if p.ModeratorInfo.Fee.Percentage < 0 {
 			return ErrModeratorFeeHasNegativePercentage
 		}
-		if p.ModeratorInfo.Fee.FixedFee != nil {
+		if p.ModeratorInfo.Fee.FixedFee != nil && p.ModeratorInfo.Fee.FixedFee.Amount != "0" {
 			return ErrPercentageFeeHasFixedFee
 		}
 	case pb.Moderator_Fee_FIXED_PLUS_PERCENTAGE.String():

--- a/repo/profile.go
+++ b/repo/profile.go
@@ -13,6 +13,9 @@ var (
 	// ErrModeratorInfoMissing indicates when the moderator information is
 	// missing while also indicating they are a moderator
 	ErrModeratorInfoMissing = errors.New("moderator is enabled but information is missing")
+	// ErrNonModeratorShouldNotHaveInfo indicates when the moderator information
+	// is present, but not indicating moderator is enabled
+	ErrNonModeratorShouldNotHaveInfo = errors.New("moderator information is provided but moderator is not enabled")
 	// ErrMissingModeratorFee indicates the fee schedule is missing
 	ErrMissingModeratorFee = errors.New("moderator info is missing fee schedule")
 	// ErrUnknownModeratorFeeType indicates the feeType is unknown
@@ -203,6 +206,7 @@ func (p *Profile) Valid() error {
 	return nil
 }
 
+// IsModerationEnabled checks if the Moderator flag and info are present
 func (p *Profile) IsModerationEnabled() bool {
 	return p != nil && p.Moderator && p.ModeratorInfo != nil
 }

--- a/repo/profile_test.go
+++ b/repo/profile_test.go
@@ -126,7 +126,7 @@ func TestProfileInvalidWithInvalidFixedFeeCurrency(t *testing.T) {
 	p.ModeratorInfo.Fee = &repo.ModeratorFee{
 		FixedFee: &repo.ModeratorFixedFee{
 			Amount:         "1",
-			AmountCurrency: invalidCurrency,
+			AmountCurrency: &invalidCurrency,
 		},
 	}
 
@@ -150,9 +150,10 @@ func TestProfileInvalidWithInvalidFixedFeeCurrency(t *testing.T) {
 
 func TestProfileInvalidWithZeroFixedFee(t *testing.T) {
 	p := factory.NewProfile()
+	ac := factory.NewCurrencyDefinition("BTC")
 	p.ModeratorInfo.Fee = &repo.ModeratorFee{
 		FixedFee: &repo.ModeratorFixedFee{
-			AmountCurrency: factory.NewCurrencyDefinition("BTC"),
+			AmountCurrency: &ac,
 		},
 	}
 
@@ -202,12 +203,13 @@ func TestProfileInvalidWithZeroFixedFee(t *testing.T) {
 
 func TestProfileValidFixedFee(t *testing.T) {
 	p := factory.NewProfile()
+	ac := factory.NewCurrencyDefinition("BTC")
 	p.ModeratorInfo = &repo.ModeratorInfo{
 		Fee: &repo.ModeratorFee{
 			FeeType: pb.Moderator_Fee_FIXED.String(),
 			FixedFee: &repo.ModeratorFixedFee{
 				Amount:         "1234",
-				AmountCurrency: factory.NewCurrencyDefinition("BTC"),
+				AmountCurrency: &ac,
 			},
 			Percentage: 0,
 		},
@@ -255,13 +257,14 @@ func TestProfileValidPercentageFeeZero(t *testing.T) {
 
 func TestProfileInvalidPercentageFeeWithFixedFee(t *testing.T) {
 	p := factory.NewProfile()
+	ac := factory.NewCurrencyDefinition("BTC")
 	p.ModeratorInfo = &repo.ModeratorInfo{
 		Fee: &repo.ModeratorFee{
 			FeeType:    pb.Moderator_Fee_PERCENTAGE.String(),
 			Percentage: 1,
 			FixedFee: &repo.ModeratorFixedFee{
 				Amount:         "1234",
-				AmountCurrency: factory.NewCurrencyDefinition("BTC"),
+				AmountCurrency: &ac,
 			},
 		},
 	}
@@ -275,13 +278,14 @@ func TestProfileInvalidPercentageFeeWithFixedFee(t *testing.T) {
 
 func TestProfileValidPercentageWithFixedFee(t *testing.T) {
 	p := factory.NewProfile()
+	ac := factory.NewCurrencyDefinition("BTC")
 	p.ModeratorInfo = &repo.ModeratorInfo{
 		Fee: &repo.ModeratorFee{
 			FeeType:    pb.Moderator_Fee_FIXED_PLUS_PERCENTAGE.String(),
 			Percentage: 1,
 			FixedFee: &repo.ModeratorFixedFee{
 				Amount:         "1234",
-				AmountCurrency: factory.NewCurrencyDefinition("BTC"),
+				AmountCurrency: &ac,
 			},
 		},
 	}
@@ -293,13 +297,14 @@ func TestProfileValidPercentageWithFixedFee(t *testing.T) {
 
 func TestProfileValidPercentWithFixedHavingZeroPercent(t *testing.T) {
 	p := factory.NewProfile()
+	ac := factory.NewCurrencyDefinition("BTC")
 	p.ModeratorInfo = &repo.ModeratorInfo{
 		Fee: &repo.ModeratorFee{
 			FeeType:    pb.Moderator_Fee_FIXED_PLUS_PERCENTAGE.String(),
 			Percentage: 0,
 			FixedFee: &repo.ModeratorFixedFee{
 				Amount:         "1234",
-				AmountCurrency: factory.NewCurrencyDefinition("BTC"),
+				AmountCurrency: &ac,
 			},
 		},
 	}
@@ -311,13 +316,14 @@ func TestProfileValidPercentWithFixedHavingZeroPercent(t *testing.T) {
 
 func TestProfileInvalidPercentWithFixedHavingNegativePercent(t *testing.T) {
 	p := factory.NewProfile()
+	ac := factory.NewCurrencyDefinition("BTC")
 	p.ModeratorInfo = &repo.ModeratorInfo{
 		Fee: &repo.ModeratorFee{
 			FeeType:    pb.Moderator_Fee_FIXED_PLUS_PERCENTAGE.String(),
 			Percentage: -1,
 			FixedFee: &repo.ModeratorFixedFee{
 				Amount:         "1234",
-				AmountCurrency: factory.NewCurrencyDefinition("BTC"),
+				AmountCurrency: &ac,
 			},
 		},
 	}
@@ -406,7 +412,7 @@ func TestProfileSetModeratorFixedFee(t *testing.T) {
 	if p.ModeratorInfo.Fee.FixedFee.Amount != fee.Amount.String() {
 		t.Errorf("expected fixed fee amount to be (%s), but was (%s)", fee.Amount.String(), p.ModeratorInfo.Fee.FixedFee.Amount)
 	}
-	if !fee.Currency.Equal(p.ModeratorInfo.Fee.FixedFee.AmountCurrency) {
+	if !fee.Currency.Equal(*p.ModeratorInfo.Fee.FixedFee.AmountCurrency) {
 		t.Errorf("expected fixed fee amount currency to be (%s), but was (%s)", fee.Currency.String(), p.ModeratorInfo.Fee.FixedFee.AmountCurrency)
 	}
 }
@@ -442,18 +448,19 @@ func TestProfileSetModeratorFixedPlusPercentageFee(t *testing.T) {
 	if p.ModeratorInfo.Fee.FixedFee.Amount != fee.Amount.String() {
 		t.Errorf("expected fixed fee amount to be (%s), but was (%s)", fee.Amount.String(), p.ModeratorInfo.Fee.FixedFee.Amount)
 	}
-	if !fee.Currency.Equal(p.ModeratorInfo.Fee.FixedFee.AmountCurrency) {
+	if !fee.Currency.Equal(*p.ModeratorInfo.Fee.FixedFee.AmountCurrency) {
 		t.Errorf("expected fixed fee amount currency to be (%s), but was (%s)", fee.Currency.String(), p.ModeratorInfo.Fee.FixedFee.AmountCurrency)
 	}
 }
 
 func TestProfileSetModeratorPercentageFee(t *testing.T) {
 	percentage := float32(2.5)
+	ac := factory.NewCurrencyDefinition("BTC")
 	p := factory.NewProfile()
 	p.ModeratorInfo.Fee.FeeType = pb.Moderator_Fee_FIXED.String()
 	p.ModeratorInfo.Fee.FixedFee = &repo.ModeratorFixedFee{
 		Amount:         "1230",
-		AmountCurrency: factory.NewCurrencyDefinition("BTC"),
+		AmountCurrency: &ac,
 	}
 	p.ModeratorInfo.Fee.Percentage = 0
 
@@ -477,11 +484,12 @@ func TestProfileSetModeratorPercentageFee(t *testing.T) {
 
 func TestProfileDisableModeration(t *testing.T) {
 	p := factory.NewProfile()
+	ac := factory.NewCurrencyDefinition("BTC")
 	p.Moderator = true
 	p.ModeratorInfo.Fee.FeeType = pb.Moderator_Fee_FIXED.String()
 	p.ModeratorInfo.Fee.FixedFee = &repo.ModeratorFixedFee{
 		Amount:         "1230",
-		AmountCurrency: factory.NewCurrencyDefinition("BTC"),
+		AmountCurrency: &ac,
 	}
 	p.ModeratorInfo.Fee.Percentage = 0
 

--- a/test/factory/profile.go
+++ b/test/factory/profile.go
@@ -6,6 +6,7 @@ import (
 )
 
 func NewProfile() *repo.Profile {
+	var amtCurr = NewCurrencyDefinition("BTC")
 	return &repo.Profile{
 		Moderator: true,
 		ModeratorInfo: &repo.ModeratorInfo{
@@ -13,7 +14,7 @@ func NewProfile() *repo.Profile {
 				FeeType: pb.Moderator_Fee_FIXED_PLUS_PERCENTAGE.String(),
 				FixedFee: &repo.ModeratorFixedFee{
 					Amount:         "1234",
-					AmountCurrency: NewCurrencyDefinition("BTC"),
+					AmountCurrency: &amtCurr,
 				},
 				Percentage: 1.1, // represents 0.011%
 			},


### PR DESCRIPTION
Fixes #1881 

Also attempts to read/write from the old profile schema in case the node is reading a v4 schema node's profile. The v4 schema data will not be available if the FixedFee amounts exceed the available precision. (This behavior contributes to #1904 but may not complete it.)