### PR TITLE
Fix transaction ordering and enable Tor flag for the qa script

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -22,7 +22,7 @@
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/go-ethwallet/util",
-			"Rev": "5c1bb634ebaa76969b11b46d31d0e9c0bd3b3e38"
+			"Rev": "b773787ffb747d3b44c56f34ffe9041789095d4e"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/go-ethwallet/wallet",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -22,7 +22,7 @@
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/go-ethwallet/util",
-			"Rev": "735e63ba49ed89be6e4649f21978c0338924f820"
+			"Rev": "5c1bb634ebaa76969b11b46d31d0e9c0bd3b3e38"
 		},
 		{
 			"ImportPath": "github.com/OpenBazaar/go-ethwallet/wallet",

--- a/qa/eth_escrow_release_after_timeout.py
+++ b/qa/eth_escrow_release_after_timeout.py
@@ -204,9 +204,6 @@ class EthEscrowTimeoutRelease(OpenBazaarTestFramework):
         if resp["state"] != "FULFILLED":
             raise TestFailure("EthEscrowTimeoutRelease - FAIL: Alice failed to order fulfillment")
 
-        for i in range(6):
-            time.sleep(600)
-
         # Alice attempt to release funds before timeout hit
         release = {
             "OrderID": orderId,
@@ -216,11 +213,11 @@ class EthEscrowTimeoutRelease(OpenBazaarTestFramework):
         if r.status_code == 500:
             resp = json.loads(r.text)
             raise TestFailure("EthEscrowTimeoutRelease - FAIL: Release escrow internal server error %s", resp["reason"])
-        elif r.status_code != 400:
+        elif r.status_code != 401:
             raise TestFailure("EthEscrowTimeoutRelease - FAIL: Failed to raise error when releasing escrow before timeout")
 
         for i in range(6):
-            time.sleep(600)
+            time.sleep(900)
 
         # Alice attempt to release funds again
         release = {

--- a/qa/test_framework/test_framework.py
+++ b/qa/test_framework/test_framework.py
@@ -112,7 +112,10 @@ class OpenBazaarTestFramework(object):
                     return
 
     def start_node(self, node):
-        args = [self.binary, "start", "-v", "-d", node["data_dir"], *self.options]
+        if self.useTor:
+            args = [self.binary, "start", "tor", "-v", "-d", node["data_dir"], *self.options]
+        else:
+            args = [self.binary, "start", "-v", "-d", node["data_dir"], *self.options]
         process = subprocess.Popen(args, stdout=PIPE)
         peerId = self.wait_for_start_success(process, node)
         node["peerId"] = peerId
@@ -189,12 +192,18 @@ class OpenBazaarTestFramework(object):
         parser.add_argument('-d', '--bitcoind', help="the bitcoind binary")
         parser.add_argument('-t', '--tempdir', action='store_true', help="temp directory to store the data folders", default="/tmp/")
         parser.add_argument('-c', '--cointype', help="cointype to test", default="BTC")
+        parser.add_argument('-T', '--Tor', help="use tor", default="no")
         args = parser.parse_args(sys.argv[1:])
         self.binary = args.binary
         self.temp_dir = args.tempdir
         self.bitcoind = args.bitcoind
         self.cointype = args.cointype
+        self.useTor = args.Tor
         self.options = options
+        if args.Tor == "yes":
+            self.useTor = True
+        else:
+            self.useTor = False
 
         try:
             shutil.rmtree(os.path.join(self.temp_dir, "openbazaar-go"))

--- a/qa/test_framework/test_framework.py
+++ b/qa/test_framework/test_framework.py
@@ -113,7 +113,7 @@ class OpenBazaarTestFramework(object):
 
     def start_node(self, node):
         if self.useTor:
-            args = [self.binary, "start", "tor", "-v", "-d", node["data_dir"], *self.options]
+            args = [self.binary, "start", "--tor", "-v", "-d", node["data_dir"], *self.options]
         else:
             args = [self.binary, "start", "-v", "-d", node["data_dir"], *self.options]
         process = subprocess.Popen(args, stdout=PIPE)
@@ -192,18 +192,14 @@ class OpenBazaarTestFramework(object):
         parser.add_argument('-d', '--bitcoind', help="the bitcoind binary")
         parser.add_argument('-t', '--tempdir', action='store_true', help="temp directory to store the data folders", default="/tmp/")
         parser.add_argument('-c', '--cointype', help="cointype to test", default="BTC")
-        parser.add_argument('-T', '--Tor', help="use tor", default="no")
+        parser.add_argument('-T', '--tor', help="use tor in QA testing", action='store_true')
         args = parser.parse_args(sys.argv[1:])
         self.binary = args.binary
         self.temp_dir = args.tempdir
         self.bitcoind = args.bitcoind
         self.cointype = args.cointype
-        self.useTor = args.Tor
+        self.useTor = args.tor
         self.options = options
-        if args.Tor == "yes":
-            self.useTor = True
-        else:
-            self.useTor = False
 
         try:
             shutil.rmtree(os.path.join(self.temp_dir, "openbazaar-go"))

--- a/qa/testdata/eth_listing.json
+++ b/qa/testdata/eth_listing.json
@@ -156,7 +156,8 @@
 			{
 				"name": "Standard",
         		"bigPrice": "800000000",
-				"estimatedDelivery": "6-8 days"
+				"estimatedDelivery": "6-8 days",
+				"bigAdditionalItemPrice": "100000000"
 			},
 			{
 				"name": "Express",

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
@@ -143,17 +143,15 @@ func DeserializePendingTxn(b []byte) (PendingTxn, error) {
 // GenScriptHash - used to generate script hash for eth as per
 // escrow smart contract
 func GenScriptHash(script EthRedeemScript) ([32]byte, string, error) {
-	//ahash := sha3.NewKeccak256()
 	a := make([]byte, 4)
 	binary.BigEndian.PutUint32(a, script.Timeout)
 	arr := append(script.TxnID.Bytes(), append([]byte{script.Threshold},
 		append(a[:], append(script.Buyer.Bytes(),
 			append(script.Seller.Bytes(), append(script.Moderator.Bytes(),
 				append(script.MultisigAddress.Bytes())...)...)...)...)...)...)
-	//ahash.Write(arr)
 	var retHash [32]byte
 
-	copy(retHash[:], crypto.Keccak256(arr)[:]) // ahash.Sum(nil)[:])
+	copy(retHash[:], crypto.Keccak256(arr)[:])
 	ahashStr := hexutil.Encode(retHash[:])
 
 	return retHash, ahashStr, nil
@@ -340,13 +338,6 @@ func (wallet *EthereumWallet) processBalanceChange(previousBalance, currentBalan
 	value := new(big.Int).Sub(currentBalance, previousBalance)
 	for count < 30 {
 		txns, err := wallet.TransactionsFromBlock(&cTip)
-		//if err != nil {
-		//	log.Error("err fetching latest transactions : ", err)
-		//	return
-		//}
-		//if len(txns) == 0 {
-		//	return
-		//}
 		if err == nil && len(txns) > 0 {
 			count = 30
 			txncb := wi.TransactionCallback{
@@ -469,9 +460,6 @@ func (wallet *EthereumWallet) DecodeAddress(addr string) (btcutil.Address, error
 		ethAddr = common.HexToAddress(addr)
 	}
 
-	//if wallet.HasKey(EthAddress{&ethAddr}) {
-	//		return *wallet.address, nil
-	//	}
 	return EthAddress{&ethAddr}, err
 }
 
@@ -1060,13 +1048,10 @@ func (wallet *EthereumWallet) GenerateMultisigScript(keys []hd.ExtendedKey, thre
 func (wallet *EthereumWallet) CreateMultisigSignature(ins []wi.TransactionInput, outs []wi.TransactionOutput, key *hd.ExtendedKey, redeemScript []byte, feePerByte big.Int) ([]wi.Signature, error) {
 
 	payouts := []wi.TransactionOutput{}
-	//delta1 := int64(0)
-	//delta2 := int64(0)
 	difference := new(big.Int)
 
 	if len(ins) > 0 {
 		totalVal := ins[0].Value
-		//num := len(outs)
 		outVal := new(big.Int)
 		for _, out := range outs {
 			outVal = new(big.Int).Add(outVal, &out.Value)
@@ -1076,9 +1061,7 @@ func (wallet *EthereumWallet) CreateMultisigSignature(ins []wi.TransactionInput,
 				return nil, errors.New("payout greater than initial amount")
 			}
 			difference = new(big.Int).Sub(&totalVal, outVal)
-			//delta1 = difference / int64(num)
 		}
-		//delta2 = totalVal - (outVal + (int64(num) * delta1))
 	}
 
 	rScript, err := DeserializeEthScript(redeemScript)
@@ -1122,23 +1105,6 @@ func (wallet *EthereumWallet) CreateMultisigSignature(ins []wi.TransactionInput,
 	})
 
 	var sigs []wi.Signature
-
-	/*
-		payables := make(map[string]*big.Int)
-		for _, out := range payouts {
-			if out.Value <= 0 {
-				continue
-			}
-			val := big.NewInt(out.Value)
-			if p, ok := payables[out.Address.String()]; ok {
-				sum := big.NewInt(0)
-				sum.Add(val, p)
-				payables[out.Address.String()] = sum
-			} else {
-				payables[out.Address.String()] = val
-			}
-		}
-	*/
 
 	payables := make(map[string]big.Int)
 	addresses := []string{}
@@ -1216,7 +1182,6 @@ func (wallet *EthereumWallet) CreateMultisigSignature(ins []wi.TransactionInput,
 
 	txData := []byte{byte(0x19)}
 	txData = append(txData, []byte("Ethereum Signed Message:\n32")...)
-	//txData = append(txData, byte(32))
 	txData = append(txData, payloadHash[:]...)
 	txnHash := crypto.Keccak256(txData)
 	log.Debugf("txnHash        : %s", hexutil.Encode(txnHash))
@@ -1240,7 +1205,6 @@ func (wallet *EthereumWallet) Multisign(ins []wi.TransactionInput, outs []wi.Tra
 
 	if len(ins) > 0 {
 		totalVal := &ins[0].Value
-		//num := len(outs)
 		outVal := new(big.Int)
 		for _, out := range outs {
 			outVal.Add(outVal, &out.Value)
@@ -1250,9 +1214,7 @@ func (wallet *EthereumWallet) Multisign(ins []wi.TransactionInput, outs []wi.Tra
 				return nil, errors.New("payout greater than initial amount")
 			}
 			difference.Sub(totalVal, outVal)
-			//delta1 = difference / int64(num)
 		}
-		//delta2 = totalVal - (outVal + (int64(num) * delta1))
 	}
 
 	rScript, err := DeserializeEthScript(redeemScript)
@@ -1311,9 +1273,9 @@ func (wallet *EthereumWallet) Multisign(ins []wi.TransactionInput, outs []wi.Tra
 		}
 	}
 
-	rSlice := [][32]byte{} //, 2)
-	sSlice := [][32]byte{} //, 2)
-	vSlice := []uint8{}    //, 2)
+	rSlice := [][32]byte{}
+	sSlice := [][32]byte{}
+	vSlice := []uint8{}
 
 	var r [32]byte
 	var s [32]byte
@@ -1332,10 +1294,6 @@ func (wallet *EthereumWallet) Multisign(ins []wi.TransactionInput, outs []wi.Tra
 		sSlice = append(sSlice, s)
 		vSlice = append(vSlice, v)
 	}
-
-	//r = [32]byte{}
-	//s = [32]byte{}
-	//v = uint8(0)
 
 	shash, _, err := GenScriptHash(rScript)
 	if err != nil {
@@ -1387,8 +1345,6 @@ func (wallet *EthereumWallet) Multisign(ins []wi.TransactionInput, outs []wi.Tra
 		// the wallet does not have the required balance
 		return nil, wi.ErrInsufficientFunds
 	}
-
-	//var tx *types.Transaction
 
 	tx, txnErr := smtct.Execute(auth, vSlice, rSlice, sSlice, shash, destinations, amounts)
 
@@ -1528,18 +1484,6 @@ func (wallet *EthereumWallet) PrintKeys() {
 
 // GenWallet creates a wallet
 func GenWallet() {
-	//privateKey, err := crypto.GenerateKey()
-	//if err != nil {
-	//	log.Fatal(err)
-	//}
-	//privateKeyBytes := crypto.FromECDSA(privateKey)
-	//publicKey := privateKey.Public()
-	//publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
-	//if !ok {
-	//	log.Fatal("error casting public key to ECDSA")
-	//}
-	//publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)
-	//address := crypto.PubkeyToAddress(*publicKeyECDSA).Hex()
 }
 
 // GenDefaultKeyStore will generate a default keystore

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
@@ -352,6 +352,7 @@ func (wallet *EthereumWallet) processBalanceChange(previousBalance, currentBalan
 			for _, l := range wallet.listeners {
 				go l(txncb)
 			}
+			continue
 		}
 
 		time.Sleep(2 * time.Second)

--- a/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
+++ b/vendor/github.com/OpenBazaar/go-ethwallet/wallet/wallet.go
@@ -47,7 +47,9 @@ var done, doneBalanceTicker chan bool
 const (
 	// InfuraAPIKey is the hard coded Infura API key
 	InfuraAPIKey = "v3/91c82af0169c4115940c76d331410749"
-	maxGasLimit  = 400000
+	// EtherScanAPIKey is needed for all Eherscan requests
+	EtherScanAPIKey = "KA15D8FCHGBFZ4CQ25Y4NZM24417AXWF7M"
+	maxGasLimit     = 400000
 )
 
 var (
@@ -338,6 +340,13 @@ func (wallet *EthereumWallet) processBalanceChange(previousBalance, currentBalan
 	value := new(big.Int).Sub(currentBalance, previousBalance)
 	for count < 30 {
 		txns, err := wallet.TransactionsFromBlock(&cTip)
+		//if err != nil {
+		//	log.Error("err fetching latest transactions : ", err)
+		//	return
+		//}
+		//if len(txns) == 0 {
+		//	return
+		//}
 		if err == nil && len(txns) > 0 {
 			count = 30
 			txncb := wi.TransactionCallback{
@@ -352,10 +361,9 @@ func (wallet *EthereumWallet) processBalanceChange(previousBalance, currentBalan
 			for _, l := range wallet.listeners {
 				go l(txncb)
 			}
-			continue
 		}
-		log.Error("err fetching latest transactions : ", err)
-		time.Sleep(1 * time.Second)
+
+		time.Sleep(2 * time.Second)
 		count++
 	}
 }
@@ -1447,7 +1455,8 @@ func (wallet *EthereumWallet) GetConfirmations(txid chainhash.Hash) (confirms, a
 	if strings.Contains(wallet.client.url, "mainnet") {
 		network = etherscan.Mainnet
 	}
-	urlStr := fmt.Sprintf("https://%s.etherscan.io/api?module=proxy&action=eth_getTransactionByHash&txhash=%s", network, hash.String())
+	urlStr := fmt.Sprintf("https://%s.etherscan.io/api?module=proxy&action=eth_getTransactionByHash&txhash=%s&apikey=%s",
+		network, hash.String(), EtherScanAPIKey)
 	res, err := http.Get(urlStr)
 	if err != nil {
 		return 0, 0, err


### PR DESCRIPTION
This PR fixes the reverse chronological ordering of eth txns. It also adds a tor flag to the qa script.

