### PR TITLE
Send addresses as slice to BlockBook

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -50,75 +50,75 @@
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/bitcoin",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/bitcoincash",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/cache",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/client",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/client/blockbook",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/client/transport",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/config",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/datastore",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/keys",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/litecoin",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/litecoin/address",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/litecoin/params",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/model",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/service",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/util",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/zcash",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/zcash/address",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/spvwallet",
@@ -2513,7 +2513,7 @@
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/client/errors",
-			"Rev": "e187f7c60330aa69165653d4200936090eaaa25a"
+			"Rev": "9279fb62abf3f072d55d9c7c19701550a5bcc694"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/multiwallet/vendor/github.com/OpenBazaar/wallet-interface",

--- a/vendor/github.com/OpenBazaar/multiwallet/client/blockbook/client.go
+++ b/vendor/github.com/OpenBazaar/multiwallet/client/blockbook/client.go
@@ -544,9 +544,7 @@ func (i *BlockBookClient) ListenAddresses(addrs ...btcutil.Address) {
 	}
 
 	if i.SocketClient != nil {
-		var args = []string{"bitcoind/addresstxid"}
-		args = append(args, convertedAddrs...)
-		i.SocketClient.Emit("subscribe", protocol.ToArgArray(args))
+		i.SocketClient.Emit("subscribe", []interface{}{"bitcoind/addresstxid", convertedAddrs})
 	} else {
 		i.listenQueue = append(i.listenQueue, convertedAddrs...)
 	}
@@ -654,9 +652,7 @@ func (i *BlockBookClient) setupListeners() error {
 
 	// Subscribe to queued addresses
 	if len(i.listenQueue) != 0 {
-		var args = []string{"bitcoind/addresstxid"}
-		args = append(args, i.listenQueue...)
-		i.SocketClient.Emit("subscribe", protocol.ToArgArray(args))
+		i.SocketClient.Emit("subscribe", []interface{}{"bitcoind/addresstxid", i.listenQueue})
 		i.listenQueue = []string{}
 	}
 


### PR DESCRIPTION
We currently send [ "command", "addr1", "addr2" ... ] to BlockBook when it should be [ "command", [ "addr1", "addr2" ] ].

Fixes #1963 