### PR TITLE
[#1681] Protect POSTReleaseEscrow sweep when there are no inputs

### DIFF
--- a/core/completion.go
+++ b/core/completion.go
@@ -349,27 +349,29 @@ func (n *OpenBazaarNode) ReleaseFundsAfterTimeout(contract *pb.RicardianContract
 		}
 	}
 
-	if len(txInputs) != 0 {
-		chaincode, err := hex.DecodeString(contract.BuyerOrder.Payment.Chaincode)
-		if err != nil {
-			return err
-		}
-		mECKey, err := n.MasterPrivateKey.ECPrivKey()
-		if err != nil {
-			return err
-		}
-		vendorKey, err := wal.ChildKey(mECKey.Serialize(), chaincode, true)
-		if err != nil {
-			return err
-		}
-		redeemScript, err := hex.DecodeString(contract.BuyerOrder.Payment.RedeemScript)
-		if err != nil {
-			return err
-		}
-		_, err = wal.SweepAddress(txInputs, nil, vendorKey, &redeemScript, wallet.NORMAL)
-		if err != nil {
-			return err
-		}
+	if len(txInputs) == 0 {
+		return errors.New("there are no inputs available for this transaction")
+	}
+
+	chaincode, err := hex.DecodeString(contract.BuyerOrder.Payment.Chaincode)
+	if err != nil {
+		return err
+	}
+	mECKey, err := n.MasterPrivateKey.ECPrivKey()
+	if err != nil {
+		return err
+	}
+	vendorKey, err := wal.ChildKey(mECKey.Serialize(), chaincode, true)
+	if err != nil {
+		return err
+	}
+	redeemScript, err := hex.DecodeString(contract.BuyerOrder.Payment.RedeemScript)
+	if err != nil {
+		return err
+	}
+	_, err = wal.SweepAddress(txInputs, nil, vendorKey, &redeemScript, wallet.NORMAL)
+	if err != nil {
+		return err
 	}
 
 	orderID, err := n.CalcOrderID(contract.BuyerOrder)

--- a/core/completion.go
+++ b/core/completion.go
@@ -349,25 +349,27 @@ func (n *OpenBazaarNode) ReleaseFundsAfterTimeout(contract *pb.RicardianContract
 		}
 	}
 
-	chaincode, err := hex.DecodeString(contract.BuyerOrder.Payment.Chaincode)
-	if err != nil {
-		return err
-	}
-	mECKey, err := n.MasterPrivateKey.ECPrivKey()
-	if err != nil {
-		return err
-	}
-	vendorKey, err := wal.ChildKey(mECKey.Serialize(), chaincode, true)
-	if err != nil {
-		return err
-	}
-	redeemScript, err := hex.DecodeString(contract.BuyerOrder.Payment.RedeemScript)
-	if err != nil {
-		return err
-	}
-	_, err = wal.SweepAddress(txInputs, nil, vendorKey, &redeemScript, wallet.NORMAL)
-	if err != nil {
-		return err
+	if len(txInputs) != 0 {
+		chaincode, err := hex.DecodeString(contract.BuyerOrder.Payment.Chaincode)
+		if err != nil {
+			return err
+		}
+		mECKey, err := n.MasterPrivateKey.ECPrivKey()
+		if err != nil {
+			return err
+		}
+		vendorKey, err := wal.ChildKey(mECKey.Serialize(), chaincode, true)
+		if err != nil {
+			return err
+		}
+		redeemScript, err := hex.DecodeString(contract.BuyerOrder.Payment.RedeemScript)
+		if err != nil {
+			return err
+		}
+		_, err = wal.SweepAddress(txInputs, nil, vendorKey, &redeemScript, wallet.NORMAL)
+		if err != nil {
+			return err
+		}
 	}
 
 	orderID, err := n.CalcOrderID(contract.BuyerOrder)


### PR DESCRIPTION
This issue fixes the scenario where the BUYER released the funds but the SELLER did not receive the completion message (but likely did receive the coins).