### PR TITLE
 Fix: Save DisputeAcceptance to the contract no matter what

### DIFF
--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -1520,11 +1520,19 @@ func (service *OpenBazaarService) handleDisputeClose(p peer.ID, pmes *pb.Message
 		return nil, err
 	}
 
+	// If DisputeAcceptance is already set then move the state directly to RESOLVED
 	if isPurchase {
-		// Set message state to complete
-		err = service.datastore.Purchases().Put(rc.DisputeResolution.OrderId, *contract, pb.OrderState_DECIDED, false)
+		if contract.DisputeAcceptance != nil {
+			err = service.datastore.Purchases().Put(rc.DisputeResolution.OrderId, *contract, pb.OrderState_RESOLVED, false)
+		} else {
+			err = service.datastore.Purchases().Put(rc.DisputeResolution.OrderId, *contract, pb.OrderState_DECIDED, false)
+		}
 	} else {
-		err = service.datastore.Sales().Put(rc.DisputeResolution.OrderId, *contract, pb.OrderState_DECIDED, false)
+		if contract.DisputeAcceptance != nil {
+			err = service.datastore.Sales().Put(rc.DisputeResolution.OrderId, *contract, pb.OrderState_RESOLVED, false)
+		} else {
+			err = service.datastore.Sales().Put(rc.DisputeResolution.OrderId, *contract, pb.OrderState_DECIDED, false)
+		}
 	}
 	if err != nil {
 		return nil, err

--- a/wallet/listeners/transaction_listener.go
+++ b/wallet/listeners/transaction_listener.go
@@ -154,8 +154,14 @@ func (l *TransactionListener) OnTransactionReceived(cb wallet.TransactionCallbac
 						log.Errorf("persist dispute acceptance notification for order (%s): %s", orderId, err)
 					}
 				}
-				if err := l.db.Sales().Put(orderId, *contract, pb.OrderState_RESOLVED, false); err != nil {
-					log.Errorf("failed updating order (%s) to RESOLVED: %s", orderId, err.Error())
+				if state == pb.OrderState_DECIDED {
+					if err := l.db.Sales().Put(orderId, *contract, pb.OrderState_RESOLVED, false); err != nil {
+						log.Errorf("failed updating order (%s) to RESOLVED: %s", orderId, err.Error())
+					}
+				} else {
+					if err := l.db.Sales().Put(orderId, *contract, state, false); err != nil {
+						log.Errorf("failed updating order (%s) with DisputeAcceptance: %s", orderId, err.Error())
+					}
 				}
 			}
 		} else {
@@ -192,8 +198,14 @@ func (l *TransactionListener) OnTransactionReceived(cb wallet.TransactionCallbac
 						log.Errorf("persist dispute acceptance notification for order (%s): %s", orderId, err)
 					}
 				}
-				if err := l.db.Purchases().Put(orderId, *contract, pb.OrderState_RESOLVED, false); err != nil {
-					log.Errorf("failed updating order (%s) to RESOLVED: %s", orderId, err.Error())
+				if state == pb.OrderState_DECIDED {
+					if err := l.db.Purchases().Put(orderId, *contract, pb.OrderState_RESOLVED, false); err != nil {
+						log.Errorf("failed updating order (%s) to RESOLVED: %s", orderId, err.Error())
+					}
+				} else {
+					if err := l.db.Purchases().Put(orderId, *contract, state, false); err != nil {
+						log.Errorf("failed updating order (%s) with DisputeAcceptance: %s", orderId, err.Error())
+					}
 				}
 			}
 		}

--- a/wallet/listeners/transaction_listener.go
+++ b/wallet/listeners/transaction_listener.go
@@ -129,7 +129,7 @@ func (l *TransactionListener) OnTransactionReceived(cb wallet.TransactionCallbac
 				log.Errorf("update funding for sale (%s): %s", orderId, err)
 			}
 			// This is a dispute payout. We should set the order state.
-			if state == pb.OrderState_DECIDED && len(records) > 0 && fundsReleased {
+			if len(records) > 0 && fundsReleased {
 				if contract.DisputeAcceptance == nil && contract != nil && contract.BuyerOrder != nil && contract.BuyerOrder.BuyerID != nil {
 					accept := new(pb.DisputeAcceptance)
 					ts, _ := ptypes.TimestampProto(time.Now())
@@ -169,7 +169,7 @@ func (l *TransactionListener) OnTransactionReceived(cb wallet.TransactionCallbac
 			if err != nil {
 				log.Errorf("update funding for purchase (%s): %s", orderId, err)
 			}
-			if state == pb.OrderState_DECIDED && len(records) > 0 && fundsReleased {
+			if len(records) > 0 && fundsReleased {
 				if contract.DisputeAcceptance == nil && contract != nil && len(contract.VendorListings) > 0 && contract.VendorListings[0].VendorID != nil {
 					accept := new(pb.DisputeAcceptance)
 					ts, _ := ptypes.TimestampProto(time.Now())


### PR DESCRIPTION
Save DisputeAcceptance data to the contract.

Also automatically progress an order contract's state to RESOLVED when a DISPUTE_CLOSE message is found and DisputeAcceptance data is already present on the contract.  This is another fix aimed at fully resolving #1651