### PR TITLE
[#1983] Support testnet reserve currency converter usage

### DIFF
--- a/qa/test_framework/test_framework.py
+++ b/qa/test_framework/test_framework.py
@@ -82,15 +82,17 @@ class OpenBazaarTestFramework(object):
         config["Swarm"]["DisableNatPortMap"] = True
 
         self.cointype = self.cointype.upper()
-
         coinConfig = config["Wallets"][self.cointype]
+
         del config["Wallets"]
         config["Wallets"] = {}
-        config["Wallets"][self.cointype] = coinConfig
+        config["Wallets"]["BTC"] = coinConfig
+        config["Wallets"]["BTC"]["Type"] = "SPV"
+        config["Wallets"]["BTC"]["TrustedPeer"] = "127.0.0.1:18444"
+        config["Wallets"]["BTC"]["FeeAPI"] = ""
 
-        config["Wallets"][self.cointype]["Type"] = "SPV"
-        config["Wallets"][self.cointype]["TrustedPeer"] = "127.0.0.1:18444"
-        config["Wallets"][self.cointype]["FeeAPI"] = ""
+        if self.cointype != "BTC":
+            config["Wallets"][self.cointype] = coinConfig
 
         with open(os.path.join(dir_path, "config"), 'w') as outfile:
             outfile.write(json.dumps(config, indent=4))

--- a/repo/currency_converter.go
+++ b/repo/currency_converter.go
@@ -42,7 +42,7 @@ func NewCurrencyConverter(reserveCode string, rater rater) (*CurrencyConverter, 
 	if rate, err := cc.getExchangeRate(cc.reserveCode); err != nil {
 		return nil, fmt.Errorf("unable to get reserve rate (%s): %s", cc.reserveCode, err.Error())
 	} else if rate != 1.0 {
-		return nil, fmt.Errorf("research exchange rate was not 1.0 (%f)", rate)
+		return nil, fmt.Errorf("reserve exchange rate was not 1.0 (%f)", rate)
 	}
 	return cc, nil
 }


### PR DESCRIPTION
Forgot to support testnet when creating reserve currency converter. This will enable testnet/regtest to work normally.