### PR TITLE
Add /ob/checkoutbreakdown Endpoint

### DIFF
--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -91,6 +91,8 @@ func post(i *jsonAPIHandler, path string, w http.ResponseWriter, r *http.Request
 		i.POSTShutdown(w, r)
 	case strings.HasPrefix(path, "/ob/estimatetotal"):
 		i.POSTEstimateTotal(w, r)
+	case strings.HasPrefix(path, "/ob/checkoutbreakdown"):
+		i.POSTCheckoutBreakdown(w, r)
 	case strings.HasPrefix(path, "/ob/fetchratings"):
 		i.POSTFetchRatings(w, r)
 	case strings.HasPrefix(path, "/ob/sales"):

--- a/api/jsonapi.go
+++ b/api/jsonapi.go
@@ -3578,6 +3578,29 @@ func (i *jsonAPIHandler) GETFees(w http.ResponseWriter, r *http.Request) {
 	SanitizedResponse(w, string(out))
 }
 
+func (i *jsonAPIHandler) POSTCheckoutBreakdown(w http.ResponseWriter, r *http.Request) {
+	decoder := json.NewDecoder(r.Body)
+	var data repo.PurchaseData
+	err := decoder.Decode(&data)
+	if err != nil {
+		ErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	cb, err := i.node.CheckoutBreakdown(&data)
+	if err != nil {
+		ErrorResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	out, err := json.MarshalIndent(cb, "", "    ")
+	if err != nil {
+		ErrorResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SanitizedResponse(w, string(out))
+}
+
 func (i *jsonAPIHandler) POSTEstimateTotal(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var data repo.PurchaseData

--- a/core/order.go
+++ b/core/order.go
@@ -1098,10 +1098,19 @@ func (n *OpenBazaarNode) CalculateOrderTotal(contract *pb.RicardianContract) (*b
 
 	for _, item := range v5Order.Items {
 		var itemOriginAmt *repo.CurrencyValue
+		l, err := ParseContractForListing(item.ListingHash, contract)
+		if err != nil {
+			return big.NewInt(0), fmt.Errorf("listing not found in contract for item %s", item.ListingHash)
+		}
 
-		nrl, err := GetNormalizedListing(item.ListingHash, contract)
+		rl, err := repo.NewListingFromProtobuf(l)
 		if err != nil {
 			return big.NewInt(0), err
+		}
+
+		nrl, err := rl.Normalize()
+		if err != nil {
+			return big.NewInt(0), fmt.Errorf("normalize legacy listing: %s", err.Error())
 		}
 
 		// keep track of physical listings for shipping caluclation

--- a/core/order.go
+++ b/core/order.go
@@ -991,10 +991,6 @@ func (n *OpenBazaarNode) CheckoutBreakdown(data *repo.PurchaseData) (repo.Checko
 	checkoutBreakdown.Coupon = finalCouponDiscount.Amount.String()
 	checkoutBreakdown.OptionSurcharge = finalOptionSurcharge.Amount.String()
 	checkoutBreakdown.BasePrice = finalBasePrice.Amount.String()
-	checkoutBreakdown.PriceCurrency = repo.CheckoutCurrency{
-		Code:         itemOriginAmt.Currency.Code.String(),
-		Divisibility: int(itemOriginAmt.Currency.Divisibility),
-	}
 	checkoutBreakdown.TotalPrice = totalPrice.String()
 	checkoutBreakdown.Quantity = totalQuantity.String()
 

--- a/core/order.go
+++ b/core/order.go
@@ -886,6 +886,9 @@ func (n *OpenBazaarNode) CheckoutBreakdown(data *repo.PurchaseData) (repo.Checko
 
 	// Get base price of item
 	v5Order, err := repo.ToV5Order(contract.BuyerOrder, n.LookupCurrency)
+	if err != nil {
+		return emptyCheckoutBreakdown, err
+	}
 	firstItem := v5Order.Items[0]
 
 	nrl, err := GetNormalizedListing(firstItem.ListingHash, contract)
@@ -930,6 +933,9 @@ func (n *OpenBazaarNode) CheckoutBreakdown(data *repo.PurchaseData) (repo.Checko
 		return emptyCheckoutBreakdown, err
 	}
 	couponDiscount, err := GetTotalCouponCodeDiscount(nrl, firstItem.CouponCodes)
+	if err != nil {
+		return emptyCheckoutBreakdown, err
+	}
 	couponDiscount = couponDiscount.Mul(couponDiscount, new(big.Int).SetInt64(-1))
 	couponCurrencyValue := repo.NewCurrencyValueFromBigInt(couponDiscount, listingCurDef)
 

--- a/repo/checkout.go
+++ b/repo/checkout.go
@@ -12,11 +12,11 @@ type CheckoutCurrency struct {
 }
 
 type CheckoutBreakdown struct {
-	BasePrice       string           `json:"basePrice"`
-	Coupon          string           `json:"coupon"`
-	OptionSurcharge string           `json:"optionSurcharge"`
-	Quantity        string           `json:"quantity"`
-	ShippingPrice   string           `json:"shippingPrice"`
-	Tax             string           `json:"tax"`
-	TotalPrice      string           `json:"totalPrice"`
+	BasePrice       string `json:"basePrice"`
+	Coupon          string `json:"coupon"`
+	OptionSurcharge string `json:"optionSurcharge"`
+	Quantity        string `json:"quantity"`
+	ShippingPrice   string `json:"shippingPrice"`
+	Tax             string `json:"tax"`
+	TotalPrice      string `json:"totalPrice"`
 }

--- a/repo/checkout.go
+++ b/repo/checkout.go
@@ -1,0 +1,23 @@
+package repo
+
+type CheckoutVariant struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	Price string `json:"price"`
+}
+
+type CheckoutCurrency struct {
+	Code         string `json:"code"`
+	Divisibility int    `json:"divisibility"`
+}
+
+type CheckoutBreakdown struct {
+	BasePrice       string            `json:"basePrice"`
+	Coupon          string            `json:"coupon"`
+	OptionSurcharge string            `json:"optionSurcharge"`
+	PriceCurrency   CheckoutCurrency  `json:"priceCurrency"`
+	Quantity        string            `json:"quantity"`
+	ShippingPrice   string            `json:"shippingPrice"`
+	Tax             string            `json:"tax"`
+	TotalPrice      string            `json:"totalPrice"`
+}

--- a/repo/checkout.go
+++ b/repo/checkout.go
@@ -15,7 +15,6 @@ type CheckoutBreakdown struct {
 	BasePrice       string           `json:"basePrice"`
 	Coupon          string           `json:"coupon"`
 	OptionSurcharge string           `json:"optionSurcharge"`
-	PriceCurrency   CheckoutCurrency `json:"priceCurrency"`
 	Quantity        string           `json:"quantity"`
 	ShippingPrice   string           `json:"shippingPrice"`
 	Tax             string           `json:"tax"`

--- a/repo/checkout.go
+++ b/repo/checkout.go
@@ -12,12 +12,12 @@ type CheckoutCurrency struct {
 }
 
 type CheckoutBreakdown struct {
-	BasePrice       string            `json:"basePrice"`
-	Coupon          string            `json:"coupon"`
-	OptionSurcharge string            `json:"optionSurcharge"`
-	PriceCurrency   CheckoutCurrency  `json:"priceCurrency"`
-	Quantity        string            `json:"quantity"`
-	ShippingPrice   string            `json:"shippingPrice"`
-	Tax             string            `json:"tax"`
-	TotalPrice      string            `json:"totalPrice"`
+	BasePrice       string           `json:"basePrice"`
+	Coupon          string           `json:"coupon"`
+	OptionSurcharge string           `json:"optionSurcharge"`
+	PriceCurrency   CheckoutCurrency `json:"priceCurrency"`
+	Quantity        string           `json:"quantity"`
+	ShippingPrice   string           `json:"shippingPrice"`
+	Tax             string           `json:"tax"`
+	TotalPrice      string           `json:"totalPrice"`
 }


### PR DESCRIPTION
This enables checkout breakdown call to get an itemized breakdown of an order.

The format to make the call is as follows:

```json
{
    "shipTo": "Elwood Blues",
    "address": "1060 W Addison",
    "city": "Chicago",
    "state": "Illinois",
    "countryCode": "UNITED_STATES",
    "postalCode": "60613",
    "addressNotes": "",
    "items": [
        {
            "listingHash": "QmTjLBaqrunGmvCD9A3joXLXGudAwxnQvMtvcggQ5rahxN",
            "bigQuantity": "1",
            "options": [
                {
                    "name": "Sizes",
                    "value": "Small"
                },
                {
                    "name": "Color",
                    "value": "Red"
                }
            ],
            "shipping": {
                "name": "Worldwide",
                "service": "Standard"
            },
            "memo": "thanks!",
            "coupons": []
        }
    ],
    "moderator": "QmcdkKM2fWCKzTZdpjEY6abzRbDhRRJvNmqwNKVyiDtGky",
    "paymentCoin": "LTC"
}
```

This call returns:

```json
{
    "basePrice": "45433155",
    "coupon": "4543316",
    "optionSurcharge": "9086631",
    "priceCurrency": {
        "code": "USD",
        "divisibility": 2
    },
    "quantity": "43",
    "shippingPrice": "290772224",
    "tax": "0",
    "totalPrice": "2439760434"
}
```