### PR TITLE
Fix purchase crypto test

### DIFF
--- a/core/order.go
+++ b/core/order.go
@@ -982,7 +982,7 @@ func (n *OpenBazaarNode) CalculateOrderTotal(contract *pb.RicardianContract) (*b
 		// calculate base amount
 		if nrl.GetContractType() == pb.Listing_Metadata_CRYPTOCURRENCY.String() &&
 			nrl.GetFormat() == pb.Listing_Metadata_MARKET_PRICE.String() {
-			var originDef = repo.NewUnknownCryptoDefinition(nrl.GetCryptoCurrencyCode(), 0)
+			var originDef = repo.NewUnknownCryptoDefinition(nrl.GetCryptoCurrencyCode(), uint(nrl.GetCryptoDivisibility()))
 			itemOriginAmt = repo.NewCurrencyValueFromBigInt(GetOrderQuantity(nrl.GetProtobuf(), item), originDef)
 
 			if priceModifier := nrl.GetPriceModifier(); priceModifier != 0 {

--- a/qa/testdata/v5/order_crypto.json
+++ b/qa/testdata/v5/order_crypto.json
@@ -2,7 +2,7 @@
     "moderator": "",
     "items": [{
         "listingHash": "",
-        "bigQuantity": "100000000",
+        "bigQuantity": "1000000000000000",
         "paymentAddress": "crypto_payment_address",
         "memo": "thanks!"
     }]


### PR DESCRIPTION
We were assuming all listings were for cryptos with base unit of 8 digits. This uses the actual precision from the listing itself.