### PR TITLE
(*repo.CurrencyValue).ConvertTo accepts a *repo.CurrencyConverter

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -586,6 +586,12 @@ func (x *Start) Execute(args []string) error {
 	}
 	core.Node.PublishLock.Lock()
 
+	// assert reserve wallet is available on startup for later usage
+	_, err = core.Node.ReserveCurrencyConverter()
+	if err != nil {
+		return fmt.Errorf("verifying reserve currency converter: %s", err.Error())
+	}
+
 	// Offline messaging storage
 	var storage sto.OfflineMessagingStorage
 	if x.Storage == "self-hosted" || x.Storage == "" {

--- a/core/order.go
+++ b/core/order.go
@@ -902,157 +902,130 @@ func (n *OpenBazaarNode) CalcOrderID(order *pb.Order) (string, error) {
 	return id.B58String(), nil
 }
 
-// CalculateOrderTotal - calculate the total in satoshi/wei
 func (n *OpenBazaarNode) CalculateOrderTotal(contract *pb.RicardianContract) (*big.Int, error) {
-	wal, err := n.Multiwallet.WalletForCurrencyCode(contract.BuyerOrder.Payment.AmountCurrency.Code)
-	if err != nil {
-		return big.NewInt(0), err
-	}
-	if wal.ExchangeRates() != nil {
-		_, err = wal.ExchangeRates().GetLatestRate("") // Refresh the exchange rates
-		if err != nil {
-			log.Error(err)
+	var (
+		total         = big.NewInt(0)
+		physicalGoods = make(map[string]*pb.Listing)
+		toHundreths   = func(f float32) *big.Float {
+			return new(big.Float).Mul(big.NewFloat(float64(f)), big.NewFloat(0.01))
 		}
-	}
+	)
 
-	var total *big.Int
-	physicalGoods := make(map[string]*pb.Listing)
-
-	// Calculate the price of each item
 	for _, item := range contract.BuyerOrder.Items {
-		var (
-			satoshis  *big.Int
-			itemTotal *big.Int
-		)
-
+		var itemOriginAmt *repo.CurrencyValue
 		l, err := ParseContractForListing(item.ListingHash, contract)
 		if err != nil {
 			return big.NewInt(0), fmt.Errorf("listing not found in contract for item %s", item.ListingHash)
 		}
+
+		// keep track of physical listings for shipping caluclation
+		if l.Metadata.ContractType == pb.Listing_Metadata_PHYSICAL_GOOD {
+			physicalGoods[item.ListingHash] = l
+		}
+
 		rl, err := repo.NewListingFromProtobuf(l)
 		if err != nil {
 			return big.NewInt(0), err
 		}
 
-		if l.Metadata.ContractType == pb.Listing_Metadata_PHYSICAL_GOOD {
-			physicalGoods[item.ListingHash] = l
-		}
-
+		// calculate base amount
 		if l.Metadata.ContractType == pb.Listing_Metadata_CRYPTOCURRENCY &&
 			l.Metadata.Format == pb.Listing_Metadata_MARKET_PRICE {
-			var priceModifier float64
+			var originDef = repo.NewUnknownCryptoDefinition(l.Metadata.CryptoCurrencyCode, 0)
+			itemOriginAmt = repo.NewCurrencyValueFromBigInt(GetOrderQuantity(l, item), originDef)
+
 			if l.Metadata.PriceModifier != 0 {
-				priceModifier = float64(l.Metadata.PriceModifier)
+				itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundreths(l.Metadata.PriceModifier))
 			} else if l.Item.PriceModifier != 0 {
-				priceModifier = float64(l.Item.PriceModifier)
+				itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundreths(l.Item.PriceModifier))
 			}
-			satoshis, err = n.getMarketPriceInSatoshis(contract.BuyerOrder.Payment.AmountCurrency.Code, l.Metadata.CryptoCurrencyCode, GetOrderQuantity(l, item))
-			if err != nil {
-				return big.NewInt(0), err
-			}
-			t0 := new(big.Float).Mul(big.NewFloat(priceModifier), new(big.Float).SetInt(satoshis))
-			t1, _ := new(big.Float).Mul(t0, big.NewFloat(0.01)).Int(nil)
-			satoshis = new(big.Int).Add(satoshis, t1)
 		} else {
-			p, ok := new(big.Int).SetString(l.Item.BigPrice, 10)
-			if !ok {
-				return big.NewInt(0), errors.New("invalid price value")
-			}
-			satoshis, err = n.getPriceInSatoshi(contract.BuyerOrder.Payment.AmountCurrency.Code, l.Item.PriceCurrency.Code, p)
+			oAmt, err := repo.NewCurrencyValueFromProtobuf(l.Item.BigPrice, l.Item.PriceCurrency)
 			if err != nil {
 				return big.NewInt(0), err
 			}
+			itemOriginAmt = oAmt
 		}
-		itemTotal = new(big.Int).Set(satoshis)
+
+		// apply surcharges
 		selectedSku, err := GetSelectedSku(l, item.Options)
 		if err != nil {
 			return big.NewInt(0), err
 		}
-		var skuExists bool
 		skus, err := rl.GetSkus()
 		if err != nil {
 			return big.NewInt(0), err
 		}
 		for i, sku := range skus {
 			if selectedSku == i {
-				skuExists = true
-				surcharge := big.NewInt(0)
-				surcharge0, ok := new(big.Int).SetString(sku.BigSurcharge, 10)
-				if ok {
-					surcharge = new(big.Int).Abs(surcharge0)
-				}
-				if surcharge.Cmp(big.NewInt(0)) != 0 {
-					satoshis, err := n.getPriceInSatoshi(contract.BuyerOrder.Payment.AmountCurrency.Code,
-						l.Item.PriceCurrency.Code, surcharge)
-					if err != nil {
-						return big.NewInt(0), err
-					}
-					if surcharge0.Cmp(big.NewInt(0)) < 0 {
-						itemTotal = new(big.Int).Sub(itemTotal, satoshis)
-					} else {
-						itemTotal = new(big.Int).Add(itemTotal, satoshis)
-					}
-				}
-				if !skuExists {
-					return big.NewInt(0), errors.New("selected variant not found in listing")
+				// surcharge may be positive or negative
+				surcharge, ok := new(big.Int).SetString(sku.BigSurcharge, 10)
+				if ok && surcharge.Cmp(big.NewInt(0)) != 0 {
+					itemOriginAmt = itemOriginAmt.AddBigInt(surcharge)
 				}
 				break
 			}
 		}
-		// Subtract any coupons
+
+		// apply coupon discounts
 		for _, couponCode := range item.CouponCodes {
+			id, err := ipfs.EncodeMultihash([]byte(couponCode))
+			if err != nil {
+				return big.NewInt(0), err
+			}
 			for _, vendorCoupon := range l.Coupons {
-				id, err := ipfs.EncodeMultihash([]byte(couponCode))
-				if err != nil {
-					return big.NewInt(0), err
-				}
 				if id.B58String() == vendorCoupon.GetHash() {
-					if d, ok := new(big.Int).SetString(vendorCoupon.BigPriceDiscount, 10); ok && d.Cmp(big.NewInt(0)) > 0 {
-						satoshis, err := n.getPriceInSatoshi(contract.BuyerOrder.Payment.AmountCurrency.Code,
-							l.Item.PriceCurrency.Code, d)
-						if err != nil {
-							log.Errorf("failed to convert currency for coupon (%s): %s", couponCode, err)
-							continue
-						}
-						itemTotal = new(big.Int).Sub(itemTotal, satoshis)
+					if disc, ok := new(big.Int).SetString(vendorCoupon.BigPriceDiscount, 10); ok && disc.Cmp(big.NewInt(0)) > 0 {
+						// apply fixed discount
+						itemOriginAmt = itemOriginAmt.SubBigInt(disc)
 					} else if discountF := vendorCoupon.GetPercentDiscount(); discountF > 0 {
-						d := new(big.Float).Mul(big.NewFloat(float64(discountF)), big.NewFloat(0.01))
-						totalDiscount, _ := new(big.Float).Mul(d, new(big.Float).SetInt(itemTotal)).Int(nil)
-						itemTotal = new(big.Int).Sub(itemTotal, totalDiscount)
+						// apply percentage discount
+						itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundreths(-discountF))
 					}
 				}
 			}
 		}
-		// Apply tax
+
+		// apply taxes
 		for _, tax := range l.Taxes {
 			for _, taxRegion := range tax.TaxRegions {
 				if contract.BuyerOrder.Shipping.Country == taxRegion {
-					t := new(big.Float).Mul(big.NewFloat(float64(tax.Percentage)), big.NewFloat(0.01))
-					totalTax, _ := new(big.Float).Mul(t, new(big.Float).SetInt(itemTotal)).Int(nil)
-					itemTotal = new(big.Int).Add(itemTotal, totalTax)
+					itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundreths(tax.Percentage))
 					break
 				}
 			}
 		}
 
+		// apply requested quantity
 		if !(l.Metadata.ContractType == pb.Listing_Metadata_CRYPTOCURRENCY &&
 			l.Metadata.Format == pb.Listing_Metadata_MARKET_PRICE) {
-			itemQuantity := GetOrderQuantity(l, item)
-			if itemQuantity.Cmp(big.NewInt(0)) <= 0 {
-				itemQuantity = big.NewInt(1)
+			if itemQuantity := GetOrderQuantity(l, item); itemQuantity.Cmp(big.NewInt(0)) > 0 {
+				itemOriginAmt = itemOriginAmt.MulBigInt(itemQuantity)
+			} else {
 				log.Debugf("missing quantity for order, assuming quantity 1")
 			}
-			itemTotal = new(big.Int).Mul(itemTotal, itemQuantity)
 		}
 
-		total = new(big.Int).Set(itemTotal)
+		// convert subtotal to final currency
+		cc, err := n.ReserveCurrencyConverter()
+		if err != nil {
+			return big.NewInt(0), fmt.Errorf("preparing reserve currency converter: %s", err.Error())
+		}
+
+		finalItemAmount, err := itemOriginAmt.ConvertUsingProtobufDef(contract.BuyerOrder.Payment.AmountCurrency, cc)
+		if err != nil {
+			return big.NewInt(0), err
+		}
+
+		// add to total
+		total.Add(total, finalItemAmount.AmountBigInt())
 	}
 
 	shippingTotal, err := n.calculateShippingTotalForListings(contract, physicalGoods)
 	if err != nil {
 		return big.NewInt(0), err
 	}
-	total = new(big.Int).Add(total, shippingTotal)
+	total.Add(total, shippingTotal)
 
 	return total, nil
 }
@@ -1102,6 +1075,11 @@ func (n *OpenBazaarNode) calculateShippingTotalForListings(contract *pb.Ricardia
 			return big.NewInt(0), errors.New("listing does ship to selected country")
 		}
 
+		cc, err := n.ReserveCurrencyConverter()
+		if err != nil {
+			return big.NewInt(0), fmt.Errorf("preparing reserve currency converter: %s", err.Error())
+		}
+
 		// Check service exists
 		services := make(map[string]*pb.Listing_ShippingOption_Service)
 		for _, shippingService := range option.Services {
@@ -1111,30 +1089,26 @@ func (n *OpenBazaarNode) calculateShippingTotalForListings(contract *pb.Ricardia
 		if !ok {
 			return big.NewInt(0), errors.New("shipping service not found in listing")
 		}
-		servicePrice, ok := new(big.Int).SetString(service.BigPrice, 10)
-		if !ok {
-			return big.NewInt(0), errors.New("invalid service price")
-		}
-		shippingSatoshi, err := n.getPriceInSatoshi(contract.BuyerOrder.Payment.AmountCurrency.Code,
-			listing.Item.PriceCurrency.Code, servicePrice)
+		servicePrice, err := repo.NewCurrencyValueFromProtobuf(service.BigPrice, listing.Item.PriceCurrency)
 		if err != nil {
-			return big.NewInt(0), err
+			return big.NewInt(0), fmt.Errorf("parsing service price (%v): %s", service.Name, err.Error())
+		}
+		convertedShippingPrice, err := servicePrice.ConvertUsingProtobufDef(contract.BuyerOrder.Payment.AmountCurrency, cc)
+		if err != nil {
+			return big.NewInt(0), fmt.Errorf("converting service price (%s): %s", service.Name, err.Error())
 		}
 
-		secondarySatoshi := big.NewInt(0)
-		if service.BigAdditionalItemPrice != "" {
-			serviceAddlItemPrice, ok := new(big.Int).SetString(service.BigAdditionalItemPrice, 10)
-			if !ok {
-				return big.NewInt(0), errors.New("invalid service additional price")
+		auxServicePrice, err := repo.NewCurrencyValueFromProtobuf(service.BigAdditionalItemPrice, listing.Item.PriceCurrency)
+		if err != nil {
+			return big.NewInt(0), fmt.Errorf("parsing aux service price (%v): %s", service.Name, err.Error())
+		}
+		var convertedAuxPrice = repo.NewCurrencyValueFromBigInt(big.NewInt(0), convertedShippingPrice.Currency)
+		if auxServicePrice.IsPositive() {
+			finalAux, err := auxServicePrice.ConvertUsingProtobufDef(contract.BuyerOrder.Payment.AmountCurrency, cc)
+			if err != nil {
+				return big.NewInt(0), fmt.Errorf("converting aux service price (%s): %s", service.Name, err.Error())
 			}
-
-			if serviceAddlItemPrice.Cmp(big.NewInt(0)) > 0 {
-				secondarySatoshi, err = n.getPriceInSatoshi(contract.BuyerOrder.Payment.AmountCurrency.Code,
-					listing.Item.PriceCurrency.Code, serviceAddlItemPrice)
-				if err != nil {
-					return big.NewInt(0), err
-				}
-			}
+			convertedAuxPrice = finalAux
 		}
 
 		// Calculate tax percentage
@@ -1153,10 +1127,13 @@ func (n *OpenBazaarNode) calculateShippingTotalForListings(contract *pb.Ricardia
 		var qty uint64
 		if q := quantityForItem(listing.Metadata.Version, item); q.IsUint64() {
 			qty = q.Uint64()
+		} else {
+			orderID, _ := n.CalcOrderID(contract.BuyerOrder)
+			log.Warningf("unable to detect quantity in contract (%s)", orderID)
 		}
 		is = append(is, itemShipping{
-			primary:               shippingSatoshi,
-			secondary:             secondarySatoshi,
+			primary:               convertedShippingPrice.AmountBigInt(),
+			secondary:             convertedAuxPrice.AmountBigInt(),
 			quantity:              qty,
 			shippingTaxPercentage: shippingTaxPercentage,
 			version:               listing.Metadata.Version,
@@ -1213,117 +1190,6 @@ func (n *OpenBazaarNode) calculateShippingTotalForListings(contract *pb.Ricardia
 	shippingTotal = new(big.Int).Add(shippingTotal, sts0)
 
 	return shippingTotal, nil
-}
-
-func (n *OpenBazaarNode) getPriceInSatoshi(paymentCoin, currencyCode string, amount *big.Int) (*big.Int, error) {
-	var reserveCurrency = n.reserveCurrency()
-	var (
-		originCurrencyDef, oErr  = n.LookupCurrency(currencyCode)
-		paymentCurrencyDef, pErr = n.LookupCurrency(paymentCoin)
-		reserveCurrencyDef, rErr = n.LookupCurrency(reserveCurrency)
-	)
-	if oErr != nil {
-		return big.NewInt(0), fmt.Errorf("invalid listing currency code: %s", oErr.Error())
-	}
-	if pErr != nil {
-		return big.NewInt(0), fmt.Errorf("invalid payment currency code: %s", pErr.Error())
-	}
-	if rErr != nil {
-		return big.NewInt(0), fmt.Errorf("invalid reserve currency code: %s", rErr.Error())
-	}
-
-	if originCurrencyDef.Equal(paymentCurrencyDef) {
-		return amount, nil
-	}
-
-	originValue, err := repo.NewCurrencyValue(amount.String(), originCurrencyDef)
-	if err != nil {
-		return big.NewInt(0), fmt.Errorf("parsing amount: %s", err.Error())
-	}
-
-	wal, err := n.Multiwallet.WalletForCurrencyCode(reserveCurrency)
-	if err != nil {
-		return big.NewInt(0), fmt.Errorf("%s wallet not found for exchange rates", reserveCurrency)
-	}
-
-	if wal.ExchangeRates() == nil {
-		return big.NewInt(0), ErrPriceCalculationRequiresExchangeRates
-	}
-	reserveIntoOriginRate, err := wal.ExchangeRates().GetExchangeRate(currencyCode)
-	if err != nil {
-		return big.NewInt(0), err
-	}
-	originIntoReserveRate := 1 / reserveIntoOriginRate
-	reserveIntoResultRate, err := wal.ExchangeRates().GetExchangeRate(paymentCoin)
-	if err != nil {
-		// TODO: remove hack once ExchangeRates can be made aware of testnet currencies
-		if strings.HasPrefix(paymentCoin, "T") {
-			reserveIntoResultRate, err = wal.ExchangeRates().GetExchangeRate(strings.TrimPrefix(paymentCoin, "T"))
-			if err != nil {
-				return big.NewInt(0), err
-			}
-		} else {
-			return big.NewInt(0), err
-		}
-	}
-
-	reserveValue, _, err := originValue.ConvertTo(reserveCurrencyDef, originIntoReserveRate)
-	if err != nil {
-		return big.NewInt(0), fmt.Errorf("converting to reserve: %s", err.Error())
-	}
-	resultValue, _, err := reserveValue.ConvertTo(paymentCurrencyDef, reserveIntoResultRate)
-	if err != nil {
-		return big.NewInt(0), fmt.Errorf("converting from reserve: %s", err.Error())
-	}
-	return resultValue.Amount, nil
-}
-
-func (n *OpenBazaarNode) reserveCurrency() string {
-	if n.TestnetEnable || n.RegressionTestEnable {
-		return "TBTC"
-	}
-	return "BTC"
-}
-
-func (n *OpenBazaarNode) getMarketPriceInSatoshis(pricingCurrency, currencyCode string, amount *big.Int) (*big.Int, error) {
-	var (
-		currencyDef, cErr = n.LookupCurrency(currencyCode)
-		pricingDef, pErr  = n.LookupCurrency(pricingCurrency)
-	)
-	if cErr != nil {
-		// if the currency is unknown, it is likely a cryptocurrency and will
-		// assume the default divisibility
-		currencyDef = repo.NewUnknownCryptoDefinition(currencyCode, repo.DefaultCryptoDivisibility)
-	}
-	if pErr != nil {
-		return big.NewInt(0), fmt.Errorf("lookup currency (%s): %s", pricingCurrency, pErr)
-	}
-
-	if currencyDef.Equal(pricingDef) {
-		return amount, nil
-	}
-	wal, err := n.Multiwallet.WalletForCurrencyCode(pricingDef.CurrencyCode().String())
-	if err != nil {
-		return big.NewInt(0), fmt.Errorf("currency (%s) unsupported by wallet", pricingDef.CurrencyCode().String())
-	}
-	if wal.ExchangeRates() == nil {
-		return big.NewInt(0), ErrPriceCalculationRequiresExchangeRates
-	}
-
-	rate, err := wal.ExchangeRates().GetExchangeRate(n.exchangeRateCode(currencyDef.CurrencyCode().String()))
-	if err != nil {
-		return big.NewInt(0), err
-	}
-
-	cv, err := repo.NewCurrencyValue(amount.String(), currencyDef)
-	if err != nil {
-		return nil, err
-	}
-	newCV, _, err := cv.ConvertTo(pricingDef, 1/rate)
-	if err != nil {
-		return nil, err
-	}
-	return newCV.Amount, nil
 }
 
 func verifySignaturesOnOrder(contract *pb.RicardianContract) error {
@@ -1825,4 +1691,31 @@ func quantityForItem(version uint32, item *pb.Order_Item) *big.Int {
 		return new(big.Int).SetUint64(item.Quantity64)
 	}
 	return new(big.Int).SetUint64(uint64(item.Quantity))
+}
+
+// ReserveCurrencyConverter will attempt to build a CurrencyConverter based on
+// the reserve currency, or will panic if unsuccessful
+func (n *OpenBazaarNode) ReserveCurrencyConverter() (*repo.CurrencyConverter, error) {
+	var reserveCode = "BTC"
+	if n.RegressionTestEnable || n.TestnetEnable {
+		reserveCode = "TBTC"
+	}
+
+	wal, err := n.Multiwallet.WalletForCurrencyCode(reserveCode)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find reserve (%s) wallet", reserveCode)
+	}
+
+	if wal.ExchangeRates() == nil {
+		return nil, fmt.Errorf("reserve wallet has exchange rates disabled or unavailable")
+	}
+
+	// priming the exchange rate cache
+	wal.ExchangeRates().GetAllRates(false)
+
+	cc, err := repo.NewCurrencyConverter(reserveCode, wal.ExchangeRates())
+	if err != nil {
+		return nil, fmt.Errorf("creating reserve currency converter: %s", err.Error())
+	}
+	return cc, nil
 }

--- a/core/order.go
+++ b/core/order.go
@@ -906,7 +906,7 @@ func (n *OpenBazaarNode) CalculateOrderTotal(contract *pb.RicardianContract) (*b
 	var (
 		total         = big.NewInt(0)
 		physicalGoods = make(map[string]*pb.Listing)
-		toHundreths   = func(f float32) *big.Float {
+		toHundredths  = func(f float32) *big.Float {
 			return new(big.Float).Mul(big.NewFloat(float64(f)), big.NewFloat(0.01))
 		}
 	)
@@ -935,9 +935,9 @@ func (n *OpenBazaarNode) CalculateOrderTotal(contract *pb.RicardianContract) (*b
 			itemOriginAmt = repo.NewCurrencyValueFromBigInt(GetOrderQuantity(l, item), originDef)
 
 			if l.Metadata.PriceModifier != 0 {
-				itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundreths(l.Metadata.PriceModifier))
+				itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundredths(l.Metadata.PriceModifier))
 			} else if l.Item.PriceModifier != 0 {
-				itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundreths(l.Item.PriceModifier))
+				itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundredths(l.Item.PriceModifier))
 			}
 		} else {
 			oAmt, err := repo.NewCurrencyValueFromProtobuf(l.Item.BigPrice, l.Item.PriceCurrency)
@@ -980,7 +980,7 @@ func (n *OpenBazaarNode) CalculateOrderTotal(contract *pb.RicardianContract) (*b
 						itemOriginAmt = itemOriginAmt.SubBigInt(disc)
 					} else if discountF := vendorCoupon.GetPercentDiscount(); discountF > 0 {
 						// apply percentage discount
-						itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundreths(-discountF))
+						itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundredths(-discountF))
 					}
 				}
 			}
@@ -990,7 +990,7 @@ func (n *OpenBazaarNode) CalculateOrderTotal(contract *pb.RicardianContract) (*b
 		for _, tax := range l.Taxes {
 			for _, taxRegion := range tax.TaxRegions {
 				if contract.BuyerOrder.Shipping.Country == taxRegion {
-					itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundreths(tax.Percentage))
+					itemOriginAmt = itemOriginAmt.AddBigFloatProduct(toHundredths(tax.Percentage))
 					break
 				}
 			}
@@ -1711,7 +1711,9 @@ func (n *OpenBazaarNode) ReserveCurrencyConverter() (*repo.CurrencyConverter, er
 	}
 
 	// priming the exchange rate cache
-	wal.ExchangeRates().GetAllRates(false)
+	if _, err := wal.ExchangeRates().GetAllRates(false); err != nil {
+		log.Warningf("priming exchange rate cache: %s", err.Error())
+	}
 
 	cc, err := repo.NewCurrencyConverter(reserveCode, wal.ExchangeRates())
 	if err != nil {

--- a/core/order_test.go
+++ b/core/order_test.go
@@ -82,7 +82,7 @@ func TestOpenBazaarNode_CalculateOrderTotal(t *testing.T) {
 		t.Error(err)
 	}
 	if total.Int64() != 125000 {
-		t.Errorf("Calculated wrong order total. Wanted %d, got %d", 125000, total.Int64())
+		t.Errorf("Calculated wrong order total. Wanted 125000, got %d", total.Int64())
 	}
 
 	// Test higher quantity
@@ -92,7 +92,7 @@ func TestOpenBazaarNode_CalculateOrderTotal(t *testing.T) {
 		t.Error(err)
 	}
 	if total.Int64() != 235000 {
-		t.Error("Calculated wrong order total")
+		t.Errorf("Calculated wrong order total. Wanted 235000, got %d", total.Int64())
 	}
 
 	// Test with options
@@ -133,7 +133,7 @@ func TestOpenBazaarNode_CalculateOrderTotal(t *testing.T) {
 		t.Error(err)
 	}
 	if total.Int64() != 175000 {
-		t.Error("Calculated wrong order total")
+		t.Errorf("Calculated wrong order total. Wanted 175000, got %d", total.Int64())
 	}
 
 	// Test negative surcharge
@@ -157,7 +157,7 @@ func TestOpenBazaarNode_CalculateOrderTotal(t *testing.T) {
 		t.Error(err)
 	}
 	if total.Int64() != 75000 {
-		t.Error("Calculated wrong order total")
+		t.Errorf("Calculated wrong order total. Wanted 75000, got %d", total.Int64())
 	}
 
 	// Test with coupon percent discount
@@ -219,7 +219,7 @@ func TestOpenBazaarNode_CalculateOrderTotal(t *testing.T) {
 		t.Error(err)
 	}
 	if total.Int64() != 69000 {
-		t.Error("Calculated wrong order total")
+		t.Errorf("Calculated wrong order total. Wanted 69000, got %d", total.Int64())
 	}
 
 	// Test with tax no tax shipping
@@ -245,7 +245,7 @@ func TestOpenBazaarNode_CalculateOrderTotal(t *testing.T) {
 		t.Error(err)
 	}
 	if total.Int64() != 71200 {
-		t.Error("Calculated wrong order total")
+		t.Errorf("Calculated wrong order total. Wanted 71200, got %d", total.Int64())
 	}
 
 	// Test with tax with tax shipping
@@ -271,8 +271,7 @@ func TestOpenBazaarNode_CalculateOrderTotal(t *testing.T) {
 		t.Error(err)
 	}
 	if total.Int64() != 72450 {
-		t.Error("Calculated wrong order total")
-		return
+		t.Fatalf("Calculated wrong order total. Wanted 72450, got %d", total.Int64())
 	}
 
 	// Test local pickup
@@ -292,7 +291,7 @@ func TestOpenBazaarNode_CalculateOrderTotal(t *testing.T) {
 		t.Error(err)
 	}
 	if total.Int64() != 46200 {
-		t.Error("Calculated wrong order total")
+		t.Errorf("Calculated wrong order total. Wanted 46200, got %d", total.Int64())
 	}
 
 	contract2 := &pb.RicardianContract{
@@ -358,7 +357,7 @@ func TestOpenBazaarNode_CalculateOrderTotal(t *testing.T) {
 		t.Error(err)
 	}
 	if total.Int64() != 1115000 {
-		t.Error("Calculated wrong order total")
+		t.Errorf("Calculated wrong order total. Wanted 1115000, got %d", total.Int64())
 	}
 }
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -113,14 +113,6 @@ func (n *OpenBazaarNode) LookupCurrency(currencyCode string) (repo.CurrencyDefin
 	return repo.AllCurrencies().Lookup(currencyCode)
 }
 
-// exchangeRateCode strips the T off the currency code if we are on testnet or regtest.
-func (n *OpenBazaarNode) exchangeRateCode(currencyCode string) string {
-	if n.TestnetEnable || n.RegressionTestEnable {
-		return strings.TrimPrefix(currencyCode, "T")
-	}
-	return currencyCode
-}
-
 func (n *OpenBazaarNode) ValidateMultiwalletHasPreferredCurrencies(data repo.SettingsData) error {
 	if data.PreferredCurrencies == nil {
 		return nil

--- a/mobile/node.go
+++ b/mobile/node.go
@@ -300,6 +300,12 @@ func NewNodeWithConfig(config *NodeConfig, password string, mnemonic string) (*N
 
 	node.PublishLock.Lock()
 
+	// assert reserve wallet is available on startup for later usage
+	_, err = node.ReserveCurrencyConverter()
+	if err != nil {
+		return nil, fmt.Errorf("verifying reserve currency converter: %s", err.Error())
+	}
+
 	return &Node{OpenBazaarNode: node, config: *config, ipfsConfig: ncfg, apiConfig: apiConfig, startMtx: sync.Mutex{}}, nil
 }
 

--- a/repo/currency_converter.go
+++ b/repo/currency_converter.go
@@ -1,0 +1,124 @@
+package repo
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+var (
+	// ErrPriceCalculationRequiresExchangeRates - exchange rates dependency err
+	ErrPriceCalculationRequiresExchangeRates = errors.New("can't calculate price with exchange rates disabled")
+)
+
+type rater interface {
+	GetExchangeRate(string) (float64, error)
+}
+
+type equivRater struct{}
+
+func (equivRater) GetExchangeRate(_ string) (float64, error) { return 1.0, nil }
+
+// NewEquivalentConverter returns a currency converter where all rates are
+// always returns as 1.0 making all currencies equivalent to one another
+func NewEquivalentConverter() *CurrencyConverter {
+	return &CurrencyConverter{reserveCode: "EQL", reserveRater: equivRater{}}
+}
+
+type CurrencyConverter struct {
+	reserveCode  string
+	reserveRater rater
+}
+
+func NewCurrencyConverter(code string, rater rater) (*CurrencyConverter, error) {
+	var cc = &CurrencyConverter{reserveCode: code, reserveRater: rater}
+	if rate, err := cc.getExchangeRate(cc.reserveCode); err != nil {
+		return nil, fmt.Errorf("unable to get reserve rate (%s): %s", cc.reserveCode, err.Error())
+	} else if rate != 1.0 {
+		return nil, fmt.Errorf("research exchange rate was not 1.0 (%f)", rate)
+	}
+	return cc, nil
+}
+
+func (c CurrencyConverter) getExchangeRate(code string) (float64, error) {
+	// TODO: remove hack once ExchangeRates can be made aware of testnet currencies
+	r, err := c.reserveRater.GetExchangeRate(strings.TrimPrefix(code, "T"))
+	if err != nil {
+		return 0.0, fmt.Errorf("get rate for (%s): %s", code, err.Error())
+	}
+	if r <= 0 {
+		return 0.0, fmt.Errorf("rate (%f) for (%s) must be greater than zero", r, code)
+	}
+	return r, nil
+}
+
+func (c *CurrencyConverter) getReserveToCurrencyRate(destinationCurrencyCode string) (*big.Float, error) {
+	reserveIntoOriginRate, err := c.getExchangeRate(destinationCurrencyCode)
+	if err != nil {
+		return big.NewFloat(0), err
+	}
+
+	// Convert to big.Float
+	return new(big.Float).SetFloat64(reserveIntoOriginRate), nil
+}
+
+func (c *CurrencyConverter) getConversionRate(originCurrencyCode string, destinationCurrencyCode string) (*big.Float, error) {
+	originRate, err := c.getReserveToCurrencyRate(originCurrencyCode)
+	if err != nil {
+		return big.NewFloat(0), err
+	}
+	paymentRate, err := c.getReserveToCurrencyRate(destinationCurrencyCode)
+	if err != nil {
+		return big.NewFloat(0), err
+	}
+	return new(big.Float).Quo(paymentRate, originRate), nil
+}
+
+func (c *CurrencyConverter) getDivisibilityRate(origin, destination CurrencyDefinition) (*big.Float, error) {
+	if err := origin.Valid(); err != nil {
+		return nil, fmt.Errorf("invalid origin currency: %s", err.Error())
+	}
+	if err := destination.Valid(); err != nil {
+		return nil, fmt.Errorf("invalid destination currency: %s", err.Error())
+	}
+	originDiv := new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), new(big.Int).SetUint64(uint64(origin.Divisibility)), nil))
+	destDiv := new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), new(big.Int).SetUint64(uint64(destination.Divisibility)), nil))
+	return new(big.Float).Quo(destDiv, originDiv), nil
+}
+
+// GetFinalPrice returns the resulting CurrencyValue after converting the amount
+// and divisibility of the originAmount to the target currency
+func (c CurrencyConverter) GetFinalPrice(originAmount *CurrencyValue, resultCurrency CurrencyDefinition) (*CurrencyValue, big.Accuracy, error) {
+	originalAmount := new(big.Float).SetInt(originAmount.Amount)
+
+	// get conversion ratio into/out-of reserve currency
+	convRate, err := c.getConversionRate(originAmount.Currency.Code.String(), resultCurrency.Code.String())
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// get divisibility ratio between currencies
+	divRate, err := c.getDivisibilityRate(originAmount.Currency, resultCurrency)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// apply the conversion and divisibility ratios to the amount
+	finalFloat := new(big.Float).Mul(convRate, originalAmount)
+	finalFloat = finalFloat.Mul(finalFloat, divRate)
+	finalPrice, acc := finalFloat.Int(nil)
+
+	// round decimal away from zero
+	if acc == big.Above {
+		finalPrice.Add(finalPrice, big.NewInt(-1))
+	}
+	if acc == big.Below {
+		finalPrice.Add(finalPrice, big.NewInt(1))
+	}
+
+	// return -acc because we have rounded to the other side of
+	// decimal (0.5 -> 1 which is Above instead of normal behavior
+	// of 0.5 -> 0 which is Below)
+	return NewCurrencyValueFromBigInt(finalPrice, resultCurrency), -acc, nil
+}

