### PR TITLE
feat: Save outbound order payment, refund, and dispute messages

### DIFF
--- a/core/disputes.go
+++ b/core/disputes.go
@@ -110,7 +110,7 @@ func (n *OpenBazaarNode) OpenDispute(orderID string, contract *pb.RicardianContr
 	contract.Signatures = append(contract.Signatures, rc.Signatures[0])
 
 	// Send to moderator
-	err = n.SendDisputeOpen(order.Payment.Moderator, nil, rc)
+	err = n.SendDisputeOpen(order.Payment.Moderator, nil, rc, orderID)
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func (n *OpenBazaarNode) OpenDispute(orderID string, contract *pb.RicardianContr
 			return nil
 		}
 	}
-	err = n.SendDisputeOpen(counterparty, &counterkey, rc)
+	err = n.SendDisputeOpen(counterparty, &counterkey, rc, orderID)
 	if err != nil {
 		return err
 	}

--- a/core/disputes.go
+++ b/core/disputes.go
@@ -764,11 +764,11 @@ func (n *OpenBazaarNode) CloseDispute(orderID string, buyerPercentage, vendorPer
 		return err
 	}
 
-	err = n.SendDisputeClose(buyerID, &buyerKey, rc)
+	err = n.SendDisputeClose(buyerID, &buyerKey, rc, orderID)
 	if err != nil {
 		return err
 	}
-	err = n.SendDisputeClose(vendorID, &vendorKey, rc)
+	err = n.SendDisputeClose(vendorID, &vendorKey, rc, orderID)
 	if err != nil {
 		return err
 	}

