### PR TITLE
Do not strip 0x in the middle of the string

### DIFF
--- a/util/utils.go
+++ b/util/utils.go
@@ -65,10 +65,7 @@ const EmojiPattern = "[\\x{2712}\\x{2714}\\x{2716}\\x{271d}\\x{2721}\\x{2728}\\x
 
 // NormalizeAddress is used to strip the 0x prefix
 func NormalizeAddress(addr string) string {
-	if addr[0:2] == "0x" {
-		return strings.Replace(addr, "0x", "", 1)
-	}
-	return addr
+	return strings.TrimPrefix(addr, "0x")
 }
 
 // AreAddressesEqual - check if addresses are equal after normalizing them

--- a/util/utils.go
+++ b/util/utils.go
@@ -65,7 +65,10 @@ const EmojiPattern = "[\\x{2712}\\x{2714}\\x{2716}\\x{271d}\\x{2721}\\x{2728}\\x
 
 // NormalizeAddress is used to strip the 0x prefix
 func NormalizeAddress(addr string) string {
-	return strings.Replace(addr, "0x", "", 1)
+	if addr[0:2] == "0x" {
+		return strings.Replace(addr, "0x", "", 1)
+	}
+	return addr
 }
 
 // AreAddressesEqual - check if addresses are equal after normalizing them


### PR DESCRIPTION
This is causing checksum validation issues for addresses where 0x appears in the middle of the address not just at the beginning.