### PR TITLE
Fix transaction ordering and enable Tor flag for the qa script

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -22,7 +22,7 @@
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/go-ethwallet/util",
-			"Rev": "735e63ba49ed89be6e4649f21978c0338924f820"
+			"Rev": "5c1bb634ebaa76969b11b46d31d0e9c0bd3b3e38"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/go-ethwallet/wallet",

--- a/qa/eth_escrow_release_after_timeout.py
+++ b/qa/eth_escrow_release_after_timeout.py
@@ -204,9 +204,6 @@ class EthEscrowTimeoutRelease(OpenBazaarTestFramework):
         if resp["state"] != "FULFILLED":
             raise TestFailure("EthEscrowTimeoutRelease - FAIL: Alice failed to order fulfillment")
 
-        for i in range(6):
-            time.sleep(600)
-
         # Alice attempt to release funds before timeout hit
         release = {
             "OrderID": orderId,
@@ -216,11 +213,11 @@ class EthEscrowTimeoutRelease(OpenBazaarTestFramework):
         if r.status_code == 500:
             resp = json.loads(r.text)
             raise TestFailure("EthEscrowTimeoutRelease - FAIL: Release escrow internal server error %s", resp["reason"])
-        elif r.status_code != 400:
+        elif r.status_code != 401:
             raise TestFailure("EthEscrowTimeoutRelease - FAIL: Failed to raise error when releasing escrow before timeout")
 
         for i in range(6):
-            time.sleep(600)
+            time.sleep(900)
 
         # Alice attempt to release funds again
         release = {

--- a/qa/eth_escrow_release_after_timeout.py
+++ b/qa/eth_escrow_release_after_timeout.py
@@ -204,6 +204,9 @@ class EthEscrowTimeoutRelease(OpenBazaarTestFramework):
         if resp["state"] != "FULFILLED":
             raise TestFailure("EthEscrowTimeoutRelease - FAIL: Alice failed to order fulfillment")
 
+        for i in range(6):
+            time.sleep(600)
+
         # Alice attempt to release funds before timeout hit
         release = {
             "OrderID": orderId,
@@ -213,11 +216,11 @@ class EthEscrowTimeoutRelease(OpenBazaarTestFramework):
         if r.status_code == 500:
             resp = json.loads(r.text)
             raise TestFailure("EthEscrowTimeoutRelease - FAIL: Release escrow internal server error %s", resp["reason"])
-        elif r.status_code != 401:
+        elif r.status_code != 400:
             raise TestFailure("EthEscrowTimeoutRelease - FAIL: Failed to raise error when releasing escrow before timeout")
 
         for i in range(6):
-            time.sleep(900)
+            time.sleep(600)
 
         # Alice attempt to release funds again
         release = {

--- a/qa/test_framework/test_framework.py
+++ b/qa/test_framework/test_framework.py
@@ -112,7 +112,10 @@ class OpenBazaarTestFramework(object):
                     return
 
     def start_node(self, node):
-        args = [self.binary, "start", "-v", "-d", node["data_dir"], *self.options]
+        if self.useTor:
+            args = [self.binary, "start", "tor", "-v", "-d", node["data_dir"], *self.options]
+        else:
+            args = [self.binary, "start", "-v", "-d", node["data_dir"], *self.options]
         process = subprocess.Popen(args, stdout=PIPE)
         peerId = self.wait_for_start_success(process, node)
         node["peerId"] = peerId
@@ -189,12 +192,18 @@ class OpenBazaarTestFramework(object):
         parser.add_argument('-d', '--bitcoind', help="the bitcoind binary")
         parser.add_argument('-t', '--tempdir', action='store_true', help="temp directory to store the data folders", default="/tmp/")
         parser.add_argument('-c', '--cointype', help="cointype to test", default="BTC")
+        parser.add_argument('-T', '--Tor', help="use tor", default="no")
         args = parser.parse_args(sys.argv[1:])
         self.binary = args.binary
         self.temp_dir = args.tempdir
         self.bitcoind = args.bitcoind
         self.cointype = args.cointype
+        self.useTor = args.Tor
         self.options = options
+        if args.Tor == "yes":
+            self.useTor = True
+        else:
+            self.useTor = False
 
         try:
             shutil.rmtree(os.path.join(self.temp_dir, "openbazaar-go"))

--- a/qa/test_framework/test_framework.py
+++ b/qa/test_framework/test_framework.py
@@ -112,10 +112,7 @@ class OpenBazaarTestFramework(object):
                     return
 
     def start_node(self, node):
-        if self.useTor:
-            args = [self.binary, "start", "tor", "-v", "-d", node["data_dir"], *self.options]
-        else:
-            args = [self.binary, "start", "-v", "-d", node["data_dir"], *self.options]
+        args = [self.binary, "start", "-v", "-d", node["data_dir"], *self.options]
         process = subprocess.Popen(args, stdout=PIPE)
         peerId = self.wait_for_start_success(process, node)
         node["peerId"] = peerId
@@ -192,18 +189,12 @@ class OpenBazaarTestFramework(object):
         parser.add_argument('-d', '--bitcoind', help="the bitcoind binary")
         parser.add_argument('-t', '--tempdir', action='store_true', help="temp directory to store the data folders", default="/tmp/")
         parser.add_argument('-c', '--cointype', help="cointype to test", default="BTC")
-        parser.add_argument('-T', '--Tor', help="use tor", default="no")
         args = parser.parse_args(sys.argv[1:])
         self.binary = args.binary
         self.temp_dir = args.tempdir
         self.bitcoind = args.bitcoind
         self.cointype = args.cointype
-        self.useTor = args.Tor
         self.options = options
-        if args.Tor == "yes":
-            self.useTor = True
-        else:
-            self.useTor = False
 
         try:
             shutil.rmtree(os.path.join(self.temp_dir, "openbazaar-go"))

--- a/qa/testdata/eth_listing.json
+++ b/qa/testdata/eth_listing.json
@@ -156,8 +156,7 @@
 			{
 				"name": "Standard",
         		"bigPrice": "800000000",
-				"estimatedDelivery": "6-8 days",
-				"bigAdditionalItemPrice": "100000000"
+				"estimatedDelivery": "6-8 days"
 			},
 			{
 				"name": "Express",

--- a/qa/testdata/eth_listing.json
+++ b/qa/testdata/eth_listing.json
@@ -156,7 +156,8 @@
 			{
 				"name": "Standard",
         		"bigPrice": "800000000",
-				"estimatedDelivery": "6-8 days"
+				"estimatedDelivery": "6-8 days",
+				"bigAdditionalItemPrice": "100000000"
 			},
 			{
 				"name": "Express",

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
@@ -360,21 +360,6 @@ func (wallet *EthereumWallet) processBalanceChange(previousBalance, currentBalan
 	}
 }
 
-func (wallet *EthereumWallet) invokeTxnCB(txnID string, value *big.Int) {
-	txncb := wi.TransactionCallback{
-		Txid:      util.EnsureCorrectPrefix(txnID),
-		Outputs:   []wi.TransactionOutput{},
-		Inputs:    []wi.TransactionInput{},
-		Height:    0,
-		Timestamp: time.Now(),
-		Value:     *value,
-		WatchOnly: false,
-	}
-	for _, l := range wallet.listeners {
-		go l(txncb)
-	}
-}
-
 // CurrencyCode returns ETH
 func (wallet *EthereumWallet) CurrencyCode() string {
 	if wallet.params == nil {
@@ -523,7 +508,7 @@ func (wallet *EthereumWallet) Balance() (confirmed, unconfirmed wi.CurrencyValue
 // TransactionsFromBlock - Returns a list of transactions for this wallet begining from the specified block
 func (wallet *EthereumWallet) TransactionsFromBlock(startBlock *int) ([]wi.Txn, error) {
 	txns, err := wallet.client.eClient.NormalTxByAddress(util.EnsureCorrectPrefix(wallet.account.Address().String()), startBlock, nil,
-		1, 0, false)
+		1, 0, true)
 	if err != nil {
 		log.Error("err fetching transactions : ", err)
 		return []wi.Txn{}, nil
@@ -735,9 +720,6 @@ func (wallet *EthereumWallet) Spend(amount big.Int, addr btcutil.Address, feeLev
 
 	if err == nil {
 		h, err = util.CreateChainHash(hash.Hex())
-		if err == nil {
-			wallet.invokeTxnCB(h.String(), &amount)
-		}
 	}
 	return h, err
 }


### PR DESCRIPTION
This PR fixes the reverse chronological ordering of eth txns. It also adds a tor flag to the qa script.