### PR TITLE
(#1943) Fix currency value in order notification

### DIFF
--- a/repo/listing.go
+++ b/repo/listing.go
@@ -919,8 +919,8 @@ func (cs ListingCoupons) GetProtobuf() []*pb.Listing_Coupon {
 	var cspb = make([]*pb.Listing_Coupon, len(cs))
 	for i, c := range cs {
 		cspb[i] = &pb.Listing_Coupon{
-			Title:            c.GetTitle(),
-			PercentDiscount:  c.GetPercentOff(),
+			Title:           c.GetTitle(),
+			PercentDiscount: c.GetPercentOff(),
 		}
 		if c.GetAmountOff() != nil {
 			cspb[i].BigPriceDiscount = c.GetAmountOff().Amount.String()

--- a/wallet/listeners/transaction_listener.go
+++ b/wallet/listeners/transaction_listener.go
@@ -1,7 +1,6 @@
 package bitcoin
 
 import (
-	"math"
 	"math/big"
 	"sync"
 	"time"
@@ -296,18 +295,6 @@ func (l *TransactionListener) processSalePayment(txid string, output wallet.Tran
 	}); err != nil {
 		log.Errorf("failed updating tx metadata (%s): %s", txid, err.Error())
 	}
-}
-
-func currencyDivisibilityFromContract(mw multiwallet.MultiWallet, contract *pb.RicardianContract) uint {
-	var currencyDivisibility = contract.VendorListings[0].Item.PriceCurrency.Divisibility
-	if currencyDivisibility != 0 {
-		return uint(currencyDivisibility)
-	}
-	wallet, err := mw.WalletForCurrencyCode(contract.BuyerOrder.Payment.AmountCurrency.Code)
-	if err == nil {
-		return uint(math.Log10(float64(wallet.ExchangeRates().UnitsPerCoin())))
-	}
-	return core.DefaultCurrencyDivisibility
 }
 
 func (l *TransactionListener) processPurchasePayment(txid string, output wallet.TransactionOutput, contract *pb.RicardianContract, state pb.OrderState, funded bool, records []*wallet.TransactionRecord) {

--- a/wallet/listeners/transaction_listener.go
+++ b/wallet/listeners/transaction_listener.go
@@ -225,19 +225,6 @@ func (l *TransactionListener) processSalePayment(txid string, output wallet.Tran
 			return
 		}
 
-		// update divisibility from contract listing
-		if contract.VendorListings[0].Metadata.ContractType != pb.Listing_Metadata_CRYPTOCURRENCY {
-			customDivisibility := currencyDivisibilityFromContract(l.multiwallet, contract)
-			if customDivisibility != currencyValue.Currency.Divisibility {
-				currencyValue.Currency.Divisibility = customDivisibility
-				if err := currencyValue.Valid(); err != nil {
-					log.Errorf("Invalid currency divisibility (%d) found in contract (%s): %s", customDivisibility, orderId, err.Error())
-					return
-				}
-			}
-		}
-
-		// TODO: this comparison needs to consider the possibility of different divisibilities
 		if funding.Cmp(currencyValue.Amount) >= 0 {
 			log.Debugf("Received payment for order %s", orderId)
 			funded = true


### PR DESCRIPTION
closes #1943

The bug here was try to set the divisibility in the notification to a custom divisibility found in the listing but the would result in overriding a crypto divisibility such as 8 or 18 with a fiat divisibility of 2. 

Since we aren't going to be doing custom divisibilities anytime soon I just removed this code block. 