### PR TITLE
Do not mark wallet address as watched + fix earlier txn errors

### DIFF
--- a/vendor/github.com/OpenBazaar/multiwallet/service/wallet_service.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/service/wallet_service.go
@@ -522,7 +522,7 @@ func (ws *WalletService) saveSingleTxToDB(u model.Transaction, chainHeight int32
 	cb.Value = value
 	cb.WatchOnly = (hits == 0)
 	saved, err := ws.db.Txns().Get(*txHash)
-	if err != nil {
+	if err != nil || saved.WatchOnly != cb.WatchOnly {
 		ts := time.Now()
 		if u.Confirmations > 0 {
 			ts = time.Unix(u.BlockTime, 0)
@@ -619,7 +619,9 @@ func (ws *WalletService) getStoredAddresses() map[string]storedAddress {
 			}
 			addr = ltcAddr
 		}
-		addrs[addr.String()] = storedAddress{addr, true}
+		if _, ok := addrs[addr.String()]; !ok {
+			addrs[addr.String()] = storedAddress{addr, true}
+		}
 	}
 
 	return addrs


### PR DESCRIPTION
These changes satisfy concerns in #1918 and rescues/corrects old order transactions