### PR TITLE
Cleanup Order State

### DIFF
--- a/wallet/listeners/transaction_listener.go
+++ b/wallet/listeners/transaction_listener.go
@@ -55,6 +55,26 @@ func (l *TransactionListener) getOrderDetails(orderID string, address btc.Addres
 	return contract, state, funded, records, err
 }
 
+// cleanupOrderState - scan each order to ensure the state in the db matches the state of the contract stored
+func (l *TransactionListener) cleanupOrderState(isSale bool, txid string, output wallet.TransactionOutput, contract *pb.RicardianContract, state pb.OrderState, funded bool, records []*wallet.TransactionRecord)  {
+
+	orderId, err := calcOrderId(contract.BuyerOrder)
+	if err != nil {
+		return
+	}
+	log.Debugf("Cleaning up order state for: #%s\n", orderId)
+
+	if contract.DisputeResolution != nil && state != pb.OrderState_RESOLVED {
+		log.Infof("Out of sync order. Found %s and should be %s\n", state, pb.OrderState_RESOLVED)
+		if isSale {
+			l.db.Sales().Put(orderId, *contract, pb.OrderState_RESOLVED, false)
+		} else {
+			l.db.Purchases().Put(orderId, *contract, pb.OrderState_RESOLVED, false)
+		}
+
+	}
+}
+
 func (l *TransactionListener) OnTransactionReceived(cb wallet.TransactionCallback) {
 	log.Info("Transaction received", cb.Txid, cb.Height)
 
@@ -75,11 +95,13 @@ func (l *TransactionListener) OnTransactionReceived(cb wallet.TransactionCallbac
 		//contract, state, funded, records, err := l.db.Sales().GetByPaymentAddress(output.Address)
 		if err == nil && state != pb.OrderState_PROCESSING_ERROR {
 			l.processSalePayment(cb.Txid, output, contract, state, funded, records)
+			l.cleanupOrderState(true, cb.Txid, output, contract, state, funded, records)
 			continue
 		}
 		contract, state, funded, records, err = l.getOrderDetails(output.OrderID, output.Address, false)
 		if err == nil {
 			l.processPurchasePayment(cb.Txid, output, contract, state, funded, records)
+			l.cleanupOrderState(false, cb.Txid, output, contract, state, funded, records)
 			continue
 		}
 	}

--- a/wallet/listeners/transaction_listener.go
+++ b/wallet/listeners/transaction_listener.go
@@ -56,7 +56,7 @@ func (l *TransactionListener) getOrderDetails(orderID string, address btc.Addres
 }
 
 // cleanupOrderState - scan each order to ensure the state in the db matches the state of the contract stored
-func (l *TransactionListener) cleanupOrderState(isSale bool, txid string, output wallet.TransactionOutput, contract *pb.RicardianContract, state pb.OrderState, funded bool, records []*wallet.TransactionRecord)  {
+func (l *TransactionListener) cleanupOrderState(isSale bool, txid string, output wallet.TransactionOutput, contract *pb.RicardianContract, state pb.OrderState, funded bool, records []*wallet.TransactionRecord) {
 
 	orderId, err := calcOrderId(contract.BuyerOrder)
 	if err != nil {
@@ -64,8 +64,8 @@ func (l *TransactionListener) cleanupOrderState(isSale bool, txid string, output
 	}
 	log.Debugf("Cleaning up order state for: #%s\n", orderId)
 
-	if contract.DisputeResolution != nil && state != pb.OrderState_RESOLVED {
-		log.Infof("Out of sync order. Found %s and should be %s\n", state, pb.OrderState_RESOLVED)
+	if contract.DisputeResolution != nil && state != pb.OrderState_DECIDED && state != pb.OrderState_RESOLVED {
+		log.Infof("Out of sync order. Found %s and should either DECIDED be %s\n", state, pb.OrderState_RESOLVED)
 		if isSale {
 			l.db.Sales().Put(orderId, *contract, pb.OrderState_RESOLVED, false)
 		} else {


### PR DESCRIPTION
When we see txs for orders then we should scan them to ensure their db state matches where the contract is.