### PR TITLE
Values from DB that get reflected into scientific notation are kept as strings

### DIFF
--- a/repo/db/sales.go
+++ b/repo/db/sales.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"math/big"
 	"sync"
 	"time"
 
@@ -196,6 +198,16 @@ func (s *SalesDB) GetAll(stateFilter []pb.OrderState, searchTerm string, sortByA
 
 		if len(rc.VendorListings) > 0 && rc.VendorListings[0].Metadata != nil && rc.VendorListings[0].Metadata.ContractType != pb.Listing_Metadata_CRYPTOCURRENCY {
 			coinType = ""
+		}
+
+		if strings.Contains(totalStr, "e") {
+			flt, _, err := big.ParseFloat(totalStr, 10, 0, big.ToNearestEven)
+			if err != nil {
+				return nil, 0, err
+			}
+			var i = new(big.Int)
+			i, _ = flt.Int(i)
+			totalStr = i.String()
 		}
 
 		cv, err := repo.NewCurrencyValueWithLookup(totalStr, paymentCoin)


### PR DESCRIPTION
Problem: When pulling extremely large numbers out of SQLite as a string type but the Go scanner will convert the string using reflection into a scientific notation string. 

Proposed Solution: Check if reflected string has an 'e' in it then we identify it as a scientific notation and convert it back to a large number in a string.