--- a/repo/currency_converter.go
+++ b/repo/currency_converter.go
@@ -26,13 +26,19 @@ func NewEquivalentConverter() *CurrencyConverter {
 	return &CurrencyConverter{reserveCode: "EQL", reserveRater: equivRater{}}
 }
 
+// CurrencyConverter is suitable for converting a currency from one CurrencyDefinition
+// to another, accounting for their differing divisibility as well as their differing
+// exchange rate as provided by the rater. The rater can represent all rates for the
+// reserve currency code provided.
 type CurrencyConverter struct {
 	reserveCode  string
 	reserveRater rater
 }
 
-func NewCurrencyConverter(code string, rater rater) (*CurrencyConverter, error) {
-	var cc = &CurrencyConverter{reserveCode: code, reserveRater: rater}
+// NewCurrencyConverter returns a valid CurrencyConverter. The rater is verified by
+// ensuring the rate of its reserveCode is 1.0 (ensuring it is equivalent to itself).
+func NewCurrencyConverter(reserveCode string, rater rater) (*CurrencyConverter, error) {
+	var cc = &CurrencyConverter{reserveCode: reserveCode, reserveRater: rater}
 	if rate, err := cc.getExchangeRate(cc.reserveCode); err != nil {
 		return nil, fmt.Errorf("unable to get reserve rate (%s): %s", cc.reserveCode, err.Error())
 	} else if rate != 1.0 {

--- a/test/factory/currency_converter.go
+++ b/test/factory/currency_converter.go
@@ -1,0 +1,28 @@
+package factory
+
+import (
+	"fmt"
+
+	"github.com/OpenBazaar/openbazaar-go/repo"
+)
+
+type mockRater struct {
+	rates map[string]float64
+}
+
+func (m mockRater) GetExchangeRate(code string) (float64, error) {
+	if r, ok := m.rates[code]; ok {
+		return r, nil
+	}
+	return 0.0, fmt.Errorf("rate for code (%s) not found", code)
+}
+
+func NewCurrencyConverter(reserveCode string, mockRates map[string]float64) (*repo.CurrencyConverter, error) {
+	r, ok := mockRates[reserveCode]
+	if !ok {
+		mockRates[reserveCode] = 1.0
+	} else if r != 1.0 {
+		return nil, fmt.Errorf("reserve currency rate is not 1.0")
+	}
+	return repo.NewCurrencyConverter(reserveCode, mockRater{mockRates})
+}


### PR DESCRIPTION
Isolated the conversion behavior within ConvertTo to live within
repo.CurrencyConverter. It will be provided with a rater interface with
a single method requirement that is satisfied by a subset of today's
wallet-interface.ExchangeRates interface. This change eventually leads
to a wallet-independent exchange rate service which can be separated
later.

Supercedes https://github.com/OpenBazaar/openbazaar-go/pull/1949
Fixes https://github.com/OpenBazaar/openbazaar-go/issues/1983