--- a/core/net.go
+++ b/core/net.go
@@ -877,6 +877,8 @@ func (n *OpenBazaarNode) SendOrderPayment(spend *SpendResponse) error {
 	if err != nil {
 		return err
 	}
+
+	// Create the ORDER_PAYMENT message
 	m := pb.Message{
 		MessageType: pb.Message_ORDER_PAYMENT,
 		Payload:     a,
@@ -887,6 +889,7 @@ func (n *OpenBazaarNode) SendOrderPayment(spend *SpendResponse) error {
 		return err
 	}
 
+	// Save ORDER_PAYMENT message to the database for this order for resending if necessary
 	orderID0 := msg.OrderID
 	if orderID0 == "" {
 		log.Errorf("failed fetching orderID")
@@ -896,7 +899,7 @@ func (n *OpenBazaarNode) SendOrderPayment(spend *SpendResponse) error {
 			orderID0, pb.Message_ORDER_PAYMENT, spend.PeerID, repo.Message{Msg: m},
 			"", 0, []byte{})
 		if err != nil {
-			log.Errorf("failed putting message (%s-%d): %v", orderID0, int(pb.Message_ORDER_COMPLETION), err)
+			log.Errorf("failed putting message (%s-%d): %v", orderID0, int(pb.Message_ORDER_PAYMENT), err)
 		}
 	}
 

--- a/core/net.go
+++ b/core/net.go
@@ -524,7 +524,7 @@ func (n *OpenBazaarNode) SendOrderCompletion(peerID string, k *libp2p.PubKey, co
 }
 
 // SendDisputeOpen - send open dispute msg to peer
-func (n *OpenBazaarNode) SendDisputeOpen(peerID string, k *libp2p.PubKey, disputeMessage *pb.RicardianContract) error {
+func (n *OpenBazaarNode) SendDisputeOpen(peerID string, k *libp2p.PubKey, disputeMessage *pb.RicardianContract, orderID string) error {
 	a, err := ptypes.MarshalAny(disputeMessage)
 	if err != nil {
 		log.Errorf("failed to marshal the contract: %v", err)
@@ -538,19 +538,16 @@ func (n *OpenBazaarNode) SendDisputeOpen(peerID string, k *libp2p.PubKey, disput
 	}
 
 	// Save DISPUTE_OPEN message to the database for this order for resending if necessary
-	var orderID0 string
-	if disputeMessage.VendorOrderConfirmation != nil {
-		orderID0 = disputeMessage.VendorOrderConfirmation.OrderID
-		if orderID0 == "" {
-			log.Errorf("failed fetching orderID")
-		} else {
+	orderID0 := orderID
+	if orderID0 == "" {
+		log.Errorf("failed fetching orderID")
+	} else {
 			err = n.Datastore.Messages().Put(
 				fmt.Sprintf("%s-%d", orderID0, int(pb.Message_DISPUTE_OPEN)),
 				orderID0, pb.Message_DISPUTE_OPEN, peerID, repo.Message{Msg: m},
 				"", 0, []byte{})
 			if err != nil {
-				log.Errorf("failed putting message (%s-%d): %v", orderID0, int(pb.Message_DISPUTE_OPEN), err)
-			}
+			log.Errorf("failed putting message (%s-%d): %v", orderID0, int(pb.Message_DISPUTE_OPEN), err)
 		}
 	}
 

--- a/core/net.go
+++ b/core/net.go
@@ -813,6 +813,20 @@ func (n *OpenBazaarNode) SendOrderPayment(spend *SpendResponse) error {
 	if err != nil {
 		return err
 	}
+
+	orderID0 := msg.OrderID
+	if orderID0 == "" {
+		log.Errorf("failed fetching orderID")
+	} else {
+		err = n.Datastore.Messages().Put(
+			fmt.Sprintf("%s-%d", orderID0, int(pb.Message_ORDER_PAYMENT)),
+			orderID0, pb.Message_ORDER_PAYMENT, spend.PeerID, repo.Message{Msg: m},
+			"", 0, []byte{})
+		if err != nil {
+			log.Errorf("failed putting message (%s-%d): %v", orderID0, int(pb.Message_ORDER_COMPLETION), err)
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), n.OfflineMessageFailoverTimeout)
 	err = n.Service.SendMessage(ctx, p, &m)
 	cancel()

--- a/core/net.go
+++ b/core/net.go
@@ -542,11 +542,11 @@ func (n *OpenBazaarNode) SendDisputeOpen(peerID string, k *libp2p.PubKey, disput
 	if orderID0 == "" {
 		log.Errorf("failed fetching orderID")
 	} else {
-			err = n.Datastore.Messages().Put(
-				fmt.Sprintf("%s-%d", orderID0, int(pb.Message_DISPUTE_OPEN)),
-				orderID0, pb.Message_DISPUTE_OPEN, peerID, repo.Message{Msg: m},
-				"", 0, []byte{})
-			if err != nil {
+		err = n.Datastore.Messages().Put(
+			fmt.Sprintf("%s-%d", orderID0, int(pb.Message_DISPUTE_OPEN)),
+			orderID0, pb.Message_DISPUTE_OPEN, peerID, repo.Message{Msg: m},
+			"", 0, []byte{})
+		if err != nil {
 			log.Errorf("failed putting message (%s-%d): %v", orderID0, int(pb.Message_DISPUTE_OPEN), err)
 		}
 	}
@@ -586,7 +586,7 @@ func (n *OpenBazaarNode) SendDisputeUpdate(peerID string, updateMessage *pb.Disp
 }
 
 // SendDisputeClose - send dispute closed msg to peer
-func (n *OpenBazaarNode) SendDisputeClose(peerID string, k *libp2p.PubKey, resolutionMessage *pb.RicardianContract) error {
+func (n *OpenBazaarNode) SendDisputeClose(peerID string, k *libp2p.PubKey, resolutionMessage *pb.RicardianContract, orderID string) error {
 	a, err := ptypes.MarshalAny(resolutionMessage)
 	if err != nil {
 		log.Errorf("failed to marshal the contract: %v", err)
@@ -600,19 +600,16 @@ func (n *OpenBazaarNode) SendDisputeClose(peerID string, k *libp2p.PubKey, resol
 	}
 
 	// Save DISPUTE_CLOSE message to the database for this order for resending if necessary
-	var orderID0 string
-	if resolutionMessage.VendorOrderConfirmation != nil {
-		orderID0 = resolutionMessage.VendorOrderConfirmation.OrderID
-		if orderID0 == "" {
-			log.Errorf("failed fetching orderID")
-		} else {
-			err = n.Datastore.Messages().Put(
-				fmt.Sprintf("%s-%d", orderID0, int(pb.Message_DISPUTE_CLOSE)),
-				orderID0, pb.Message_DISPUTE_CLOSE, peerID, repo.Message{Msg: m},
-				"", 0, []byte{})
-			if err != nil {
-				log.Errorf("failed putting message (%s-%d): %v", orderID0, int(pb.Message_DISPUTE_CLOSE), err)
-			}
+	orderID0 := orderID
+	if orderID0 == "" {
+		log.Errorf("failed fetching orderID")
+	} else {
+		err = n.Datastore.Messages().Put(
+			fmt.Sprintf("%s-%d", orderID0, int(pb.Message_DISPUTE_CLOSE)),
+			orderID0, pb.Message_DISPUTE_CLOSE, peerID, repo.Message{Msg: m},
+			"", 0, []byte{})
+		if err != nil {
+			log.Errorf("failed putting message (%s-%d): %v", orderID0, int(pb.Message_DISPUTE_CLOSE), err)
 		}
 	}
 


### PR DESCRIPTION
This PR is designed to save more outgoing messages so they can be replayed if there is some message handling error by the recipient. This is useful especially in Haven where we've baked into the app logic to resend old order messages to give the best chance at preventing orders from being stuck.

The following order messages are saved into the database:

| Order message | [Message #](https://github.com/OpenBazaar/openbazaar-go/blob/ethereum-master/pb/protos/message.proto#L14) | Sent by | Tested |
| --- | :---: | :---: | :---: |
| ORDER_PAYMENT | 21 | Buyer | ✅ 
| DISPUTE_OPEN | 10 | Buyer/Seller | ✅ |
| DISPUTE_UPDATE | 11 | Buyer/Seller | ✅ |
| DISPUTE_CLOSE | 12 | Buyer/Seller | ✅ |
| REFUND | 13 | Seller | ✅ |

The checked-off items are the ones I've tested to for their presence in the database.