### PR TITLE
[#1879] Ensure PATCH /ob/profile returns appropriate response

### DIFF
--- a/api/jsonapi_test.go
+++ b/api/jsonapi_test.go
@@ -203,13 +203,13 @@ func TestProfileSwitchesFromPercentToFixedWithLegacySchema(t *testing.T) {
 			if amt := fixedFee.GetBigAmount(); amt != "1234" {
 				return fmt.Errorf("expected patched profile fixed fee big amount to be (1234), but was (%s)", amt)
 			}
-			if amt := fixedFee.GetAmount(); amt != 1234 {
+			if amt := fixedFee.GetAmount(); amt != 1234 { //nolint:staticcheck
 				return fmt.Errorf("expected patched profile fixed fee amount to be (1234), but was (%d)", amt)
 			}
 			if cc := fixedFee.GetAmountCurrency().GetCode(); cc != "USD" {
 				return fmt.Errorf("expected patched profile fixed fee currency to be (USD), but was (%s)", cc)
 			}
-			if cc := fixedFee.GetCurrencyCode(); cc != "USD" {
+			if cc := fixedFee.GetCurrencyCode(); cc != "USD" { //nolint:staticcheck
 				return fmt.Errorf("expected patched profile fixed fee currency code to be (USD), but was (%s)", cc)
 			}
 

--- a/api/jsonapi_test.go
+++ b/api/jsonapi_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OpenBazaar/jsonpb"
 	"github.com/OpenBazaar/openbazaar-go/core"
 	"github.com/OpenBazaar/openbazaar-go/pb"
 	"github.com/OpenBazaar/openbazaar-go/repo"
@@ -129,6 +130,99 @@ func TestProfile(t *testing.T) {
 	})
 }
 
+func TestProfileSwitchesFromPercentToFixedWithLegacySchema(t *testing.T) {
+	var (
+		postProfile = `{
+	"handle": "test",
+	"name": "Test User",
+	"location": "Internet",
+	"about": "The test fixture",
+	"shortDescription": "Fixture",
+	"contactInfo": {
+		"website": "internet.com",
+		"email": "email@address.com",
+		"phoneNumber": "687-5309"
+	},
+	"nsfw": false,
+	"vendor": false,
+	"moderator": true,
+	"moderatorInfo": {
+		"description": "Percentage. Test moderator account. DO NOT USE.",
+		"fee": {
+			"feeType": "PERCENTAGE",
+			"percentage": 12.0
+		}
+	},
+	"colors": {
+		"primary": "#000000",
+		"secondary": "#FFD700",
+		"text": "#ffffff",
+		"highlight": "#123ABC",
+		"highlightText": "#DEAD00"
+	},
+	"currencies": ["LTC"]
+}`
+		patchProfile = `{
+	"moderatorInfo": {
+		"fee": {
+			"feeType": "FIXED",
+			"fixedFee": {
+				"bigAmount": "1234",
+				"amountCurrency": {
+					"code": "USD",
+					"divisibility": 2
+				}
+			}
+		}
+	}
+}`
+		validateProfileFees = func(testRepo *test.Repository) error {
+			m, err := schema.NewCustomSchemaManager(schema.SchemaContext{
+				DataPath:        testRepo.Path,
+				TestModeEnabled: true,
+			})
+			if err != nil {
+				return fmt.Errorf("schema setup: %s", err.Error())
+			}
+			profileBytes, err := ioutil.ReadFile(m.DataPathJoin("root", "profile.json"))
+			if err != nil {
+				return fmt.Errorf("get profile: %s", err.Error())
+			}
+
+			var actualProfile pb.Profile
+			if err := jsonpb.UnmarshalString(string(profileBytes), &actualProfile); err != nil {
+				return fmt.Errorf("unmarshal profile: %s", err.Error())
+			}
+
+			fees := actualProfile.ModeratorInfo.Fee
+			if ft := fees.GetFeeType().String(); ft != pb.Moderator_Fee_FIXED.String() {
+				return fmt.Errorf("expected patched profile fee type to be (%s), but was (%s)", pb.Moderator_Fee_FIXED.String(), ft)
+			}
+
+			fixedFee := fees.GetFixedFee()
+			if amt := fixedFee.GetBigAmount(); amt != "1234" {
+				return fmt.Errorf("expected patched profile fixed fee big amount to be (1234), but was (%s)", amt)
+			}
+			if amt := fixedFee.GetAmount(); amt != 1234 {
+				return fmt.Errorf("expected patched profile fixed fee amount to be (1234), but was (%d)", amt)
+			}
+			if cc := fixedFee.GetAmountCurrency().GetCode(); cc != "USD" {
+				return fmt.Errorf("expected patched profile fixed fee currency to be (USD), but was (%s)", cc)
+			}
+			if cc := fixedFee.GetCurrencyCode(); cc != "USD" {
+				return fmt.Errorf("expected patched profile fixed fee currency code to be (USD), but was (%s)", cc)
+			}
+
+			return nil
+		}
+	)
+
+	runAPITestsWithSetup(t, apiTests{
+		{"POST", "/ob/profile", postProfile, 200, anyResponseJSON},
+		{"PATCH", "/ob/profile", patchProfile, 200, "{}"},
+	}, nil, validateProfileFees)
+}
+
 func TestPatchProfileCurrencyUpdate(t *testing.T) {
 	var (
 		postProfile = `{
@@ -189,7 +283,7 @@ func TestPatchProfileCurrencyUpdate(t *testing.T) {
 
 	runAPITestsWithSetup(t, apiTests{
 		{"POST", "/ob/profile", postProfile, 200, anyResponseJSON},
-		{"PATCH", "/ob/profile", patchProfile, 200, anyResponseJSON},
+		{"PATCH", "/ob/profile", patchProfile, 200, "{}"},
 	}, nil, validateProfile)
 }
 
@@ -254,9 +348,96 @@ func TestPatchProfileCanBeInvalid(t *testing.T) {
 	expectedErr := fmt.Errorf("invalid profile: %s", repo.ErrModeratorFeeHasNegativePercentage)
 	runAPITests(t, apiTests{
 		{"POST", "/ob/profile", postProfile, 200, anyResponseJSON},
-		{"PATCH", "/ob/profile", patchProfile, 200, anyResponseJSON},
+		{"PATCH", "/ob/profile", patchProfile, 200, "{}"},
 		{"PATCH", "/ob/profile", invalidPatchProfile, 500, errorResponseJSON(expectedErr)},
 	})
+}
+
+func TestProfileSwitchesFromFixedToPercent(t *testing.T) {
+	var (
+		postProfile = `{
+	"handle": "test",
+	"name": "Test User",
+	"location": "Internet",
+	"about": "The test fixture",
+	"shortDescription": "Fixture",
+	"contactInfo": {
+		"website": "internet.com",
+		"email": "email@address.com",
+		"phoneNumber": "687-5309"
+	},
+	"nsfw": false,
+	"vendor": false,
+	"moderator": true,
+	"moderatorInfo": {
+		"description": "Fix plus percentage. Test moderator account. DO NOT USE.",
+		"fee": {
+			"feeType": "FIXED_PLUS_PERCENTAGE",
+			"fixedFee": {
+				"amountCurrency": {
+					"code": "USD",
+					"divisibility": 2
+				},
+				"bigAmount": "2"
+			},
+			"percentage": 0.1
+		},
+		"languages": [
+			"en-US"
+		],
+		"termsAndConditions": "Test moderator account. DO NOT USE."
+	},
+	"colors": {
+		"primary": "#000000",
+		"secondary": "#FFD700",
+		"text": "#ffffff",
+		"highlight": "#123ABC",
+		"highlightText": "#DEAD00"
+	},
+	"currencies": ["LTC"]
+}`
+		patchProfile = `{
+	"moderatorInfo": {
+		"fee": {
+			"feeType": "PERCENTAGE",
+			"percentage": 0.1
+		}
+	}
+}`
+		validateProfileFees = func(testRepo *test.Repository) error {
+			m, err := schema.NewCustomSchemaManager(schema.SchemaContext{
+				DataPath:        testRepo.Path,
+				TestModeEnabled: true,
+			})
+			if err != nil {
+				return fmt.Errorf("schema setup: %s", err.Error())
+			}
+			profileBytes, err := ioutil.ReadFile(m.DataPathJoin("root", "profile.json"))
+			if err != nil {
+				return fmt.Errorf("get profile: %s", err.Error())
+			}
+
+			var actualProfile pb.Profile
+			if err := jsonpb.UnmarshalString(string(profileBytes), &actualProfile); err != nil {
+				return fmt.Errorf("unmarshal profile: %s", err.Error())
+			}
+
+			fees := actualProfile.ModeratorInfo.Fee
+			if ft := fees.GetFeeType().String(); ft != pb.Moderator_Fee_PERCENTAGE.String() {
+				return fmt.Errorf("expected patched profile fee type to be (%s), but was (%s)", pb.Moderator_Fee_PERCENTAGE.String(), ft)
+			}
+
+			if p := fees.GetPercentage(); p != 0.1 {
+				return fmt.Errorf("expected patched profile fee percentage to be (0.1), but was (%f)", p)
+			}
+
+			return nil
+		}
+	)
+	runAPITestsWithSetup(t, apiTests{
+		{"POST", "/ob/profile", postProfile, 200, anyResponseJSON},
+		{"PATCH", "/ob/profile", patchProfile, 200, "{}"},
+	}, nil, validateProfileFees)
 }
 
 func TestAvatar(t *testing.T) {

--- a/core/profile.go
+++ b/core/profile.go
@@ -93,30 +93,6 @@ func (n *OpenBazaarNode) UpdateProfile(profile *pb.Profile) error {
 	profile.Currencies = acceptedCurrencies
 	if profile.ModeratorInfo != nil {
 		profile.ModeratorInfo.AcceptedCurrencies = acceptedCurrencies
-
-		// Update moderator info fixed fee details
-		if profile.ModeratorInfo.Fee != nil {
-			if profile.ModeratorInfo.Fee.FixedFee != nil {
-				if profile.ModeratorInfo.Fee.FixedFee.AmountCurrency != nil {
-					fixedFee, err := repo.NewCurrencyValueFromProtobuf(profile.ModeratorInfo.Fee.FixedFee.BigAmount, profile.ModeratorInfo.Fee.FixedFee.AmountCurrency)
-					if err != nil {
-						return fmt.Errorf("unable to parse fixed fee currency: %s", err.Error())
-					}
-					normalizedFee, err := fixedFee.Normalize()
-					if err != nil {
-						feeDivisibility := uint(profile.ModeratorInfo.Fee.FixedFee.AmountCurrency.Divisibility)
-						return fmt.Errorf("converting divisibility for fixed fee (%s) from (%d) to (%d): %s", fixedFee.Currency.String(), fixedFee.Currency.Divisibility, feeDivisibility, err.Error())
-					}
-					profile.ModeratorInfo.Fee.FixedFee = &pb.Moderator_Price{
-						AmountCurrency: &pb.CurrencyDefinition{
-							Code:         normalizedFee.Currency.CurrencyCode().String(),
-							Divisibility: uint32(normalizedFee.Currency.Divisibility),
-						},
-						BigAmount: normalizedFee.Amount.String(),
-					}
-				}
-			}
-		}
 	}
 
 	profile.PeerID = n.IpfsNode.Identity.Pretty()

--- a/repo/listing.go
+++ b/repo/listing.go
@@ -1066,7 +1066,7 @@ func (l *Listing) GetSkus() ([]*pb.Listing_Item_Sku, error) {
 	if err != nil {
 		return nil, err
 	}
-	if pbl == nil || pbl.Item == nil {
+	if pbl.Item == nil {
 		return nil, nil
 	}
 	switch l.ListingVersion {

--- a/repo/profile.go
+++ b/repo/profile.go
@@ -143,8 +143,8 @@ func (p *Profile) ToValidModeratorFee() (*pb.Moderator_Fee, error) {
 		return nil, ErrModeratorInfoMissing
 	}
 
-	var feeType pb.Moderator_Fee_FeeType
 	// Setters will normalize the fee schedule
+	var feeType pb.Moderator_Fee_FeeType
 	switch p.ModeratorInfo.Fee.FeeType {
 	case pb.Moderator_Fee_FIXED.String():
 		modFee, err := p.GetModeratedFixedFee()
@@ -155,12 +155,6 @@ func (p *Profile) ToValidModeratorFee() (*pb.Moderator_Fee, error) {
 			return nil, err
 		}
 		feeType = pb.Moderator_Fee_FIXED
-	case pb.Moderator_Fee_PERCENTAGE.String():
-		err := p.SetModeratorPercentageFee(p.ModeratorInfo.Fee.Percentage)
-		if err != nil {
-			return nil, err
-		}
-		feeType = pb.Moderator_Fee_PERCENTAGE
 	case pb.Moderator_Fee_FIXED_PLUS_PERCENTAGE.String():
 		percentFee := p.ModeratorInfo.Fee.Percentage
 		modFee, err := p.GetModeratedFixedFee()
@@ -172,26 +166,37 @@ func (p *Profile) ToValidModeratorFee() (*pb.Moderator_Fee, error) {
 			return nil, err
 		}
 		feeType = pb.Moderator_Fee_FIXED_PLUS_PERCENTAGE
+	case pb.Moderator_Fee_PERCENTAGE.String():
+		err := p.SetModeratorPercentageFee(p.ModeratorInfo.Fee.Percentage)
+		if err != nil {
+			return nil, err
+		}
+		feeType = pb.Moderator_Fee_PERCENTAGE
 	}
 
 	if err := p.Valid(); err != nil {
 		return nil, fmt.Errorf("invalid profile: %s", err.Error())
 	}
 
-	var amtInt uint64
-	if ai, err := strconv.Atoi(p.ModeratorInfo.Fee.FixedFee.Amount); err == nil {
-		amtInt = uint64(ai)
-	}
-	return &pb.Moderator_Fee{
-		FixedFee: &pb.Moderator_Price{
-			CurrencyCode: p.ModeratorInfo.Fee.FixedFee.AmountCurrency.Code.String(),
+	var normalizedFixedFee *pb.Moderator_Price
+	if ff, err := p.GetModeratedFixedFee(); err == nil {
+		var amtInt uint64
+		if ai, err := strconv.Atoi(p.ModeratorInfo.Fee.FixedFee.Amount); err == nil {
+			amtInt = uint64(ai)
+		}
+		normalizedFixedFee = &pb.Moderator_Price{
+			CurrencyCode: ff.Currency.Code.String(),
 			AmountCurrency: &pb.CurrencyDefinition{
-				Code:         p.ModeratorInfo.Fee.FixedFee.AmountCurrency.Code.String(),
-				Divisibility: uint32(p.ModeratorInfo.Fee.FixedFee.AmountCurrency.Divisibility),
+				Code:         ff.Currency.Code.String(),
+				Divisibility: uint32(ff.Currency.Divisibility),
 			},
-			BigAmount: p.ModeratorInfo.Fee.FixedFee.Amount,
+			BigAmount: ff.Amount.String(),
 			Amount:    amtInt,
-		},
+		}
+	}
+
+	return &pb.Moderator_Fee{
+		FixedFee:   normalizedFixedFee,
 		Percentage: p.ModeratorInfo.Fee.Percentage,
 		FeeType:    feeType,
 	}, nil

--- a/repo/profile.go
+++ b/repo/profile.go
@@ -68,8 +68,7 @@ func ProfileFromProtobuf(p *pb.Profile) (*Profile, error) {
 		var fees = p.ModeratorInfo.Fee
 
 		// build FixedFee
-		if fees != nil ||
-			fees.FixedFee != nil {
+		if fees.FixedFee != nil {
 			var (
 				amtStr      string
 				amtCurrency *CurrencyDefinition


### PR DESCRIPTION
This PR adds some tests which protect the `PATCH /ob/profile` response and ensures a few of the moderator fee scenarios work as expected.

Fixes #1879