### PR TITLE
feat: Endpoint to hash a message

### DIFF
--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -115,6 +115,8 @@ func post(i *jsonAPIHandler, path string, w http.ResponseWriter, r *http.Request
 		i.POSTBulkUpdateCurrency(w, r)
 	case strings.HasPrefix(path, "/ob/resendordermessage"):
 		i.POSTResendOrderMessage(w, r)
+	case strings.HasPrefix(path, "/ob/hashmessage"):
+		i.POSTHashMessage(w, r)
 	default:
 		ErrorResponse(w, http.StatusNotFound, "Not Found")
 	}

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -4406,3 +4406,26 @@ func (i *jsonAPIHandler) GETScanOfflineMessages(w http.ResponseWriter, r *http.R
 	}
 	SanitizedResponse(w, `{}`)
 }
+
+func (i *jsonAPIHandler) POSTHashMessage(w http.ResponseWriter, r *http.Request) {
+	type hashRequest struct {
+		Content string `json:"content"`
+	}
+	var (
+		req hashRequest
+		err = json.NewDecoder(r.Body).Decode(&req)
+	)
+	if err != nil {
+		ErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	messageHash, err := ipfs.EncodeMultihash([]byte(req.Content))
+	if err != nil {
+		ErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	SanitizedResponse(w, fmt.Sprintf(`{"hash": "%s"}`,
+		messageHash.B58String()))
+}


### PR DESCRIPTION
This will take a string and encode it as a multihash + convert it to a Base 58 string in the same way we do to our coupons. This makes it easy for clients to determine if a given coupon matches a listing's coupon secret.