### PR TITLE
(#1976) Normalize legacy listings via GET /ob/listings/...

### DIFF
--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -1496,6 +1496,11 @@ func (i *jsonAPIHandler) GETListing(w http.ResponseWriter, r *http.Request) {
 			log.Warningf("updating coupons for listing (%s): %s", rsl.GetSlug(), err.Error())
 		}
 
+		if err := rsl.Normalize(); err != nil {
+			ErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("normalizing listing: %s", err.Error()))
+			return
+		}
+
 		out, err := rsl.MarshalJSON()
 		if err != nil {
 			ErrorResponse(w, http.StatusInternalServerError, err.Error())
@@ -1537,7 +1542,14 @@ func (i *jsonAPIHandler) GETListing(w http.ResponseWriter, r *http.Request) {
 	}
 	sl.Hash = hash
 
-	out, err := repo.NewSignedListingFromProtobuf(sl).MarshalJSON()
+	rsl := repo.NewSignedListingFromProtobuf(sl)
+
+	if err := rsl.Normalize(); err != nil {
+		ErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("normalizing listing: %s", err.Error()))
+		return
+	}
+
+	out, err := rsl.MarshalJSON()
 	if err != nil {
 		ErrorResponse(w, http.StatusInternalServerError, err.Error())
 		return

--- a/core/order.go
+++ b/core/order.go
@@ -61,6 +61,21 @@ func (n *OpenBazaarNode) GetOrder(orderID string) (*pb.OrderRespApi, error) {
 		}
 		isSale = true
 	}
+
+	for i, l := range contract.VendorListings {
+		repoListing, err := repo.NewListingFromProtobuf(l)
+		if err != nil {
+			log.Errorf("failed getting contract listing: %s", err.Error())
+			return nil, err
+		}
+		normalizedListing, err := repoListing.Normalize()
+		if err != nil {
+			log.Errorf("failed converting contract listing to v5 schema: %s", err.Error())
+			return nil, err
+		}
+		contract.VendorListings[i] = normalizedListing.GetProtobuf()
+	}
+
 	resp := new(pb.OrderRespApi)
 	resp.Contract = contract
 	resp.Funded = funded

--- a/repo/db/sales.go
+++ b/repo/db/sales.go
@@ -315,9 +315,11 @@ func (s *SalesDB) GetByOrderId(orderId string) (*pb.RicardianContract, pb.OrderS
 		return nil, pb.OrderState(0), false, nil, false, nil, fmt.Errorf("validating payment coin: %s", err.Error())
 	}
 	var records []*wallet.TransactionRecord
-	err = json.Unmarshal(serializedTransactions, &records)
-	if err != nil {
-		log.Error(err)
+	if len(serializedTransactions) > 0 {
+		err = json.Unmarshal(serializedTransactions, &records)
+		if err != nil {
+			return nil, pb.OrderState(0), false, nil, false, nil, fmt.Errorf("unmarshal purchase transactions: %s", err.Error())
+		}
 	}
 	cc := def.CurrencyCode()
 	return rc, pb.OrderState(stateInt), funded, records, read, &cc, nil

--- a/repo/signed_listing.go
+++ b/repo/signed_listing.go
@@ -43,6 +43,19 @@ func (l *SignedListing) Reset()         { *l = SignedListing{} }
 func (l *SignedListing) String() string { return proto.CompactTextString(l) }
 func (*SignedListing) ProtoMessage()    {}
 
+// Normalize is a helper method which will mutate the listing protobuf
+// in-place but maintain the original signature for external verification
+// purposes.
+func (l *SignedListing) Normalize() error {
+	nl, err := l.GetListing().Normalize()
+	if err != nil {
+		return err
+	}
+
+	l.signedListingProto.Listing = nl.listingProto
+	return nil
+}
+
 // GetListing returns the underlying repo.Listing object
 func (l SignedListing) GetListing() *Listing {
 	return &Listing{


### PR DESCRIPTION
All lookups of listings via `GET /ob/listing/...` (for all permutations of that call) will attempt to normalize the listing data before returning the data so clients do not have to worry about reading data from the various schema versions.

Fixes #1976 