### PR TITLE
Fix fixedfee disputes from v4

### DIFF
--- a/core/moderation.go
+++ b/core/moderation.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	routing "gx/ipfs/QmSY3nkMNLzh9GdbFKK5tT7YMfLpf52iUZ8ZRkr29MJaa5/go-libp2p-kad-dht"
 	ma "gx/ipfs/QmTZBfrPJmjWsCvHEtX5FE6KimVJhsJg5sBbqEFYf4UZtL/go-multiaddr"
@@ -148,6 +149,9 @@ func (n *OpenBazaarNode) RemoveSelfAsModerator() error {
 
 // GetModeratorFee is called by the Moderator when determining their take of the dispute
 func (n *OpenBazaarNode) GetModeratorFee(transactionTotal *big.Int, txCurrencyCode string) (*big.Int, error) {
+	var curDef *pb.CurrencyDefinition
+	var bigAmount string
+
 	file, err := ioutil.ReadFile(path.Join(n.RepoPath, "root", "profile.json"))
 	if err != nil {
 		return big.NewInt(0), err
@@ -168,7 +172,29 @@ func (n *OpenBazaarNode) GetModeratorFee(transactionTotal *big.Int, txCurrencyCo
 		return feePercentAmt.AmountBigInt(), nil
 
 	case pb.Moderator_Fee_FIXED:
-		modFeeValue, err := repo.NewCurrencyValueFromProtobuf(profile.ModeratorInfo.Fee.FixedFee.BigAmount, profile.ModeratorInfo.Fee.FixedFee.AmountCurrency)
+		if profile.ModeratorInfo.Fee.FixedFee.AmountCurrency == nil {
+			currency, err := n.LookupCurrency(profile.ModeratorInfo.Fee.FixedFee.CurrencyCode)
+			if err != nil {
+				return nil, err
+			}
+			curDef = &pb.CurrencyDefinition{
+				Code:         currency.Code.String(),
+				Divisibility: uint32(currency.Divisibility),
+			}
+			bigAmount = strconv.FormatUint(profile.ModeratorInfo.Fee.FixedFee.Amount, 10)
+		} else {
+			currency, err := n.LookupCurrency(profile.ModeratorInfo.Fee.FixedFee.AmountCurrency.Code)
+			if err != nil {
+				return nil, err
+			}
+			curDef = &pb.CurrencyDefinition{
+				Code:         currency.Code.String(),
+				Divisibility: uint32(currency.Divisibility),
+			}
+			bigAmount = profile.ModeratorInfo.Fee.FixedFee.BigAmount
+		}
+
+		modFeeValue, err := repo.NewCurrencyValueFromProtobuf(bigAmount, curDef)
 		if err != nil {
 			return big.NewInt(0), fmt.Errorf("parse moderator fee currency: %s", err)
 		}
@@ -188,6 +214,28 @@ func (n *OpenBazaarNode) GetModeratorFee(transactionTotal *big.Int, txCurrencyCo
 		return convertedModFee.AmountBigInt(), nil
 
 	case pb.Moderator_Fee_FIXED_PLUS_PERCENTAGE:
+		if profile.ModeratorInfo.Fee.FixedFee.AmountCurrency == nil {
+			currency, err := n.LookupCurrency(profile.ModeratorInfo.Fee.FixedFee.CurrencyCode)
+			if err != nil {
+				return nil, err
+			}
+			curDef = &pb.CurrencyDefinition{
+				Code:         currency.Code.String(),
+				Divisibility: uint32(currency.Divisibility),
+			}
+			bigAmount = strconv.FormatUint(profile.ModeratorInfo.Fee.FixedFee.Amount, 10)
+		} else {
+			currency, err := n.LookupCurrency(profile.ModeratorInfo.Fee.FixedFee.AmountCurrency.Code)
+			if err != nil {
+				return nil, err
+			}
+			curDef = &pb.CurrencyDefinition{
+				Code:         currency.Code.String(),
+				Divisibility: uint32(currency.Divisibility),
+			}
+			bigAmount = profile.ModeratorInfo.Fee.FixedFee.BigAmount
+		}
+
 		modFeeValue, err := repo.NewCurrencyValueFromProtobuf(profile.ModeratorInfo.Fee.FixedFee.BigAmount, profile.ModeratorInfo.Fee.FixedFee.AmountCurrency)
 		if err != nil {
 			return big.NewInt(0), fmt.Errorf("parse moderator fee currency: %s", err)

--- a/core/moderation.go
+++ b/core/moderation.go
@@ -236,7 +236,7 @@ func (n *OpenBazaarNode) GetModeratorFee(transactionTotal *big.Int, txCurrencyCo
 			bigAmount = profile.ModeratorInfo.Fee.FixedFee.BigAmount
 		}
 
-		modFeeValue, err := repo.NewCurrencyValueFromProtobuf(profile.ModeratorInfo.Fee.FixedFee.BigAmount, profile.ModeratorInfo.Fee.FixedFee.AmountCurrency)
+		modFeeValue, err := repo.NewCurrencyValueFromProtobuf(bigAmount, curDef)
 		if err != nil {
 			return big.NewInt(0), fmt.Errorf("parse moderator fee currency: %s", err)
 		}

--- a/core/profile.go
+++ b/core/profile.go
@@ -362,8 +362,15 @@ func ValidateProfile(profile *pb.Profile) error {
 			}
 		}
 		if profile.ModeratorInfo.Fee != nil {
+			var moderatorCurrencyCode string
+			if profile.ModeratorInfo.Fee.FixedFee.AmountCurrency == nil {
+				moderatorCurrencyCode = profile.ModeratorInfo.Fee.FixedFee.CurrencyCode
+			} else {
+				moderatorCurrencyCode = profile.ModeratorInfo.Fee.FixedFee.AmountCurrency.Code
+			}
+
 			if profile.ModeratorInfo.Fee.FeeType != pb.Moderator_Fee_PERCENTAGE && profile.ModeratorInfo.Fee.FixedFee != nil &&
-				len(profile.ModeratorInfo.Fee.FixedFee.AmountCurrency.Code) > repo.WordMaxCharacters {
+				len(moderatorCurrencyCode) > repo.WordMaxCharacters {
 				return fmt.Errorf("moderator fee currency code character length is greater than the max of %d", repo.WordMaxCharacters)
 			}
 		}

--- a/core/profile.go
+++ b/core/profile.go
@@ -363,10 +363,12 @@ func ValidateProfile(profile *pb.Profile) error {
 		}
 		if profile.ModeratorInfo.Fee != nil {
 			var moderatorCurrencyCode string
-			if profile.ModeratorInfo.Fee.FixedFee.AmountCurrency == nil {
-				moderatorCurrencyCode = profile.ModeratorInfo.Fee.FixedFee.CurrencyCode
-			} else {
-				moderatorCurrencyCode = profile.ModeratorInfo.Fee.FixedFee.AmountCurrency.Code
+			if profile.ModeratorInfo.Fee.FixedFee != nil {
+				if profile.ModeratorInfo.Fee.FixedFee.AmountCurrency == nil {
+					moderatorCurrencyCode = profile.ModeratorInfo.Fee.FixedFee.CurrencyCode
+				} else {
+					moderatorCurrencyCode = profile.ModeratorInfo.Fee.FixedFee.AmountCurrency.Code
+				}
 			}
 
 			if profile.ModeratorInfo.Fee.FeeType != pb.Moderator_Fee_PERCENTAGE && profile.ModeratorInfo.Fee.FixedFee != nil &&


### PR DESCRIPTION
Any disputes from v4 carried over to v5 who have a moderator with FIXED FEE or FIXED FEE PLUS will have issues closing disputes or viewing. This should address that.